### PR TITLE
Just label the real GCPs

### DIFF
--- a/gallery/brooklyn_ny_1906_vol_6.iiif.json
+++ b/gallery/brooklyn_ny_1906_vol_6.iiif.json
@@ -24,8 +24,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -110,7 +110,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -141,8 +141,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -227,7 +227,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -258,8 +258,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -344,7 +344,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -375,8 +375,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -461,7 +461,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -492,8 +492,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -578,7 +578,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -609,8 +609,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -726,8 +726,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -843,8 +843,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -960,8 +960,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1046,7 +1046,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1077,8 +1077,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1194,8 +1194,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1280,7 +1280,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1311,8 +1311,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1427,6 +1427,27 @@
                 40.661284335604904
               ]
             }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                200.8,
+                7724.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.004076,
+                40.6614617
+              ]
+            }
           }
         ]
       }
@@ -1449,8 +1470,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1566,8 +1587,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1652,7 +1673,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1683,8 +1704,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1769,7 +1790,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1800,8 +1821,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1886,7 +1907,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1917,8 +1938,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2003,7 +2024,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2034,8 +2055,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2120,7 +2141,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2151,8 +2172,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2237,7 +2258,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2268,8 +2289,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2354,7 +2375,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2385,8 +2406,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2471,7 +2492,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2502,8 +2523,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2588,7 +2609,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2619,8 +2640,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2705,7 +2726,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2736,8 +2757,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2822,7 +2843,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2853,8 +2874,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2939,7 +2960,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2970,8 +2991,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3087,8 +3108,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3173,7 +3194,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3204,8 +3225,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3290,7 +3311,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3321,8 +3342,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3438,8 +3459,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3524,7 +3545,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3555,8 +3576,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3641,7 +3662,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3672,8 +3693,8 @@
           "value": "21"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3758,7 +3779,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3789,8 +3810,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3875,7 +3896,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3906,8 +3927,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3992,7 +4013,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4023,8 +4044,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4109,7 +4130,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4140,8 +4161,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4226,7 +4247,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4257,8 +4278,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4343,7 +4364,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4374,8 +4395,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4491,8 +4512,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4577,7 +4598,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4608,8 +4629,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4694,7 +4715,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4725,8 +4746,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4811,7 +4832,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4842,8 +4863,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4928,7 +4949,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4959,8 +4980,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5045,7 +5066,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5076,8 +5097,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5162,7 +5183,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5193,8 +5214,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5279,7 +5300,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5310,8 +5331,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5396,7 +5417,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5427,8 +5448,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5513,7 +5534,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5544,8 +5565,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5630,7 +5651,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5661,8 +5682,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5747,7 +5768,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5778,8 +5799,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5864,7 +5885,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5895,8 +5916,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5981,7 +6002,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6012,8 +6033,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6129,8 +6150,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6246,8 +6267,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6332,7 +6353,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6363,8 +6384,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6449,7 +6470,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6480,8 +6501,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6566,7 +6587,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6597,8 +6618,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6714,8 +6735,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6800,7 +6821,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6831,8 +6852,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6917,7 +6938,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6948,8 +6969,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7034,7 +7055,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7065,8 +7086,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7151,7 +7172,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7182,8 +7203,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7268,7 +7289,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7299,8 +7320,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7385,7 +7406,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7416,8 +7437,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7502,7 +7523,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7533,8 +7554,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7619,7 +7640,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7650,8 +7671,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7736,7 +7757,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7767,8 +7788,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7853,7 +7874,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7884,8 +7905,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7970,7 +7991,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8001,8 +8022,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8087,7 +8108,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8118,8 +8139,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8234,6 +8255,27 @@
                 40.651921081041685
               ]
             }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5261.7,
+                7671.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0150499,
+                40.6543625
+              ]
+            }
           }
         ]
       }
@@ -8256,8 +8298,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8342,7 +8384,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8373,8 +8415,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8459,7 +8501,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8490,8 +8532,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8576,7 +8618,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8607,8 +8649,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8693,7 +8735,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8724,8 +8766,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8810,7 +8852,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -8841,8 +8883,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8958,8 +9000,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:19:42Z",
-      "modified": "2026-05-25T13:19:42Z",
+      "created": "2026-05-25T14:42:43Z",
+      "modified": "2026-05-25T14:42:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",

