### PR TITLE
Look at neighboring page's rotation for 1-gcp fits

### DIFF
--- a/fit.sh
+++ b/fit.sh
@@ -12,13 +12,23 @@ if [ ! -e $centerlines ]; then
     centerlines=$dir/../centerlines.geojson
 fi
 
-uv run mapsnap/georef_from_labels.py $dir/p*.scaled.jpg \
+if compgen -G "$dir/p*.scaled.jpg" > /dev/null; then
+    input_images=$dir/p*.scaled.jpg
+elif compgen -G "$dir/p*.raw.jpg" > /dev/null; then
+    input_images=$dir/p*.raw.jpg
+else
+    echo "Error: no p*.scaled.jpg or p*.raw.jpg found in $dir" >&2
+    exit 1
+fi
+
+uv run mapsnap/georef_from_labels.py $input_images \
     --centerlines $centerlines \
     --min-long-side 45 \
     --min-short-side 20 \
     --edge-margin 0 \
     --min-confidence 0.15 \
-    --min-aspect-ratio 1.75
+    --min-aspect-ratio 1.75 \
+    --one-gcp-fits
 
 if [ -e $dir/main.iiif.json ]; then
     ref_iiif=$dir/main.iiif.json

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -68,6 +68,7 @@ class ProcessResult:
     success: bool
     scale_deg_per_px: float | None = None  # set on success
     center: tuple[float, float] | None = None  # (lon, lat) page center, set on success
+    rotation: float | None = None  # directed rotation in radians, set on success
     deferred: dict | None = None  # set when deferred (exactly 1 GCP, needs scale)
 
 
@@ -1006,6 +1007,8 @@ def process_image(
                 "centerlines_path": centerlines_path,
                 "features": features,
                 "gcps": gcps,
+                "img_w": img_w,
+                "img_h": img_h,
             },
         )
 
@@ -1047,7 +1050,69 @@ def process_image(
         centerlines_path,
         initial_pair=seed_pair,
     )
