### PR TITLE
Generate masks block-by-block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@
 
 ### Python
 
+This project uses `uv` for package management and running scripts. The `uv` binary can be found in `~/.local/bin/uv`.
+
 Write type hints for all function parameters, and local variables where pyright cannot infer a type. Write return types for functions, unless they're very complicated and can be inferred.
 
 Provide generic type parameters where types take them: don't use plain `dict`, use `dict[str, str]` if that's what the type is.

--- a/fit.sh
+++ b/fit.sh
@@ -15,6 +15,7 @@ uv run mapsnap/georef_from_labels.py $dir/*.scaled.jpg \
 
 uv run python mapsnap/make_iiif_georef.py \
     $dir/main.iiif.json $dir'/*.georef.json' \
+    --centerlines $dir/centerlines.geojson \
     --output $dir/$tag.iiif.json
 
 uv run python mapsnap/compare_iiif_georef.py \

--- a/gallery/brooklyn_ny_1906_vol_6.iiif.json
+++ b/gallery/brooklyn_ny_1906_vol_6.iiif.json
@@ -24,8 +24,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7737.1 -0.0,9.9 1418.6,169.4 5341.6,161.3 5309.3,7713.1 -0.0,7737.1\" /></svg>"
         }
       },
       "body": {
@@ -141,8 +141,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,7 +161,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5339.8,7782.6 167.2,7798.5 174.9,125.7 5111.9,100.1 5123.6,3962.2 5228.1,3961.8 5343.4,3961.4 5339.8,7782.6\" /></svg>"
         }
       },
       "body": {
@@ -258,8 +258,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,7 +278,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"219.6,3910.5 -0.0,3910.6 0.0,51.4 5395.9,45.2 5365.2,7722.8 204.5,7727.0 219.6,3910.5\" /></svg>"
         }
       },
       "body": {
@@ -375,8 +375,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -395,7 +395,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5325.6,7740.4 178.1,7748.7 183.6,131.7 4035.2,98.9 4035.2,436.9 5344.0,403.9 5325.6,7740.4\" /></svg>"
         }
       },
       "body": {
@@ -492,8 +492,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -512,7 +512,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"210.2,7803.6 181.5,167.7 5308.3,116.3 5330.8,7739.1 210.2,7803.6\" /></svg>"
         }
       },
       "body": {
@@ -609,8 +609,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -629,7 +629,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"152.9,7165.3 180.0,574.2 318.3,573.7 316.3,0.0 5115.3,0.0 5127.9,3592.0 5298.8,3591.4 5282.4,7271.9 152.9,7165.3\" /></svg>"
         }
       },
       "body": {
@@ -726,8 +726,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -746,7 +746,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5484.0,7743.4 175.3,7743.4 173.3,7987.0 -0.0,7987.0 -0.0,-0.0 5484.0,0.0 5484.0,7743.4\" /></svg>"
         }
       },
       "body": {
@@ -843,8 +843,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -863,7 +863,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"1137.1,7693.3 1210.5,624.3 -0.0,611.8 0.0,-0.0 5484.0,0.0 5484.0,542.8 4432.3,551.7 4495.1,7961.6 2872.7,7987.0 2873.1,7711.4 1137.1,7693.3\" /></svg>"
         }
       },
       "body": {
@@ -960,8 +960,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -980,7 +980,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4206.9,7192.3 243.4,7182.7 203.6,-0.0 4066.7,-0.0 4064.0,711.3 4644.9,701.8 4636.7,-0.0 5484.0,-0.0 5484.0,3305.1 4666.0,3306.7 4665.3,3171.1 4186.4,3173.5 4206.9,7192.3\" /></svg>"
         }
       },
       "body": {
@@ -1077,8 +1077,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1097,7 +1097,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5108.2,7735.3 1391.6,7739.0 -0.0,7578.7 0.0,-0.0 5484.0,0.0 5484.0,148.5 5100.0,148.9 5108.2,7735.3\" /></svg>"
         }
       },
       "body": {
@@ -1194,8 +1194,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1214,7 +1214,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"1159.3,6492.3 993.9,1544.7 4666.6,1487.7 4711.0,4770.9 5484.0,4760.7 5484.0,6469.0 5299.5,6470.1 5312.2,7173.2 4730.2,7186.4 4728.4,6473.8 1159.3,6492.3\" /></svg>"
         }
       },
       "body": {
@@ -1311,8 +1311,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1331,7 +1331,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"3149.6,6829.6 3131.9,7987.0 -0.0,7987.0 -0.0,-0.0 5484.0,0.0 5484.0,6865.3 3149.6,6829.6\" /></svg>"
         }
       },
       "body": {
@@ -1470,8 +1470,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1490,7 +1490,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4682.6,-0.0 4717.2,7987.0 -0.0,7987.0 -0.0,-0.0 4682.6,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1587,8 +1587,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1607,7 +1607,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 636.3,0.0 637.4,166.5 4661.5,124.0 4687.6,7784.4 879.6,7818.1 879.6,7646.5 6.1,7650.6 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1704,8 +1704,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1724,7 +1724,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"227.6,7810.3 262.2,53.0 5395.2,46.2 5369.7,7808.5 227.6,7810.3\" /></svg>"
         }
       },
       "body": {
@@ -1821,8 +1821,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1841,7 +1841,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"148.2,7796.9 174.8,40.6 5316.5,55.9 5287.2,7796.9 148.2,7796.9\" /></svg>"
         }
       },
       "body": {
@@ -1938,8 +1938,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1958,7 +1958,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"174.1,7826.3 197.3,178.0 5276.0,170.9 5245.7,7823.8 174.1,7826.3\" /></svg>"
         }
       },
       "body": {
@@ -2055,8 +2055,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2075,7 +2075,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"104.0,7774.0 141.9,4.0 5300.5,0.0 5261.7,7778.2 104.0,7774.0\" /></svg>"
         }
       },
       "body": {
@@ -2172,8 +2172,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2192,7 +2192,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"117.0,7802.8 154.5,0.0 5331.0,0.0 5292.0,7803.1 117.0,7802.8\" /></svg>"
         }
       },
       "body": {
@@ -2289,8 +2289,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2309,7 +2309,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"102.5,7987.0 132.9,0.0 5484.0,0.0 5484.0,482.2 5347.4,482.2 5344.9,1305.9 5484.0,1306.6 5484.0,7987.0 102.5,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -2406,8 +2406,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2426,7 +2426,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7987.0 -0.0,63.4 5314.9,50.5 5292.5,7987.0 -0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -2523,8 +2523,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2543,7 +2543,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"199.1,235.1 5267.9,233.6 5221.1,7830.8 176.7,7826.3 199.1,235.1\" /></svg>"
         }
       },
       "body": {
@@ -2640,8 +2640,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2660,7 +2660,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"208.5,7748.2 151.5,98.4 762.6,69.9 1283.8,26.2 5370.7,0.0 5234.5,376.4 5276.2,7689.7 208.5,7748.2\" /></svg>"
         }
       },
       "body": {
@@ -2757,8 +2757,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2777,7 +2777,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"501.7,7779.1 1302.7,439.3 1442.2,161.4 1520.0,0.0 4631.8,0.0 4631.5,144.8 4723.5,144.6 4818.6,144.3 4826.6,7779.5 501.7,7779.1\" /></svg>"
         }
       },
       "body": {
@@ -2874,8 +2874,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2894,7 +2894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"208.4,7775.1 186.5,161.2 -0.0,162.1 -0.0,-0.0 5484.0,0.0 5484.0,138.6 5313.0,139.1 5319.5,7756.2 208.4,7775.1\" /></svg>"
         }
       },
       "body": {
@@ -2991,8 +2991,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3011,7 +3011,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"183.1,7709.6 208.6,0.0 5400.2,0.0 5374.2,7708.5 183.1,7709.6\" /></svg>"
         }
       },
       "body": {
@@ -3108,8 +3108,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3128,7 +3128,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"151.3,7770.1 177.1,131.4 -0.0,131.4 -0.0,-0.0 5484.0,0.0 5484.0,3740.9 5298.8,3741.9 5284.2,7770.3 151.3,7770.1\" /></svg>"
         }
       },
       "body": {
@@ -3225,8 +3225,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3245,7 +3245,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"166.0,3651.5 352.8,3650.5 352.8,0.0 4490.8,0.0 5183.1,7595.9 3895.4,7712.7 151.3,7712.6 166.0,3651.5\" /></svg>"
         }
       },
       "body": {
@@ -3342,8 +3342,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3362,7 +3362,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5484.0,7694.7 -0.0,7695.1 -0.0,-0.0 5484.0,0.0 5484.0,7694.7\" /></svg>"
         }
       },
       "body": {
@@ -3459,8 +3459,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3479,7 +3479,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"143.3,301.0 0.0,-0.0 5271.9,2.0 5275.8,7623.9 5378.6,7764.8 158.0,7764.8 143.3,301.0\" /></svg>"
         }
       },
       "body": {
@@ -3576,8 +3576,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3596,7 +3596,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"181.8,7644.9 176.5,0.0 5200.2,0.0 5200.1,136.1 5219.6,136.1 5328.6,136.3 5345.1,7791.5 285.3,7786.7 181.8,7644.9\" /></svg>"
         }
       },
       "body": {
@@ -3693,8 +3693,8 @@
           "value": "21"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3713,7 +3713,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"128.6,166.4 0.0,166.3 0.0,-0.0 5484.0,0.0 5484.0,7987.0 0.0,7987.0 0.0,7826.9 151.3,7826.3 128.6,166.4\" /></svg>"
         }
       },
       "body": {
@@ -3810,8 +3810,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3830,7 +3830,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7987.0 -0.0,-0.0 880.8,0.0 879.9,173.0 4719.7,157.1 4718.2,3987.1 5484.0,3984.3 5484.0,7816.7 869.8,7833.3 869.7,7987.0 -0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -3927,8 +3927,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3947,7 +3947,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"940.4,3967.0 174.1,3973.4 157.2,140.6 5280.8,98.1 5309.4,7766.1 1469.1,7798.7 1468.3,7630.8 958.1,7683.0 940.4,3967.0\" /></svg>"
         }
       },
       "body": {
@@ -4044,8 +4044,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4064,7 +4064,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"173.1,7801.9 205.3,137.3 5327.6,136.5 5297.7,7801.0 173.1,7801.9\" /></svg>"
         }
       },
       "body": {
@@ -4161,8 +4161,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4181,7 +4181,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5295.5,7760.4 172.3,7794.7 173.2,132.1 5288.3,113.2 5295.5,7760.4\" /></svg>"
         }
       },
       "body": {
@@ -4278,8 +4278,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4298,7 +4298,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5339.4,7821.0 226.3,7812.1 254.4,170.0 5374.5,176.8 5339.4,7821.0\" /></svg>"
         }
       },
       "body": {
@@ -4395,8 +4395,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4415,7 +4415,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4784.1,7644.9 152.2,7731.4 247.9,190.7 5296.1,235.4 5293.1,459.7 5484.0,461.5 5484.0,7987.0 4780.3,7987.0 4784.1,7644.9\" /></svg>"
         }
       },
       "body": {
@@ -4512,8 +4512,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4532,7 +4532,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7987.0 3.9,283.4 875.4,282.6 875.4,128.6 4726.8,110.3 4727.8,7788.9 4549.3,7789.4 4549.8,7987.0 -0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -4629,8 +4629,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4649,7 +4649,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"177.8,7766.2 197.1,119.1 966.4,118.8 966.6,0.0 1475.7,0.0 1475.4,118.7 5484.0,111.0 5484.0,7987.0 -0.0,7987.0 -0.0,7766.2 177.8,7766.2\" /></svg>"
         }
       },
       "body": {
@@ -4746,8 +4746,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4766,7 +4766,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"418.3,112.0 5484.0,109.1 5484.0,7987.0 410.1,7987.0 418.3,112.0\" /></svg>"
         }
       },
       "body": {
@@ -4863,8 +4863,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4883,7 +4883,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5303.4,93.5 5325.1,7987.0 349.4,7987.0 295.1,144.5 5303.4,93.5\" /></svg>"
         }
       },
       "body": {
@@ -4980,8 +4980,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5000,7 +5000,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"251.3,7987.0 251.7,7771.5 252.8,4636.2 255.8,3804.0 257.3,151.6 5335.9,137.0 5349.0,7748.9 4532.1,7752.1 4532.4,7975.3 251.3,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -5097,8 +5097,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5117,7 +5117,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7763.5 817.9,7761.4 815.8,139.9 2081.2,128.9 2080.0,0.0 5484.0,0.0 5484.0,7987.0 -0.0,7987.0 -0.0,7763.5\" /></svg>"
         }
       },
       "body": {
@@ -5214,8 +5214,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5234,7 +5234,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7987.0 -0.0,312.9 314.6,315.2 317.5,106.4 5417.7,146.7 5332.8,7987.0 -0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -5331,8 +5331,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5351,7 +5351,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5265.5,7764.1 231.6,7786.2 229.3,172.2 5298.9,159.1 5265.5,7764.1\" /></svg>"
         }
       },
       "body": {
@@ -5448,8 +5448,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5468,7 +5468,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5307.2,7749.8 154.9,7761.8 964.0,135.6 5285.2,118.0 5307.2,7749.8\" /></svg>"
         }
       },
       "body": {
@@ -5565,8 +5565,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5585,7 +5585,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"175.4,7692.5 178.2,103.7 5270.3,89.7 5269.8,7678.6 175.4,7692.5\" /></svg>"
         }
       },
       "body": {
@@ -5682,8 +5682,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5702,7 +5702,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"175.2,7758.1 161.8,107.1 5297.4,80.3 5309.9,7732.6 175.2,7758.1\" /></svg>"
         }
       },
       "body": {
@@ -5799,8 +5799,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5819,7 +5819,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"261.8,7678.8 294.8,82.3 5396.2,87.3 5356.6,7683.3 261.8,7678.8\" /></svg>"
         }
       },
       "body": {
@@ -5916,8 +5916,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5936,7 +5936,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5028.5,7702.4 598.7,7720.6 597.7,95.2 4303.1,79.0 5028.5,7702.4\" /></svg>"
         }
       },
       "body": {
@@ -6033,8 +6033,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6053,7 +6053,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"225.9,201.8 1492.9,201.0 5482.9,204.8 5300.3,7794.7 231.0,7784.1 225.9,201.8\" /></svg>"
         }
       },
       "body": {
@@ -6150,8 +6150,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6170,7 +6170,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,303.7 5127.6,181.3 5227.7,305.8 5442.1,6810.1 4692.0,7987.0 9.5,7987.0 0.0,303.7\" /></svg>"
         }
       },
       "body": {
@@ -6267,8 +6267,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6287,7 +6287,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"188.0,7828.0 188.4,7641.6 -0.0,7607.9 0.0,326.1 203.2,324.3 203.6,124.9 5301.7,115.1 5280.3,7823.9 188.0,7828.0\" /></svg>"
         }
       },
       "body": {
@@ -6384,8 +6384,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6404,7 +6404,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4564.1,7744.9 373.0,7732.0 1174.3,113.0 5039.3,121.6 5037.7,7078.6 5445.8,7515.4 5484.0,7987.0 4641.8,7987.0 4564.1,7744.9\" /></svg>"
         }
       },
       "body": {
@@ -6501,8 +6501,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6521,7 +6521,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"175.8,7129.7 194.4,171.2 5308.3,168.2 5297.9,7788.9 5484.0,7788.6 5484.0,7987.0 587.8,7987.0 582.9,7567.6 175.8,7129.7\" /></svg>"
         }
       },
       "body": {
@@ -6618,8 +6618,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6638,7 +6638,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"249.4,7770.6 265.3,198.9 5349.4,201.0 5319.9,7763.1 5209.5,7764.9 5132.9,7766.2 5132.6,7987.0 434.1,7967.6 434.3,7770.4 249.4,7770.6\" /></svg>"
         }
       },
       "body": {
@@ -6735,8 +6735,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6755,7 +6755,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5423.1,7743.2 5484.0,7987.0 0.0,7987.0 0.0,7750.3 187.5,7746.9 208.5,165.3 5302.1,159.2 5293.9,7743.3 5423.1,7743.2\" /></svg>"
         }
       },
       "body": {
@@ -6852,8 +6852,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6872,7 +6872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"875.6,7727.3 881.4,95.5 4722.5,87.3 4712.1,7724.7 5484.0,7847.8 5484.0,7987.0 1067.0,7972.4 1005.7,7727.1 875.6,7727.3\" /></svg>"
         }
       },
       "body": {
@@ -6969,8 +6969,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6989,7 +6989,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5484.0,7987.0 0.0,7987.0 0.0,7867.9 182.5,7866.5 170.0,246.3 2037.8,240.0 4587.2,0.0 5220.0,6712.2 5484.0,7436.9 5484.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -7086,8 +7086,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7106,7 +7106,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"101.1,603.1 5358.1,563.6 5447.3,3243.4 4129.8,5261.0 4741.2,5579.2 5103.5,6102.4 3705.7,6412.4 3699.4,6689.1 3133.2,6539.4 2340.4,6715.2 1923.2,7014.3 1587.5,7496.6 1707.1,7413.5 1834.3,7987.0 342.6,7987.0 165.9,7332.7 101.1,603.1\" /></svg>"
         }
       },
       "body": {
@@ -7203,8 +7203,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7223,7 +7223,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7987.0 -0.0,-0.0 3978.6,0.0 5215.4,6976.3 5125.2,7501.6 5484.0,7589.5 5484.0,7987.0 -0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -7320,8 +7320,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7340,7 +7340,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"401.3,7861.1 466.5,7477.1 134.3,7333.4 307.8,6840.6 259.0,83.3 5316.5,36.4 5364.6,7735.9 5484.0,7987.0 -0.0,7987.0 -0.0,7793.0 401.3,7861.1\" /></svg>"
         }
       },
       "body": {
@@ -7437,8 +7437,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7457,7 +7457,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,7987.0 691.7,112.6 4868.8,66.9 4949.5,307.1 5484.0,299.6 5484.0,7987.0 0.0,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -7554,8 +7554,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7574,7 +7574,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"432.5,6519.3 694.5,5479.8 854.9,5520.1 2236.0,28.8 2121.5,0.0 4841.4,63.9 4981.8,427.0 4783.5,5512.7 5484.0,6317.4 4610.0,6212.5 4315.5,7400.9 582.2,6454.7 432.5,6519.3\" /></svg>"
         }
       },
       "body": {
@@ -7671,8 +7671,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7691,7 +7691,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5038.8,7619.7 3182.8,7605.4 218.0,7092.0 451.9,5934.5 1325.9,6001.6 589.7,5252.9 567.4,344.0 416.9,0.0 5484.0,0.0 5484.0,123.9 4886.5,126.2 4985.8,285.5 5038.8,7619.7\" /></svg>"
         }
       },
       "body": {
@@ -7788,8 +7788,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7808,7 +7808,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5052.8,7678.1 504.8,7661.7 509.5,242.4 409.4,51.7 4948.9,69.9 5066.6,251.7 5052.8,7678.1\" /></svg>"
         }
       },
       "body": {
@@ -7905,8 +7905,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7925,7 +7925,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"703.2,7700.2 710.8,317.2 593.6,136.5 -0.0,136.1 -0.0,-0.0 5484.0,0.0 5484.0,146.6 5033.5,145.3 5484.0,1189.4 5484.0,1514.0 4832.6,1520.5 4840.6,7713.9 703.2,7700.2\" /></svg>"
         }
       },
       "body": {
@@ -8022,8 +8022,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8042,7 +8042,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4933.9,7699.0 479.3,7701.8 441.9,1500.5 1243.5,1491.0 636.6,122.6 975.8,122.0 1087.7,121.8 1087.1,0.0 4405.1,0.0 4405.3,114.5 4938.8,115.3 4933.9,7699.0\" /></svg>"
         }
       },
       "body": {
@@ -8139,8 +8139,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8159,7 +8159,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5002.0,7668.4 5261.7,7671.1 5262.0,7987.0 3953.1,7987.0 3961.6,7649.2 -0.0,7581.0 -0.0,-0.0 5484.0,0.0 5484.0,664.9 5148.7,657.9 5002.0,7668.4\" /></svg>"
         }
       },
       "body": {
@@ -8298,8 +8298,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8318,7 +8318,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"4946.3,7720.8 514.7,7723.0 531.4,170.5 -0.0,168.9 -0.0,-0.0 5484.0,0.0 5484.0,7987.0 4947.1,7987.0 4946.3,7720.8\" /></svg>"
         }
       },
       "body": {
@@ -8415,8 +8415,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8435,7 +8435,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"832.1,7102.3 925.3,6494.3 753.6,5936.9 131.7,5358.9 1873.9,3650.2 2369.1,980.5 0.0,477.8 0.0,362.1 4227.6,1362.4 5219.5,398.6 5150.5,7090.5 832.1,7102.3\" /></svg>"
         }
       },
       "body": {
@@ -8532,8 +8532,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8552,7 +8552,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"481.5,7987.0 204.2,7686.0 -0.0,7223.9 -0.0,6386.6 272.0,5860.1 -0.0,5793.1 -0.0,4344.4 698.8,4424.9 694.0,109.6 4816.7,124.8 4806.5,3427.2 4517.6,3426.2 4506.6,5219.8 4796.9,5100.3 4794.9,5607.9 4292.5,5581.9 4173.4,7987.0 481.5,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -8649,8 +8649,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8669,7 +8669,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"295.1,7987.0 -0.0,5667.3 -0.0,3880.5 277.8,589.7 4694.1,582.4 5484.0,4460.9 5484.0,7987.0 295.1,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -8766,8 +8766,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8786,7 +8786,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"2861.3,7987.0 2381.7,6887.7 -0.0,6883.7 -0.0,5518.4 1775.6,5532.5 329.5,2220.4 552.3,2221.6 542.2,577.0 4966.2,583.8 4966.3,706.7 4966.4,849.5 5484.0,850.6 5484.0,7987.0 2861.3,7987.0\" /></svg>"
         }
       },
       "body": {
@@ -8883,8 +8883,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8903,7 +8903,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"2966.8,0.0 3051.2,0.0 5484.0,0.0 5484.0,4455.7 4948.2,6893.6 3890.1,7987.0 0.0,7987.0 0.0,-0.0 2966.8,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9000,8 +9000,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T14:42:43Z",
-      "modified": "2026-05-25T14:42:43Z",
+      "created": "2026-05-27T01:49:09Z",
+      "modified": "2026-05-27T01:49:09Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9020,7 +9020,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7987 0,0 5484,0 5484,7987 0,7987\" /></svg>"
+          "value": "<svg><polygon points=\"5347.2,7987.0 5346.1,6940.1 -0.0,6946.3 -0.0,-0.0 5484.0,0.0 5484.0,7987.0 5347.2,7987.0\" /></svg>"
         }
       },
       "body": {

--- a/gallery/brooklyn_ny_1939_vol_2.iiif.json
+++ b/gallery/brooklyn_ny_1939_vol_2.iiif.json
@@ -21,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "3"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4904.1,6588.1 5036.4,7796.7 2345.9,7794.0 2205.3,7904.6 2206.1,8268.0 0.0,8268.0 0.0,-0.0 5679.0,0.0 5679.0,1038.4 4314.7,1051.8 4347.6,4407.5 4922.7,4481.1 4904.1,6588.1\" /></svg>"
         }
       },
       "body": {
@@ -141,8 +141,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,7 +161,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1001.8,8268.0 831.1,4238.8 825.4,3303.0 933.9,3153.4 880.4,1441.8 3175.1,1406.7 3191.9,2028.1 3504.7,2507.6 5679.0,2448.4 5679.0,7534.2 4464.5,7811.6 4470.2,8268.0 1001.8,8268.0\" /></svg>"
         }
       },
       "body": {
@@ -258,8 +258,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,7 +278,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,922.8 1662.2,926.1 1662.0,562.6 1802.9,452.3 4493.3,460.2 5453.2,7791.9 390.5,7780.6 390.2,8268.0 0.0,8268.0 0.0,922.8\" /></svg>"
         }
       },
       "body": {
@@ -375,8 +375,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -395,7 +395,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5655,0 5655,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"788.4,6999.5 151.1,1162.3 5655.0,1157.4 5655.0,7007.4 788.4,6999.5\" /></svg>"
         }
       },
       "body": {
@@ -492,8 +492,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -512,7 +512,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4204.1,0.0 4197.5,1031.1 5679.0,1045.1 5679.0,2015.3 4191.3,2011.8 4183.4,3245.0 5204.8,3250.9 5196.9,4511.5 5679.0,4523.4 5679.0,7804.0 5171.4,7800.5 5182.4,6828.2 215.2,6773.1 218.0,6126.1 0.0,6124.0 0.0,-0.0 4204.1,0.0\" /></svg>"
         }
       },
       "body": {
@@ -609,8 +609,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -629,7 +629,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5588,0 5588,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4166.0,1174.5 4711.0,208.3 5030.0,1137.4 5046.8,7338.2 3639.3,8009.1 970.6,7954.8 982.2,6693.3 1411.4,6655.3 1455.5,4900.8 1207.2,5209.6 928.5,5207.5 924.5,3816.1 577.5,3728.4 1601.5,391.9 2923.8,833.7 3107.6,1432.7 3550.9,1571.8 3660.6,1453.2 3478.7,945.4 4166.0,1174.5\" /></svg>"
         }
       },
       "body": {
@@ -726,8 +726,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -746,7 +746,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5547,0 5547,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"3505.7,787.1 4934.2,101.4 4933.6,0.0 5547.0,0.0 5547.0,744.2 4938.2,741.7 4948.4,7506.7 3239.5,7537.6 3091.6,7427.4 2157.6,7420.8 222.7,7531.3 192.5,5676.0 379.5,2885.7 1168.3,2526.4 1185.8,1740.6 647.8,1983.9 680.7,2143.0 388.4,2283.3 385.5,737.8 3505.7,787.1\" /></svg>"
         }
       },
       "body": {
@@ -840,11 +840,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -863,7 +863,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5547,0 5547,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"965.8,1674.8 966.8,1180.0 5547.0,1194.8 5547.0,4154.2 4732.9,4157.1 4730.9,7206.9 816.1,6720.8 897.7,5472.5 271.0,5393.6 -0.0,-0.0 572.1,0.0 569.6,1674.2 965.8,1674.8\" /></svg>"
         }
       },
       "body": {
@@ -960,8 +960,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -980,7 +980,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5657,0 5657,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1737.9,4016.1 1320.5,1240.2 4521.3,1223.4 4558.4,6927.7 1181.3,6936.5 1183.9,4011.2 1737.9,4016.1\" /></svg>"
         }
       },
       "body": {
@@ -1077,8 +1077,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1097,7 +1097,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5592,0 5592,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"216.0,652.1 1885.4,653.6 1880.9,0.0 5340.5,0.0 5356.9,2813.1 5393.4,2954.8 5592.0,2853.9 5592.0,3062.8 4300.3,3772.4 4568.8,4608.6 2417.0,5255.4 2636.6,5888.6 4545.0,5268.4 4786.5,6039.5 4997.0,5972.0 5194.2,6605.4 5592.0,6477.6 5592.0,6649.7 5241.3,6755.0 5338.6,7050.5 5117.2,7120.8 5025.0,6818.2 0.0,8268.0 0.0,6361.4 271.2,6302.8 216.0,652.1\" /></svg>"
         }
       },
       "body": {
@@ -1194,8 +1194,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1214,7 +1214,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"5268.0,2471.1 5263.1,7759.2 3345.8,7702.3 3234.1,7795.1 3223.2,8268.0 -0.0,8268.0 -0.0,-0.0 5679.0,0.0 5679.0,2471.8 5268.0,2471.1\" /></svg>"
         }
       },
       "body": {
@@ -1311,8 +1311,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1331,7 +1331,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5443,0 5443,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4655.0,7159.4 3144.5,7159.1 2864.0,5718.0 2654.5,5555.8 2701.2,5873.6 2555.7,5865.2 501.2,5220.5 2029.6,478.6 2957.9,778.0 3112.1,292.8 3264.6,340.1 3365.3,0.0 4747.7,0.0 4655.0,7159.4\" /></svg>"
         }
       },
       "body": {
@@ -1428,8 +1428,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1448,7 +1448,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5482,0 5482,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"702.6,1242.1 4625.7,1235.9 4659.7,1476.3 4675.8,6980.6 809.4,6961.4 809.0,6348.2 56.8,6343.5 0.0,0.0 628.1,0.0 702.6,1242.1\" /></svg>"
         }
       },
       "body": {
@@ -1545,8 +1545,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1565,7 +1565,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5541,0 5541,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"5179.3,6272.9 2107.0,7661.1 2132.0,6603.2 231.6,6586.4 281.3,1093.9 2268.7,554.1 2281.2,272.8 2446.8,217.1 2962.2,1373.4 3035.4,1339.0 5179.3,6272.9\" /></svg>"
         }
       },
       "body": {
@@ -1662,8 +1662,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1682,7 +1682,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5556,0 5556,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"797.0,8267.0 0.0,8267.0 -0.0,-0.0 744.0,0.0 748.1,606.7 4572.4,602.2 4611.5,7323.9 791.3,7339.4 797.0,8267.0\" /></svg>"
         }
       },
       "body": {
@@ -1776,11 +1776,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "14"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1799,7 +1799,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5479,0 5479,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"140.6,5346.4 1208.2,5349.6 -0.0,2815.7 -0.0,2358.3 2682.0,1068.4 3268.0,2311.4 3266.5,2123.6 5479.0,4096.5 5479.0,4390.2 5103.0,4067.0 3550.7,4840.4 3560.2,5352.3 4917.3,5359.7 4927.0,7251.3 163.2,7264.0 140.6,5346.4\" /></svg>"
         }
       },
       "body": {
@@ -1896,8 +1896,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1916,7 +1916,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5512,0 5512,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,1117.6 378.7,1125.8 392.9,200.3 4205.2,267.0 4129.2,2733.2 3776.4,3239.6 3763.4,4051.1 3635.8,4133.4 5512.0,6829.2 5512.0,6877.1 4978.8,6078.7 2386.2,7876.2 1704.5,6863.7 773.7,7511.0 235.7,8268.0 0.0,8268.0 0.0,1117.6\" /></svg>"
         }
       },
       "body": {
@@ -2010,11 +2010,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2033,7 +2033,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5526,0 5526,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"345.7,6108.4 355.4,1592.5 2215.4,1597.9 2233.4,263.4 2736.9,258.1 3485.1,1790.7 3164.3,2157.9 3453.1,2160.2 3587.8,2009.1 5174.5,5467.4 2168.8,7448.6 2192.2,5973.1 0.0,7436.0 0.0,6621.8 345.7,6108.4\" /></svg>"
         }
       },
       "body": {
@@ -2046,27 +2046,6 @@
           }
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2234.8,
-                3410.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9809395,
-                40.6889029
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -2092,8 +2071,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                354.9,
-                5636.8
+                2232.0,
+                263.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9829511,
+                40.6897015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2234.8,
+                3335.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2104,8 +2104,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.98014136634764,
-                40.68743299008994
+                -73.98097005346162,
+                40.688932201908734
               ]
             }
           }
@@ -2127,11 +2127,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2150,7 +2150,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5556,0 5556,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"982.3,7067.1 992.5,2934.8 1048.6,3205.1 2944.6,3220.9 2945.9,3059.4 3488.4,4380.3 3623.3,5027.6 3895.8,5072.6 4189.8,7071.5 982.3,7067.1\" /></svg>"
         }
       },
       "body": {
@@ -2189,7 +2189,7 @@
             "properties": {
               "resourceCoords": [
                 992.5,
-                7103.5
+                2933.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2200,8 +2200,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9914484,
-                40.6915966
+                -73.9904251,
+                40.6937557
               ]
             }
           },
@@ -2221,8 +2221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.98945829395223,
-                40.6923112318052
+                -73.98942791242641,
+                40.69231389631711
               ]
             }
           }
@@ -2244,11 +2244,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2267,7 +2267,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5573,0 5573,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,886.9 1947.0,751.5 1789.2,705.9 5573.0,752.5 5573.0,1095.5 5080.8,1114.7 5214.5,7615.2 5573.0,7448.6 5573.0,7749.4 4440.8,8268.0 2984.2,8268.0 2927.9,7404.3 215.0,7513.8 0.0,886.9\" /></svg>"
         }
       },
       "body": {
@@ -2280,27 +2280,6 @@
           }
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                9479.6,
-                6105.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9850084,
-                40.6972149
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -2333,13 +2312,34 @@
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9889427,
+                40.6950251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5068.4,
+                7719.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
               "type": "intersection"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.98899334954517,
-                40.69493843840462
+                -73.98395165513361,
+                40.69476134632027
               ]
             }
           }
@@ -2361,11 +2361,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "16"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2384,7 +2384,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5531,0 5531,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 2309.6,0.0 5531.0,648.3 5531.0,1183.6 5531.0,2156.8 5531.0,6212.6 5531.0,6237.6 5531.0,6907.4 5203.0,7334.5 3038.2,8268.0 2645.8,8268.0 2168.5,8268.0 116.6,7718.4 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2478,11 +2478,11 @@
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2501,7 +2501,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5541,0 5541,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"543.6,4565.8 0.0,4584.8 0.0,1975.9 767.1,2017.9 925.5,1971.3 874.1,486.1 5297.0,408.0 5541.0,88.4 5541.0,1869.3 5106.5,1918.8 5126.9,3198.7 4719.6,3206.0 4756.9,4749.1 5045.6,4602.5 5009.2,4444.4 5541.0,4189.5 5541.0,4974.5 4761.4,5350.8 4767.2,6229.0 935.6,6688.0 928.8,5999.4 595.7,5975.3 543.6,4565.8\" /></svg>"
         }
       },
       "body": {
@@ -2595,11 +2595,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2618,7 +2618,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5545,0 5545,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"5121.6,4333.2 5100.7,4159.0 5545.0,4092.7 5545.0,8267.0 789.0,8267.0 799.9,1122.3 3241.7,75.2 3077.3,0.0 4535.0,0.0 4505.6,4340.1 5121.6,4333.2\" /></svg>"
         }
       },
       "body": {
@@ -2715,8 +2715,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2735,7 +2735,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5532,0 5532,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"2836.3,1716.2 4249.7,1765.9 4670.3,1596.7 4537.8,6574.2 3219.2,7674.8 651.5,8094.0 670.5,8268.0 56.2,8268.0 125.2,3942.1 0.0,3936.3 0.0,889.5 2811.2,876.4 2836.3,1716.2\" /></svg>"
         }
       },
       "body": {
@@ -2832,8 +2832,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2852,7 +2852,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5612,0 5612,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"3139.2,1272.2 5225.0,368.7 5282.1,6755.2 3578.0,7031.5 3536.9,6834.6 2983.7,5651.9 2333.2,5771.8 3043.7,7099.9 0.0,7752.0 0.0,2728.2 693.7,2411.6 696.2,2117.1 343.7,2277.3 321.4,747.2 2286.3,670.3 2303.3,1380.4 2594.8,1246.3 3139.2,1272.2\" /></svg>"
         }
       },
       "body": {
@@ -2949,8 +2949,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2969,7 +2969,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5492,0 5492,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"292.5,6781.9 892.9,409.2 1328.9,0.0 5011.4,0.0 4678.3,1839.0 4547.4,3641.4 2521.5,3467.5 2178.4,6820.0 292.5,6781.9\" /></svg>"
         }
       },
       "body": {
@@ -3066,8 +3066,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3086,7 +3086,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5369,0 5369,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8268.0 -0.0,5608.9 181.0,5734.7 316.5,5540.0 -0.0,4660.5 -0.0,3519.4 1228.5,3537.9 1233.0,362.8 5074.5,435.2 5109.8,7913.2 5369.0,8028.6 5369.0,8268.0 5110.1,8176.6 5113.2,8268.0 -0.0,8268.0\" /></svg>"
         }
       },
       "body": {
@@ -3183,8 +3183,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3203,7 +3203,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5478,0 5478,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6428.0 403.6,6425.7 400.0,6332.5 664.5,6424.2 663.1,6180.0 398.1,6063.7 320.8,97.5 2082.8,1378.9 2309.2,1181.7 4474.0,1158.5 4524.4,7865.9 5425.9,8267.0 -0.0,8267.0 -0.0,6428.0\" /></svg>"
         }
       },
       "body": {
@@ -3300,8 +3300,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3320,7 +3320,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5527,0 5527,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"69.5,0.0 1063.6,2814.5 1139.6,1855.1 5487.2,268.5 4258.9,4432.0 4468.1,5017.6 4883.0,4861.7 5354.6,6171.8 932.8,7759.6 703.3,7777.5 740.2,7261.1 0.0,7524.5 69.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3417,8 +3417,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3437,7 +3437,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5431,0 5431,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4483.8,659.9 4505.4,7522.8 454.7,7532.7 444.4,4789.0 0.0,4796.7 0.0,4160.0 2564.9,653.5 4483.8,659.9\" /></svg>"
         }
       },
       "body": {
@@ -3531,11 +3531,11 @@
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3554,7 +3554,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5427,0 5427,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5470.2 478.7,5680.1 539.4,5455.8 526.0,714.2 4785.0,692.7 4796.5,4147.1 5110.5,4285.8 4796.2,4284.9 4793.9,7584.2 5427.0,7863.8 5427.0,8117.9 4027.9,7501.7 4025.5,8268.0 -0.0,8268.0 -0.0,5470.2\" /></svg>"
         }
       },
       "body": {
@@ -3572,7 +3572,7 @@
             "properties": {
               "resourceCoords": [
                 3322.2,
-                7053.6
+                3499.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3583,8 +3583,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9644042,
-                40.6811206
+                -73.964779,
+                40.68304
               ]
             }
           },
@@ -3613,8 +3613,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4794.7,
-                4170.0
+                1880.2,
+                2842.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3625,8 +3625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.96365867173002,
-                40.68279276944946
+                -73.96587124942562,
+                40.68327991134477
               ]
             }
           }
@@ -3651,8 +3651,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3671,7 +3671,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1522.1,4143.6 0.0,4139.0 0.0,-0.0 5679.0,0.0 5679.0,3321.5 4029.5,3686.7 4164.1,4294.6 4696.2,4344.9 4786.4,4696.0 4616.8,5797.5 4517.4,5732.6 4754.0,6854.4 4505.2,6592.4 4270.7,7695.5 3534.3,7682.4 3865.4,8119.6 3795.1,8268.0 3322.7,8268.0 2889.3,7721.6 1039.9,7707.9 1049.4,6412.9 0.0,6413.7 0.0,5145.7 1528.5,5140.4 1522.1,4143.6\" /></svg>"
         }
       },
       "body": {
@@ -3765,11 +3765,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3788,7 +3788,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5447,0 5447,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"285.2,6509.4 294.9,894.0 4370.9,906.8 4360.8,6517.2 285.2,6509.4\" /></svg>"
         }
       },
       "body": {
@@ -3882,11 +3882,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "14"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3905,7 +3905,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5534,0 5534,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1937.5,1407.7 2216.7,770.4 5534.0,762.4 5534.0,1078.8 4704.1,2972.3 4707.6,3494.2 5070.9,3494.9 5108.4,7504.2 5534.0,7502.6 5534.0,8268.0 0.0,8268.0 0.0,-0.0 2297.2,0.0 1682.0,1408.5 1937.5,1407.7\" /></svg>"
         }
       },
       "body": {
@@ -4002,8 +4002,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4022,7 +4022,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5483,0 5483,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"374.7,7533.0 363.7,3520.4 0.0,3517.3 0.0,2995.0 984.0,789.8 4461.0,790.5 4470.7,7533.3 4354.7,7533.1 3662.6,7532.3 3659.0,8268.0 795.9,8268.0 800.8,7534.2 374.7,7533.0\" /></svg>"
         }
       },
       "body": {
@@ -4119,8 +4119,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4139,7 +4139,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5501,0 5501,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"5501.0,5929.9 5501.0,8268.0 4348.7,8268.0 4568.5,7168.9 0.0,7157.6 0.0,915.1 2805.9,1015.0 1918.5,2207.3 5501.0,2355.0 4845.4,5800.5 5501.0,5929.9\" /></svg>"
         }
       },
       "body": {
@@ -4233,11 +4233,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4256,7 +4256,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5500,0 5500,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"505.0,2037.7 2489.9,1981.2 3234.6,1744.7 4214.2,987.8 4782.8,740.0 5500.0,699.7 5500.0,6721.0 1854.4,6995.4 1684.8,8268.0 0.0,8268.0 0.0,6238.3 505.0,2037.7\" /></svg>"
         }
       },
       "body": {
@@ -4350,11 +4350,11 @@
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4373,7 +4373,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5472,0 5472,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4023.3,0.0 4700.0,0.0 5030.6,1379.7 3967.5,6956.5 1772.2,6976.1 2145.4,1445.7 4461.0,1471.6 4023.3,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4467,11 +4467,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4490,7 +4490,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5449,0 5449,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"47.8,6964.9 1240.3,1449.6 3044.5,1566.5 5449.0,1944.7 5449.0,8268.0 3119.2,8268.0 3397.8,7006.1 47.8,6964.9\" /></svg>"
         }
       },
       "body": {
@@ -4587,8 +4587,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4607,7 +4607,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5464,0 5464,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"318.2,7493.8 1795.7,729.8 5058.9,763.9 4789.8,1993.3 5464.0,1992.1 5464.0,8268.0 4257.2,8268.0 4256.9,6815.3 3727.3,6815.4 3567.1,7531.9 318.2,7493.8\" /></svg>"
         }
       },
       "body": {
@@ -4701,11 +4701,11 @@
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "18"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4724,7 +4724,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5420,0 5420,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1488.8,676.6 4731.4,715.3 4891.4,0.0 5420.0,0.0 5420.0,7486.6 3738.1,7134.4 3824.7,6724.9 3389.1,6720.5 3194.5,7590.0 16.5,7511.0 1488.8,676.6\" /></svg>"
         }
       },
       "body": {
@@ -4741,8 +4741,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                889.9,
-                3482.4
+                596.1,
+                4818.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4753,8 +4753,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9694016,
-                40.6960641
+                -73.9684038,
+                40.6960275
               ]
             }
           },
@@ -4762,8 +4762,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3515.4,
-                6166.3
+                4732.5,
+                715.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4774,8 +4774,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9677372,
-                40.69772
+                -73.9718096,
+                40.697896
               ]
             }
           },
@@ -4783,8 +4783,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4114.2,
-                3482.4
+                3817.6,
+                4818.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4795,8 +4795,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9697427936518,
-                40.69783327302527
+                -73.96878109665573,
+                40.697766479759935
               ]
             }
           }
@@ -4821,8 +4821,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4841,7 +4841,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5445,0 5445,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4266.9,0.0 4700.5,0.0 4618.4,408.5 5445.0,572.9 5445.0,8267.0 359.4,8267.0 327.4,5247.2 92.6,4330.5 321.8,4331.1 749.4,2978.4 671.8,2121.9 919.0,820.9 4082.1,867.4 4266.9,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4938,8 +4938,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4958,7 +4958,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"41.1,2535.9 141.2,2638.2 673.5,1103.1 577.0,920.4 0.0,750.8 0.0,-0.0 5679.0,0.0 5679.0,8268.0 3636.7,8268.0 3470.3,7558.2 596.2,7805.0 290.3,4646.0 0.0,3843.1 41.1,2535.9\" /></svg>"
         }
       },
       "body": {
@@ -5055,8 +5055,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5075,7 +5075,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5347,0 5347,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"3038.7,8268.0 -0.0,8268.0 -0.0,8141.8 1363.0,8245.8 1479.4,6720.6 338.3,6479.1 341.4,994.9 4386.9,1823.1 4397.0,7306.3 3039.8,7032.2 3038.7,8268.0\" /></svg>"
         }
       },
       "body": {
@@ -5172,8 +5172,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5192,7 +5192,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5406,0 5406,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4570.6,1925.1 4590.5,7401.7 484.6,6586.2 460.2,1092.0 4570.6,1925.1\" /></svg>"
         }
       },
       "body": {
@@ -5289,8 +5289,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5309,7 +5309,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5449,0 5449,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4453.5,7518.0 1507.6,7511.0 311.2,7273.4 307.8,1733.5 4453.3,2574.0 4453.5,7518.0\" /></svg>"
         }
       },
       "body": {
@@ -5406,8 +5406,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5426,7 +5426,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5440,0 5440,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4516.7,6562.8 570.3,6563.9 567.4,1673.8 3221.3,2188.1 4080.9,2107.9 5440.0,2533.7 5440.0,2779.8 4514.6,3003.6 4516.7,6562.8\" /></svg>"
         }
       },
       "body": {
@@ -5523,8 +5523,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5543,7 +5543,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5457,0 5457,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"1859.0,4649.7 306.3,4656.6 292.7,1050.8 2376.9,503.8 5457.0,508.7 5457.0,8268.0 5323.5,8268.0 5324.3,7603.8 1867.3,7589.8 1859.0,4649.7\" /></svg>"
         }
       },
       "body": {
@@ -5640,8 +5640,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5660,7 +5660,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5386,0 5386,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4589.6,1078.9 4616.7,7904.1 508.4,7086.2 504.7,6351.3 -0.0,6355.2 -0.0,1522.1 487.5,1519.8 482.6,270.5 4589.6,1078.9\" /></svg>"
         }
       },
       "body": {
@@ -5757,8 +5757,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5777,7 +5777,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5430,0 5430,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4508.3,1078.6 4470.0,7933.7 2944.0,7927.2 276.1,7389.4 311.6,532.7 2923.9,1065.3 4508.3,1078.6\" /></svg>"
         }
       },
       "body": {
@@ -5874,8 +5874,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5894,7 +5894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5468,0 5468,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4541.9,6647.4 694.3,6619.2 704.5,1357.6 4527.5,1364.8 4541.9,6647.4\" /></svg>"
         }
       },
       "body": {
@@ -5991,8 +5991,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6011,7 +6011,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5365,0 5365,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"802.2,1380.7 3755.7,1384.8 3761.7,8268.0 820.8,8268.0 802.2,1380.7\" /></svg>"
         }
       },
       "body": {
@@ -6105,11 +6105,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6128,7 +6128,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5427,0 5427,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4720.0,7615.7 2569.0,7617.8 2342.2,7811.4 604.0,6521.8 646.3,173.4 1755.2,399.3 1756.7,0.0 3376.1,0.0 3374.2,739.4 4737.8,1024.7 4720.0,7615.7\" /></svg>"
         }
       },
       "body": {
@@ -6225,8 +6225,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6245,7 +6245,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"583.7,7727.3 580.9,5337.3 1178.7,5249.5 1321.5,3563.4 -0.0,3451.5 -0.0,-0.0 5679.0,0.0 5679.0,139.0 4034.9,141.1 4039.7,4029.4 4890.2,4026.0 4896.0,7118.9 4151.9,7118.1 4151.3,7729.5 583.7,7727.3\" /></svg>"
         }
       },
       "body": {
@@ -6342,8 +6342,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6362,7 +6362,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5453,0 5453,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"318.1,7254.8 324.0,687.6 4492.2,1536.0 4486.4,7257.4 318.1,7254.8\" /></svg>"
         }
       },
       "body": {
@@ -6459,8 +6459,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6479,7 +6479,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5380,0 5380,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"432.6,6787.4 450.7,1059.9 1703.5,1304.2 4620.9,1321.7 4638.5,6802.5 432.6,6787.4\" /></svg>"
         }
       },
       "body": {
@@ -6573,11 +6573,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6596,7 +6596,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5435,0 5435,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4589.2,4095.1 4582.3,6894.2 273.6,6894.0 241.1,1302.4 3835.3,1300.2 3820.9,4095.7 4589.2,4095.1\" /></svg>"
         }
       },
       "body": {
@@ -6655,8 +6655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1835.7,
-                4167.3
+                1625.0,
+                3571.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6667,8 +6667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.96473070922352,
-                40.68829621144262
+                -73.9649390750868,
+                40.68859189282898
               ]
             }
           }
@@ -6690,11 +6690,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6713,7 +6713,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5401,0 5401,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7334.7 -0.0,4612.4 425.9,4610.2 432.0,727.2 5401.0,719.3 5401.0,7305.4 -0.0,7334.7\" /></svg>"
         }
       },
       "body": {
@@ -6807,11 +6807,11 @@
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6830,7 +6830,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8267 0,0 5423,0 5423,8267 0,8267\" /></svg>"
+          "value": "<svg><polygon points=\"4495.6,7468.3 529.6,7492.4 494.0,725.8 5121.6,695.6 5120.8,0.0 5423.0,0.0 5423.0,8267.0 4498.6,8267.0 4495.6,7468.3\" /></svg>"
         }
       },
       "body": {
@@ -6868,8 +6868,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                504.6,
-                726.6
+                4497.0,
+                7468.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6880,8 +6880,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.962836,
-                40.688555
+                -73.959276,
+                40.685217
               ]
             }
           },
@@ -6890,7 +6890,7 @@
             "properties": {
               "resourceCoords": [
                 4497.0,
-                4792.1
+                3438.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6901,8 +6901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.95955036065111,
-                40.68667682128946
+                -73.9596933570826,
+                40.68740004697051
               ]
             }
           }
@@ -6927,8 +6927,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6947,7 +6947,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"4887.3,3851.2 4879.9,7482.0 836.2,7477.0 838.1,3829.5 -0.0,3831.8 -0.0,-0.0 5679.0,0.0 5679.0,3849.9 4887.3,3851.2\" /></svg>"
         }
       },
       "body": {
@@ -7044,8 +7044,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7064,7 +7064,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5679,0 5679,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"188.7,7454.4 188.4,3802.1 984.8,3799.1 976.7,0.0 5679.0,0.0 5679.0,205.6 3937.2,229.7 3972.0,2739.4 5153.3,2741.0 5095.7,7444.9 188.7,7454.4\" /></svg>"
         }
       },
       "body": {
@@ -7161,8 +7161,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T19:43:43Z",
-      "modified": "2026-05-25T19:43:43Z",
+      "created": "2026-05-27T01:47:33Z",
+      "modified": "2026-05-27T01:47:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7181,7 +7181,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5618,0 5618,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"5618.0,0.0 5618.0,8268.0 1344.9,8268.0 1050.7,7789.0 1172.7,2509.7 -0.0,2491.9 0.0,0.0 5618.0,0.0\" /></svg>"
         }
       },
       "body": {

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -440,9 +440,6 @@ def compute_all_clip_masks(
 
         mask_geo = mask_geo.simplify(simplify_tolerance, preserve_topology=True)
 
-        if isinstance(mask_geo, Polygon):
-            mask_geo = _remove_spike_vertices(mask_geo)
-
         if isinstance(mask_geo, MultiPolygon):
             # Filter out disconnected slivers (< 5% of the largest component).
             parts = sorted(mask_geo.geoms, key=lambda p: p.area, reverse=True)
@@ -481,6 +478,12 @@ def compute_all_clip_masks(
                         f"fallback also failed. Investigate the street network or block "
                         f"assignment for this page."
                     )
+
+        # Remove backtrack vertices from any path (direct Polygon or resolved
+        # MultiPolygon). Simplification can introduce spikes when it removes
+        # intermediate vertices from narrow arms.
+        if isinstance(mask_geo, Polygon):
+            mask_geo = _remove_spike_vertices(mask_geo)
 
         # Warn if interior holes are present (unexpected with city block geometry).
         if len(mask_geo.interiors) > 0:

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -99,10 +99,16 @@ def _assign_blocks_to_pages(
     blocks: list[Polygon],
     page_polys: list[Polygon],
 ) -> dict[int, list[int]]:
-    """Assign each block to the page with the greatest intersection area.
+    """Assign each block to the page whose centroid is nearest (Voronoi assignment).
 
-    Tie-break (equal area): assign to the page whose centroid is closest
-    to the block centroid.
+    Each block is assigned to the page with the minimum centroid-to-centroid
+    distance. Only pages with non-zero intersection with the block are eligible.
+    Tie-break: maximum intersection area.
+
+    Distance-based (Voronoi) assignment naturally partitions the overlap zone
+    along perpendicular bisectors between page centers, producing connected
+    page territories. The earlier area-based approach let overlapping pages
+    steal blocks from deep inside a page's interior, creating disconnected masks.
 
     Returns a dict mapping page_index → list of block indices.
     Blocks with zero intersection with every page are dropped.
@@ -111,20 +117,21 @@ def _assign_blocks_to_pages(
     assignment: dict[int, list[int]] = {i: [] for i in range(len(page_polys))}
 
     for block_idx, block in enumerate(blocks):
+        block_centroid = block.centroid
         best_page = -1
-        best_area = 0.0
         best_dist = float("inf")
+        best_area = 0.0
 
         for page_idx, page_poly in enumerate(page_polys):
             inter = block.intersection(page_poly)
             area = inter.area
             if area <= 0:
                 continue
-            dist = block.centroid.distance(page_centroids[page_idx])
-            if area > best_area or (area == best_area and dist < best_dist):
-                best_area = area
-                best_page = page_idx
+            dist = block_centroid.distance(page_centroids[page_idx])
+            if dist < best_dist or (dist == best_dist and area > best_area):
                 best_dist = dist
+                best_page = page_idx
+                best_area = area
 
         if best_page >= 0:
             assignment[best_page].append(block_idx)
@@ -214,12 +221,29 @@ def compute_all_clip_masks(
                 )
                 mask_geo = substantial[0]
             else:
-                raise ValueError(
-                    f"Page {page_idx} (corners starting at {georef['corners'][0]}) "
-                    f"produced a MultiPolygon clipping mask with {len(substantial)} "
-                    f"substantial parts (each ≥5% of largest). This is unexpected — "
-                    f"investigate the street network or block assignment for this page."
-                )
+                # Multiple substantial parts — likely due to a rotated page whose diagonal
+                # boundary clips the axis-aligned block grid into disconnected pieces.
+                # Try the convex hull of the parts clipped to the page; since both the
+                # convex hull and the page polygon (a convex quadrilateral) are convex,
+                # their intersection is always a connected Polygon.
+                hull_mask = mask_geo.convex_hull.intersection(page_polys[page_idx])
+                if isinstance(hull_mask, Polygon) and not hull_mask.is_empty:
+                    hull_pct = hull_mask.area / page_polys[page_idx].area * 100
+                    print(
+                        f"Warning: page {page_idx} mask had {len(substantial)} disconnected "
+                        f"substantial parts; using convex hull "
+                        f"({hull_pct:.1f}% of page). Corners: {georef['corners'][0]}",
+                        file=sys.stderr,
+                    )
+                    mask_geo = hull_mask
+                else:
+                    raise ValueError(
+                        f"Page {page_idx} (corners starting at {georef['corners'][0]}) "
+                        f"produced a MultiPolygon clipping mask with {len(substantial)} "
+                        f"substantial parts (each ≥5% of largest), and the convex hull "
+                        f"fallback also failed. Investigate the street network or block "
+                        f"assignment for this page."
+                    )
 
         # Warn if interior holes are present (unexpected with city block geometry).
         if len(mask_geo.interiors) > 0:

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -1,9 +1,22 @@
 """Compute block-based clipping polygons for Sanborn map pages.
 
 Street network polygonization divides the mapped region into city blocks.
-Each block is assigned to exactly one page (the one with the greatest
-intersection area; tie-break: closest page centroid), producing gapless,
+Each block is assigned to exactly one page, which hopefully produces gapless,
 non-overlapping clipping masks.
+
+Blocks are assigned based on:
+
+- Which page has the most color pixels in this block
+- Centroid-distance assignment (Voronoi)
+
+This can leave gaps where a block isn't fully covered by any page.
+These can be patched by adding the uncovered part of the block back to the queue.
+Since geometry subtraction can create artifacts, there are some heuristics to remove
+"spikes" from clipping polygons, which look bad and can trip up Allmaps.
+
+This also makes an effort to fill in concave "dents" in clipping polygons by
+borrowing that part from the adjacent page, so long as it doesn't drop a meaningful
+number of color pixels and improves convexity.
 """
 
 import math

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -1,0 +1,293 @@
+"""Compute block-based clipping polygons for Sanborn map pages.
+
+Street network polygonization divides the mapped region into city blocks.
+Each block is assigned to exactly one page (the one with the greatest
+intersection area; tie-break: closest page centroid), producing gapless,
+non-overlapping clipping masks.
+"""
+
+import math
+import sys
+from typing import cast
+
+import numpy as np
+from shapely.geometry import LineString, MultiPolygon, Polygon
+from shapely.geometry import shape as geom_shape
+from shapely.geometry.base import BaseMultipartGeometry
+from shapely.ops import polygonize, unary_union
+
+# ~0.5 miles in degrees latitude (constant regardless of location).
+_BUFFER_LAT_DEG = 0.5 * 1609.344 / 111_320.0
+
+
+def _fit_affine(georef: dict) -> tuple[np.ndarray, np.ndarray]:
+    """Fit a 2×3 pixel→geo affine from the 4 georef corners.
+
+    Pixel positions are (0,0), (w,0), (w,h), (0,h) corresponding to
+    corners[0..3] (TL, TR, BR, BL). Uses least-squares so the result is
+    numerically stable even if the corners aren't perfectly affine.
+
+    Returns (A_fwd, A_inv) where:
+      [lon, lat] = A_fwd @ [px, py, 1]^T
+      [px, py]   = A_inv @ ([lon, lat] - A_fwd[:, 2])
+    """
+    w = float(georef["width"])
+    h = float(georef["height"])
+    corners = georef["corners"]
+
+    pixel_pts = np.array([[0, 0], [w, 0], [w, h], [0, h]], dtype=float)
+    geo_pts = np.array(corners, dtype=float)  # shape (4, 2): [[lon, lat], ...]
+
+    # Build overdetermined system: geo = [px, py, 1] @ A^T
+    ones = np.ones((4, 1))
+    X = np.hstack([pixel_pts, ones])  # (4, 3)
+    A_T, _, _, _ = np.linalg.lstsq(X, geo_pts, rcond=None)
+    A_fwd = A_T.T  # (2, 3): [lon, lat]^T = A_fwd @ [px, py, 1]^T
+
+    A_inv = np.linalg.inv(A_fwd[:, :2])  # (2, 2)
+    return A_fwd, A_inv
+
+
+def _geo_to_pixel(
+    lon: float, lat: float, A_fwd: np.ndarray, A_inv: np.ndarray
+) -> tuple[float, float]:
+    """Convert a single (lon, lat) point to pixel coordinates."""
+    geo_vec = np.array([lon, lat]) - A_fwd[:, 2]
+    px, py = A_inv @ geo_vec
+    return float(px), float(py)
+
+
+def _polygonize_streets(
+    centerlines_geojson: dict,
+    coverage: Polygon | MultiPolygon,
+) -> list[Polygon]:
+    """Polygonize street network clipped to the coverage region.
+
+    Clips each LineString/MultiLineString feature to coverage, adds each
+    coverage boundary ring as a closing edge, then polygonizes the union of
+    all line segments. coverage may be a Polygon or MultiPolygon.
+    """
+    lines: list[LineString] = []
+    for feat in centerlines_geojson.get("features", []):
+        geom = geom_shape(feat["geometry"])
+        clipped = geom.intersection(coverage)
+        if clipped.is_empty:
+            continue
+        # intersection of a LineString with a Polygon can be a Point, LineString,
+        # MultiLineString, or GeometryCollection; collect only linear parts.
+        if hasattr(clipped, "geoms"):
+            for part in clipped.geoms:
+                if isinstance(part, LineString) and not part.is_empty:
+                    lines.append(part)
+        elif isinstance(clipped, LineString) and not clipped.is_empty:
+            lines.append(clipped)
+
+    # Add each coverage boundary exterior to close off edge/waterfront blocks.
+    coverage_polys: list[Polygon] = (
+        list(coverage.geoms)
+        if isinstance(coverage, BaseMultipartGeometry)
+        else [coverage]
+    )
+    for poly in coverage_polys:
+        lines.append(LineString(list(poly.exterior.coords)))
+
+    all_lines = unary_union(lines)
+    return [p for p in polygonize(all_lines) if isinstance(p, Polygon)]
+
+
+def _assign_blocks_to_pages(
+    blocks: list[Polygon],
+    page_polys: list[Polygon],
+) -> dict[int, list[int]]:
+    """Assign each block to the page with the greatest intersection area.
+
+    Tie-break (equal area): assign to the page whose centroid is closest
+    to the block centroid.
+
+    Returns a dict mapping page_index → list of block indices.
+    Blocks with zero intersection with every page are dropped.
+    """
+    page_centroids = [p.centroid for p in page_polys]
+    assignment: dict[int, list[int]] = {i: [] for i in range(len(page_polys))}
+
+    for block_idx, block in enumerate(blocks):
+        best_page = -1
+        best_area = 0.0
+        best_dist = float("inf")
+
+        for page_idx, page_poly in enumerate(page_polys):
+            inter = block.intersection(page_poly)
+            area = inter.area
+            if area <= 0:
+                continue
+            dist = block.centroid.distance(page_centroids[page_idx])
+            if area > best_area or (area == best_area and dist < best_dist):
+                best_area = area
+                best_page = page_idx
+                best_dist = dist
+
+        if best_page >= 0:
+            assignment[best_page].append(block_idx)
+
+    return assignment
+
+
+def compute_all_clip_masks(
+    georefs: list[dict],
+    centerlines_geojson: dict,
+    simplify_tolerance: float = 0.00005,
+) -> list[Polygon | None]:
+    """Compute block-based clipping masks for all georeferenced pages.
+
+    Returns one entry per georef: a Shapely Polygon in geo (lon/lat) space
+    clipped to that page's boundary, or None if no street blocks were
+    assigned to the page (caller should fall back to the full-page rectangle).
+
+    Raises ValueError if any page's mask turns out to be a MultiPolygon
+    (unexpected; indicates a problem with the street network or assignment
+    algorithm worth investigating).
+
+    Args:
+        georefs: list of parsed georef.json dicts with 'corners', 'width', 'height'.
+        centerlines_geojson: parsed GeoJSON FeatureCollection of LineStrings.
+        simplify_tolerance: Douglas-Peucker tolerance in degrees (~0.00005 ≈ 5 m).
+    """
+    if not georefs:
+        return []
+
+    page_polys = [Polygon(g["corners"]) for g in georefs]
+
+    # Build coverage region: union of all pages, buffered by ~0.5 miles.
+    # Scale lon coords by cos(lat) so the isotropic shapely buffer gives a
+    # lat-equivalent distance in all directions, then undo the scaling.
+    all_lats = [c[1] for g in georefs for c in g["corners"]]
+    mean_lat = float(np.mean(all_lats))
+
+    # Buffer each page polygon by ~0.5 miles, then union the results.
+    # Scale lon by cos(lat) before buffering so the isotropic shapely buffer
+    # gives equal metric distance in all directions; undo scaling afterward.
+    cos_lat = math.cos(math.radians(mean_lat))
+    buffered: list[Polygon] = []
+    for poly in page_polys:
+        scaled = Polygon([(lon * cos_lat, lat) for lon, lat in poly.exterior.coords])
+        scaled_buf = scaled.buffer(_BUFFER_LAT_DEG)
+        unbuf = Polygon(
+            [(lon / cos_lat, lat) for lon, lat in scaled_buf.exterior.coords]
+        )
+        buffered.append(unbuf)
+    coverage_buffered: Polygon | MultiPolygon = unary_union(buffered)
+
+    blocks = _polygonize_streets(centerlines_geojson, coverage_buffered)
+    if not blocks:
+        return [None] * len(georefs)
+
+    assignment = _assign_blocks_to_pages(blocks, page_polys)
+
+    masks: list[Polygon | None] = []
+    for page_idx, georef in enumerate(georefs):
+        block_indices = assignment.get(page_idx, [])
+        if not block_indices:
+            masks.append(None)
+            continue
+
+        assigned = [blocks[i] for i in block_indices]
+        mask_geo = unary_union(assigned).intersection(page_polys[page_idx])
+
+        if mask_geo.is_empty:
+            masks.append(None)
+            continue
+
+        mask_geo = mask_geo.simplify(simplify_tolerance, preserve_topology=True)
+
+        if isinstance(mask_geo, MultiPolygon):
+            # Filter out disconnected slivers (< 5% of the largest component).
+            parts = sorted(mask_geo.geoms, key=lambda p: p.area, reverse=True)
+            threshold = parts[0].area * 0.05
+            substantial = [p for p in parts if p.area >= threshold]
+            if len(substantial) == 1:
+                sliver_pct = sum(p.area for p in parts[1:]) / parts[0].area * 100
+                print(
+                    f"Warning: page {page_idx} mask had {len(parts) - 1} sliver(s) "
+                    f"({sliver_pct:.1f}% of main area) dropped. "
+                    f"Corners: {georef['corners'][0]}",
+                    file=sys.stderr,
+                )
+                mask_geo = substantial[0]
+            else:
+                raise ValueError(
+                    f"Page {page_idx} (corners starting at {georef['corners'][0]}) "
+                    f"produced a MultiPolygon clipping mask with {len(substantial)} "
+                    f"substantial parts (each ≥5% of largest). This is unexpected — "
+                    f"investigate the street network or block assignment for this page."
+                )
+
+        # Warn if interior holes are present (unexpected with city block geometry).
+        if len(mask_geo.interiors) > 0:
+            print(
+                f"Warning: page {page_idx} mask has {len(mask_geo.interiors)} interior "
+                f"hole(s); only the exterior will be used. Corners: {georef['corners'][0]}",
+                file=sys.stderr,
+            )
+
+        masks.append(cast(Polygon, mask_geo))
+
+    return masks
+
+
+def geo_polygon_to_svg(
+    geo_polygon: Polygon | None,
+    georef: dict,
+    source_width: int,
+    source_height: int,
+    split_canvas: tuple[float, float, float, float] | None = None,
+) -> str:
+    """Convert a geo-space Shapely Polygon to an IIIF SvgSelector string.
+
+    Canvas coordinate mapping:
+      Full canvas (split_canvas=None):
+        canvas_x = pixel_x * (source_width / georef_width)
+        canvas_y = pixel_y * (source_height / georef_height)
+      Split sub-image (split_canvas=(cx, cy, cw, ch)):
+        canvas_x = cx + pixel_x * (cw / georef_width)
+        canvas_y = cy + pixel_y * (ch / georef_height)
+
+    Falls back to the standard full-page rectangle when geo_polygon is
+    None or empty. Raises ValueError for MultiPolygon input.
+    """
+    georef_width = float(georef["width"])
+    georef_height = float(georef["height"])
+
+    def fallback_rect() -> str:
+        return (
+            f'<svg><polygon points="0,{source_height} 0,0 '
+            f'{source_width},0 {source_width},{source_height} 0,{source_height}" /></svg>'
+        )
+
+    if geo_polygon is None or geo_polygon.is_empty:
+        return fallback_rect()
+
+    if isinstance(geo_polygon, MultiPolygon):
+        raise ValueError(
+            "geo_polygon_to_svg received a MultiPolygon; only Polygon is supported."
+        )
+
+    A_fwd, A_inv = _fit_affine(georef)
+
+    if split_canvas is not None:
+        cx, cy, cw, ch = split_canvas
+        scale_x = cw / georef_width
+        scale_y = ch / georef_height
+    else:
+        cx, cy = 0.0, 0.0
+        scale_x = source_width / georef_width
+        scale_y = source_height / georef_height
+
+    def geo_to_canvas(lon: float, lat: float) -> tuple[float, float]:
+        px, py = _geo_to_pixel(lon, lat, A_fwd, A_inv)
+        return round(cx + px * scale_x, 1), round(cy + py * scale_y, 1)
+
+    coords = list(geo_polygon.exterior.coords)
+    points = " ".join(
+        f"{x},{y}" for x, y in (geo_to_canvas(lon, lat) for lon, lat in coords)
+    )
+    return f'<svg><polygon points="{points}" /></svg>'

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -343,6 +343,196 @@ def _assign_blocks_to_pages_with_splits(
     return page_territory
 
 
+def _convexity_ratio(poly: Polygon) -> float:
+    """Return area/convex_hull.area (1.0 = convex, lower = more concave)."""
+    hull = poly.convex_hull
+    return poly.area / hull.area if hull.area > 0 else 1.0
+
+
+def _fill_concave_dents(
+    masks: list[Polygon | None],
+    page_color_data: list[PageColorData | None] | None,
+    page_polys: list[Polygon] | None = None,
+    simplify_tolerance: float = 0.00005,
+    color_dominance_threshold: float = 3.0,
+    color_min_score: float = 500.0,
+) -> list[Polygon | None]:
+    """Fill concave dents in page masks when the neighboring page has no color advantage.
+
+    When page_polys is provided, uses page_poly_i − mask_i to find candidate regions
+    (areas within the page's geographic extent that aren't in its mask). This catches
+    arms and protrusions at territory edges that don't fall within the convex hull.
+    Without page_polys, falls back to hull(mask_i) − mask_i.
+
+    For each candidate piece owned by exactly one other page j, the piece is transferred
+    from j to i unless: j's color score substantially exceeds i's (color_dominance_threshold),
+    or (when using page_polys) removing the piece from j would not improve j's convexity
+    ratio (meaning it isn't a protrusion in j).
+
+    After all transfers, re-applies simplification and spike removal to modified masks.
+    """
+    new_masks: list[Polygon | None] = list(masks)
+    modified: set[int] = set()
+    transfer_count = 0
+
+    # Pre-compute all transfer candidates using the ORIGINAL masks so that dent
+    # computations for all pages use a consistent baseline.  Applying transfers
+    # incrementally would shrink a page's mask before later pages are inspected,
+    # causing the dent region to change and hiding dents that should have been found.
+    candidates: list[tuple[int, Polygon, int]] = []
+
+    if page_polys is not None:
+        # Page-poly-based detection: for each (i, j) pair, directly compute the
+        # part of j's mask that lies within i's geographic extent but not in i's
+        # mask.  This avoids the owner-check problem (the arm is guaranteed to
+        # come from j) and catches arms at territory edges that hull(mask_i) misses.
+        for i, mask_i in enumerate(masks):
+            if mask_i is None:
+                continue
+            for j, mask_j in enumerate(masks):
+                if j == i or mask_j is None:
+                    continue
+                arm_geo = mask_j.intersection(page_polys[i]).difference(mask_i)
+                if arm_geo.is_empty:
+                    continue
+                for piece in _collect_polygons(arm_geo):
+                    if piece.area < mask_i.area * 0.001:
+                        continue  # ignore tiny fragments
+
+                    # Compute color scores for both pages in this piece's region.
+                    score_i, score_j = 0.0, 0.0
+                    if page_color_data is not None:
+                        pcd_i = page_color_data[i]
+                        pcd_j = page_color_data[j]
+                        if pcd_i is not None:
+                            score_i = _score_block_on_page(piece, pcd_i)
+                        if pcd_j is not None:
+                            score_j = _score_block_on_page(piece, pcd_j)
+
+                    # Skip if j has a clear, substantial color advantage.
+                    if (
+                        score_j
+                        > max(score_i, color_min_score) * color_dominance_threshold
+                    ):
+                        continue
+
+                    # Verify removing piece from j improves j's convexity ratio
+                    # (confirms it's a protrusion in j, not a legitimate block
+                    # assignment that happens to lie within i's page extent).
+                    test_j = mask_j.difference(piece)
+                    if not test_j.is_empty:
+                        test_j_poly: Polygon | None = None
+                        if isinstance(test_j, Polygon):
+                            test_j_poly = test_j
+                        elif isinstance(test_j, MultiPolygon):
+                            parts = sorted(
+                                test_j.geoms, key=lambda p: p.area, reverse=True
+                            )
+                            if parts[0].area >= test_j.area * 0.9:
+                                test_j_poly = parts[0]
+                        if test_j_poly is None:
+                            continue  # too fragmented after removal; skip
+                        if _convexity_ratio(test_j_poly) <= _convexity_ratio(mask_j):
+                            continue  # removing piece doesn't improve j's convexity; skip
+
+                    candidates.append((i, piece, j))
+    else:
+        # Hull-based detection: find pieces in hull(mask_i) − mask_i that are
+        # fully owned by exactly one other page j.
+        for i, mask_i in enumerate(masks):
+            if mask_i is None:
+                continue
+            dent_i = mask_i.convex_hull.difference(mask_i)
+            if dent_i.is_empty:
+                continue
+            for piece in _collect_polygons(dent_i):
+                if piece.area < mask_i.area * 0.001:
+                    continue  # ignore tiny fragments
+
+                # Find the single page that fully owns this piece.
+                owners = [
+                    j
+                    for j, mask_j in enumerate(masks)
+                    if j != i
+                    and mask_j is not None
+                    and piece.intersection(mask_j).area > piece.area * 0.9
+                ]
+                if len(owners) != 1:
+                    continue
+                j = owners[0]
+
+                # Compute color scores for both pages in this piece's region.
+                score_i, score_j = 0.0, 0.0
+                if page_color_data is not None:
+                    pcd_i = page_color_data[i]
+                    pcd_j = page_color_data[j]
+                    if pcd_i is not None:
+                        score_i = _score_block_on_page(piece, pcd_i)
+                    if pcd_j is not None:
+                        score_j = _score_block_on_page(piece, pcd_j)
+
+                # Skip if j has a clear, substantial color advantage.
+                if score_j > max(score_i, color_min_score) * color_dominance_threshold:
+                    continue
+
+                candidates.append((i, piece, j))
+
+    # Apply transfers using incrementally updated masks.
+    for i, piece, j in candidates:
+        if new_masks[i] is None or new_masks[j] is None:
+            continue
+        # Verify j still owns the piece; an earlier transfer may have claimed it.
+        if new_masks[j].intersection(piece).area <= piece.area * 0.5:
+            continue
+
+        candidate_i = new_masks[i].union(piece)
+        candidate_j = new_masks[j].difference(piece)
+        if not isinstance(candidate_i, Polygon):
+            continue
+
+        # For the source, allow a MultiPolygon if one component dominates (≥90%).
+        # This handles the case where the arm bridges two parts of j's territory —
+        # removing it leaves a main body plus a small disconnected remnant.
+        new_j: Polygon | None
+        if candidate_j.is_empty:
+            new_j = None
+        elif isinstance(candidate_j, Polygon):
+            new_j = candidate_j
+        elif isinstance(candidate_j, MultiPolygon):
+            parts = sorted(candidate_j.geoms, key=lambda p: p.area, reverse=True)
+            if parts[0].area >= candidate_j.area * 0.9:
+                new_j = parts[0]
+            else:
+                continue  # too fragmented; skip
+        else:
+            continue
+
+        new_masks[i] = candidate_i
+        new_masks[j] = new_j
+        modified.update([i, j])
+        transfer_count += 1
+
+    if transfer_count:
+        print(
+            f"Dent-filling: {transfer_count} transfer(s) across {len(modified)} page(s).",
+            file=sys.stderr,
+        )
+
+    # Re-apply simplification and spike removal to modified masks.
+    for i in modified:
+        mask = new_masks[i]
+        if mask is None:
+            continue
+        simplified = mask.simplify(simplify_tolerance, preserve_topology=True)
+        if isinstance(simplified, Polygon):
+            new_masks[i] = _remove_spike_vertices(simplified)
+        elif isinstance(simplified, MultiPolygon):
+            parts = sorted(simplified.geoms, key=lambda p: p.area, reverse=True)
+            new_masks[i] = _remove_spike_vertices(parts[0])
+
+    return new_masks
+
+
 def compute_all_clip_masks(
     georefs: list[dict],
     centerlines_geojson: dict,
@@ -494,6 +684,10 @@ def compute_all_clip_masks(
             )
 
         masks.append(cast(Polygon, mask_geo))
+
+    # Fill concave dents: transfer pieces from neighboring pages when there's no
+    # strong color reason to keep them there.
+    masks = _fill_concave_dents(masks, page_color_data, page_polys, simplify_tolerance)
 
     # Report what fraction of the original page coverage is still covered.
     # Pages without a computed mask fall back to their full page polygon.

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -8,9 +8,12 @@ non-overlapping clipping masks.
 
 import math
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 
 import numpy as np
+from PIL import Image, ImageDraw
 from shapely.geometry import LineString, MultiPolygon, Polygon
 from shapely.geometry import mapping as geom_mapping
 from shapely.geometry import shape as geom_shape
@@ -19,6 +22,25 @@ from shapely.ops import polygonize, unary_union
 
 # ~0.5 miles in degrees latitude (constant regardless of location).
 _BUFFER_LAT_DEG = 0.5 * 1609.344 / 111_320.0
+
+
+@dataclass
+class PageColorData:
+    """Color-score array and affine for one page's raw image.
+
+    color_score holds max(0, spread-20) per pixel where spread = max(R,G,B)-min(R,G,B).
+    Background paper tint has spread ≈ 20, so this zeroes it out; real colored ink
+    has spread > 20.
+
+    A_fwd/A_inv operate in georef pixel space. scale_x/scale_y map from georef pixels
+    to work-image pixels.
+    """
+
+    color_score: np.ndarray  # (H, W) int16
+    A_fwd: np.ndarray  # (2, 3) pixel→geo at georef pixel scale
+    A_inv: np.ndarray  # (2, 2) geo→pixel (inverse of A_fwd[:, :2])
+    scale_x: float  # work_w / georef_w
+    scale_y: float  # work_h / georef_h
 
 
 def _fit_affine(georef: dict) -> tuple[np.ndarray, np.ndarray]:
@@ -56,6 +78,67 @@ def _geo_to_pixel(
     geo_vec = np.array([lon, lat]) - A_fwd[:, 2]
     px, py = A_inv @ geo_vec
     return float(px), float(py)
+
+
+def _load_page_color_data(
+    raw_path: Path,
+    georef: dict,
+    work_long_side: int = 512,
+) -> PageColorData | None:
+    """Load a raw JPEG and build a color-score array for block assignment scoring.
+
+    Decodes the JPEG at reduced resolution using PIL's draft() hint (JPEG 1/8 DCT),
+    then resizes to work_long_side on the long side. Computes per-pixel spread =
+    max(R,G,B) - min(R,G,B), subtracts 20 (approximate background paper tint), and
+    clamps to zero. Returns None if the file is missing or unreadable.
+
+    Assumes georef["width"] / georef["height"] match the original raw image dimensions
+    (true for full-canvas Sanborn pages).
+    """
+    if not raw_path.exists():
+        return None
+    try:
+        img = Image.open(raw_path)
+        img.draft("RGB", (work_long_side, work_long_side))
+        img = img.convert("RGB")
+        raw_w, raw_h = img.size
+        scale = work_long_side / max(raw_w, raw_h)
+        work_w = max(1, round(raw_w * scale))
+        work_h = max(1, round(raw_h * scale))
+        img = img.resize((work_w, work_h), Image.Resampling.LANCZOS)
+        arr = np.array(img, dtype=np.int16)  # (H, W, 3)
+        spread = arr.max(axis=2) - arr.min(axis=2)
+        color_score = np.maximum(0, spread - 20).astype(np.int16)
+        A_fwd, A_inv = _fit_affine(georef)
+        georef_w = float(georef["width"])
+        georef_h = float(georef["height"])
+        return PageColorData(
+            color_score=color_score,
+            A_fwd=A_fwd,
+            A_inv=A_inv,
+            scale_x=work_w / georef_w,
+            scale_y=work_h / georef_h,
+        )
+    except Exception:
+        return None
+
+
+def _score_block_on_page(block: Polygon, pcd: PageColorData) -> float:
+    """Sum color-score values within the block polygon projected onto the page image.
+
+    Projects the block exterior from geo coords to work-pixel coords using the page's
+    affine, rasterizes with PIL.ImageDraw, then sums the color_score within the mask.
+    """
+    H, W = pcd.color_score.shape
+    coords_px = []
+    for lon, lat in block.exterior.coords:
+        px, py = _geo_to_pixel(lon, lat, pcd.A_fwd, pcd.A_inv)
+        coords_px.append((px * pcd.scale_x, py * pcd.scale_y))
+    mask_img = Image.new("L", (W, H), 0)
+    draw = ImageDraw.Draw(mask_img)
+    draw.polygon(coords_px, fill=1)
+    mask = np.array(mask_img, dtype=bool)
+    return float(pcd.color_score[mask].sum())
 
 
 def _polygonize_streets(
@@ -99,17 +182,17 @@ def _polygonize_streets(
 def _assign_blocks_to_pages(
     blocks: list[Polygon],
     page_polys: list[Polygon],
+    page_color_data: list[PageColorData | None] | None = None,
 ) -> dict[int, list[int]]:
-    """Assign each block to the page whose centroid is nearest (Voronoi assignment).
+    """Assign each block to the page with the highest color score (or nearest centroid).
 
-    Each block is assigned to the page with the minimum centroid-to-centroid
-    distance. Only pages with non-zero intersection with the block are eligible.
-    Tie-break: maximum intersection area.
+    When page_color_data is provided, each eligible (block, page) pair is scored by
+    summing color-spread values within the block on that page's work image. The page
+    with the highest score wins; centroid distance breaks ties, then intersection area.
+    Pages without color data receive a score of 0.
 
-    Distance-based (Voronoi) assignment naturally partitions the overlap zone
-    along perpendicular bisectors between page centers, producing connected
-    page territories. The earlier area-based approach let overlapping pages
-    steal blocks from deep inside a page's interior, creating disconnected masks.
+    When page_color_data is None, falls back to centroid-distance assignment (Voronoi):
+    the nearest page centroid wins with intersection area as tiebreak.
 
     Returns a dict mapping page_index → list of block indices.
     Blocks with zero intersection with every page are dropped.
@@ -120,6 +203,7 @@ def _assign_blocks_to_pages(
     for block_idx, block in enumerate(blocks):
         block_centroid = block.centroid
         best_page = -1
+        best_score = -1.0
         best_dist = float("inf")
         best_area = 0.0
 
@@ -128,11 +212,26 @@ def _assign_blocks_to_pages(
             area = inter.area
             if area <= 0:
                 continue
+
             dist = block_centroid.distance(page_centroids[page_idx])
-            if dist < best_dist or (dist == best_dist and area > best_area):
-                best_dist = dist
-                best_page = page_idx
-                best_area = area
+
+            if page_color_data is not None:
+                pcd = page_color_data[page_idx]
+                score = _score_block_on_page(block, pcd) if pcd is not None else 0.0
+                if (
+                    score > best_score
+                    or (score == best_score and dist < best_dist)
+                    or (score == best_score and dist == best_dist and area > best_area)
+                ):
+                    best_score = score
+                    best_page = page_idx
+                    best_dist = dist
+                    best_area = area
+            else:
+                if dist < best_dist or (dist == best_dist and area > best_area):
+                    best_dist = dist
+                    best_page = page_idx
+                    best_area = area
 
         if best_page >= 0:
             assignment[best_page].append(block_idx)
@@ -204,6 +303,7 @@ def _remove_spike_vertices(polygon: Polygon, min_turn_deg: float = 170.0) -> Pol
 def _assign_blocks_to_pages_with_splits(
     blocks: list[Polygon],
     page_polys: list[Polygon],
+    page_color_data: list[PageColorData | None] | None = None,
 ) -> dict[int, list[Polygon]]:
     """Assign blocks to pages, splitting blocks that straddle page boundaries.
 
@@ -222,7 +322,7 @@ def _assign_blocks_to_pages_with_splits(
     remaining: list[Polygon] = list(blocks)
 
     while remaining:
-        assignment = _assign_blocks_to_pages(remaining, page_polys)
+        assignment = _assign_blocks_to_pages(remaining, page_polys, page_color_data)
         if not any(assignment.values()):
             break  # all remaining subblocks are outside every page
 
@@ -248,6 +348,7 @@ def compute_all_clip_masks(
     centerlines_geojson: dict,
     simplify_tolerance: float = 0.00005,
     debug_blocks_out: list[dict] | None = None,
+    raw_paths: list[Path] | None = None,
 ) -> list[Polygon | None]:
     """Compute block-based clipping masks for all georeferenced pages.
 
@@ -265,6 +366,8 @@ def compute_all_clip_masks(
         simplify_tolerance: Douglas-Peucker tolerance in degrees (~0.00005 ≈ 5 m).
         debug_blocks_out: if provided, GeoJSON Feature dicts for each block are
             appended here (properties include 'page_idx': int | null).
+        raw_paths: if provided, raw JPEG paths parallel to georefs; used to load
+            color-score data for block assignment scoring.
     """
     if not georefs:
         return []
@@ -295,7 +398,21 @@ def compute_all_clip_masks(
     if not blocks:
         return [None] * len(georefs)
 
-    page_pieces = _assign_blocks_to_pages_with_splits(blocks, page_polys)
+    page_color_data: list[PageColorData | None] | None = None
+    if raw_paths is not None:
+        page_color_data = [
+            _load_page_color_data(path, georef)
+            for path, georef in zip(raw_paths, georefs)
+        ]
+        n_loaded = sum(pcd is not None for pcd in page_color_data)
+        print(
+            f"Loaded color data for {n_loaded}/{len(georefs)} pages.",
+            file=sys.stderr,
+        )
+
+    page_pieces = _assign_blocks_to_pages_with_splits(
+        blocks, page_polys, page_color_data
+    )
 
     if debug_blocks_out is not None:
         for page_idx, pieces in page_pieces.items():

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -563,7 +563,7 @@ def _fill_coverage_gaps(
         return masks
 
     new_masks: list[Polygon | None] = list(masks)
-    fill_count = 0
+    transfer_count = 0
     modified: set[int] = set()
 
     for gap_piece in gap_pieces:
@@ -594,6 +594,7 @@ def _fill_coverage_gaps(
             unclaimed = piece.difference(claimed)
             if unclaimed.is_empty:
                 continue
+            added = False
             for sub in _collect_polygons(unclaimed):
                 cur = new_masks[j]
                 if cur is None:
@@ -604,11 +605,13 @@ def _fill_coverage_gaps(
                 new_masks[j] = candidate
                 claimed = claimed.union(sub)
                 modified.add(j)
-                fill_count += 1
+                added = True
+            if added:
+                transfer_count += 1
 
-    if fill_count:
+    if transfer_count:
         print(
-            f"Gap-filling: {fill_count} piece(s) added across {len(modified)} page(s).",
+            f"Gap-filling: {transfer_count} transfer(s) across {len(modified)} page(s).",
             file=sys.stderr,
         )
 

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -713,6 +713,7 @@ def compute_all_clip_masks(
                 )
 
     masks: list[Polygon | None] = []
+    convex_hull_count = 0
     for page_idx, georef in enumerate(georefs):
         pieces = page_pieces.get(page_idx, [])
         if not pieces:
@@ -757,6 +758,7 @@ def compute_all_clip_masks(
                         file=sys.stderr,
                     )
                     mask_geo = hull_mask
+                    convex_hull_count += 1
                 else:
                     raise ValueError(
                         f"Page {page_idx} (corners starting at {georef['corners'][0]}) "
@@ -801,6 +803,41 @@ def compute_all_clip_masks(
         f"Coverage retention: {retention:.1%} of pre-clip area remains covered.",
         file=sys.stderr,
     )
+
+    # Pages not fully block-clipped: None mask (full-page rect) or convex hull fallback.
+    none_count = sum(1 for m in masks if m is None)
+    fallback_total = none_count + convex_hull_count
+    print(
+        f"Unclipped: {fallback_total} page(s) without full block mask "
+        f"({none_count} no blocks, {convex_hull_count} convex hull).",
+        file=sys.stderr,
+    )
+
+    # Double-coverage: excess area from overlapping effective masks.
+    individual_area = sum(m.area for m in effective)
+    double_coverage = (
+        (individual_area - post_area) / post_area if post_area > 0 else 0.0
+    )
+    print(f"Double-coverage: {double_coverage:.1%} of covered area.", file=sys.stderr)
+
+    # Color retention: fraction of each page's colored pixels that fall within its mask.
+    if page_color_data is not None:
+        total_color = 0.0
+        retained_color = 0.0
+        for mask, pcd in zip(masks, page_color_data):
+            if pcd is None:
+                continue
+            page_total = float(pcd.color_score.sum())
+            total_color += page_total
+            if mask is None:
+                retained_color += page_total  # full-page rect retains all color
+            else:
+                retained_color += _score_block_on_page(mask, pcd)
+        if total_color > 0:
+            print(
+                f"Color retention: {retained_color / total_color:.1%} of color pixels within mask.",
+                file=sys.stderr,
+            )
 
     return masks
 

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -140,6 +140,57 @@ def _assign_blocks_to_pages(
     return assignment
 
 
+def _collect_polygons(geom: object) -> list[Polygon]:
+    """Extract all non-empty Polygon parts from any Shapely geometry."""
+    if isinstance(geom, Polygon):
+        return [] if geom.is_empty else [geom]
+    if isinstance(geom, BaseMultipartGeometry):
+        return [p for p in geom.geoms if isinstance(p, Polygon) and not p.is_empty]
+    return []
+
+
+def _assign_blocks_to_pages_with_splits(
+    blocks: list[Polygon],
+    page_polys: list[Polygon],
+) -> dict[int, list[Polygon]]:
+    """Assign blocks to pages, splitting blocks that straddle page boundaries.
+
+    Iteratively assigns the current pool of subblocks. For each subblock assigned
+    to a page, the intersection with that page is added to that page's territory;
+    the remainder (outside the page) is queued for the next round. Because the
+    remainder has zero intersection with the page that already claimed the inside,
+    it will be assigned to a different page (or dropped if it overlaps none).
+
+    Convergence is guaranteed: each outside part is strictly smaller than the
+    subblock it came from, and the set of eligible pages shrinks each round.
+
+    Returns page_idx → list of Polygon pieces already clipped to the page boundary.
+    """
+    page_territory: dict[int, list[Polygon]] = {i: [] for i in range(len(page_polys))}
+    remaining: list[Polygon] = list(blocks)
+
+    while remaining:
+        assignment = _assign_blocks_to_pages(remaining, page_polys)
+        if not any(assignment.values()):
+            break  # all remaining subblocks are outside every page
+
+        next_remaining: list[Polygon] = []
+        for page_idx, block_indices in assignment.items():
+            page_poly = page_polys[page_idx]
+            for block_idx in block_indices:
+                subblock = remaining[block_idx]
+                inside = subblock.intersection(page_poly)
+                outside = subblock.difference(page_poly)
+                page_territory[page_idx].extend(_collect_polygons(inside))
+                for piece in _collect_polygons(outside):
+                    if piece.area > 1e-14:
+                        next_remaining.append(piece)
+
+        remaining = next_remaining
+
+    return page_territory
+
+
 def compute_all_clip_masks(
     georefs: list[dict],
     centerlines_geojson: dict,
@@ -192,32 +243,27 @@ def compute_all_clip_masks(
     if not blocks:
         return [None] * len(georefs)
 
-    assignment = _assign_blocks_to_pages(blocks, page_polys)
+    page_pieces = _assign_blocks_to_pages_with_splits(blocks, page_polys)
 
     if debug_blocks_out is not None:
-        block_to_page = {
-            block_idx: page_idx
-            for page_idx, block_indices in assignment.items()
-            for block_idx in block_indices
-        }
-        for block_idx, block in enumerate(blocks):
-            debug_blocks_out.append(
-                {
-                    "type": "Feature",
-                    "properties": {"page_idx": block_to_page.get(block_idx)},
-                    "geometry": geom_mapping(block),
-                }
-            )
+        for page_idx, pieces in page_pieces.items():
+            for piece in pieces:
+                debug_blocks_out.append(
+                    {
+                        "type": "Feature",
+                        "properties": {"page_idx": page_idx},
+                        "geometry": geom_mapping(piece),
+                    }
+                )
 
     masks: list[Polygon | None] = []
     for page_idx, georef in enumerate(georefs):
-        block_indices = assignment.get(page_idx, [])
-        if not block_indices:
+        pieces = page_pieces.get(page_idx, [])
+        if not pieces:
             masks.append(None)
             continue
 
-        assigned = [blocks[i] for i in block_indices]
-        mask_geo = unary_union(assigned).intersection(page_polys[page_idx])
+        mask_geo = unary_union(pieces)
 
         if mask_geo.is_empty:
             masks.append(None)

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -533,6 +533,98 @@ def _fill_concave_dents(
     return new_masks
 
 
+def _fill_coverage_gaps(
+    masks: list[Polygon | None],
+    page_polys: list[Polygon],
+    simplify_tolerance: float = 0.00005,
+    min_gap_fraction: float = 0.001,
+) -> list[Polygon | None]:
+    """Fill uncovered regions within page extents by adding them to adjacent masks.
+
+    Computes union(page_polys) − union(masks) to find all gap areas, then for each
+    gap piece tries to assign it to a page whose mask it connects to (mask.union(piece)
+    is a Polygon). When the gap spans multiple page extents, the overlapping portion is
+    split and each page gets the part within its own extent.
+
+    Unlike dent-filling, no color check is applied — gap areas have no existing owner.
+    Convexity improvement is used only to break ties when multiple pages could absorb
+    the same overlapping gap area.
+    """
+    page_union = unary_union(page_polys)
+    mask_union = unary_union([m for m in masks if m is not None])
+    total_gaps = page_union.difference(mask_union)
+    if total_gaps.is_empty:
+        return masks
+
+    gap_pieces = _collect_polygons(total_gaps)
+    if not gap_pieces:
+        return masks
+
+    new_masks: list[Polygon | None] = list(masks)
+    fill_count = 0
+    modified: set[int] = set()
+
+    for gap_piece in gap_pieces:
+        claimed = Polygon()  # portion of this gap already assigned to some page
+
+        # For each page, compute the clipped sub-piece and check connectivity.
+        assignments: list[tuple[float, int, Polygon]] = []
+        for j, (mask_j, page_poly_j) in enumerate(zip(masks, page_polys)):
+            if mask_j is None:
+                continue
+            sub = gap_piece.intersection(page_poly_j)
+            if sub.is_empty:
+                continue
+            for piece in _collect_polygons(sub):
+                if piece.area < mask_j.area * min_gap_fraction:
+                    continue  # ignore tiny fragments
+                candidate = mask_j.union(piece)
+                if not isinstance(candidate, Polygon):
+                    continue  # piece doesn't connect to mask; skip
+                improvement = _convexity_ratio(candidate) - _convexity_ratio(mask_j)
+                assignments.append((improvement, j, piece))
+
+        # Process in descending convexity-improvement order; track claimed area to
+        # prevent the same gap region from being assigned to two overlapping pages.
+        assignments.sort(key=lambda t: (-t[0], t[1]))
+
+        for _, j, piece in assignments:
+            unclaimed = piece.difference(claimed)
+            if unclaimed.is_empty:
+                continue
+            for sub in _collect_polygons(unclaimed):
+                cur = new_masks[j]
+                if cur is None:
+                    continue
+                candidate = cur.union(sub)
+                if not isinstance(candidate, Polygon):
+                    continue
+                new_masks[j] = candidate
+                claimed = claimed.union(sub)
+                modified.add(j)
+                fill_count += 1
+
+    if fill_count:
+        print(
+            f"Gap-filling: {fill_count} piece(s) added across {len(modified)} page(s).",
+            file=sys.stderr,
+        )
+
+    # Re-apply simplification and spike removal to modified masks.
+    for j in modified:
+        mask = new_masks[j]
+        if mask is None:
+            continue
+        simplified = mask.simplify(simplify_tolerance, preserve_topology=True)
+        if isinstance(simplified, Polygon):
+            new_masks[j] = _remove_spike_vertices(simplified)
+        elif isinstance(simplified, MultiPolygon):
+            parts = sorted(simplified.geoms, key=lambda p: p.area, reverse=True)
+            new_masks[j] = _remove_spike_vertices(parts[0])
+
+    return new_masks
+
+
 def compute_all_clip_masks(
     georefs: list[dict],
     centerlines_geojson: dict,
@@ -688,6 +780,10 @@ def compute_all_clip_masks(
     # Fill concave dents: transfer pieces from neighboring pages when there's no
     # strong color reason to keep them there.
     masks = _fill_concave_dents(masks, page_color_data, page_polys, simplify_tolerance)
+
+    # Fill coverage gaps: add uncovered regions (within the page extent union but
+    # absent from every mask) to adjacent pages based on connectivity.
+    masks = _fill_coverage_gaps(masks, page_polys, simplify_tolerance)
 
     # Report what fraction of the original page coverage is still covered.
     # Pages without a computed mask fall back to their full page polygon.

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -159,7 +159,7 @@ def _polygonize_streets(
             continue
         # intersection of a LineString with a Polygon can be a Point, LineString,
         # MultiLineString, or GeometryCollection; collect only linear parts.
-        if hasattr(clipped, "geoms"):
+        if isinstance(clipped, BaseMultipartGeometry):
             for part in clipped.geoms:
                 if isinstance(part, LineString) and not part.is_empty:
                     lines.append(part)
@@ -479,14 +479,16 @@ def _fill_concave_dents(
 
     # Apply transfers using incrementally updated masks.
     for i, piece, j in candidates:
-        if new_masks[i] is None or new_masks[j] is None:
+        cur_i = new_masks[i]
+        cur_j = new_masks[j]
+        if cur_i is None or cur_j is None:
             continue
         # Verify j still owns the piece; an earlier transfer may have claimed it.
-        if new_masks[j].intersection(piece).area <= piece.area * 0.5:
+        if cur_j.intersection(piece).area <= piece.area * 0.5:
             continue
 
-        candidate_i = new_masks[i].union(piece)
-        candidate_j = new_masks[j].difference(piece)
+        candidate_i = cur_i.union(piece)
+        candidate_j = cur_j.difference(piece)
         if not isinstance(candidate_i, Polygon):
             continue
 
@@ -674,7 +676,7 @@ def compute_all_clip_masks(
             [(lon / cos_lat, lat) for lon, lat in scaled_buf.exterior.coords]
         )
         buffered.append(unbuf)
-    coverage_buffered: Polygon | MultiPolygon = unary_union(buffered)
+    coverage_buffered = cast(Polygon | MultiPolygon, unary_union(buffered))
 
     blocks = _polygonize_streets(centerlines_geojson, coverage_buffered)
     if not blocks:
@@ -764,8 +766,9 @@ def compute_all_clip_masks(
         # Remove backtrack vertices from any path (direct Polygon or resolved
         # MultiPolygon). Simplification can introduce spikes when it removes
         # intermediate vertices from narrow arms.
-        if isinstance(mask_geo, Polygon):
-            mask_geo = _remove_spike_vertices(mask_geo)
+        if not isinstance(mask_geo, Polygon):
+            continue
+        mask_geo = _remove_spike_vertices(mask_geo)
 
         # Warn if interior holes are present (unexpected with city block geometry).
         if len(mask_geo.interiors) > 0:
@@ -775,7 +778,7 @@ def compute_all_clip_masks(
                 file=sys.stderr,
             )
 
-        masks.append(cast(Polygon, mask_geo))
+        masks.append(mask_geo)
 
     # Fill concave dents: transfer pieces from neighboring pages when there's no
     # strong color reason to keep them there.

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -12,6 +12,7 @@ from typing import cast
 
 import numpy as np
 from shapely.geometry import LineString, MultiPolygon, Polygon
+from shapely.geometry import mapping as geom_mapping
 from shapely.geometry import shape as geom_shape
 from shapely.geometry.base import BaseMultipartGeometry
 from shapely.ops import polygonize, unary_union
@@ -143,6 +144,7 @@ def compute_all_clip_masks(
     georefs: list[dict],
     centerlines_geojson: dict,
     simplify_tolerance: float = 0.00005,
+    debug_blocks_out: list[dict] | None = None,
 ) -> list[Polygon | None]:
     """Compute block-based clipping masks for all georeferenced pages.
 
@@ -158,6 +160,8 @@ def compute_all_clip_masks(
         georefs: list of parsed georef.json dicts with 'corners', 'width', 'height'.
         centerlines_geojson: parsed GeoJSON FeatureCollection of LineStrings.
         simplify_tolerance: Douglas-Peucker tolerance in degrees (~0.00005 ≈ 5 m).
+        debug_blocks_out: if provided, GeoJSON Feature dicts for each block are
+            appended here (properties include 'page_idx': int | null).
     """
     if not georefs:
         return []
@@ -189,6 +193,21 @@ def compute_all_clip_masks(
         return [None] * len(georefs)
 
     assignment = _assign_blocks_to_pages(blocks, page_polys)
+
+    if debug_blocks_out is not None:
+        block_to_page = {
+            block_idx: page_idx
+            for page_idx, block_indices in assignment.items()
+            for block_idx in block_indices
+        }
+        for block_idx, block in enumerate(blocks):
+            debug_blocks_out.append(
+                {
+                    "type": "Feature",
+                    "properties": {"page_idx": block_to_page.get(block_idx)},
+                    "geometry": geom_mapping(block),
+                }
+            )
 
     masks: list[Polygon | None] = []
     for page_idx, georef in enumerate(georefs):

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -149,6 +149,27 @@ def _collect_polygons(geom: object) -> list[Polygon]:
     return []
 
 
+def _is_substantial(
+    piece: Polygon, reference: Polygon, min_fraction: float = 0.10
+) -> bool:
+    """Return True if piece is substantial relative to reference.
+
+    Requires the piece's area to be >= min_fraction of reference area AND
+    its bounding-box extent in both dimensions to be >= min_fraction of
+    reference extent. Rejects slivers that are narrow in any direction.
+    """
+    if piece.area < reference.area * min_fraction:
+        return False
+    rx_min, ry_min, rx_max, ry_max = reference.bounds
+    px_min, py_min, px_max, py_max = piece.bounds
+    ref_w, ref_h = rx_max - rx_min, ry_max - ry_min
+    if ref_w > 0 and (px_max - px_min) < ref_w * min_fraction:
+        return False
+    if ref_h > 0 and (py_max - py_min) < ref_h * min_fraction:
+        return False
+    return True
+
+
 def _assign_blocks_to_pages_with_splits(
     blocks: list[Polygon],
     page_polys: list[Polygon],
@@ -157,9 +178,9 @@ def _assign_blocks_to_pages_with_splits(
 
     Iteratively assigns the current pool of subblocks. For each subblock assigned
     to a page, the intersection with that page is added to that page's territory;
-    the remainder (outside the page) is queued for the next round. Because the
-    remainder has zero intersection with the page that already claimed the inside,
-    it will be assigned to a different page (or dropped if it overlaps none).
+    the remainder (outside the page) is queued for the next round only if it is
+    substantial relative to the subblock (≥10% of area and ≥10% of extent in both
+    dimensions). Thin slivers are discarded to avoid invalid geometry.
 
     Convergence is guaranteed: each outside part is strictly smaller than the
     subblock it came from, and the set of eligible pages shrinks each round.
@@ -183,7 +204,7 @@ def _assign_blocks_to_pages_with_splits(
                 outside = subblock.difference(page_poly)
                 page_territory[page_idx].extend(_collect_polygons(inside))
                 for piece in _collect_polygons(outside):
-                    if piece.area > 1e-14:
+                    if _is_substantial(piece, subblock):
                         next_remaining.append(piece)
 
         remaining = next_remaining

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -803,7 +803,7 @@ def compute_all_clip_masks(
 
 
 def geo_polygon_to_svg(
-    geo_polygon: Polygon | None,
+    geo_polygon: Polygon | MultiPolygon | None,
     georef: dict,
     source_width: int,
     source_height: int,

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -255,6 +255,17 @@ def compute_all_clip_masks(
 
         masks.append(cast(Polygon, mask_geo))
 
+    # Report what fraction of the original page coverage is still covered.
+    # Pages without a computed mask fall back to their full page polygon.
+    effective = [m if m is not None else p for m, p in zip(masks, page_polys)]
+    pre_area = unary_union(page_polys).area
+    post_area = unary_union(effective).area
+    retention = post_area / pre_area if pre_area > 0 else 1.0
+    print(
+        f"Coverage retention: {retention:.1%} of pre-clip area remains covered.",
+        file=sys.stderr,
+    )
+
     return masks
 
 

--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -170,6 +170,37 @@ def _is_substantial(
     return True
 
 
+def _remove_spike_vertices(polygon: Polygon, min_turn_deg: float = 170.0) -> Polygon:
+    """Remove backtrack vertices from a polygon's exterior ring.
+
+    A backtrack vertex is one where the signed turn angle is ≥ min_turn_deg,
+    meaning the polygon boundary reverses direction and creates a spike or
+    antenna. These vertices cause triangulation failures in viewers like Allmaps.
+
+    Iterates until no more backtrack vertices remain (multi-vertex spikes may
+    require more than one pass).
+    """
+    coords = list(polygon.exterior.coords[:-1])  # drop closing duplicate
+    while True:
+        n = len(coords)
+        keep = []
+        for i in range(n):
+            prev = coords[(i - 1) % n]
+            cur = coords[i]
+            nxt = coords[(i + 1) % n]
+            v1 = (cur[0] - prev[0], cur[1] - prev[1])
+            v2 = (nxt[0] - cur[0], nxt[1] - cur[1])
+            cross = v1[0] * v2[1] - v1[1] * v2[0]
+            dot = v1[0] * v2[0] + v1[1] * v2[1]
+            turn = math.degrees(math.atan2(cross, dot))
+            if abs(turn) < min_turn_deg:
+                keep.append(cur)
+        if len(keep) == n or len(keep) < 3:
+            break
+        coords = keep
+    return Polygon(coords)
+
+
 def _assign_blocks_to_pages_with_splits(
     blocks: list[Polygon],
     page_polys: list[Polygon],
@@ -291,6 +322,9 @@ def compute_all_clip_masks(
             continue
 
         mask_geo = mask_geo.simplify(simplify_tolerance, preserve_topology=True)
+
+        if isinstance(mask_geo, Polygon):
+            mask_geo = _remove_spike_vertices(mask_geo)
 
         if isinstance(mask_geo, MultiPolygon):
             # Filter out disconnected slivers (< 5% of the largest component).

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -8,6 +8,7 @@ from shapely.geometry import MultiPolygon, Polygon
 
 from mapsnap.clip_masks import (
     _assign_blocks_to_pages,
+    _assign_blocks_to_pages_with_splits,
     _fit_affine,
     _polygonize_streets,
     compute_all_clip_masks,
@@ -210,6 +211,41 @@ def test_assign_no_double_assignment():
 
 
 # ---------------------------------------------------------------------------
+# _assign_blocks_to_pages_with_splits
+# ---------------------------------------------------------------------------
+
+
+def test_split_border_block_covers_both_pages():
+    """A block straddling two pages is split, giving each page its half."""
+    page0 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    page1 = Polygon([(1, 0), (2, 0), (2, 1), (1, 1)])
+    # Block x in [0.5, 1.5]: equal halves in each page.
+    block = Polygon([(0.5, 0.2), (1.5, 0.2), (1.5, 0.8), (0.5, 0.8)])
+    pieces = _assign_blocks_to_pages_with_splits([block], [page0, page1])
+    assert len(pieces[0]) > 0, "page0 should receive a piece"
+    assert len(pieces[1]) > 0, "page1 should receive a piece"
+    total_area = sum(p.area for ps in pieces.values() for p in ps)
+    assert abs(total_area - block.area) < 1e-10, "pieces should cover the full block"
+
+
+def test_split_fully_inside_block_stays_whole():
+    """A block entirely inside a page is not split."""
+    page = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+    block = Polygon([(2, 2), (5, 2), (5, 5), (2, 5)])
+    pieces = _assign_blocks_to_pages_with_splits([block], [page])
+    assert len(pieces[0]) == 1
+    assert abs(pieces[0][0].area - block.area) < 1e-10
+
+
+def test_split_outside_block_dropped():
+    """A block with no overlap with any page produces no pieces."""
+    page = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    block = Polygon([(5, 5), (6, 5), (6, 6), (5, 6)])
+    pieces = _assign_blocks_to_pages_with_splits([block], [page])
+    assert all(len(ps) == 0 for ps in pieces.values())
+
+
+# ---------------------------------------------------------------------------
 # compute_all_clip_masks
 # ---------------------------------------------------------------------------
 
@@ -261,9 +297,9 @@ def test_compute_masks_empty_centerlines():
     masks = compute_all_clip_masks(
         georefs, {"type": "FeatureCollection", "features": []}
     )
-    # With no centerlines the boundary ring creates at most 1 block; most pages get None.
+    # With no centerlines the boundary ring creates a single large block that is
+    # split among all overlapping pages, so all pages may get a non-None mask.
     assert len(masks) == len(georefs)
-    assert sum(m is None for m in masks) >= len(georefs) - 1
 
 
 # ---------------------------------------------------------------------------

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -11,6 +11,8 @@ from mapsnap.clip_masks import (
     PageColorData,
     _assign_blocks_to_pages,
     _assign_blocks_to_pages_with_splits,
+    _convexity_ratio,
+    _fill_concave_dents,
     _fit_affine,
     _is_substantial,
     _load_page_color_data,
@@ -488,6 +490,92 @@ def test_score_block_bright_region():
     pcd = _make_page_color_data(georef, arr)
     block = Polygon([(0.2, 0.2), (0.8, 0.2), (0.8, 0.8), (0.2, 0.8)])
     assert _score_block_on_page(block, pcd) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# _fill_concave_dents
+# ---------------------------------------------------------------------------
+
+
+def test_fill_concave_dents_transfers_notch():
+    """Dent region owned by page j is transferred to page i when color is equal."""
+    # mask_i: L-shape (area=3). convex_hull is a pentagon (area=3.5); the
+    # dent is the triangle [(2,1),(1,1),(1,2)] with area=0.5.
+    # mask_j: unit square [(1,1)×(2,2)] that owns the dent triangle.
+    mask_i = Polygon([(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)])
+    mask_j = Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])
+
+    result = _fill_concave_dents([mask_i, mask_j], page_color_data=None)
+
+    # mask_i should absorb the dent triangle and equal its convex hull (area=3.5).
+    assert result[0] is not None
+    assert abs(result[0].area - mask_i.convex_hull.area) < 1e-6
+    # mask_j lost the dent triangle → area shrank from 1.0 to 0.5.
+    assert result[1] is not None
+    assert result[1].area < mask_j.area
+
+
+def test_fill_concave_dents_no_transfer_when_color_dominates():
+    """Notch is NOT transferred when the owning page has substantially more color."""
+    mask_i = Polygon([(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)])
+    mask_j = Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])
+
+    # page j has high color everywhere; page i has none.
+    georef_i = _axis_aligned_georef(0.0, 0.0, 2.0, 2.0, w=20, h=20)
+    georef_j = _axis_aligned_georef(1.0, 1.0, 2.0, 2.0, w=10, h=10)
+    pcd_i = _make_page_color_data(georef_i, np.zeros((20, 20), dtype=np.int16))
+    pcd_j = _make_page_color_data(georef_j, np.full((10, 10), 200, dtype=np.int16))
+
+    result = _fill_concave_dents([mask_i, mask_j], page_color_data=[pcd_i, pcd_j])
+
+    # Transfer should be blocked — mask_j still owns the notch.
+    assert result[1] is not None
+    assert abs(result[1].area - mask_j.area) < 1e-6
+
+
+def test_fill_concave_dents_arm_via_page_poly():
+    """Arm in j's territory inside i's page extent is transferred using page_poly detection.
+
+    Hull-based detection would miss this arm because it isn't inside hull(mask_i).
+    Page_poly-based detection finds it via page_poly_i − mask_i.
+
+    Geometry:
+      page_poly_p32: [(0,0)-(4,6)]  p32's full geographic extent
+      mask_p32:      [(0,0)-(4,3)]  only south half of p32
+      page_poly_p24: [(0,5)-(4,9)]  p24's extent (north of p32)
+      arm:     [(1,3)-(2,5.5)]      thin strip in p32's upper area, protrudes down from p24
+      mask_p24: rect[(0,5)-(4,9)] ∪ arm  — arm hangs below p24's main territory into p32's extent
+    """
+    page_poly_p32 = Polygon([(0, 0), (4, 0), (4, 6), (0, 6)])
+    mask_p32 = Polygon([(0, 0), (4, 0), (4, 3), (0, 3)])
+    page_poly_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)])
+    arm = Polygon([(1, 3), (2, 3), (2, 5.5), (1, 5.5)])
+    mask_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)]).union(arm)
+    assert isinstance(mask_p24, Polygon), "test setup: mask_p24 must be a Polygon"
+
+    # Without page_polys (hull-based), the arm should NOT be detected:
+    # hull(mask_p32) only extends to y=3, so the arm at y=[3,5.5] is outside it.
+    result_hull = _fill_concave_dents(
+        [mask_p32, mask_p24], page_color_data=None, page_polys=None
+    )
+    assert result_hull[1] is not None
+    assert abs(result_hull[1].area - mask_p24.area) < 1e-6, (
+        "hull-based: arm should NOT be transferred (it's outside hull(mask_p32))"
+    )
+
+    # With page_polys (page-poly-based), the arm IS in page_poly_p32.difference(mask_p32),
+    # and removing it improves p24's convexity ratio.
+    result_poly = _fill_concave_dents(
+        [mask_p32, mask_p24],
+        page_color_data=None,
+        page_polys=[page_poly_p32, page_poly_p24],
+    )
+    assert result_poly[0] is not None
+    assert result_poly[0].area > mask_p32.area, "p32 should gain the arm"
+    assert result_poly[1] is not None
+    assert result_poly[1].area < mask_p24.area, "p24 should lose the arm"
+    # Convexity of p24 should improve after losing the arm.
+    assert _convexity_ratio(result_poly[1]) > _convexity_ratio(mask_p24)
 
 
 def test_assign_uses_color_score_over_centroid():

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -1,0 +1,337 @@
+"""Tests for clip_masks.py."""
+
+import math
+
+import numpy as np
+import pytest
+from shapely.geometry import MultiPolygon, Polygon
+
+from mapsnap.clip_masks import (
+    _assign_blocks_to_pages,
+    _fit_affine,
+    _polygonize_streets,
+    compute_all_clip_masks,
+    geo_polygon_to_svg,
+)
+
+
+def _make_georef(
+    width: int,
+    height: int,
+    corners: list[list[float]],
+) -> dict:
+    """Build a minimal georef dict for testing."""
+    return {"width": width, "height": height, "corners": corners}
+
+
+def _axis_aligned_georef(
+    lon0: float, lat0: float, lon1: float, lat1: float, w: int = 1000, h: int = 1000
+) -> dict:
+    """Return a georef whose corners form an axis-aligned lon/lat rectangle.
+
+    corners: TL=(lon0,lat1), TR=(lon1,lat1), BR=(lon1,lat0), BL=(lon0,lat0)
+    (image y increases downward, lat increases upward).
+    """
+    return _make_georef(
+        w,
+        h,
+        [
+            [lon0, lat1],  # TL: pixel (0,0)
+            [lon1, lat1],  # TR: pixel (w,0)
+            [lon1, lat0],  # BR: pixel (w,h)
+            [lon0, lat0],  # BL: pixel (0,h)
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _fit_affine
+# ---------------------------------------------------------------------------
+
+
+def test_fit_affine_round_trips_corners():
+    """Forward affine maps pixel corners to the correct geo coords."""
+    georef = _axis_aligned_georef(-90.0, 30.0, -89.9, 30.1)
+    A_fwd, _ = _fit_affine(georef)
+    w, h = float(georef["width"]), float(georef["height"])
+    pixel_pts = np.array([[0, 0], [w, 0], [w, h], [0, h]])
+    for (px, py), expected in zip(pixel_pts, georef["corners"]):
+        result = A_fwd @ np.array([px, py, 1.0])
+        np.testing.assert_allclose(result, expected, atol=1e-9)
+
+
+def test_fit_affine_inverse_round_trips():
+    """Inverse affine maps geo corners back to pixel coords."""
+    georef = _axis_aligned_georef(-90.0, 30.0, -89.9, 30.1)
+    A_fwd, A_inv = _fit_affine(georef)
+    w, h = float(georef["width"]), float(georef["height"])
+    expected_pixels = [(0, 0), (w, 0), (w, h), (0, h)]
+    for (lon, lat), (ex, ey) in zip(georef["corners"], expected_pixels):
+        geo_vec = np.array([lon, lat]) - A_fwd[:, 2]
+        px, py = A_inv @ geo_vec
+        assert abs(px - ex) < 1e-5
+        assert abs(py - ey) < 1e-5
+
+
+def test_fit_affine_handles_rotated_map():
+    """Affine fit works when the map is ~45° rotated in geo space."""
+    # Rotate a square 45°: TL→top, TR→right, BR→bottom, BL→left.
+    d = 0.1
+    corners = [
+        [0.0, d],  # TL: pixel (0,0) → north tip
+        [d, 0.0],  # TR: pixel (w,0) → east tip
+        [0.0, -d],  # BR: pixel (w,h) → south tip
+        [-d, 0.0],  # BL: pixel (0,h) → west tip
+    ]
+    georef = _make_georef(1000, 1000, corners)
+    A_fwd, A_inv = _fit_affine(georef)
+    w, h = 1000.0, 1000.0
+    for (px, py), expected in zip([(0, 0), (w, 0), (w, h), (0, h)], corners):
+        result = A_fwd @ np.array([px, py, 1.0])
+        np.testing.assert_allclose(result, expected, atol=1e-9)
+        geo_vec = np.array(expected) - A_fwd[:, 2]
+        rx, ry = A_inv @ geo_vec
+        assert abs(rx - px) < 1e-6
+        assert abs(ry - py) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# _polygonize_streets
+# ---------------------------------------------------------------------------
+
+
+def _line_feature(coords: list[list[float]]) -> dict:
+    return {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {"type": "LineString", "coordinates": coords},
+    }
+
+
+def _geojson(*features: dict) -> dict:
+    return {"type": "FeatureCollection", "features": list(features)}
+
+
+def test_polygonize_simple_grid():
+    """A 2×2 street grid inside a bounding box produces ≥4 blocks."""
+    # Coverage: unit square [0,1]×[0,1]
+    coverage = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    gj = _geojson(
+        _line_feature([[0.5, 0.0], [0.5, 1.0]]),  # vertical line x=0.5
+        _line_feature([[0.0, 0.5], [1.0, 0.5]]),  # horizontal line y=0.5
+    )
+    blocks = _polygonize_streets(gj, coverage)
+    # With the boundary ring added: 4 cells from the grid + boundary edges
+    assert len(blocks) >= 4
+
+
+def test_polygonize_boundary_closes_open_ends():
+    """A single horizontal line + coverage boundary creates ≥2 blocks."""
+    coverage = Polygon([(0, 0), (2, 0), (2, 1), (0, 1)])
+    gj = _geojson(
+        _line_feature([[0.0, 0.5], [2.0, 0.5]]),  # divides rectangle in half
+    )
+    blocks = _polygonize_streets(gj, coverage)
+    assert len(blocks) >= 2
+
+
+def test_polygonize_empty_centerlines():
+    """No features → no blocks (just the boundary, which doesn't polygonize alone)."""
+    coverage = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    gj = _geojson()
+    blocks = _polygonize_streets(gj, coverage)
+    # A single closed ring with no interior lines produces 0 blocks from polygonize.
+    assert isinstance(blocks, list)
+
+
+def test_polygonize_clips_outside_coverage():
+    """Lines entirely outside the coverage polygon are excluded."""
+    coverage = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    gj = _geojson(
+        _line_feature([[2.0, 0.5], [3.0, 0.5]]),  # entirely outside
+        _line_feature([[0.5, 0.0], [0.5, 1.0]]),  # inside — splits coverage
+    )
+    blocks = _polygonize_streets(gj, coverage)
+    # Only the inside line contributes; should produce ≥2 blocks.
+    assert len(blocks) >= 2
+
+
+# ---------------------------------------------------------------------------
+# _assign_blocks_to_pages
+# ---------------------------------------------------------------------------
+
+
+def test_assign_primary_by_area():
+    """Block mostly inside page 0 is assigned to page 0."""
+    page0 = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])  # x in [0,10]
+    page1 = Polygon([(8, 0), (20, 0), (20, 10), (8, 10)])  # x in [8,20]
+    # Block x in [0,9]: 90% in page0, 10% in page1.
+    block = Polygon([(0, 0), (9, 0), (9, 10), (0, 10)])
+    result = _assign_blocks_to_pages([block], [page0, page1])
+    assert 0 in result[0]
+    assert result[1] == []
+
+
+def test_assign_tiebreak_by_distance():
+    """When overlap areas are equal, the closer page centroid wins."""
+    # Two adjacent unit squares; block is exactly on the border.
+    page0 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])  # centroid (0.5, 0.5)
+    page1 = Polygon([(1, 0), (2, 0), (2, 1), (1, 1)])  # centroid (1.5, 0.5)
+    # Block spans both pages equally (0.5 units each side of x=1).
+    block = Polygon([(0.5, 0.25), (1.5, 0.25), (1.5, 0.75), (0.5, 0.75)])
+    result = _assign_blocks_to_pages([block], [page0, page1])
+    # Block centroid is at (1.0, 0.5); both pages equally distant at 0.5 units.
+    # Either assignment is valid; just verify it went somewhere.
+    assert result[0] == [0] or result[1] == [0]
+
+
+def test_assign_no_overlap_block_dropped():
+    """Block with no overlap with any page is not assigned."""
+    page = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    block = Polygon([(5, 5), (6, 5), (6, 6), (5, 6)])  # far away
+    result = _assign_blocks_to_pages([block], [page])
+    assert result[0] == []
+
+
+def test_assign_no_double_assignment():
+    """No block is assigned to more than one page."""
+    page0 = Polygon([(0, 0), (5, 0), (5, 5), (0, 5)])
+    page1 = Polygon([(4, 0), (10, 0), (10, 5), (4, 5)])
+    blocks = [
+        Polygon([(0, 0), (4, 0), (4, 5), (0, 5)]),
+        Polygon([(4, 0), (5, 0), (5, 5), (4, 5)]),
+        Polygon([(5, 0), (10, 0), (10, 5), (5, 5)]),
+    ]
+    result = _assign_blocks_to_pages(blocks, [page0, page1])
+    all_assigned = result[0] + result[1]
+    assert len(all_assigned) == len(set(all_assigned)), (
+        "Block assigned to multiple pages"
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_all_clip_masks
+# ---------------------------------------------------------------------------
+
+
+def _simple_georef_row() -> tuple[list[dict], dict]:
+    """Three adjacent pages with a simple 3-column street grid.
+
+    Pages are 1°×1° boxes at lon 0-1, 1-2, 2-3; all at lat 0-1.
+    Centerlines are the vertical lines at lon=0.5, 1.5, 2.5 (one per page interior).
+    """
+    georefs = [
+        _axis_aligned_georef(0.0, 0.0, 1.0, 1.0),
+        _axis_aligned_georef(1.0, 0.0, 2.0, 1.0),
+        _axis_aligned_georef(2.0, 0.0, 3.0, 1.0),
+    ]
+    gj = _geojson(
+        _line_feature([[0.5, 0.0], [0.5, 1.0]]),
+        _line_feature([[1.5, 0.0], [1.5, 1.0]]),
+        _line_feature([[2.5, 0.0], [2.5, 1.0]]),
+    )
+    return georefs, gj
+
+
+def test_compute_masks_returns_one_per_georef():
+    georefs, gj = _simple_georef_row()
+    masks = compute_all_clip_masks(georefs, gj)
+    assert len(masks) == 3
+
+
+def test_compute_masks_within_page_bounds():
+    georefs, gj = _simple_georef_row()
+    masks = compute_all_clip_masks(georefs, gj)
+    for georef, mask in zip(georefs, masks):
+        if mask is None:
+            continue
+        page_poly = Polygon(georef["corners"])
+        # mask should be (approximately) contained in the page polygon.
+        assert mask.difference(page_poly.buffer(1e-8)).area < 1e-8
+
+
+def test_compute_masks_empty_georefs():
+    assert (
+        compute_all_clip_masks([], {"type": "FeatureCollection", "features": []}) == []
+    )
+
+
+def test_compute_masks_empty_centerlines():
+    georefs, _ = _simple_georef_row()
+    masks = compute_all_clip_masks(
+        georefs, {"type": "FeatureCollection", "features": []}
+    )
+    # With no centerlines the boundary ring creates at most 1 block; most pages get None.
+    assert len(masks) == len(georefs)
+    assert sum(m is None for m in masks) >= len(georefs) - 1
+
+
+# ---------------------------------------------------------------------------
+# geo_polygon_to_svg
+# ---------------------------------------------------------------------------
+
+
+def test_svg_none_returns_full_page_rect():
+    georef = _axis_aligned_georef(-90.0, 30.0, -89.9, 30.1, w=2000, h=3000)
+    svg = geo_polygon_to_svg(None, georef, 2000, 3000)
+    assert "2000" in svg
+    assert "3000" in svg
+    assert svg.count("<polygon") == 1
+
+
+def test_svg_full_page_polygon_gives_corner_coords():
+    """A polygon equal to the page corners should give approximately full-page coords."""
+    georef = _axis_aligned_georef(-90.0, 30.0, -89.9, 30.1, w=1000, h=1000)
+    page_poly = Polygon(georef["corners"])
+    svg = geo_polygon_to_svg(page_poly, georef, 1000, 1000)
+    assert "<polygon" in svg
+    assert "<svg>" in svg
+
+
+def test_svg_known_coords():
+    """For an axis-aligned page, corners map to exact pixel coords."""
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=100, h=100)
+    # A polygon exactly matching the page corners (but using just 4 points).
+    poly = Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)])
+    svg = geo_polygon_to_svg(poly, georef, 100, 100)
+    # Should include corner pixel coords (0,0), (100,0), (100,100), (0,100).
+    assert "0.0,0.0" in svg or "0,0" in svg
+
+
+def test_svg_split_canvas_offset():
+    """Split-canvas coordinates include the (cx, cy) offset."""
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=100, h=100)
+    poly = Polygon([(0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)])
+    split = (500.0, 200.0, 100.0, 100.0)  # offset (500, 200)
+    svg = geo_polygon_to_svg(poly, georef, 1000, 1000, split_canvas=split)
+    # The top-left corner pixel (0,0) → canvas (500, 200).
+    assert "500.0,200.0" in svg
+
+
+def test_svg_multipolygon_raises():
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0)
+    mp = MultiPolygon(
+        [
+            Polygon([(0, 0), (0.4, 0), (0.4, 1), (0, 1)]),
+            Polygon([(0.6, 0), (1, 0), (1, 1), (0.6, 1)]),
+        ]
+    )
+    with pytest.raises(ValueError, match="MultiPolygon"):
+        geo_polygon_to_svg(mp, georef, 1000, 1000)
+
+
+def test_svg_empty_polygon_returns_full_page_rect():
+    georef = _axis_aligned_georef(-90.0, 30.0, -89.9, 30.1, w=2000, h=3000)
+    empty = Polygon()
+    svg = geo_polygon_to_svg(empty, georef, 2000, 3000)
+    assert "2000" in svg
+    assert "3000" in svg
+
+
+def test_svg_buffer_is_0_5_miles():
+    """Verify the buffer constant is approximately 0.5 miles in degrees lat."""
+    from mapsnap.clip_masks import _BUFFER_LAT_DEG
+
+    miles_per_degree_lat = 111_320.0 / 1609.344  # ≈ 69.1 miles
+    expected = 0.5 / miles_per_degree_lat
+    assert math.isclose(_BUFFER_LAT_DEG, expected, rel_tol=1e-6)

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -319,6 +319,23 @@ def test_remove_spike_collinear_not_removed():
 
 
 # ---------------------------------------------------------------------------
+# _convexity_ratio
+# ---------------------------------------------------------------------------
+
+
+def test_convexity_ratio_square():
+    """A square is perfectly convex: ratio = 1.0."""
+    square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    assert abs(_convexity_ratio(square) - 1.0) < 1e-9
+
+
+def test_convexity_ratio_l_shape():
+    """An L-shape has ratio < 1.0 (area=3, convex hull is a pentagon with area=3.5 → 6/7)."""
+    l_shape = Polygon([(0, 0), (2, 0), (2, 1), (1, 1), (1, 2), (0, 2)])
+    assert abs(_convexity_ratio(l_shape) - 6 / 7) < 1e-9
+
+
+# ---------------------------------------------------------------------------
 # compute_all_clip_masks
 # ---------------------------------------------------------------------------
 
@@ -373,6 +390,31 @@ def test_compute_masks_empty_centerlines():
     # With no centerlines the boundary ring creates a single large block that is
     # split among all overlapping pages, so all pages may get a non-None mask.
     assert len(masks) == len(georefs)
+
+
+def test_compute_masks_overlapping_pages_no_overlap():
+    """Masks for geographically overlapping pages do not overlap each other.
+
+    Pages cover lon=[0,2] and lon=[1,3] (overlap at lon=[1,2]). Each block is
+    assigned to exactly one page via the split-assignment loop, so the resulting
+    masks must be disjoint.
+    """
+    georefs = [
+        _axis_aligned_georef(0.0, 0.0, 2.0, 1.0),  # lon 0-2
+        _axis_aligned_georef(1.0, 0.0, 3.0, 1.0),  # lon 1-3, overlaps with page 0
+    ]
+    gj = _geojson(
+        _line_feature([[0.5, 0.0], [0.5, 1.0]]),
+        _line_feature([[1.5, 0.0], [1.5, 1.0]]),
+        _line_feature([[2.5, 0.0], [2.5, 1.0]]),
+    )
+    masks = compute_all_clip_masks(georefs, gj)
+    assert len(masks) == 2
+    m0, m1 = masks
+    assert m0 is not None and m1 is not None
+    assert m0.intersection(m1).area < 1e-8, (
+        "masks for overlapping pages must not overlap"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -579,6 +621,59 @@ def test_fill_concave_dents_arm_via_page_poly():
     assert _convexity_ratio(result_poly[1]) > _convexity_ratio(mask_p24)
 
 
+def test_fill_concave_dents_page_poly_with_color_transfers():
+    """With both page_polys and color_data, arm is transferred when color is similar."""
+    # Same arm geometry as test_fill_concave_dents_arm_via_page_poly.
+    page_poly_p32 = Polygon([(0, 0), (4, 0), (4, 6), (0, 6)])
+    mask_p32 = Polygon([(0, 0), (4, 0), (4, 3), (0, 3)])
+    page_poly_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)])
+    arm = Polygon([(1, 3), (2, 3), (2, 5.5), (1, 5.5)])
+    mask_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)]).union(arm)
+    assert isinstance(mask_p24, Polygon)
+
+    # Both pages have zero color — no dominance, transfer should proceed.
+    georef_p32 = _axis_aligned_georef(0.0, 0.0, 4.0, 6.0, w=40, h=60)
+    georef_p24 = _axis_aligned_georef(0.0, 5.0, 4.0, 9.0, w=40, h=40)
+    pcd_p32 = _make_page_color_data(georef_p32, np.zeros((60, 40), dtype=np.int16))
+    pcd_p24 = _make_page_color_data(georef_p24, np.zeros((40, 40), dtype=np.int16))
+
+    result = _fill_concave_dents(
+        [mask_p32, mask_p24],
+        page_color_data=[pcd_p32, pcd_p24],
+        page_polys=[page_poly_p32, page_poly_p24],
+    )
+    assert result[0] is not None
+    assert result[0].area > mask_p32.area, "p32 should gain the arm"
+    assert result[1] is not None
+    assert result[1].area < mask_p24.area, "p24 should lose the arm"
+
+
+def test_fill_concave_dents_page_poly_color_blocks_transfer():
+    """With both page_polys and color_data, arm is NOT transferred when j dominates."""
+    page_poly_p32 = Polygon([(0, 0), (4, 0), (4, 6), (0, 6)])
+    mask_p32 = Polygon([(0, 0), (4, 0), (4, 3), (0, 3)])
+    page_poly_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)])
+    arm = Polygon([(1, 3), (2, 3), (2, 5.5), (1, 5.5)])
+    mask_p24 = Polygon([(0, 5), (4, 5), (4, 9), (0, 9)]).union(arm)
+    assert isinstance(mask_p24, Polygon)
+
+    # p24 has high color everywhere; p32 has none → color dominance blocks transfer.
+    georef_p32 = _axis_aligned_georef(0.0, 0.0, 4.0, 6.0, w=40, h=60)
+    georef_p24 = _axis_aligned_georef(0.0, 5.0, 4.0, 9.0, w=40, h=40)
+    pcd_p32 = _make_page_color_data(georef_p32, np.zeros((60, 40), dtype=np.int16))
+    pcd_p24 = _make_page_color_data(georef_p24, np.full((40, 40), 200, dtype=np.int16))
+
+    result = _fill_concave_dents(
+        [mask_p32, mask_p24],
+        page_color_data=[pcd_p32, pcd_p24],
+        page_polys=[page_poly_p32, page_poly_p24],
+    )
+    assert result[0] is not None
+    assert abs(result[0].area - mask_p32.area) < 1e-6, "p32 should NOT gain the arm"
+    assert result[1] is not None
+    assert abs(result[1].area - mask_p24.area) < 1e-6, "p24 should keep the arm"
+
+
 def test_assign_uses_color_score_over_centroid():
     """Block is assigned to the page with higher color score, even if more distant."""
     # Two adjacent pages; block straddles the boundary near page0.
@@ -656,6 +751,38 @@ def test_fill_coverage_gaps_clipped_to_page_extent():
     assert result[0].area > mask.area
     # page0 mask must stay within its page extent
     assert result[0].difference(page_poly.buffer(1e-9)).area < 1e-8
+
+
+def test_fill_coverage_gaps_disconnected_from_mask():
+    """Gap piece that doesn't touch a page's mask is not added to that page.
+
+    page_0's mask is a small corner square; the gap piece (a floating island)
+    is disjoint from it, so mask_0.union(island) is a MultiPolygon and the
+    connectivity check at line 584 rejects it for page 0.
+
+    page_1's mask has the island as an interior hole, so mask_1.union(island)
+    fills the hole and gives a solid Polygon — page 1 absorbs the gap.
+    """
+    big_square = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+    island = Polygon([(4, 4), (6, 4), (6, 6), (4, 6)])
+
+    # page_0: small bottom-left corner, nowhere near the island
+    mask_0 = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    # page_1: big square with the island punched out as an interior hole
+    mask_1 = big_square.difference(island)
+    assert isinstance(mask_1, Polygon) and len(list(mask_1.interiors)) == 1
+
+    # The only gap is the island itself (page_union = big_square; mask_union = mask_0 ∪ mask_1
+    # = big_square - island + tiny corner, so gap ≈ island).
+    result = _fill_coverage_gaps([mask_0, mask_1], [big_square, big_square])
+
+    # page_1 fills its hole (island connects to mask_1's boundary)
+    assert result[1] is not None
+    assert abs(result[1].area - big_square.area) < 1e-6
+
+    # page_0 does NOT absorb the island (disconnected from its mask)
+    assert result[0] is not None
+    assert abs(result[0].area - mask_0.area) < 1e-6
 
 
 def test_fill_coverage_gaps_no_gaps():

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -13,6 +13,7 @@ from mapsnap.clip_masks import (
     _assign_blocks_to_pages_with_splits,
     _convexity_ratio,
     _fill_concave_dents,
+    _fill_coverage_gaps,
     _fit_affine,
     _is_substantial,
     _load_page_color_data,
@@ -599,3 +600,68 @@ def test_assign_uses_color_score_over_centroid():
     pcd1 = _make_page_color_data(georef1, np.full((10, 10), 100, dtype=np.int16))
     result_with_color = _assign_blocks_to_pages([block], [page0, page1], [pcd0, pcd1])
     assert result_with_color[1] == [0], "with color scoring, block should go to page1"
+
+
+# ---------------------------------------------------------------------------
+# _fill_coverage_gaps
+# ---------------------------------------------------------------------------
+
+
+def test_fill_coverage_gaps_notch_within_single_page():
+    """A triangular notch in a page's mask is filled when it lies within the page extent."""
+    page_poly = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    # mask has a triangular notch cut from the top-right corner
+    mask = Polygon([(0, 0), (4, 0), (4, 2), (2, 4), (0, 4)])
+    # gap = triangle [(2,4)-(4,4)-(4,2)], entirely within page_poly
+
+    result = _fill_coverage_gaps([mask], [page_poly])
+
+    assert result[0] is not None
+    assert abs(result[0].area - page_poly.area) < 1e-6, (
+        "gap should be absorbed, covering full page"
+    )
+
+
+def test_fill_coverage_gaps_split_across_pages():
+    """A gap spanning two adjacent page extents is split and each page gets its portion."""
+    page_poly_0 = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    page_poly_1 = Polygon([(4, 0), (8, 0), (8, 4), (4, 4)])
+    mask_0 = Polygon([(0, 0), (3, 0), (3, 4), (0, 4)])  # leaves x=[3,4] uncovered
+    mask_1 = Polygon([(5, 0), (8, 0), (8, 4), (5, 4)])  # leaves x=[4,5] uncovered
+
+    result = _fill_coverage_gaps([mask_0, mask_1], [page_poly_0, page_poly_1])
+
+    assert result[0] is not None
+    assert result[0].area > mask_0.area, "page0 should gain x=[3,4] strip"
+    assert result[1] is not None
+    assert result[1].area > mask_1.area, "page1 should gain x=[4,5] strip"
+    # No region should be double-covered (shared edge at x=4 has zero area)
+    assert result[0].intersection(result[1]).area < 1e-8
+
+
+def test_fill_coverage_gaps_clipped_to_page_extent():
+    """Gap extending outside a page's extent is clipped before being added."""
+    page_poly = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    mask = Polygon([(0, 0), (4, 0), (4, 2), (2, 4), (0, 4)])
+    # Simulate another page whose mask doesn't cover the top-right region
+    # The gap is partially outside page_poly (e.g., extends to y=6).
+    # Only the part within page_poly should be added to mask.
+    extra_page_poly = Polygon([(2, 4), (6, 4), (6, 8), (2, 8)])
+    extra_mask = Polygon([(4, 4), (6, 4), (6, 8), (2, 8)])  # leaves triangle at left
+
+    result = _fill_coverage_gaps([mask, extra_mask], [page_poly, extra_page_poly])
+
+    # page0 mask should grow (absorb the top-right triangle within page_poly)
+    assert result[0] is not None
+    assert result[0].area > mask.area
+    # page0 mask must stay within its page extent
+    assert result[0].difference(page_poly.buffer(1e-9)).area < 1e-8
+
+
+def test_fill_coverage_gaps_no_gaps():
+    """When masks already cover all page extents, nothing changes."""
+    page_poly = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    mask = page_poly  # exact coverage
+
+    result = _fill_coverage_gaps([mask], [page_poly])
+    assert result[0] is mask  # same object returned (no modification)

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -1,18 +1,22 @@
 """Tests for clip_masks.py."""
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pytest
 from shapely.geometry import MultiPolygon, Polygon
 
 from mapsnap.clip_masks import (
+    PageColorData,
     _assign_blocks_to_pages,
     _assign_blocks_to_pages_with_splits,
     _fit_affine,
     _is_substantial,
+    _load_page_color_data,
     _polygonize_streets,
     _remove_spike_vertices,
+    _score_block_on_page,
     compute_all_clip_masks,
     geo_polygon_to_svg,
 )
@@ -437,3 +441,73 @@ def test_svg_buffer_is_0_5_miles():
     miles_per_degree_lat = 111_320.0 / 1609.344  # ≈ 69.1 miles
     expected = 0.5 / miles_per_degree_lat
     assert math.isclose(_BUFFER_LAT_DEG, expected, rel_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# _load_page_color_data / _score_block_on_page
+# ---------------------------------------------------------------------------
+
+
+def _make_page_color_data(georef: dict, score_array: np.ndarray) -> PageColorData:
+    """Build a PageColorData directly from a georef and a pre-made score array."""
+    A_fwd, A_inv = _fit_affine(georef)
+    H, W = score_array.shape
+    return PageColorData(
+        color_score=score_array,
+        A_fwd=A_fwd,
+        A_inv=A_inv,
+        scale_x=W / float(georef["width"]),
+        scale_y=H / float(georef["height"]),
+    )
+
+
+def test_load_color_data_missing_file():
+    """Returns None when the raw image file does not exist."""
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=100, h=100)
+    result = _load_page_color_data(Path("/nonexistent/file.jpg"), georef)
+    assert result is None
+
+
+def test_score_block_zero_image():
+    """A block over an all-zero color image returns score 0."""
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=10, h=10)
+    pcd = _make_page_color_data(georef, np.zeros((10, 10), dtype=np.int16))
+    block = Polygon([(0.2, 0.2), (0.8, 0.2), (0.8, 0.8), (0.2, 0.8)])
+    assert _score_block_on_page(block, pcd) == 0.0
+
+
+def test_score_block_bright_region():
+    """A block over colored pixels returns a positive score."""
+    georef = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=10, h=10)
+    # For this axis-aligned georef:
+    #   lon=0.2 → px=2, lat=0.8 → py=(1-0.8)*10=2
+    #   lon=0.8 → px=8, lat=0.2 → py=(1-0.2)*10=8
+    # So the block maps to pixel rows 2-8, cols 2-8.
+    arr = np.zeros((10, 10), dtype=np.int16)
+    arr[2:8, 2:8] = 50
+    pcd = _make_page_color_data(georef, arr)
+    block = Polygon([(0.2, 0.2), (0.8, 0.2), (0.8, 0.8), (0.2, 0.8)])
+    assert _score_block_on_page(block, pcd) > 0.0
+
+
+def test_assign_uses_color_score_over_centroid():
+    """Block is assigned to the page with higher color score, even if more distant."""
+    # Two adjacent pages; block straddles the boundary near page0.
+    # Without color: page0 centroid is closer → block goes to page0.
+    # With color: page1 has rich content in the block area → block goes to page1.
+    georef0 = _axis_aligned_georef(0.0, 0.0, 1.0, 1.0, w=10, h=10)
+    georef1 = _axis_aligned_georef(0.9, 0.0, 2.0, 1.0, w=10, h=10)
+    page0 = Polygon(georef0["corners"])
+    page1 = Polygon(georef1["corners"])
+    # Block centroid at (0.75, 0.5): closer to page0 centroid (0.5, 0.5) than
+    # page1 centroid (1.45, 0.5), so centroid-distance would assign to page0.
+    block = Polygon([(0.6, 0.2), (0.95, 0.2), (0.95, 0.8), (0.6, 0.8)])
+
+    result_no_color = _assign_blocks_to_pages([block], [page0, page1])
+    assert result_no_color[0] == [0], "without color, block should go to closer page0"
+
+    # page0: zero color score; page1: rich color score everywhere
+    pcd0 = _make_page_color_data(georef0, np.zeros((10, 10), dtype=np.int16))
+    pcd1 = _make_page_color_data(georef1, np.full((10, 10), 100, dtype=np.int16))
+    result_with_color = _assign_blocks_to_pages([block], [page0, page1], [pcd0, pcd1])
+    assert result_with_color[1] == [0], "with color scoring, block should go to page1"

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -12,6 +12,7 @@ from mapsnap.clip_masks import (
     _fit_affine,
     _is_substantial,
     _polygonize_streets,
+    _remove_spike_vertices,
     compute_all_clip_masks,
     geo_polygon_to_svg,
 )
@@ -279,6 +280,35 @@ def test_is_substantial_small_area_rejected():
     reference = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
     small = Polygon([(0, 0), (1, 0), (1, 0.9), (0, 0.9)])  # 0.9% of area
     assert not _is_substantial(small, reference)
+
+
+# ---------------------------------------------------------------------------
+# _remove_spike_vertices
+# ---------------------------------------------------------------------------
+
+
+def test_remove_spike_removes_backtrack_vertex():
+    """A vertex where the polygon reverses direction (≥150° turn) is removed."""
+    # Square with a spike: goes to (1, 0.5), which requires a ≥150° turn to reach
+    # from (2, 0.9) and another to leave toward (2, 1.1).
+    spike_poly = Polygon([(0, 0), (2, 0), (2, 0.9), (1, 0.5), (2, 1.1), (2, 2), (0, 2)])
+    cleaned = _remove_spike_vertices(spike_poly, min_turn_deg=150.0)
+    assert len(list(cleaned.exterior.coords)) < len(list(spike_poly.exterior.coords))
+
+
+def test_remove_spike_preserves_clean_polygon():
+    """A polygon with no spike vertices is returned unchanged."""
+    square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    cleaned = _remove_spike_vertices(square)
+    assert list(cleaned.exterior.coords) == list(square.exterior.coords)
+
+
+def test_remove_spike_collinear_not_removed():
+    """A collinear vertex (0° turn, same direction) is NOT treated as a spike."""
+    # (1,1) lies exactly on the top edge between (2,1) and (0,1) — 0° turn, not 180°.
+    poly = Polygon([(0, 0), (2, 0), (2, 1), (1, 1), (0, 1)])
+    cleaned = _remove_spike_vertices(poly)
+    assert len(list(cleaned.exterior.coords)) == len(list(poly.exterior.coords))
 
 
 # ---------------------------------------------------------------------------

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -10,6 +10,7 @@ from mapsnap.clip_masks import (
     _assign_blocks_to_pages,
     _assign_blocks_to_pages_with_splits,
     _fit_affine,
+    _is_substantial,
     _polygonize_streets,
     compute_all_clip_masks,
     geo_polygon_to_svg,
@@ -243,6 +244,41 @@ def test_split_outside_block_dropped():
     block = Polygon([(5, 5), (6, 5), (6, 6), (5, 6)])
     pieces = _assign_blocks_to_pages_with_splits([block], [page])
     assert all(len(ps) == 0 for ps in pieces.values())
+
+
+def test_split_sliver_remainder_dropped():
+    """A thin outside remainder (<10% of block width) is not passed on."""
+    page0 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    page1 = Polygon([(1, 0), (2, 0), (2, 1), (1, 1)])
+    # Block x in [0, 1.05]: outside piece is only ~5% of block width → sliver.
+    block = Polygon([(0.0, 0.2), (1.05, 0.2), (1.05, 0.8), (0.0, 0.8)])
+    pieces = _assign_blocks_to_pages_with_splits([block], [page0, page1])
+    assert sum(p.area for p in pieces[1]) == 0, "sliver remainder should be dropped"
+
+
+# ---------------------------------------------------------------------------
+# _is_substantial
+# ---------------------------------------------------------------------------
+
+
+def test_is_substantial_full_overlap():
+    """A piece identical to the reference is substantial."""
+    poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    assert _is_substantial(poly, poly)
+
+
+def test_is_substantial_thin_strip_rejected():
+    """A strip that is <10% of reference height is not substantial."""
+    reference = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    thin = Polygon([(0, 0), (1, 0), (1, 0.05), (0, 0.05)])  # 5% of height
+    assert not _is_substantial(thin, reference)
+
+
+def test_is_substantial_small_area_rejected():
+    """A piece with <10% of reference area is not substantial."""
+    reference = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+    small = Polygon([(0, 0), (1, 0), (1, 0.9), (0, 0.9)])  # 0.9% of area
+    assert not _is_substantial(small, reference)
 
 
 # ---------------------------------------------------------------------------

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -707,7 +707,10 @@ def main() -> None:
         print("Computing block-based clipping masks...", file=sys.stderr)
         debug_blocks: list[dict] | None = [] if args.debug_blocks else None
         geo_masks = compute_all_clip_masks(
-            all_georefs, centerlines_geojson, debug_blocks_out=debug_blocks
+            all_georefs,
+            centerlines_geojson,
+            debug_blocks_out=debug_blocks,
+            raw_paths=[raw_path for _, _, _, raw_path in valid_items],
         )
         n_masked = sum(m is not None for m in geo_masks)
         print(

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -37,7 +37,10 @@ from pathlib import Path
 import cv2
 import numpy as np
 from PIL import Image
+from shapely.geometry import Polygon as ShapelyPolygon
 
+from mapsnap.clip_masks import compute_all_clip_masks
+from mapsnap.clip_masks import geo_polygon_to_svg
 from mapsnap.utils import jpeg_dimensions
 
 
@@ -449,6 +452,7 @@ def make_annotation(
     raw_path: Path,
     creator_url: str,
     now: str,
+    geo_mask: ShapelyPolygon | None = None,
 ) -> dict:
     """Build a IIIF georeferencing annotation for one page.
 
@@ -460,6 +464,9 @@ def make_annotation(
     (e.g. p4.unsplit.jpg) is located via template matching to determine the non-circular
     canvas placement. Raises ValueError if the unsplit file is missing or the match
     is too uncertain.
+
+    geo_mask, when provided, is a Shapely Polygon in geographic (lon/lat) space used
+    as the SvgSelector clipping polygon. Falls back to the full-page rectangle if None.
     """
     source = item["target"]["source"]
     source_id: str = source["id"]
@@ -578,9 +585,8 @@ def make_annotation(
             },
             "selector": {
                 "type": "SvgSelector",
-                "value": (
-                    f'<svg><polygon points="0,{source_height} 0,0 '
-                    f'{source_width},0 {source_width},{source_height} 0,{source_height}" /></svg>'
+                "value": geo_polygon_to_svg(
+                    geo_mask, georef, source_width, source_height, split_canvas
                 ),
             },
         },
@@ -624,6 +630,11 @@ def main() -> None:
         default="https://oldinsurancemaps.net/profile/danvk",
         help="Creator profile URL (default: %(default)s)",
     )
+    parser.add_argument(
+        "--centerlines",
+        metavar="FILE",
+        help="GeoJSON centerlines file for block-based clipping masks",
+    )
     args = parser.parse_args()
 
     source_data: dict = json.load(open(args.oim_iiif))
@@ -655,7 +666,8 @@ def main() -> None:
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    annotations: list[dict] = []
+    # Pass 1: collect all valid (page_key, canvas_item, georef, raw_path) tuples.
+    valid_items: list[tuple[str, dict, dict, Path]] = []
     for path in georef_paths:
         page_key = georef_path_to_page_key(path)
         if not page_key:
@@ -672,11 +684,32 @@ def main() -> None:
                 file=sys.stderr,
             )
             continue
-        georef: dict = json.load(open(path))
+        georef = json.load(open(path))
         raw_path = Path(path).parent / f"{page_key}.raw.jpg"
+        valid_items.append((page_key, canvas_item, georef, raw_path))
+
+    # Compute block-based clipping masks when a centerlines file is provided.
+    geo_masks: list[ShapelyPolygon | None] = [None] * len(valid_items)
+    if args.centerlines:
+        centerlines_geojson: dict = json.load(open(args.centerlines))
+        all_georefs = [georef for _, _, georef, _ in valid_items]
+        print("Computing block-based clipping masks...", file=sys.stderr)
+        geo_masks = compute_all_clip_masks(all_georefs, centerlines_geojson)
+        n_masked = sum(m is not None for m in geo_masks)
+        print(
+            f"Computed masks for {n_masked}/{len(valid_items)} pages.", file=sys.stderr
+        )
+
+    # Pass 2: build annotations with the per-page geo mask.
+    annotations: list[dict] = []
+    for (page_key, canvas_item, georef, raw_path), geo_mask in zip(
+        valid_items, geo_masks
+    ):
         try:
             annotations.append(
-                make_annotation(canvas_item, georef, raw_path, args.creator, now)
+                make_annotation(
+                    canvas_item, georef, raw_path, args.creator, now, geo_mask
+                )
             )
         except ValueError as exc:
             print(f"Warning: skipping {page_key}: {exc}", file=sys.stderr)

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -38,6 +38,7 @@ import cv2
 import numpy as np
 from PIL import Image
 from shapely.geometry import Polygon as ShapelyPolygon
+from shapely.geometry import mapping as geom_mapping
 
 from mapsnap.clip_masks import compute_all_clip_masks
 from mapsnap.clip_masks import geo_polygon_to_svg
@@ -640,6 +641,11 @@ def main() -> None:
         metavar="FILE",
         help="Write a GeoJSON file with one Polygon feature per block (requires --centerlines)",
     )
+    parser.add_argument(
+        "--debug-clip",
+        metavar="FILE",
+        help="Write a GeoJSON file with one Polygon feature per clipping mask (requires --centerlines)",
+    )
     args = parser.parse_args()
 
     source_data: dict = json.load(open(args.oim_iiif))
@@ -713,6 +719,22 @@ def main() -> None:
                 json.dump(blocks_geojson, f)
             print(
                 f"Wrote {len(debug_blocks)} block features to {args.debug_blocks}",
+                file=sys.stderr,
+            )
+        if args.debug_clip:
+            clip_features = [
+                {
+                    "type": "Feature",
+                    "properties": {"page_key": page_key},
+                    "geometry": geom_mapping(mask),
+                }
+                for (page_key, _, _, _), mask in zip(valid_items, geo_masks)
+                if mask is not None
+            ]
+            with open(args.debug_clip, "w") as f:
+                json.dump({"type": "FeatureCollection", "features": clip_features}, f)
+            print(
+                f"Wrote {len(clip_features)} clip features to {args.debug_clip}",
                 file=sys.stderr,
             )
 

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -702,7 +702,8 @@ def main() -> None:
     # Compute block-based clipping masks when a centerlines file is provided.
     geo_masks: list[ShapelyPolygon | None] = [None] * len(valid_items)
     if args.centerlines:
-        centerlines_geojson: dict = json.load(open(args.centerlines))
+        with open(args.centerlines) as f:
+            centerlines_geojson: dict = json.load(f)
         all_georefs = [georef for _, _, georef, _ in valid_items]
         print("Computing block-based clipping masks...", file=sys.stderr)
         debug_blocks: list[dict] | None = [] if args.debug_blocks else None

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -635,6 +635,11 @@ def main() -> None:
         metavar="FILE",
         help="GeoJSON centerlines file for block-based clipping masks",
     )
+    parser.add_argument(
+        "--debug-blocks",
+        metavar="FILE",
+        help="Write a GeoJSON file with one Polygon feature per block (requires --centerlines)",
+    )
     args = parser.parse_args()
 
     source_data: dict = json.load(open(args.oim_iiif))
@@ -694,11 +699,22 @@ def main() -> None:
         centerlines_geojson: dict = json.load(open(args.centerlines))
         all_georefs = [georef for _, _, georef, _ in valid_items]
         print("Computing block-based clipping masks...", file=sys.stderr)
-        geo_masks = compute_all_clip_masks(all_georefs, centerlines_geojson)
+        debug_blocks: list[dict] | None = [] if args.debug_blocks else None
+        geo_masks = compute_all_clip_masks(
+            all_georefs, centerlines_geojson, debug_blocks_out=debug_blocks
+        )
         n_masked = sum(m is not None for m in geo_masks)
         print(
             f"Computed masks for {n_masked}/{len(valid_items)} pages.", file=sys.stderr
         )
+        if debug_blocks is not None:
+            blocks_geojson = {"type": "FeatureCollection", "features": debug_blocks}
+            with open(args.debug_blocks, "w") as f:
+                json.dump(blocks_geojson, f)
+            print(
+                f"Wrote {len(debug_blocks)} block features to {args.debug_blocks}",
+                file=sys.stderr,
+            )
 
     # Pass 2: build annotations with the per-page geo mask.
     annotations: list[dict] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "numpy>=2.0",
     "opencv-python>=4.13.0.92",
     "pillow>=12.2.0",
+    "shapely>=2.0",
     "tqdm>=4.67.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,7 @@ dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },
     { name = "pillow" },
+    { name = "shapely" },
     { name = "tqdm" },
 ]
 
@@ -199,6 +200,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92" },
     { name = "pillow", specifier = ">=12.2.0" },
+    { name = "shapely", specifier = ">=2.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
 


### PR DESCRIPTION
Fixes #2

I tried this before using Voronoi diagrams, but the block-by-block color approach works much, much better. When the maps are well-aligned, this forces the "cuts" to be along street centerlines, which avoids breaking up colored blocks.

This _mostly_ works, but because the block-to-page assignment is all or nothing, it can leave gaps (where a block isn't fully-covered by any page) and can produce odd, complex polygons. So this is followed by a somewhat elaborate series of patches to make the clipping polygons more reasonable.

This has trouble where our notion of "block" breaks down. Divided highways are problematic, as are places where OSM's blocks are a little off from Sanborn's, which can create "slivers." Areas where the street grid has changed are also problematic, since a block in the Sanborn map may have been replaced by a superblock that gets assigned to another page. It would be interesting to try using the maps themselves to define the blocks, but then you probably run into other issues.

Regardless, this works pretty well and is a huge win.

Before:

<img width="990" height="754" alt="image" src="https://github.com/user-attachments/assets/f4a25791-69d9-400a-8561-789b489584fb" />

After:

<img width="990" height="754" alt="image" src="https://github.com/user-attachments/assets/3db7a8fc-5b4a-440c-b1c7-991b1063c401" />

🤖 Claude's summary of this algorithm is below.

## Background

Each Sanborn map page overlaps with its neighbors. The previous approach used a full-page rectangle as the `SvgSelector` clipping mask, so content in the overlap zones was hidden by whichever page rendered last.

The key insight is that each city block is only colored on **one** page — it's the page whose surveyor walked that block. So we can look at which page has color pixels in each block and let that decide who owns it.

## Algorithm

1. **Polygonize streets**: Clip `centerlines.geojson` to the union of all page extents (buffered by ~0.5 miles), add the boundary ring to close off waterfront/edge blocks, then call `shapely.ops.polygonize` to turn the line network into a list of city block polygons.

2. **Score blocks**: For each (block, page) pair, load the raw JPEG at 1/8 resolution, compute per-pixel color spread (`max(R,G,B) − min(R,G,B)`, background paper ≈ 20), and sum the spread values within the block. The page with the highest sum wins the block; centroid distance breaks ties.

3. **Split border blocks**: Blocks that straddle page boundaries are clipped to each page's extent and re-scored iteratively, so both sides of a block on a page boundary get correctly assigned rather than being dropped.

4. **Build masks**: Union the assigned block pieces per page, simplify, and clip to the page polygon. Handle slivers (< 5% of largest component, dropped with a warning) and rare disconnected multi-polygon results (convex hull fallback).

5. **Remove spike vertices**: Simplification can introduce backtrack vertices (turn angle ≥ 170°) that cause triangulation failures in Allmaps. These are removed iteratively.

6. **Fill concave dents**: After initial assignment, some pages have arms or protrusions that belong more naturally to a neighbor. For each page pair (i, j), pieces of j's mask that lie within i's geographic extent are candidates for transfer. A piece is transferred if: (a) page j has no strong color advantage (< 3× i's score, minimum threshold 500), and (b) removing the piece from j improves j's convexity ratio (confirming it's a protrusion, not a legitimate assignment).

7. **Fill coverage gaps**: Compute `union(page_polys) − union(masks)` to find any uncovered regions. For each gap piece, find which page's mask it connects to (i.e. `mask.union(piece)` is a single Polygon), preferring the page with the greatest convexity improvement. A `claimed` tracker prevents double-assignment when multiple page extents overlap a single gap.

8. **Emit SVG**: Convert the geo-space polygon back to canvas pixel coordinates via the inverse of the georef affine, and format as an IIIF `SvgSelector`.

## Usage

```bash
uv run python -m mapsnap.make_iiif_georef main.iiif.json '*.georef.json' \
    --centerlines centerlines.geojson \
    --output output.iiif.json
```

Optional debug flags write GeoJSON files showing the block assignments (`--debug-blocks`) and final clipping polygons (`--debug-clips`).

## Results on Brooklyn 1939 vol. 2 (62 pages)

- 99.8% of pre-clip area remains covered after masking
- 6 dent transfers across 11 pages
- 48 gap-fill pieces across 35 pages