### PR TITLE
Fix a pathological O(N^2) loop in ransac_hybrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ OldInsuranceMaps.net (OIM) uses a six parameter affine model. In addition to tra
 
 In practice, the Sanborn maps are all very well-made and well-scanned and don't exhibit much of either of these. Most fits on OIM have scale anisitropy of less than 3% and skew of less than 3°. These are both close enough to zero that it's unclear if they're real or the result of inaccurate georeferencing. Removing these parameters makes it easier to fit a model since you only need two GCPs rather than three. And it eliminates a failure mode of detecting heavily skewed maps due to an inaccurate GCP.
 
+In the GIS world, the four parameter model is known as a [Helmert transformation].
+
+[Helmert transformation]: https://en.wikipedia.org/wiki/Helmert_transformation#Variations
+
 ### How I developed this model
 
 The initial idea was to ask the OpenAI API to find intersections in the Sanborn map. It did an OK job at this, but it was slow (~3 minutes/task), expensive (~$0.10/image) and not always very accurate. It didn't do well on the non-skeleton maps, and its process was opaque, so it was hard to improve on.

--- a/mapsnap/block_index_test.py
+++ b/mapsnap/block_index_test.py
@@ -1,0 +1,284 @@
+"""Unit tests for build_block_index and find_intersection_gcps.
+
+Test data: testdata/chicago_p29n_centerlines.geojson — cook-county-centerlines.geojson
+clipped to the bounding box of Chicago p29n (Streeterville / Lake Shore Drive area, 1950).
+Eight streets appear: East Erie, East Grand Avenue, East Illinois, East Ohio, East Ontario,
+North Lake Shore Drive, North McClurg Court, North Peshtigo Court.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mapsnap.georef_from_labels import LabelFeature, find_intersection_gcps
+from mapsnap.streets import build_block_index
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+TESTDATA = Path(__file__).parent.parent / "testdata"
+
+
+def _load_p29n() -> dict:
+    return json.loads((TESTDATA / "chicago_p29n_centerlines.geojson").read_text())
+
+
+def _make_geojson(*name_and_lines: tuple[str, list[list[float]]]) -> dict:
+    """Build a minimal GeoJSON FeatureCollection from (street_name, coords) pairs."""
+    features = [
+        {
+            "type": "Feature",
+            "properties": {"street_name": name},
+            "geometry": {"type": "LineString", "coordinates": coords},
+        }
+        for name, coords in name_and_lines
+    ]
+    return {"type": "FeatureCollection", "features": features}
+
+
+def _feat(text: str, cx: float, cy: float, dir_pix: float) -> LabelFeature:
+    """Build a LabelFeature with canonical text, pixel center, and label direction."""
+    return LabelFeature(raw_text=text, text=text, center=(cx, cy), dir_pix=dir_pix)
+
+
+EW = 0.0  # dir_pix for an east-west label (horizontal)
+NS = math.pi / 2  # dir_pix for a north-south label (vertical)
+
+
+# ---------------------------------------------------------------------------
+# build_block_index — basic construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_index_all_raw_streets_indexed():
+    index = build_block_index(_load_p29n())
+    for name in [
+        "EAST GRAND AVENUE",
+        "NORTH LAKE SHORE DRIVE",
+        "NORTH PESHTIGO COURT",
+        "EAST OHIO STREET",
+        "EAST ILLINOIS STREET",
+        "EAST ONTARIO STREET",
+        "EAST ERIE STREET",
+        "NORTH MCCLURG COURT",
+    ]:
+        assert name in index, f"{name!r} missing from index"
+
+
+def test_build_index_block_counts():
+    index = build_block_index(_load_p29n())
+    assert len(index["EAST GRAND AVENUE"]) == 11
+    assert len(index["NORTH LAKE SHORE DRIVE"]) == 4
+    assert len(index["NORTH PESHTIGO COURT"]) == 1
+
+
+def test_build_index_coords_are_numpy_arrays():
+    index = build_block_index(_load_p29n())
+    for block in index["EAST GRAND AVENUE"]:
+        assert isinstance(block.coords, np.ndarray)
+        assert block.coords.ndim == 2
+        assert block.coords.shape[1] == 2
+
+
+def test_build_index_street_type_alias_added():
+    # e.g. "EAST GRAND AVENUE" → also "EAST GRAND" (type suffix stripped).
+    index = build_block_index(_load_p29n())
+    assert "EAST GRAND" in index
+    assert "EAST OHIO" in index
+    assert "NORTH PESHTIGO" in index
+
+
+def test_build_index_direction_alias_added():
+    # e.g. "EAST GRAND AVENUE" → also "GRAND AVENUE" and "GRAND" (direction stripped).
+    index = build_block_index(_load_p29n())
+    assert "GRAND AVENUE" in index
+    assert "GRAND" in index
+    assert "OHIO STREET" in index
+    assert "OHIO" in index
+    assert "LAKE SHORE DRIVE" in index
+    assert "LAKE SHORE" in index
+
+
+def test_build_index_alias_shares_same_block_list():
+    # Aliases share the same list object so that id()-based deduplication in
+    # process_image correctly collapses them to a single canonical entry.
+    index = build_block_index(_load_p29n())
+    assert index["GRAND"] is index["EAST GRAND AVENUE"]
+    assert index["GRAND AVENUE"] is index["EAST GRAND AVENUE"]
+    assert index["EAST GRAND"] is index["EAST GRAND AVENUE"]
+    assert index["OHIO"] is index["EAST OHIO STREET"]
+    assert index["LAKE SHORE"] is index["NORTH LAKE SHORE DRIVE"]
+
+
+def test_build_index_ambiguous_bare_name_not_aliased():
+    # "MAIN" is the bare name for both "North Main Street" and "South Main Street"
+    # → ambiguous, so "MAIN" and "MAIN STREET" must not be added.
+    data = _make_geojson(
+        ("North Main Street", [[-90.0, 30.0], [-90.0, 30.1]]),
+        ("South Main Street", [[-90.0, 29.9], [-90.0, 30.0]]),
+    )
+    index = build_block_index(data)
+    assert "NORTH MAIN STREET" in index
+    assert "SOUTH MAIN STREET" in index
+    assert "MAIN STREET" not in index
+    assert "MAIN" not in index
+
+
+def test_build_index_unambiguous_bare_name_aliased():
+    # "ELM" is unambiguous (only one Elm Street) → alias is added and shares the list.
+    data = _make_geojson(("Elm Street", [[-90.0, 30.0], [-90.1, 30.0]]))
+    index = build_block_index(data)
+    assert "ELM STREET" in index
+    assert "ELM" in index
+    assert index["ELM"] is index["ELM STREET"]
+
+
+def test_build_index_empty_geojson():
+    assert build_block_index({"type": "FeatureCollection", "features": []}) == {}
+
+
+def test_build_index_multilinestring():
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"street_name": "Elm Street"},
+                "geometry": {
+                    "type": "MultiLineString",
+                    "coordinates": [
+                        [[-90.0, 30.0], [-90.1, 30.0]],
+                        [[-90.2, 30.0], [-90.3, 30.0]],
+                    ],
+                },
+            }
+        ],
+    }
+    index = build_block_index(data)
+    assert "ELM STREET" in index
+    assert len(index["ELM STREET"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# find_intersection_gcps — basic intersection detection
+# ---------------------------------------------------------------------------
+
+
+def test_find_gcps_empty_features():
+    assert find_intersection_gcps([], build_block_index(_load_p29n())) == []
+
+
+def test_find_gcps_no_matching_streets():
+    # Features whose text doesn't match any block_index key produce no GCPs.
+    index = build_block_index(_load_p29n())
+    feats = [_feat("NONEXISTENT STREET", 500.0, 500.0, EW)]
+    assert find_intersection_gcps(feats, index) == []
+
+
+def test_find_gcps_grand_x_peshtigo():
+    # East Grand Avenue (E-W) and North Peshtigo Court (N-S) share one GeoJSON
+    # node: (-87.6151976, 41.8918751).  E-W line through (802, 2215) × N-S line
+    # through (1354, 2372) = pixel crossing (1354, 2215).
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
+        _feat("NORTH PESHTIGO COURT", 1354.0, 2372.0, NS),
+    ]
+    gcps = find_intersection_gcps(feats, index)
+    assert len(gcps) == 1
+    gcp = gcps[0]
+    assert {gcp.label_a, gcp.label_b} == {"EAST GRAND AVENUE", "NORTH PESHTIGO COURT"}
+    assert gcp.geo == pytest.approx((-87.6151976, 41.8918751), abs=1e-6)
+    assert gcp.pixel == pytest.approx((1354.0, 2215.0), abs=1e-6)
+
+
+def test_find_gcps_lake_shore_x_ohio():
+    # North Lake Shore Drive (N-S) and East Ohio Street (E-W) share one node:
+    # (-87.6145965, 41.8926846).  Pixel crossing: (1883, 1591).
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
+        _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
+    ]
+    gcps = find_intersection_gcps(feats, index)
+    assert len(gcps) == 1
+    gcp = gcps[0]
+    assert {gcp.label_a, gcp.label_b} == {"NORTH LAKE SHORE DRIVE", "EAST OHIO STREET"}
+    assert gcp.geo == pytest.approx((-87.6145965, 41.8926846), abs=1e-6)
+    assert gcp.pixel == pytest.approx((1883.0, 1591.0), abs=1e-6)
+
+
+def test_find_gcps_parallel_streets_produce_no_gcp():
+    # East Grand Avenue and East Ohio Street run parallel (both E-W) and share
+    # no GeoJSON coordinate node.
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
+        _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
+    ]
+    assert find_intersection_gcps(feats, index) == []
+
+
+def test_find_gcps_sorted_by_pixel_dist():
+    # Grand×Peshtigo (pixel_dist ≈ 574) comes before Lake Shore×Ohio (≈ 1166).
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
+        _feat("NORTH PESHTIGO COURT", 1354.0, 2372.0, NS),
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
+        _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
+    ]
+    gcps = find_intersection_gcps(feats, index)
+    assert len(gcps) == 2
+    assert gcps[0].pixel_dist < gcps[1].pixel_dist
+    assert {gcps[0].label_a, gcps[0].label_b} == {
+        "EAST GRAND AVENUE",
+        "NORTH PESHTIGO COURT",
+    }
+
+
+# ---------------------------------------------------------------------------
+# find_intersection_gcps — one GCP per (label_a, label_b, cluster)
+# ---------------------------------------------------------------------------
+
+
+def test_find_gcps_three_lake_instances_one_gcp():
+    # Three detections of "NORTH LAKE SHORE DRIVE" at different pixel positions.
+    # Combined with one EAST OHIO STREET, exactly one GCP must be returned —
+    # the (fa, fb) pair with the smallest pixel_dist.
+    #
+    #   (1883, 1969) × (780, 1591)  pixel_dist ≈ 1166
+    #   (1606,  613) × (780, 1591)  pixel_dist ≈ 1280
+    #   (1186, 1775) × (780, 1591)  pixel_dist ≈  446  ← selected
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
+        _feat("NORTH LAKE SHORE DRIVE", 1606.0, 613.0, NS),
+        _feat("NORTH LAKE SHORE DRIVE", 1186.0, 1775.0, NS),
+        _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
+    ]
+    gcps = find_intersection_gcps(feats, index)
+    assert len(gcps) == 1
+    gcp = gcps[0]
+    assert {gcp.label_a, gcp.label_b} == {"NORTH LAKE SHORE DRIVE", "EAST OHIO STREET"}
+    # Best crossing: N-S line through (1186, 1775) × E-W line through (780, 1591).
+    assert gcp.pixel == pytest.approx((1186.0, 1591.0), abs=1e-6)
+    assert gcp.pixel_dist == pytest.approx(445.7, abs=1.0)
+
+
+def test_find_gcps_two_instances_selects_closer_pair():
+    # Two Peshtigo labels: the one closer to the Grand label wins.
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("NORTH PESHTIGO COURT", 1354.0, 2372.0, NS),  # pixel_dist ≈  574
+        _feat("NORTH PESHTIGO COURT", 1354.0, 500.0, NS),  # pixel_dist ≈ 1716
+        _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
+    ]
+    gcps = find_intersection_gcps(feats, index)
+    assert len(gcps) == 1
+    assert gcps[0].pixel == pytest.approx((1354.0, 2215.0), abs=1e-6)
+    assert gcps[0].pixel_dist < 600.0

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -456,8 +456,10 @@ def find_intersection_gcps(
             for cluster in geo_clusters:
                 cluster_pts = np.array(cluster)
                 geo = (float(cluster_pts[:, 0].mean()), float(cluster_pts[:, 1].mean()))
-                # Try every combination of detected instances for the two streets.
-                # RANSAC will select the geometrically consistent subset.
+                # For each (text_a, text_b, cluster), keep only the best (fa, fb) pair
+                # by pixel_dist. All pairs share the same geo centroid, so extra pairs
+                # only add RANSAC iterations without adding independent intersection anchors.
+                best: IntersectionGCP | None = None
                 for fa in feats_by_text[text_a]:
                     for fb in feats_by_text[text_b]:
                         ca, cb = np.array(fa.center), np.array(fb.center)
@@ -467,8 +469,8 @@ def find_intersection_gcps(
                         )
                         if crossing is None:
                             continue
-                        gcps.append(
-                            IntersectionGCP(
+                        if best is None or pixel_dist < best.pixel_dist:
+                            best = IntersectionGCP(
                                 label_a=text_a,
                                 label_b=text_b,
                                 pixel=crossing,
@@ -477,7 +479,8 @@ def find_intersection_gcps(
                                 feat_a=fa,
                                 feat_b=fb,
                             )
-                        )
+                if best is not None:
+                    gcps.append(best)
 
     return sorted(gcps, key=lambda g: g.pixel_dist)
 

--- a/testdata/chicago_p29n_centerlines.geojson
+++ b/testdata/chicago_p29n_centerlines.geojson
@@ -1,0 +1,1013 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6141958,
+            41.8911276
+          ],
+          [
+            -87.6139692,
+            41.8911245
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Ontario Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6148753,
+            41.8934964
+          ],
+          [
+            -87.6149738,
+            41.8934942
+          ],
+          [
+            -87.6152636,
+            41.8934906
+          ],
+          [
+            -87.6153285,
+            41.8934897
+          ],
+          [
+            -87.6155861,
+            41.8934859
+          ],
+          [
+            -87.6167287,
+            41.8934688
+          ],
+          [
+            -87.6176558,
+            41.8934552
+          ],
+          [
+            -87.6177462,
+            41.8934537
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North Peshtigo Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6151976,
+            41.8918751
+          ],
+          [
+            -87.6151956,
+            41.8918028
+          ],
+          [
+            -87.6151783,
+            41.8911966
+          ],
+          [
+            -87.6151792,
+            41.8911123
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North Lake Shore Drive"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6153782,
+            41.894289
+          ],
+          [
+            -87.6150508,
+            41.8937734
+          ],
+          [
+            -87.6149312,
+            41.893585
+          ],
+          [
+            -87.6148753,
+            41.8934964
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North Lake Shore Drive"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6145965,
+            41.8926846
+          ],
+          [
+            -87.6145711,
+            41.8927021
+          ],
+          [
+            -87.6145536,
+            41.8927244
+          ],
+          [
+            -87.6145422,
+            41.8927666
+          ],
+          [
+            -87.6145474,
+            41.8928537
+          ],
+          [
+            -87.6145709,
+            41.8929989
+          ],
+          [
+            -87.6146299,
+            41.8931347
+          ],
+          [
+            -87.6147182,
+            41.8932678
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6176647,
+            41.8910671
+          ],
+          [
+            -87.6175318,
+            41.8910697
+          ],
+          [
+            -87.6167122,
+            41.8910848
+          ],
+          [
+            -87.6155176,
+            41.8911058
+          ],
+          [
+            -87.6153882,
+            41.8911078
+          ],
+          [
+            -87.6153298,
+            41.8911094
+          ],
+          [
+            -87.6151792,
+            41.8911123
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6133599,
+            41.8919277
+          ],
+          [
+            -87.613732,
+            41.8919192
+          ],
+          [
+            -87.6138817,
+            41.891913
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Ohio Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6177145,
+            41.8926319
+          ],
+          [
+            -87.6176201,
+            41.8926325
+          ],
+          [
+            -87.6158359,
+            41.8926545
+          ],
+          [
+            -87.6153075,
+            41.8926609
+          ],
+          [
+            -87.6150576,
+            41.8926639
+          ],
+          [
+            -87.6146353,
+            41.8926734
+          ],
+          [
+            -87.6145965,
+            41.8926846
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6176875,
+            41.8918326
+          ],
+          [
+            -87.6176909,
+            41.8919426
+          ],
+          [
+            -87.6177119,
+            41.8925526
+          ],
+          [
+            -87.6177145,
+            41.8926319
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6177145,
+            41.8926319
+          ],
+          [
+            -87.6177177,
+            41.8927337
+          ],
+          [
+            -87.6177405,
+            41.8933056
+          ],
+          [
+            -87.6177424,
+            41.8933625
+          ],
+          [
+            -87.6177462,
+            41.8934537
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6177462,
+            41.8934537
+          ],
+          [
+            -87.6177494,
+            41.8935422
+          ],
+          [
+            -87.6177509,
+            41.8935844
+          ],
+          [
+            -87.6177709,
+            41.8941407
+          ],
+          [
+            -87.6177717,
+            41.8941633
+          ],
+          [
+            -87.617775,
+            41.8942551
+          ],
+          [
+            -87.617778,
+            41.894337
+          ],
+          [
+            -87.6177786,
+            41.8943559
+          ],
+          [
+            -87.617793,
+            41.8947556
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North Lake Shore Drive"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6164066,
+            41.8958729
+          ],
+          [
+            -87.6158998,
+            41.895086
+          ],
+          [
+            -87.6153782,
+            41.894289
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6176299,
+            41.8895105
+          ],
+          [
+            -87.6176284,
+            41.8896185
+          ],
+          [
+            -87.6176418,
+            41.8901386
+          ],
+          [
+            -87.6176634,
+            41.8909691
+          ],
+          [
+            -87.6176647,
+            41.8910671
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.619304,
+            41.8910394
+          ],
+          [
+            -87.6186096,
+            41.8910511
+          ],
+          [
+            -87.6180681,
+            41.8910603
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6181064,
+            41.8918283
+          ],
+          [
+            -87.6186741,
+            41.8918213
+          ],
+          [
+            -87.619225,
+            41.8918175
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Ontario Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6177462,
+            41.8934537
+          ],
+          [
+            -87.6178384,
+            41.8934527
+          ],
+          [
+            -87.6184073,
+            41.8934457
+          ],
+          [
+            -87.6184506,
+            41.8934452
+          ],
+          [
+            -87.6190241,
+            41.8934382
+          ],
+          [
+            -87.6194333,
+            41.8934332
+          ],
+          [
+            -87.6196312,
+            41.8934308
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6138817,
+            41.891913
+          ],
+          [
+            -87.6139973,
+            41.8919098
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Erie Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6199175,
+            41.8942208
+          ],
+          [
+            -87.6198248,
+            41.8942222
+          ],
+          [
+            -87.6194319,
+            41.8942283
+          ],
+          [
+            -87.6192434,
+            41.8942313
+          ],
+          [
+            -87.6190558,
+            41.8942343
+          ],
+          [
+            -87.6189331,
+            41.8942362
+          ],
+          [
+            -87.6188393,
+            41.8942376
+          ],
+          [
+            -87.61875,
+            41.8942391
+          ],
+          [
+            -87.6179865,
+            41.894251
+          ],
+          [
+            -87.6179131,
+            41.8942521
+          ],
+          [
+            -87.6178761,
+            41.8942527
+          ],
+          [
+            -87.617775,
+            41.8942551
+          ],
+          [
+            -87.6176923,
+            41.8942557
+          ],
+          [
+            -87.6167575,
+            41.8942644
+          ],
+          [
+            -87.6157167,
+            41.8942818
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.617102,
+            41.8918426
+          ],
+          [
+            -87.6175566,
+            41.8918354
+          ],
+          [
+            -87.6176875,
+            41.8918326
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6163764,
+            41.891855
+          ],
+          [
+            -87.617102,
+            41.8918426
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6151976,
+            41.8918751
+          ],
+          [
+            -87.6153656,
+            41.8918715
+          ],
+          [
+            -87.6155524,
+            41.8918693
+          ],
+          [
+            -87.6158086,
+            41.8918647
+          ],
+          [
+            -87.6158863,
+            41.8918633
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6143349,
+            41.8918999
+          ],
+          [
+            -87.6144535,
+            41.8918959
+          ],
+          [
+            -87.6146635,
+            41.8918896
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6139973,
+            41.8919098
+          ],
+          [
+            -87.6143349,
+            41.8918999
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6176875,
+            41.8918326
+          ],
+          [
+            -87.6178468,
+            41.8918311
+          ],
+          [
+            -87.6181064,
+            41.8918283
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6146635,
+            41.8918896
+          ],
+          [
+            -87.6150927,
+            41.8918769
+          ],
+          [
+            -87.6151976,
+            41.8918751
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6138164,
+            41.8911235
+          ],
+          [
+            -87.6136482,
+            41.8911255
+          ],
+          [
+            -87.6133952,
+            41.8911284
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6151792,
+            41.8911123
+          ],
+          [
+            -87.6143684,
+            41.8911277
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Erie Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6157167,
+            41.8942818
+          ],
+          [
+            -87.6154868,
+            41.8942884
+          ],
+          [
+            -87.6153782,
+            41.894289
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North Lake Shore Drive"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6147182,
+            41.8932678
+          ],
+          [
+            -87.6147399,
+            41.8933004
+          ],
+          [
+            -87.6148105,
+            41.8934026
+          ],
+          [
+            -87.6148753,
+            41.8934964
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Ohio Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6186178,
+            41.8926165
+          ],
+          [
+            -87.6178419,
+            41.8926297
+          ],
+          [
+            -87.6177145,
+            41.8926319
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Grand Avenue"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6158863,
+            41.8918633
+          ],
+          [
+            -87.6163764,
+            41.891855
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6180681,
+            41.8910603
+          ],
+          [
+            -87.6179186,
+            41.8910628
+          ],
+          [
+            -87.6178288,
+            41.8910642
+          ],
+          [
+            -87.6176647,
+            41.8910671
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6176647,
+            41.8910671
+          ],
+          [
+            -87.6176674,
+            41.8911529
+          ],
+          [
+            -87.6176833,
+            41.8916714
+          ],
+          [
+            -87.6176858,
+            41.8917471
+          ],
+          [
+            -87.6176875,
+            41.8918326
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "North McClurg Court"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.617793,
+            41.8947556
+          ],
+          [
+            -87.6177978,
+            41.8949037
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6143684,
+            41.8911277
+          ],
+          [
+            -87.6143462,
+            41.8911285
+          ],
+          [
+            -87.6141958,
+            41.8911276
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "street_name": "East Illinois Street"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            -87.6139692,
+            41.8911245
+          ],
+          [
+            -87.6138164,
+            41.8911235
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
p29n in Chicago previously took 16 minutes to fit, now it takes 20 seconds. It makes the same choices. Claude says this is "essentially a sure win," see below. I'll be honest, I do not fully understand what's going on here. I think the issue is that, when a street curved, it would project every part of that curve to try and find an intersection.

----

This certainly speeds up p29n (by something like 50x) and does not change the fit that it finds. But I want to understand this change a bit better. What do we potentially lose here? Sometimes it's genuinely ambiguous which street a label refers to and it's important to try every possibility that results in an intersection. Is it possible for us to lose a good fit because of this change? Or is it more of a sure win?

# Analysis: One GCP per (text_a, text_b, cluster)

## What the change does NOT affect

The "genuinely ambiguous" case — where one raw label like "LAKE" could refer to
"EAST LAKE STREET" *or* "WEST LAKE STREET" — is handled entirely at the
canonical-name level, not at the `(fa, fb)` level. Each canonical match produces a
feature with a distinct `text`, and those features appear under different keys in
`feats_by_text`. The pairs `("EAST LAKE STREET", "BROADWAY")` and
`("WEST LAKE STREET", "BROADWAY")` are different `(text_a, text_b)` pairs, each
producing their own independent GCP. The change doesn't touch that logic at all.

## What the change does affect

For a fixed `(text_a, text_b, cluster)` — one physical intersection — the old code
generated one GCP per `(fa, fb)` combination. All of them share the same `geo`
centroid and differ only in their pixel crossing estimate. Each different `fa` is a
different detected instance of the same street (different block label). The crossing
estimate is the pixel where the two label direction-lines meet, extrapolated from
their respective centers.

For **straight streets** (the common case) the crossing estimate is essentially
independent of which label instance you use — extending the same-direction line from
block 3 or block 7 hits the other street at the same pixel. So the extra GCPs were
genuinely redundant.

For a **curved street** the direction `dir_pix` varies between instances, so different
`fa` choices give different crossings. In this case the closest-label heuristic
(`pixel_dist`) is actually *better*, not worse: the label nearest the physical
intersection has the most accurate local direction and gives the best crossing
estimate.

## Where there is theoretical risk

The one scenario that could hurt: `fa_close` and `fa_far` both map to "EAST LAKE
STREET", and their direction lines cross "BROADWAY" at very different pixels. If
`fa_close` produces a nearly-degenerate crossing (lines close to parallel —
`pixel_line_intersection` returns `None` for those, so they're already filtered) or
a crossing far off the image, but `fa_far` would have given a clean crossing, we'd
miss that GCP entirely. This requires:

1. The closest pair's crossing is bad despite passing the parallel-line filter, AND
2. No other seed pair combination produces a good fit.

Given that RANSAC evaluates all C(K, 2) pairs of GCPs — where K is now the count of
*distinct physical intersections* rather than the raw GCP count — and scores each by
counting all-label inliers, a single bad GCP just makes that seed pair score poorly.
The correct fit still emerges from the seed pairs with good crossings.

## Verdict

Essentially a sure win. The theoretical risk exists but requires a specific
conjunction of conditions that RANSAC's exhaustive seed-pair evaluation would recover
from anyway. The cases you'd actually worry about — label ambiguity between canonical
names — are unaffected. What was being removed was redundant pixel estimates for the
same physical intersection, not independent information.