-    return ProcessResult(success=True, scale_deg_per_px=scale, center=center)
+    rotation = math.atan2(float(A[1, 0]), float(-A[1, 1]))
+    return ProcessResult(
+        success=True, scale_deg_per_px=scale, center=center, rotation=rotation
+    )
+
+
+def _angle_diff_abs(a: float, b: float) -> float:
+    """Smallest angular separation between two angles (radians), result in [0, π]."""
+    d = (a - b) % (2 * math.pi)
+    return min(d, 2 * math.pi - d)
+
+
+def _rotation_from_neighbors(
+    candidate: float,
+    approx_center: tuple[float, float],
+    page_dim_deg: tuple[float, float],
+    neighbor_rotations: list[tuple[tuple[float, float], float]],
+    angle_threshold_rad: float = 10 * math.pi / 180,
+) -> float | None:
+    """Validate and direct an undirected rotation using adjacent pages' rotation angles.
+
+    candidate is undirected (in [0, π)); the two directed candidates are candidate and
+    candidate + π. Neighbours within 1.5× page dimensions in both lon and lat are
+    considered adjacent. If 2+ adjacent neighbours agree with one of the two directed
+    candidates (within angle_threshold_rad), returns that directed rotation.
+    Returns None if no candidate has sufficient adjacent support.
+    """
+    approx_lon, approx_lat = approx_center
+    page_dim_lon, page_dim_lat = page_dim_deg
+    thresh_lon = 1.5 * page_dim_lon
+    thresh_lat = 1.5 * page_dim_lat
+
+    adjacent = [
+        rotation
+        for (n_lon, n_lat), rotation in neighbor_rotations
+        if abs(n_lon - approx_lon) <= thresh_lon
+        and abs(n_lat - approx_lat) <= thresh_lat
+    ]
+
+    print(
+        f"  Rotation validation: {len(adjacent)} adjacent georeferenced page(s) found.",
+        file=sys.stderr,
+    )
+
+    for directed in (candidate, candidate + math.pi):
+        n_agree = sum(
+            1 for r in adjacent if _angle_diff_abs(r, directed) <= angle_threshold_rad
+        )
+        if n_agree >= 2:
+            print(
+                f"  Rotation {math.degrees(directed):.1f}° confirmed by {n_agree} neighbours.",
+                file=sys.stderr,
+            )
+            return directed
+
+    candidates_deg = (
+        f"{math.degrees(candidate):.1f}° / {math.degrees(candidate + math.pi):.1f}°"
+    )
+    print(
+        f"  Neither rotation candidate ({candidates_deg}) supported by ≥2 adjacent pages; skipping.",
+        file=sys.stderr,
+    )
+    return None
 
 
 def _rotation_from_gcp_features(
@@ -1078,13 +1143,15 @@ def process_deferred_image(
     scale_deg_per_px: float,
     block_index: dict[str, list[Block]],
     cos_phi: float,
+    neighbor_rotations: list[tuple[tuple[float, float], float]],
 ) -> ProcessResult:
     """Georeference an image that was deferred due to having only 1 intersection GCP.
 
-    Uses the provided scale (deg/px) and estimates rotation from label-angle histogram
-    cross-correlation. The rotation estimate is undirected (mod π); the 180° ambiguity
-    is resolved by requiring north to point upward in the image (A[1,1] < 0, equivalently
-    cos(rotation) > 0).
+    Uses the provided scale (deg/px) and estimates rotation from the two streets at the
+    single GCP. The undirected rotation is then validated against adjacent pages (already
+    successfully georeferenced): if ≥2 neighbours within 1.5× page dimensions agree with
+    one of the two directed candidates (±180°), that direction is used. If fewer than 2
+    neighbours agree, the image is skipped.
     """
     image_path: str = deferred["image_path"]
     output_path: str = deferred["output_path"]
@@ -1092,6 +1159,8 @@ def process_deferred_image(
     centerlines_path: str = deferred["centerlines_path"]
     features: list[LabelFeature] = deferred["features"]
     gcps: list[IntersectionGCP] = deferred["gcps"]
+    img_w: int = deferred["img_w"]
+    img_h: int = deferred["img_h"]
     gcp = gcps[0]
 
     rotation = _rotation_from_gcp_features(gcp, block_index)
@@ -1099,11 +1168,17 @@ def process_deferred_image(
         print("Could not estimate rotation from GCP street angles.", file=sys.stderr)
         return ProcessResult(success=False)
 
-    # The rotation estimate is mod π; pick the directed angle where north points up.
-    # In the similarity affine, A[1,1] = -scale·cos(rotation); north is up when
-    # A[1,1] < 0, i.e. cos(rotation) > 0.
-    if math.cos(rotation) < 0:
-        rotation += math.pi
+    page_dim_lat = scale_deg_per_px * img_h
+    page_dim_lon = scale_deg_per_px * img_w / cos_phi
+    directed_rotation = _rotation_from_neighbors(
+        candidate=rotation,
+        approx_center=gcp.geo,
+        page_dim_deg=(page_dim_lon, page_dim_lat),
+        neighbor_rotations=neighbor_rotations,
+    )
+    if directed_rotation is None:
+        return ProcessResult(success=False)
+    rotation = directed_rotation
 
     pos_threshold = 0.001
     A = build_affine_from_scale_rotation_gcp(scale_deg_per_px, rotation, gcp, cos_phi)
@@ -1285,6 +1360,9 @@ def main() -> None:
         tuple[str, float]
     ] = []  # (image_path, px_per_ft) for outlier check
     location_records: list[tuple[str, tuple[float, float]]] = []  # (image_path, center)
+    neighbor_rotations: list[
+        tuple[tuple[float, float], float]
+    ] = []  # (center, rotation)
     deferred_list: list[dict] = []
 
     for image_path in args.images:
@@ -1323,6 +1401,8 @@ def main() -> None:
                 scale_records.append((image_path, px_per_ft))
             if result.center is not None:
                 location_records.append((image_path, result.center))
+                if result.rotation is not None:
+                    neighbor_rotations.append((result.center, result.rotation))
         elif result.deferred is not None:
             deferred_list.append(result.deferred)
 
@@ -1362,6 +1442,7 @@ def main() -> None:
                     scale_deg_per_px=scale_deg_per_px,
                     block_index=block_index,
                     cos_phi=cos_phi,
+                    neighbor_rotations=neighbor_rotations,
                 )
                 if deferred_result.success:
                     n_success += 1

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -613,6 +613,7 @@ def _finalize_georef(
     labels_path: str,
     centerlines_path: str,
     initial_pair: tuple[int, int] | None = None,
+    extra_fields: dict | None = None,
 ) -> tuple[float, tuple[float, float]]:
     """Print fit stats, write georef JSON, and return (scale_deg_per_px, page_center)."""
 
@@ -696,6 +697,8 @@ def _finalize_georef(
         "streets": streets_out,
         "intersections": intersections_out,
     }
+    if extra_fields:
+        result.update(extra_fields)
     with open(output_path, "w") as f:
         f.write(json.dumps(result, indent=2))
     print(
@@ -1056,6 +1059,18 @@ def process_image(
     )
 
 
+@dataclass
+class RotationDecision:
+    """Outcome of the rotation-direction resolution for a 1-GCP deferred image."""
+
+    rotation: float  # chosen directed rotation (radians)
+    confirmed: bool  # True when ≥2 adjacent neighbours agreed
+    method: str  # "neighbor_confirmed" | "neighbor_plurality" | "north_up_fallback"
+    n_agree: int  # adjacent neighbours matching the chosen direction
+    n_other: int  # adjacent neighbours matching the other direction
+    adjacent_deg: list[float]  # rotation of every adjacent neighbour (degrees)
+
+
 def _angle_diff_abs(a: float, b: float) -> float:
     """Smallest angular separation between two angles (radians), result in [0, π]."""
     d = (a - b) % (2 * math.pi)
@@ -1068,14 +1083,17 @@ def _rotation_from_neighbors(
     page_dim_deg: tuple[float, float],
     neighbor_rotations: list[tuple[tuple[float, float], float]],
     angle_threshold_rad: float = 10 * math.pi / 180,
-) -> float | None:
-    """Validate and direct an undirected rotation using adjacent pages' rotation angles.
+) -> RotationDecision:
+    """Select and validate a directed rotation using adjacent pages' rotation angles.
 
     candidate is undirected (in [0, π)); the two directed candidates are candidate and
     candidate + π. Neighbours within 1.5× page dimensions in both lon and lat are
-    considered adjacent. If 2+ adjacent neighbours agree with one of the two directed
-    candidates (within angle_threshold_rad), returns that directed rotation.
-    Returns None if no candidate has sufficient adjacent support.
+    considered adjacent.
+
+    If one candidate has strictly more adjacent supporters than the other, that
+    candidate is chosen ('neighbor_confirmed' when the winner has ≥2, else
+    'neighbor_plurality'). When both are equally supported (including 0 vs 0), the
+    180° ambiguity is resolved by requiring north to point upward ('north_up_fallback').
     """
     approx_lon, approx_lat = approx_center
     page_dim_lon, page_dim_lat = page_dim_deg
@@ -1088,31 +1106,60 @@ def _rotation_from_neighbors(
         if abs(n_lon - approx_lon) <= thresh_lon
         and abs(n_lat - approx_lat) <= thresh_lat
     ]
+    adjacent_deg = [math.degrees(r) for r in adjacent]
 
-    print(
-        f"  Rotation validation: {len(adjacent)} adjacent georeferenced page(s) found.",
-        file=sys.stderr,
+    c1 = sum(
+        1 for r in adjacent if _angle_diff_abs(r, candidate) <= angle_threshold_rad
+    )
+    c2 = sum(
+        1
+        for r in adjacent
+        if _angle_diff_abs(r, candidate + math.pi) <= angle_threshold_rad
     )
 
-    for directed in (candidate, candidate + math.pi):
-        n_agree = sum(
-            1 for r in adjacent if _angle_diff_abs(r, directed) <= angle_threshold_rad
+    if c1 > c2:
+        chosen = candidate
+        n_agree, n_other = c1, c2
+        method = "neighbor_confirmed" if c1 >= 2 else "neighbor_plurality"
+    elif c2 > c1:
+        chosen = candidate + math.pi
+        n_agree, n_other = c2, c1
+        method = "neighbor_confirmed" if c2 >= 2 else "neighbor_plurality"
+    else:
+        # Equal support (including 0 vs 0): north-up heuristic resolves the ambiguity.
+        chosen = candidate if math.cos(candidate) >= 0 else candidate + math.pi
+        n_agree, n_other = c1, c2
+        method = "north_up_fallback"
+
+    confirmed = method == "neighbor_confirmed"
+
+    # Log decision with annotated list of every adjacent neighbour.
+    adj_parts = [
+        f"{r_deg:.1f}°{'✓' if _angle_diff_abs(r_rad, chosen) <= angle_threshold_rad else ''}"
+        for r_deg, r_rad in zip(adjacent_deg, adjacent)
+    ]
+    adj_str = ", ".join(adj_parts) if adj_parts else "(no adjacent pages)"
+    if confirmed:
+        status_str = f"confirmed by {n_agree}/{len(adjacent)} adjacent"
+    elif method == "neighbor_plurality":
+        status_str = (
+            f"chosen by plurality ({n_agree} vs {n_other}, {len(adjacent)} adjacent)"
         )
-        if n_agree >= 2:
-            print(
-                f"  Rotation {math.degrees(directed):.1f}° confirmed by {n_agree} neighbours.",
-                file=sys.stderr,
-            )
-            return directed
-
-    candidates_deg = (
-        f"{math.degrees(candidate):.1f}° / {math.degrees(candidate + math.pi):.1f}°"
-    )
+    else:
+        status_str = f"chosen by north-up fallback ({n_agree} vs {n_other}, {len(adjacent)} adjacent)"
     print(
-        f"  Neither rotation candidate ({candidates_deg}) supported by ≥2 adjacent pages; skipping.",
+        f"  Rotation {math.degrees(chosen):.1f}° {status_str}: {adj_str}",
         file=sys.stderr,
     )
-    return None
+
+    return RotationDecision(
+        rotation=chosen,
+        confirmed=confirmed,
+        method=method,
+        n_agree=n_agree,
+        n_other=n_other,
+        adjacent_deg=adjacent_deg,
+    )
 
 
 def _rotation_from_gcp_features(
@@ -1150,8 +1197,10 @@ def process_deferred_image(
     Uses the provided scale (deg/px) and estimates rotation from the two streets at the
     single GCP. The undirected rotation is then validated against adjacent pages (already
     successfully georeferenced): if ≥2 neighbours within 1.5× page dimensions agree with
-    one of the two directed candidates (±180°), that direction is used. If fewer than 2
-    neighbours agree, the image is skipped.
+    one of the two directed candidates (±180°), that candidate is used. When both are
+    equally supported, the 180° ambiguity is resolved by the north-up heuristic. Confirmed
+    fits (≥2 neighbours) are written to output_path (.georef.json); unconfirmed fits are
+    written to a .georef-1gcp.json sidecar instead and returned with success=False.
     """
     image_path: str = deferred["image_path"]
     output_path: str = deferred["output_path"]
@@ -1163,22 +1212,20 @@ def process_deferred_image(
     img_h: int = deferred["img_h"]
     gcp = gcps[0]
 
-    rotation = _rotation_from_gcp_features(gcp, block_index)
-    if rotation is None:
+    undirected = _rotation_from_gcp_features(gcp, block_index)
+    if undirected is None:
         print("Could not estimate rotation from GCP street angles.", file=sys.stderr)
         return ProcessResult(success=False)
 
     page_dim_lat = scale_deg_per_px * img_h
     page_dim_lon = scale_deg_per_px * img_w / cos_phi
-    directed_rotation = _rotation_from_neighbors(
-        candidate=rotation,
+    decision = _rotation_from_neighbors(
+        candidate=undirected,
         approx_center=gcp.geo,
         page_dim_deg=(page_dim_lon, page_dim_lat),
         neighbor_rotations=neighbor_rotations,
     )
-    if directed_rotation is None:
-        return ProcessResult(success=False)
-    rotation = directed_rotation
+    rotation = decision.rotation
 
     pos_threshold = 0.001
     A = build_affine_from_scale_rotation_gcp(scale_deg_per_px, rotation, gcp, cos_phi)
@@ -1209,6 +1256,21 @@ def process_deferred_image(
             float(np.linalg.norm(np.array([lon - nearest_lon, lat - nearest_lat])))
         )
 
+    actual_output_path = (
+        output_path
+        if decision.confirmed
+        else output_path.replace(".georef.json", ".georef-1gcp.json")
+    )
+    one_gcp_extra = {
+        "one_gcp": {
+            "method": decision.method,
+            "confirmed": decision.confirmed,
+            "rotation_deg": round(math.degrees(decision.rotation), 2),
+            "n_agree": decision.n_agree,
+            "n_other": decision.n_other,
+            "adjacent_rotations_deg": [round(r, 1) for r in decision.adjacent_deg],
+        }
+    }
     scale, center = _finalize_georef(
         A,
         features,
@@ -1216,11 +1278,14 @@ def process_deferred_image(
         inlier_feat_indices,
         residuals,
         image_path,
-        output_path,
+        actual_output_path,
         labels_path,
         centerlines_path,
+        extra_fields=one_gcp_extra,
     )
-    return ProcessResult(success=True, scale_deg_per_px=scale, center=center)
+    return ProcessResult(
+        success=decision.confirmed, scale_deg_per_px=scale, center=center
+    )
 
 
 def main() -> None:
@@ -1373,7 +1438,11 @@ def main() -> None:
         # doesn't leave a previous result in place.
         if os.path.exists(output_path):
             os.remove(output_path)
-        for stale_suffix in (".georef-misscale.json", ".georef-outlier.json"):
+        for stale_suffix in (
+            ".georef-misscale.json",
+            ".georef-outlier.json",
+            ".georef-1gcp.json",
+        ):
             stale_path = output_path.replace(".georef.json", stale_suffix)
             if os.path.exists(stale_path):
                 os.remove(stale_path)

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -6,7 +6,9 @@ import numpy as np
 
 from mapsnap.georef_from_labels import (
     _FT_PER_DEG_LAT,
+    _angle_diff_abs,
     _cluster_geo_coords,
+    _rotation_from_neighbors,
     correct_square_feature_dirs,
     label_features,
     promote_avenue_letters,
@@ -348,3 +350,100 @@ def test_project_extrapolation_start_terminal_capped():
 
 def test_project_returns_none_for_empty_blocks():
     assert project_to_polyline(-90.0, 30.0, []) is None
+
+
+# ---------------------------------------------------------------------------
+# _angle_diff_abs
+# ---------------------------------------------------------------------------
+
+
+def test_angle_diff_abs_same():
+    assert _angle_diff_abs(1.0, 1.0) == 0.0
+
+
+def test_angle_diff_abs_opposite():
+    assert abs(_angle_diff_abs(0.0, math.pi) - math.pi) < 1e-10
+
+
+def test_angle_diff_abs_wraparound():
+    # 10° and 350° are 20° apart
+    assert (
+        abs(_angle_diff_abs(math.radians(10), math.radians(350)) - math.radians(20))
+        < 1e-10
+    )
+
+
+def test_angle_diff_abs_symmetric():
+    a, b = math.radians(30), math.radians(200)
+    assert abs(_angle_diff_abs(a, b) - _angle_diff_abs(b, a)) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# _rotation_from_neighbors
+# ---------------------------------------------------------------------------
+
+_PAGE_DIM = (0.01, 0.01)  # 0.01° in each direction
+
+
+def _neighbors(angles_deg: list[float], center: tuple[float, float] = (0.0, 0.0)):
+    return [(center, math.radians(a)) for a in angles_deg]
+
+
+def test_rotation_from_neighbors_two_agree_candidate():
+    # Two neighbours match the candidate (5°); should return ~5°.
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=_neighbors([4, 6, 180 + 90]),
+    )
+    assert result is not None
+    assert abs(math.degrees(result) - 5) < 1
+
+
+def test_rotation_from_neighbors_two_agree_flipped():
+    # Two neighbours match candidate+180 (185°); should return ~185°.
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=_neighbors([184, 186, 5]),
+    )
+    assert result is not None
+    assert abs(math.degrees(result) - 185) < 1
+
+
+def test_rotation_from_neighbors_only_one_agree_returns_none():
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=_neighbors([4, 90, 135]),
+    )
+    assert result is None
+
+
+def test_rotation_from_neighbors_no_adjacent_returns_none():
+    # Neighbours are far away (> 1.5 × page_dim).
+    far = [((-1.0, -1.0), math.radians(5)), ((-1.0, -1.0), math.radians(6))]
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=far,
+    )
+    assert result is None
+
+
+def test_rotation_from_neighbors_adjacency_boundary():
+    # Neighbours exactly at 1.5 × page_dim should be included.
+    on_edge = [
+        ((1.5 * _PAGE_DIM[0], 1.5 * _PAGE_DIM[1]), math.radians(a)) for a in [4, 6]
+    ]
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=on_edge,
+    )
+    assert result is not None

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -390,41 +390,50 @@ def _neighbors(angles_deg: list[float], center: tuple[float, float] = (0.0, 0.0)
 
 
 def test_rotation_from_neighbors_two_agree_candidate():
-    # Two neighbours match the candidate (5°); should return ~5°.
+    # Two neighbours match the candidate (5°); confirmed, rotation ≈ 5°.
     result = _rotation_from_neighbors(
         candidate=math.radians(5),
         approx_center=(0.0, 0.0),
         page_dim_deg=_PAGE_DIM,
         neighbor_rotations=_neighbors([4, 6, 180 + 90]),
     )
-    assert result is not None
-    assert abs(math.degrees(result) - 5) < 1
+    assert result.confirmed is True
+    assert result.method == "neighbor_confirmed"
+    assert abs(math.degrees(result.rotation) - 5) < 1
+    assert result.n_agree == 2
+    assert len(result.adjacent_deg) == 3
 
 
 def test_rotation_from_neighbors_two_agree_flipped():
-    # Two neighbours match candidate+180 (185°); should return ~185°.
+    # Two neighbours match candidate+180 (185°); confirmed, rotation ≈ 185°.
     result = _rotation_from_neighbors(
         candidate=math.radians(5),
         approx_center=(0.0, 0.0),
         page_dim_deg=_PAGE_DIM,
         neighbor_rotations=_neighbors([184, 186, 5]),
     )
-    assert result is not None
-    assert abs(math.degrees(result) - 185) < 1
+    assert result.confirmed is True
+    assert result.method == "neighbor_confirmed"
+    assert abs(math.degrees(result.rotation) - 185) < 1
 
 
-def test_rotation_from_neighbors_only_one_agree_returns_none():
+def test_rotation_from_neighbors_plurality():
+    # Only 1 neighbour agrees with candidate — unconfirmed plurality.
     result = _rotation_from_neighbors(
         candidate=math.radians(5),
         approx_center=(0.0, 0.0),
         page_dim_deg=_PAGE_DIM,
         neighbor_rotations=_neighbors([4, 90, 135]),
     )
-    assert result is None
+    assert result.confirmed is False
+    assert result.method == "neighbor_plurality"
+    assert abs(math.degrees(result.rotation) - 5) < 1
+    assert result.n_agree == 1
+    assert result.n_other == 0
 
 
-def test_rotation_from_neighbors_no_adjacent_returns_none():
-    # Neighbours are far away (> 1.5 × page_dim).
+def test_rotation_from_neighbors_no_adjacent_north_up_fallback():
+    # No adjacent neighbours → north-up fallback.
     far = [((-1.0, -1.0), math.radians(5)), ((-1.0, -1.0), math.radians(6))]
     result = _rotation_from_neighbors(
         candidate=math.radians(5),
@@ -432,11 +441,27 @@ def test_rotation_from_neighbors_no_adjacent_returns_none():
         page_dim_deg=_PAGE_DIM,
         neighbor_rotations=far,
     )
-    assert result is None
+    assert result.confirmed is False
+    assert result.method == "north_up_fallback"
+    assert result.n_agree == 0
+    assert result.n_other == 0
+    assert result.adjacent_deg == []
+
+
+def test_rotation_from_neighbors_tie_uses_north_up():
+    # Equal supporters (1 vs 1) → north-up fallback, not plurality.
+    result = _rotation_from_neighbors(
+        candidate=math.radians(5),
+        approx_center=(0.0, 0.0),
+        page_dim_deg=_PAGE_DIM,
+        neighbor_rotations=_neighbors([4, 184]),
+    )
+    assert result.confirmed is False
+    assert result.method == "north_up_fallback"
 
 
 def test_rotation_from_neighbors_adjacency_boundary():
-    # Neighbours exactly at 1.5 × page_dim should be included.
+    # Neighbours exactly at 1.5 × page_dim should be included and confirm.
     on_edge = [
         ((1.5 * _PAGE_DIM[0], 1.5 * _PAGE_DIM[1]), math.radians(a)) for a in [4, 6]
     ]
@@ -446,4 +471,5 @@ def test_rotation_from_neighbors_adjacency_boundary():
         page_dim_deg=_PAGE_DIM,
         neighbor_rotations=on_edge,
     )
-    assert result is not None
+    assert result.confirmed is True
+    assert result.n_agree == 2


### PR DESCRIPTION
Closes #21 

If two or more adjacent pages have a similar rotation, then we use that to disambiguate the +/-180° rotation. Otherwise we toss the page. This works pretty well on the volumes where I've tested it. It picks 11/14 1-gcps for Detroit 1929. Ten of these are good. The three it rejects are all bad. One of the fits it picks isn't great, but this is because of the JEAN vs. OLD JEAN ambiguity.

This moves bad 1-gcp fits to `.georef-1gcp.json` files so you can still inspect them.