--- a/gallery/brooklyn_ny_1939_vol_2.iiif.json
+++ b/gallery/brooklyn_ny_1939_vol_2.iiif.json
@@ -24,8 +24,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -110,7 +110,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -141,8 +141,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -227,7 +227,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -258,8 +258,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -344,7 +344,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -375,8 +375,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -461,7 +461,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -492,8 +492,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -578,7 +578,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -609,8 +609,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +695,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -726,8 +726,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -812,7 +812,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -843,8 +843,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -929,7 +929,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -960,8 +960,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1046,7 +1046,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1077,8 +1077,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1163,7 +1163,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1194,8 +1194,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1311,8 +1311,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1397,7 +1397,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1428,8 +1428,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1514,7 +1514,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1545,8 +1545,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1631,7 +1631,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1662,8 +1662,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1748,7 +1748,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1779,8 +1779,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1865,7 +1865,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -1896,8 +1896,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1982,7 +1982,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2013,8 +2013,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2099,7 +2099,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2130,8 +2130,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2216,7 +2216,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2247,8 +2247,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2333,7 +2333,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2364,8 +2364,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2450,7 +2450,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2481,8 +2481,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2567,7 +2567,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2598,8 +2598,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2684,7 +2684,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2715,8 +2715,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2801,7 +2801,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2832,8 +2832,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2918,7 +2918,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -2949,8 +2949,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3035,7 +3035,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3066,8 +3066,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3152,7 +3152,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3183,8 +3183,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3269,7 +3269,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3300,8 +3300,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3386,7 +3386,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3417,8 +3417,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3503,7 +3503,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3534,8 +3534,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3620,7 +3620,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3651,8 +3651,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3768,8 +3768,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3854,7 +3854,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -3885,8 +3885,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3971,7 +3971,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4002,8 +4002,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4088,7 +4088,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4119,8 +4119,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4236,8 +4236,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4322,7 +4322,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4353,8 +4353,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4439,7 +4439,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4470,8 +4470,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4556,7 +4556,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4587,8 +4587,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4673,7 +4673,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4704,8 +4704,8 @@
           "value": "21"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4790,7 +4790,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4821,8 +4821,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4907,7 +4907,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -4938,8 +4938,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5024,7 +5024,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5055,8 +5055,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5141,7 +5141,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5172,8 +5172,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5258,7 +5258,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5289,8 +5289,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5375,7 +5375,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5406,8 +5406,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5492,7 +5492,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5523,8 +5523,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5609,7 +5609,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5640,8 +5640,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5726,7 +5726,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5757,8 +5757,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5843,7 +5843,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -5874,8 +5874,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5991,8 +5991,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6077,7 +6077,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6108,8 +6108,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6194,7 +6194,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6225,8 +6225,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6342,8 +6342,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6428,7 +6428,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6459,8 +6459,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6545,7 +6545,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6576,8 +6576,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6662,7 +6662,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6693,8 +6693,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6779,7 +6779,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6810,8 +6810,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6896,7 +6896,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -6927,8 +6927,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7013,7 +7013,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7044,8 +7044,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7130,7 +7130,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",
