### PR TITLE
Sanborn fetch scripts

### DIFF
--- a/mapsnap/fetch_loc.py
+++ b/mapsnap/fetch_loc.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fetch all Sanborn map metadata pages from the Library of Congress."""
+
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OUTPUT_DIR = Path(__file__).parent / "loc"
+DELAY_SECONDS = 10
+BASE_URL = (
+    "https://www.loc.gov/collections/sanborn-maps/?fo=json&c=100&at=results,pagination"
+)
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    "Accept": "application/json",
+}
+
+
+MAX_RETRIES = 5
+RETRY_DELAYS = [30, 60, 120, 300, 600]  # seconds between retries
+
+
+def fetch_page(page_num: int) -> dict | None:
+    url = BASE_URL if page_num == 1 else f"{BASE_URL}&sp={page_num}"
+    req = urllib.request.Request(url, headers=HEADERS)
+    for attempt in range(MAX_RETRIES):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            print(f"  HTTP {e.code} on page {page_num} (attempt {attempt + 1})")
+        except Exception as e:
+            print(f"  Error on page {page_num} (attempt {attempt + 1}): {e}")
+        if attempt < MAX_RETRIES - 1:
+            delay = RETRY_DELAYS[attempt]
+            print(f"  Retrying in {delay}s...", flush=True)
+            time.sleep(delay)
+    return None
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    page_num = 1
+
+    while True:
+        out_path = OUTPUT_DIR / f"page_{page_num:04d}.json"
+
+        if out_path.exists():
+            print(f"Page {page_num}: already exists, skipping")
+            page_num += 1
+            continue
+
+        print(f"Page {page_num}: fetching...", flush=True)
+        data = fetch_page(page_num)
+
+        if data is None:
+            print(f"Page {page_num}: all retries failed, stopping")
+            break
+
+        results = data.get("results", [])
+        if not results:
+            print(f"Page {page_num}: no results, stopping")
+            break
+
+        pagination = data.get("pagination", {})
+        total_pages = pagination.get("total", "?")
+
+        out_path.write_text(json.dumps(data, indent=2))
+        print(
+            f"Page {page_num}/{total_pages}: saved {len(results)} results to {out_path.name}"
+        )
+
+        page_num += 1
+
+        if page_num > 1:
+            print(f"  Waiting {DELAY_SECONDS}s...", flush=True)
+            time.sleep(DELAY_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/merge_loc.py
+++ b/mapsnap/merge_loc.py
@@ -1,0 +1,14 @@
+import json
+import sys
+from pathlib import Path
+
+if __name__ == "__main__":
+    in_glob, out = sys.argv[1:]
+    results = []
+    for p in Path().glob(in_glob):
+        with open(p) as f:
+            response = json.load(f)
+        results += response["results"]
+    with open(out, "w") as f:
+        json.dump(results, f)
+    print(f"Wrote {len(results)} Sanborn items to {out}")


### PR DESCRIPTION
51367 Sanborn items in a 120MB JSON file.

Fixes #17 

<p>Here's a summary of the 51,367 Sanborn map listings:</p>
<h3>Access &amp; Digitization</h3>
<ul>
<li><strong>Access restricted:</strong> 0 (0%) — every item is publicly accessible</li>
<li><strong>Digitized:</strong> 35,171 (68.5%) — the remaining 31.5% are catalog entries only</li>
</ul>
<h3>Images per Item</h3>
<p>The <code>resources.files</code> field counts the map sheets per item:</p>

Images | Count | %
-- | -- | --
0 | 16,204 | 31.5%
1 | 4,940 | 9.6%
2–5 | 15,818 | 30.8%
6–10 | 6,134 | 11.9%
11–20 | 3,723 | 7.2%
21–50 | 2,168 | 4.2%
51–100 | 1,510 | 2.9%
101+ | 870 | 1.7%

<p>Among digitized items: median <strong>4 sheets</strong>, mean <strong>12.5</strong>, max <strong>174</strong>, p90 <strong>28</strong>.</p>

<h3>Geography</h3>
<p>Nearly everything is the US (51,343 / 100%). Ten items are Mexico, five Canada, one Cuba. Top states:</p>

State | Count | %
-- | -- | --
New York | 3,814 | 7.4%
Pennsylvania | 3,118 | 6.1%
Illinois | 2,904 | 5.7%
California | 2,654 | 5.2%
Ohio | 2,412 | 4.7%
Texas | 2,263 | 4.4%
Michigan | 1,975 | 3.8%
Indiana | 1,725 | 3.4%
Oklahoma | 1,707 | 3.3%


<p>60 unique state/territory values total.</p>

<h3>Date Distribution</h3>
<p>Dates span <strong>1867–1999</strong>, almost all falling in the peak Sanborn production era:</p>

Decade | Count
-- | --
1880s | 3,698
1890s | 8,225
1900s | 8,848
1910s | 8,327
1920s | 10,580 ← peak
1930s | 4,801
1940s | 3,877
1950s | 2,160
1960s–90s | ~800


<p>Peak year was <strong>1929</strong> (1,470 items). The collection closely tracks the historical arc of Sanborn's fire insurance mapping business.</p>

<p><strong>441,183 total images</strong> across the collection. The distribution is heavily concentrated in large items:</p>

Min images/item | Items | % of items | Images | % of images
-- | -- | -- | -- | --
≥ 1 | 35,163 | 68.5% | 441,183 | 100%
≥ 2 | 30,223 | 58.8% | 436,243 | 98.9%
≥ 5 | 16,968 | 33.0% | 399,175 | 90.5%
≥ 10 | 9,046 | 17.6% | 347,659 | 78.8%
≥ 20 | 4,761 | 9.3% | 290,197 | 65.8%
≥ 50 | 2,397 | 4.7% | 221,107 | 50.1%
≥ 100 | 907 | 1.8% | 103,224 | 23.4%


<p>The top <strong>4.7% of items</strong> (those with 50+ sheets) account for <strong>half of all images</strong>. The ~30% of items with 1–4 sheets contribute only 9.5% of images. So if you're trying to maximize coverage, focusing on the large-volume items is where the bulk of the collection lives.</p>