@@ -7161,8 +7161,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:24:59Z",
-      "modified": "2026-05-25T14:24:59Z",
+      "created": "2026-05-25T19:43:43Z",
+      "modified": "2026-05-25T19:43:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7247,7 +7247,7 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "intersection"
             },
             "geometry": {
               "type": "Point",

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -289,9 +289,9 @@ def _corner_fallback(
     corners: list,
     width: int,
     height: int,
-    initials: list[dict],
+    intersections: list[dict],
 ) -> list[GcpPoint]:
-    """Return 4 image-corner GCPs plus any initial intersection GCPs.
+    """Return 4 image-corner GCPs plus any detected intersection GCPs.
 
     Used as a fallback when there are fewer than 2 non-coincident initial
     intersections and a full affine fit is not possible.
@@ -303,11 +303,11 @@ def _corner_fallback(
         ((w, h), (float(corners[2][0]), float(corners[2][1])), "corner"),
         ((0.0, h), (float(corners[3][0]), float(corners[3][1])), "corner"),
     ]
-    initial_pts: list[GcpPoint] = [
+    intersection_pts: list[GcpPoint] = [
         ((float(i["x"]), float(i["y"])), (float(i["lon"]), float(i["lat"])), "gcp")
-        for i in initials
+        for i in intersections
     ]
-    return corner_pts + initial_pts
+    return corner_pts + intersection_pts
 
 
 def georef_gcp_points(
@@ -327,10 +327,11 @@ def georef_gcp_points(
     through the similarity affine defined by the two initial GCPs alone, so it
     carries no independent information and cannot shift the fitted transform.
 
-    Type values: "gcp" for detected intersections, "projected" for the synthetic
-    perpendicular third point (option 3), "corner" for image-corner fallback points.
+    Type values: "gcp" for the two initial seed intersections that determine the fit,
+    "intersection" for the third detected intersection (options 1 & 2), "projected" for
+    the synthetic perpendicular third point (option 3), "corner" for image-corner fallback.
 
-    Falls back to 4 image corners (type "corner") plus any initial intersections
+    Falls back to 4 image corners (type "corner") plus any inlier intersections
     (type "gcp") when fewer than 2 non-coincident initial intersections exist
     (e.g. georefs produced by deferred single-GCP processing).
     """
@@ -339,9 +340,11 @@ def georef_gcp_points(
     corners: list = georef["corners"]
     image_center = np.array([width / 2.0, height / 2.0])
 
-    initials = [i for i in georef.get("intersections", []) if i.get("initial")]
+    all_intersections: list[dict] = georef.get("intersections", [])
+    inlier_intersections = [i for i in all_intersections if i.get("inlier")]
+    initials = [i for i in all_intersections if i.get("initial")]
     if len(initials) < 2:
-        return _corner_fallback(corners, width, height, initials)
+        return _corner_fallback(corners, width, height, inlier_intersections)
 
     int1, int2 = initials[0], initials[1]
     p1_pixel = (float(int1["x"]), float(int1["y"]))
@@ -352,14 +355,13 @@ def georef_gcp_points(
     p1 = np.array(p1_pixel)
     p2 = np.array(p2_pixel)
     if float(np.linalg.norm(p2 - p1)) < 1.0:
-        return _corner_fallback(corners, width, height, initials)
+        return _corner_fallback(corners, width, height, inlier_intersections)
 
     streets_set = {int1["label_a"], int1["label_b"], int2["label_a"], int2["label_b"]}
     initial_pairs = {
         frozenset({int1["label_a"], int1["label_b"]}),
         frozenset({int2["label_a"], int2["label_b"]}),
     }
-    all_intersections: list[dict] = georef.get("intersections", [])
 
     def dist_to_center(x: float, y: float) -> float:
         return float(np.linalg.norm(np.array([x, y]) - image_center))
@@ -389,7 +391,7 @@ def georef_gcp_points(
     p3_type: str
     if option1:
         p3_x, p3_y = min(option1, key=lambda c: dist_to_center(*c))
-        p3_type = "gcp"
+        p3_type = "intersection"
     else:
         # Option 2: any other intersection; inliers preferred, then closest to center.
         # Only consider candidates offset from the P1-P2 line by ≥ 25% of dist(P1, P2)
@@ -413,7 +415,7 @@ def georef_gcp_points(
 
         if pool:
             p3_x, p3_y = min(pool, key=lambda c: dist_to_center(*c))
-            p3_type = "gcp"
+            p3_type = "intersection"
         else:
             # Option 3: perpendicular offset from midpoint.
             diff = p2 - p1

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -88,6 +88,25 @@ def test_one_initial_returns_corners_plus_initial():
     assert pts[4][2] == "gcp"
 
 
+def test_deferred_single_gcp_includes_inlier():
+    # Deferred image: one inlier intersection with initial=False (as written by
+    # process_deferred_image). Should appear as "gcp" alongside the four corners.
+    georef = make_georef(
+        2000,
+        2000,
+        [
+            make_intersection(
+                "A", "B", 183, 1953, lon=-82.97, lat=42.37, inlier=True, initial=False
+            )
+        ],
+    )
+    pts = georef_gcp_points(georef)
+    assert len(pts) == 5
+    assert all(p[2] == "corner" for p in pts[:4])
+    assert pts[4][0] == (183.0, 1953.0)
+    assert pts[4][2] == "gcp"
+
+
 def test_coincident_initials_returns_corners():
     # Both initial intersections at the same pixel → degenerate, fall back to corners
     # plus both initial GCPs.
@@ -144,7 +163,7 @@ def test_option1_uses_cross_intersection():
     pts = georef_gcp_points(georef)
     assert len(pts) == 3
     assert pts[2][0] == (500.0, 900.0)
-    assert pts[2][2] == "gcp"
+    assert pts[2][2] == "intersection"
 
 
 def test_option1_picks_candidate_closest_to_center():


### PR DESCRIPTION
Follow on to #23, relates to #15.

Previously all three "GCPs" would be output with `{"type": "gcp"}`. Now only the two that define the model are.