### PR TITLE
Update test stats and IIIF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 
 Volume | Pages | Num Fit | Median RMSE | Within 15ft | Within 25ft | Allmaps
 ------ | ----- | ------- | ----------- | ----------- | ----------- | -------
-[New Orleans 1951 Vol 5][nola5] | 109 | 101 (93%) | 12ft | 67% | 84% | [view][nola5-iiif]
-[New Orleans 1896 Vol 2][nola2] | 91 | 83 (91%) | 25ft | 37% | 49% | [view][nola2-iiif]
-[Detroit 1929 Vol 11][detroit] | 103 | 85 (83%) | 13ft | 58% | 73% | [view][detroit-iiif]
-[Chicago 1950 Vol 1][chicago] | 111 | 100 (90%) | 10ft | 70% | 83% | [view][chicago-iiif]
-[Champaign, Ill. 1915][champaign] | 33 | 28 (85%) | 11ft | 79% | 93% | [view][champaign-iiif]
+[New Orleans 1951 Vol 5][nola5] | 109 | 101 (93%) | 12ft | 70% | 85% | [view][nola5-iiif]
+[New Orleans 1896 Vol 2][nola2] | 91 | 82 (90%) | 26ft | 38% | 48% | [view][nola2-iiif]
+[Detroit 1929 Vol 11][detroit] | 103 | 84 (82%) | 13ft | 58% | 75% | [view][detroit-iiif]
+[Chicago 1950 Vol 1][chicago] | 111 | 100 (90%) | 10ft | 72% | 88% | [view][chicago-iiif]
+[Champaign, Ill. 1915][champaign] | 33 | 26 (79%)[^1] | 11ft | 85% | 100% | [view][champaign-iiif]
 
 RMSE was measured across 49 equally-spaced points on each image. You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes][].
 
@@ -24,12 +24,14 @@ RMSE was measured across 49 equally-spaced points on each image. You can view th
 [chicago]: https://oldinsurancemaps.net/map/sanborn01790_085
 [champaign]: https://oldinsurancemaps.net/map/sanborn01778_006
 
-[nola5-iiif]: https://viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json
-[nola2-iiif]: https://viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json
-[detroit-iiif]: https://viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json
-[chicago-iiif]: https://viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json
-[champaign-iiif]: https://viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json
+[nola5-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json
+[nola2-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json
+[detroit-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json
+[chicago-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json
+[champaign-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json
 [test data notes]: https://github.com/danvk/mapsnap/wiki/Test-data-notes
+
+[^1]: Requires running with `--scale-outlier-threshold 0` since this volume contains maps using two different scales.
 
 ## How it Works
 

--- a/gallery/champaign_ill_1915.iiif.json
+++ b/gallery/champaign_ill_1915.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,61 +44,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"211.5,688.2 5838.9,619.4 5837.6,4653.3 5982.1,6785.4 1068.3,6852.2 446.9,7650.0 -0.0,7650.0 -0.0,5966.0 261.5,5399.2 211.5,688.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0010/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2878.6,
-                2667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2354345,
-                40.1173359
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5949.2,
-                6916.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.233525,
-                40.115377
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -115,8 +70,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23379925906343,
-                40.11735434331793
+                -88.233769,
+                40.117344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                236.2,
+                4815.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2371024,
+                40.1163368
               ]
             }
           }
@@ -134,15 +110,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "9"
         },
         {
           "label": "intersections",
           "value": "23"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,45 +137,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6338.3,7507.0 4802.3,7516.9 4240.0,7650.0 269.6,7650.0 167.4,85.8 400.7,80.9 399.5,-0.0 6450.0,-0.0 6450.0,141.4 5840.8,151.3 5843.7,331.8 6251.2,330.7 6338.3,7507.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4305.2,
-                5303.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.232105,
-                40.116357
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2192.0,
+                6273.6,
                 2632.9
               ],
               "creator": {
@@ -211,8 +163,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.230426,
-                40.117358
+                -88.230434,
+                40.11539
               ]
             }
           },
@@ -220,8 +172,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4305.2,
-                2648.7
+                239.4,
+                5316.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -232,8 +184,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23044537748835,
-                40.116347840187586
+                -88.232106,
+                40.118327
               ]
             }
           }
@@ -258,8 +210,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,17 +230,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6450.0,7254.6 613.1,7167.0 591.6,639.5 5960.9,639.9 5972.1,6327.4 6450.0,6481.4 6450.0,7254.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0012/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -332,160 +281,6 @@
                 40.1125772
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5971.3,
-                3439.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24349541746969,
-                40.11437807981931
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p13 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "5780.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2602.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "1870.0"
-        }
-      ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                715.1,
-                7442.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2431337,
-                40.1125757
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                280.4,
-                7442.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2434886,
-                40.1125772
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                497.7,
-                7007.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24330918865164,
-                40.11284787042096
-              ]
-            }
           }
         ]
       }
@@ -501,15 +296,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "12"
+          "value": "13"
         },
         {
           "label": "intersections",
-          "value": "34"
+          "value": "31"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -528,19 +323,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"55.3,85.9 1672.6,51.1 1672.1,330.6 3446.6,0.0 4775.5,135.7 6450.0,70.0 6450.0,7274.6 5365.8,7650.0 2524.3,7650.0 55.3,85.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1684.9,
+                1411.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.242814,
+                40.115934
+              ]
+            }
+          },
           {
             "type": "Feature",
             "properties": {
@@ -561,48 +374,6 @@
                 40.114523
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1684.9,
-                4160.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2433348,
-                40.1147055
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3319.5,
-                2781.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2421009916161,
-                40.115088085232244
-              ]
-            }
           }
         ]
       }
@@ -618,15 +389,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "12"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "21"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -645,17 +416,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"663.7,7273.1 750.0,7017.9 448.8,7016.4 2667.0,372.3 4370.8,903.3 4370.2,1441.4 5876.6,1398.1 6450.0,980.5 6450.0,7305.7 663.7,7273.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0014/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -699,27 +467,6 @@
                 40.115812
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3281.7,
-                3445.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.23937424390004,
-                40.11441453220167
-              ]
-            }
           }
         ]
       }
@@ -735,15 +482,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -762,17 +509,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6265.6,6814.4 -0.0,6861.4 -0.0,6508.9 1141.7,6523.7 1147.7,6057.0 323.0,5397.2 319.8,265.0 5190.0,266.8 6228.3,411.7 6265.6,6814.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -816,27 +560,6 @@
                 40.113469
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2503.8,
-                6160.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.23704047861928,
-                40.114362907666475
-              ]
-            }
           }
         ]
       }
@@ -859,8 +582,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -879,17 +602,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"5996.8,194.0 6025.7,7619.4 5034.3,7477.9 382.6,7462.3 413.0,188.5 -0.0,186.6 -0.0,-0.0 6450.0,-0.0 6450.0,194.3 5996.8,194.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -933,27 +653,6 @@
                 40.1144192
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4371.4,
-                2522.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.23041243383173,
-                40.113489314666026
-              ]
-            }
           }
         ]
       }
@@ -969,15 +668,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -996,17 +695,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"856.8,7580.4 820.1,159.2 1273.0,153.4 1272.8,-0.0 5861.4,-0.0 5900.5,7547.4 856.8,7580.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1050,27 +746,6 @@
                 40.1126956
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3354.1,
-                2491.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2303938984013,
-                40.11149933006545
-              ]
-            }
           }
         ]
       }
@@ -1090,11 +765,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1113,45 +788,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"1206.9,7650.0 1206.6,7428.0 878.3,7424.8 705.5,7423.2 705.5,115.0 6450.0,121.1 6450.0,7650.0 1206.9,7650.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3407.7,
-                2680.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2303702,
-                40.109056
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3407.7,
+                705.5,
                 7423.2
               ],
               "creator": {
@@ -1163,8 +814,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2303281,
-                40.1068384
+                -88.2319954,
+                40.1068287
               ]
             }
           },
@@ -1173,7 +824,7 @@
             "properties": {
               "resourceCoords": [
                 705.5,
-                2680.2
+                113.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1184,8 +835,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23202208363244,
-                40.10903765530521
+                -88.2320465,
+                40.1102829
               ]
             }
           }
@@ -1207,11 +858,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1230,40 +881,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,176.8 4950.9,185.8 4954.9,2803.7 6198.9,2796.2 6193.3,6540.9 6450.0,6543.8 6450.0,7650.0 -0.0,7650.0 -0.0,829.4 -0.0,176.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2075.5,
-                1483.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2370603,
-                40.1114458
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -1289,8 +916,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2075.5,
-                5319.4
+                4950.9,
+                185.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1301,8 +928,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.23699197634907,
-                40.10789934113695
+                -88.233592,
+                40.112676
               ]
             }
           }
@@ -1320,15 +947,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1347,25 +974,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"88.5,102.0 3084.6,162.8 3085.4,0.0 3800.1,0.0 4223.7,139.0 4810.8,129.5 4853.3,0.0 5005.3,0.0 4962.4,129.0 6100.4,133.2 6134.9,7621.7 -0.0,7650.0 -0.0,4307.3 86.8,4308.1 88.5,102.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                176.4,
-                4043.9
+                1464.5,
+                2771.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1376,8 +1000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2467657,
-                40.1089793
+                -88.245117,
+                40.110162
               ]
             }
           },
@@ -1385,7 +1009,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                176.4,
+                1464.5,
                 1152.7
               ],
               "creator": {
@@ -1397,29 +1021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2467872,
-                40.1116581
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1464.5,
-                4043.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.245205177697,
-                40.10898662605245
+                -88.245133,
+                40.1116522
               ]
             }
           }
@@ -1460,8 +1063,8 @@
           "value": "4256.0"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1480,17 +1083,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"3491.0,7650.0 3491.0,3495.5 6273.8,3503.4 6307.6,7650.0 3491.0,7650.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0020__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1534,27 +1134,6 @@
                 40.1101382
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4923.3,
-                6150.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24845076836635,
-                40.110137784554425
-              ]
-            }
           }
         ]
       }
@@ -1593,8 +1172,8 @@
           "value": "5023.0"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1613,17 +1192,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2627.0 4216.0,2627.0 4216.0,7397.5 4050.1,7396.2 4048.9,7515.1 2964.0,7511.0 2962.9,7650.0 123.0,7650.0 122.9,7340.5 -0.0,7339.3 -0.0,2627.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1667,27 +1243,6 @@
                 40.1284836
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2178.8,
-                6226.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24109278441941,
-                40.127201191597166
-              ]
-            }
           }
         ]
       }
@@ -1703,15 +1258,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "10"
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1730,17 +1285,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7650.0 -0.0,-0.0 5929.4,0.0 5927.5,95.8 5882.6,95.5 5833.9,7414.9 4035.3,7388.1 4035.8,7254.9 3236.2,7252.9 3235.1,7650.0 -0.0,7650.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1748,7 +1300,7 @@
             "properties": {
               "resourceCoords": [
                 6015.4,
-                5552.5
+                6475.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1759,8 +1311,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2542698,
-                40.1143564
+                -88.2542645,
+                40.1134977
               ]
             }
           },
@@ -1768,7 +1320,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6015.4,
+                6031.1,
                 2387.3
               ],
               "creator": {
@@ -1782,27 +1334,6 @@
               "coordinates": [
                 -88.25429,
                 40.117274
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1058.2,
-                3461.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.26025829286054,
-                40.11625985425965
               ]
             }
           }
@@ -1824,11 +1355,11 @@
         },
         {
           "label": "intersections",
-          "value": "59"
+          "value": "37"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1847,17 +1378,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6329.7,7328.0 -0.0,7292.3 -0.0,-0.0 44.8,-0.0 42.1,209.6 6319.0,209.9 6323.6,1230.7 6047.9,1230.3 6049.0,3391.4 6320.2,3391.4 6329.7,7328.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1885,8 +1413,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2242.4,
-                2286.5
+                4957.2,
+                211.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1897,29 +1425,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.251772,
-                40.117275
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2242.4,
-                3360.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25176818760471,
-                40.11627812360907
+                -88.248484,
+                40.119205
               ]
             }
           }
@@ -1941,7 +1448,7 @@
         },
         {
           "label": "intersections",
-          "value": "31"
+          "value": "25"
         },
         {
           "label": "split_canvas_x",
@@ -1960,8 +1467,8 @@
           "value": "5345.0"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1980,17 +1487,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7431.4 -0.0,2305.0 6178.6,2305.0 6249.2,7353.2 -0.0,7431.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2034,27 +1538,6 @@
                 40.122646
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6198.0,
-                5281.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24686947325989,
-                40.12113881736803
-              ]
-            }
           }
         ]
       }
@@ -2070,11 +1553,11 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "9"
         },
         {
           "label": "split_canvas_x",
@@ -2093,8 +1576,8 @@
           "value": "3255.0"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2113,17 +1596,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 794.7,0.0 794.7,132.3 6099.0,188.5 6078.3,3255.0 -0.0,3255.0 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2167,27 +1647,6 @@
                 40.1101382
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2947.9,
-                1155.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25402144291351,
-                40.11169952302534
-              ]
-            }
           }
         ]
       }
@@ -2203,15 +1662,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "13"
+          "value": "14"
         },
         {
           "label": "intersections",
-          "value": "34"
+          "value": "30"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2230,17 +1689,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6327.0,193.9 6314.4,7102.0 6198.9,7101.4 5800.3,7097.8 5680.4,7096.9 5666.7,7650.0 -0.0,7614.6 -0.0,0.0 6450.0,-0.0 6450.0,194.3 6327.0,193.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0024/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2284,27 +1740,6 @@
                 40.11928
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4261.2,
-                2947.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2321211956504,
-                40.12022440288981
-              ]
-            }
           }
         ]
       }
@@ -2327,8 +1762,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2347,17 +1782,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"679.4,4765.6 -0.0,4756.9 -0.0,-0.0 6072.3,0.0 6068.7,7327.3 683.2,7319.7 679.4,4765.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2401,181 +1833,6 @@
                 40.122647
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3351.0,
-                3316.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24522470118727,
-                40.12459114818535
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p3 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "4847.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "1016.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "1603.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "1098.0"
-        }
-      ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4847.0,
-                1016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.26512357503888,
-                40.11742281382648
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6450.0,
-                1016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.26412150162328,
-                40.11742268959467
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6450.0,
-                2114.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.26412161299623,
-                40.116897195399986
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4847.0,
-                2114.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.26512368641184,
-                40.1168973196318
-              ]
-            }
           }
         ]
       }
@@ -2591,15 +1848,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2618,40 +1875,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"416.8,6873.4 424.8,427.8 5994.7,372.9 6007.1,6897.7 416.8,6873.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4421.8,
-                2434.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2410878,
-                40.124928
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -2678,7 +1911,7 @@
             "properties": {
               "resourceCoords": [
                 425.2,
-                2434.5
+                148.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2689,8 +1922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.24356604818844,
-                40.1249138390561
+                -88.243563,
+                40.125991
               ]
             }
           }
@@ -2724,15 +1957,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "3733.0"
+          "value": "3719.0"
         },
         {
           "label": "split_canvas_h",
           "value": "7650.0"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2751,24 +1984,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"1337.0,7650.0 -0.0,7650.0 -0.0,238.7 2090.2,229.9 2090.7,0.0 3719.0,0.0 3719.0,7650.0 1520.9,7650.0 1524.4,7083.3 1337.0,7650.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0004__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2098.0,
+                2090.2,
                 2510.1
               ],
               "creator": {
@@ -2789,7 +2019,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2098.0,
+                2090.2,
                 229.9
               ],
               "creator": {
@@ -2803,27 +2033,6 @@
               "coordinates": [
                 -88.238808,
                 40.126028
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                267.8,
-                2510.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2399491062188,
-                40.12493131834652
               ]
             }
           }
@@ -2841,15 +2050,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "19"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2868,40 +2077,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"5941.8,7378.5 638.4,7443.6 620.0,0.0 5966.3,0.0 5966.6,320.4 5967.0,372.3 5941.8,7378.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0005/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3291.1,
-                3228.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2452084,
-                40.121179
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -2928,7 +2113,7 @@
             "properties": {
               "resourceCoords": [
                 620.4,
-                3228.2
+                148.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2939,8 +2124,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.24683925766288,
-                40.12117442377556
+                -88.2468495,
+                40.122646
               ]
             }
           }
@@ -2965,8 +2150,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2985,17 +2170,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6273.2,7187.6 6450.0,7244.6 6450.0,7308.1 -0.0,7311.9 -0.0,1589.5 738.3,1584.9 729.6,191.6 139.8,-0.0 6450.0,-0.0 6273.2,7187.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0006/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3039,27 +2221,6 @@
                 40.121099
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6198.0,
-                3439.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24122810708651,
-                40.1199478464376
-              ]
-            }
           }
         ]
       }
@@ -3075,15 +2236,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "11"
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "22"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3102,17 +2263,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"539.4,6437.7 -0.0,6437.4 -0.0,2140.4 548.2,2141.6 540.1,111.9 5897.8,55.0 5973.4,7650.0 532.2,7650.0 539.4,6437.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0007/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3156,27 +2314,6 @@
                 40.1162878
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3253.3,
-                4232.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24517137402809,
-                40.11729083777206
-              ]
-            }
           }
         ]
       }
@@ -3192,15 +2329,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "13"
+          "value": "14"
         },
         {
           "label": "intersections",
           "value": "31"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3219,17 +2356,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1555.2 -0.0,1160.5 3595.3,0.0 6450.0,0.0 6450.0,1272.1 4620.8,1830.9 5508.5,4736.8 5961.3,4770.9 6002.2,6353.0 6324.9,7409.3 5381.3,7404.5 4629.8,7650.0 3611.1,7650.0 3611.0,7463.7 2004.9,7506.0 -0.0,1555.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0008/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3273,27 +2407,6 @@
                 40.117163
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4853.2,
-                6100.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24157248528559,
-                40.11697926654901
-              ]
-            }
           }
         ]
       }
@@ -3313,11 +2426,11 @@
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:21:39Z",
-      "modified": "2026-05-25T13:21:39Z",
+      "created": "2026-06-10T19:18:25Z",
+      "modified": "2026-06-10T19:18:25Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3336,17 +2449,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7650 0,0 6450,0 6450,7650 0,7650\" /></svg>"
+          "value": "<svg><polygon points=\"6262.2,6287.5 5418.8,7342.7 4879.7,7532.0 3651.8,7570.7 3636.1,7039.0 319.1,6115.5 -0.0,5887.6 -0.0,4772.7 427.1,3233.4 -0.0,3066.9 -0.0,-0.0 6174.3,0.0 6262.2,6287.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3388,27 +2498,6 @@
               "coordinates": [
                 -88.2370995,
                 40.118307
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                494.5,
-                3231.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.24062375304703,
-                40.117417216654104
               ]
             }
           }

--- a/gallery/chicago_il_1950_vol_1.iiif.json
+++ b/gallery/chicago_il_1950_vol_1.iiif.json
@@ -24,8 +24,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,17 +44,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5882,0 5882,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5882.0,7323.0 -0.0,7323.0 -0.0,1000.2 5882.0,1010.3 5882.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -98,27 +95,6 @@
                 41.8712518
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1285.3,
-                6329.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64688627362594,
-                41.87191046637535
-              ]
-            }
           }
         ]
       }
@@ -141,8 +117,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,17 +137,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5844,0 5844,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4201.5,6234.1 1791.2,6243.3 1731.4,37.8 4127.1,0.0 4201.5,6234.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0101W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -215,27 +188,6 @@
                 41.8719711
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4201.5,
-                1256.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64231592146,
-                41.871987815836725
-              ]
-            }
           }
         ]
       }
@@ -258,8 +210,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,17 +230,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5882,0 5882,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1755.2,6226.4 1716.6,0.0 4077.0,0.0 4132.7,6228.3 1755.2,6226.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0102W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -332,27 +281,6 @@
                 41.8697525
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4132.7,
-                1290.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64087146649575,
-                41.8720138514541
-              ]
-            }
           }
         ]
       }
@@ -375,8 +303,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -395,17 +323,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5844,0 5844,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1603.6,1251.1 4117.9,1231.5 4152.3,6222.5 1682.9,6208.1 1603.6,1251.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0103W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -449,27 +374,6 @@
                 41.8697525
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1682.9,
-                1233.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64085013239752,
-                41.87201760416809
-              ]
-            }
           }
         ]
       }
@@ -492,8 +396,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -512,17 +416,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5901,0 5901,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1440.9,4711.8 1440.6,2380.7 3938.4,2352.6 3912.0,0.0 5901.0,0.0 5901.0,7323.0 5147.0,7323.0 5145.6,4709.8 1440.9,4711.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0104W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -566,51 +467,30 @@
                 41.8697612
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5901.0,
-                3769.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6366245508491,
-                41.87093817044732
-              ]
-            }
           }
         ]
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0105W/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p105W",
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p106W",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -619,47 +499,44 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0105W/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0105W/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/info.json",
           "type": "ImageService2",
           "height": 7323,
-          "width": 5849
+          "width": 5901
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5849,0 5849,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"2285.3,7017.3 2287.4,6810.5 -0.0,6789.9 -0.0,1498.1 2286.3,1532.6 2287.4,0.0 5901.0,0.0 5901.0,7323.0 5157.1,7323.0 5155.4,7040.2 2285.3,7017.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0105W/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                2287.8,
+                6913.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.68317753573604,
-                41.89793830188146
+                -87.6392291,
+                41.8672683
               ]
             }
           },
@@ -667,62 +544,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5849.0,
-                0.0
+                2284.9,
+                1532.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.68310448184444,
-                41.89529839433088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5849.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.68754429650745,
-                41.895230281920504
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.68761735039905,
-                41.897870189471085
+                -87.6392994,
+                41.8697612
               ]
             }
           }
@@ -747,8 +582,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -767,17 +602,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5849,0 5849,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,7019.5 2224.5,7051.8 2311.5,1046.9 3420.9,1065.3 3236.0,7323.0 -0.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0107W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -821,27 +653,6 @@
                 41.8696118
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                3719.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64542472592423,
-                41.870990380176195
-              ]
-            }
           }
         ]
       }
@@ -864,8 +675,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -884,17 +695,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5877,0 5877,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1065.1 5092.6,1002.1 5101.7,1712.1 5718.5,1698.2 5679.2,-0.0 5877.0,-0.0 5877.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0108W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -938,27 +746,6 @@
                 41.8672095
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                3684.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64534456306248,
-                41.869481918453126
-              ]
-            }
           }
         ]
       }
@@ -981,8 +768,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1001,17 +788,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5861,0 5861,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4167.6,995.3 4102.7,7323.0 918.1,7323.0 918.4,6686.5 1651.1,6694.1 1711.6,956.4 4167.6,995.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0109W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1055,27 +839,6 @@
                 41.8697104
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4149.4,
-                956.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64228225719306,
-                41.86974798134937
-              ]
-            }
           }
         ]
       }
@@ -1098,8 +861,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1118,17 +881,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5809,0 5809,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4111.5,725.9 4137.2,6528.9 1679.9,6530.8 1680.0,732.7 4111.5,725.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0010N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1172,27 +932,6 @@
                 41.8940363
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4120.5,
-                2967.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62975102464432,
-                41.89565158953739
-              ]
-            }
           }
         ]
       }
@@ -1208,15 +947,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1235,17 +974,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5877,0 5877,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1699.7,967.9 4270.1,984.7 4244.5,6445.6 4126.9,6446.2 4125.3,7323.0 1691.4,7243.2 1699.7,967.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0110W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1273,8 +1009,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4085.1,
-                2633.1
+                1699.7,
+                967.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1285,29 +1021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6407824,
-                41.8690097
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4085.1,
-                4433.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64076512080163,
-                41.86819364677179
+                -87.6422705,
+                41.8697309
               ]
             }
           }
@@ -1332,8 +1047,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1352,17 +1067,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5861,0 5861,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"405.1,6483.3 2892.0,6518.6 2888.6,6732.7 5861.0,6774.5 5861.0,7323.0 402.3,7323.0 405.1,6483.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0111W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1406,27 +1118,6 @@
                 41.8697525
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2818.1,
-                1002.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.639364646986,
-                41.869781610003365
-              ]
-            }
           }
         ]
       }
@@ -1446,11 +1137,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1469,17 +1160,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5806,0 5806,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4114.6,6548.7 1538.7,6539.4 1538.7,798.0 903.4,796.9 907.3,61.1 5806.0,0.0 5806.0,801.3 4121.2,804.1 4114.6,6548.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0011N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1523,27 +1211,6 @@
                 41.8966555
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4157.8,
-                2996.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62815847745573,
-                41.895686326466034
-              ]
-            }
           }
         ]
       }
@@ -1566,8 +1233,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1586,17 +1253,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5809,0 5809,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4043.1,732.1 4044.1,6517.4 1798.0,6522.1 1788.5,741.4 4043.1,732.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0012N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1640,27 +1304,6 @@
                 41.8940776
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1798.0,
-                2944.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62817945716951,
-                41.89568721901286
-              ]
-            }
           }
         ]
       }
@@ -1676,15 +1319,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1703,40 +1346,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5806,0 5806,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"842.1,740.8 288.0,741.1 288.0,0.0 5806.0,66.6 5806.0,6470.4 5123.0,6469.3 5125.0,7233.4 4840.1,7232.7 4837.7,6464.1 827.0,6473.2 842.1,740.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0013N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                827.0,
-                4710.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6268047,
-                41.8948999
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -1762,8 +1381,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3057.2,
-                2932.7
+                827.0,
+                6473.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1774,8 +1393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62546906243782,
-                41.895728630480285
+                -87.6267812,
+                41.894099
               ]
             }
           }
@@ -1800,8 +1419,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1820,17 +1439,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5809,0 5809,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4718.6,0.0 4720.5,726.6 5809.0,730.4 5809.0,6537.5 1032.5,6541.8 1015.6,0.0 4718.6,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1874,27 +1490,6 @@
                 41.8941636
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                440.9,
-                2944.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6241405546017,
-                41.89574365484056
-              ]
-            }
           }
         ]
       }
@@ -1914,11 +1509,11 @@
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1937,17 +1532,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5806,0 5806,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1066.6,6542.2 1081.6,772.2 914.2,771.0 175.9,767.6 -0.0,765.5 -0.0,-0.0 5806.0,0.0 5806.0,6517.1 1066.6,6542.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1991,27 +1583,6 @@
                 41.8942136
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5610.1,
-                4734.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61818919096412,
-                41.895045436501924
-              ]
-            }
           }
         ]
       }
@@ -2034,8 +1605,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2054,17 +1625,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5798,0 5798,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1104.6,5481.9 1467.3,0.0 5798.0,0.0 5798.0,7323.0 5182.9,5743.6 1542.4,5894.6 1565.8,5512.2 1104.6,5481.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2108,27 +1676,6 @@
                 41.8968396
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5898.9,
-                6493.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61520821374421,
-                41.89442373534083
-              ]
-            }
           }
         ]
       }
@@ -2151,8 +1698,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2171,17 +1718,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5806,0 5806,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4315.2,958.0 4726.3,6286.6 4681.5,7323.0 270.3,7219.6 216.0,6699.4 652.6,5646.8 655.8,923.1 4315.2,958.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2225,27 +1769,6 @@
                 41.893922
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2143.8,
-                962.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64174236574497,
-                41.89388762575259
-              ]
-            }
           }
         ]
       }
@@ -2268,8 +1791,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2288,17 +1811,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5798,0 5798,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5559.3,6337.6 483.0,6366.0 417.5,5635.4 -0.0,4885.0 -0.0,973.3 5519.0,955.6 5559.3,6337.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2342,27 +1862,6 @@
                 41.8915062
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5538.6,
-                6352.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63703132981877,
-                41.8915368195104
-              ]
-            }
           }
         ]
       }
@@ -2385,8 +1884,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2405,17 +1904,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5794,0 5794,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4049.2,6324.2 1694.1,6307.7 1685.0,967.4 4053.8,972.7 4049.2,6324.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2459,27 +1955,6 @@
                 41.8915431
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5240.8,
-                4534.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63488503766281,
-                41.892377708112775
-              ]
-            }
           }
         ]
       }
@@ -2502,8 +1977,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2522,17 +1997,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5798,0 5798,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4221.1,916.9 4261.8,6324.9 1711.7,6322.9 1700.2,916.1 4221.1,916.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2576,27 +2048,6 @@
                 41.8939783
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4239.0,
-                4522.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63408636080301,
-                41.89238243348672
-              ]
-            }
           }
         ]
       }
@@ -2619,8 +2070,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2639,17 +2090,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5794,0 5794,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"3863.7,6276.9 1653.8,6267.4 1653.8,945.1 4187.2,960.4 4176.8,2733.2 3920.3,2733.0 3863.7,6276.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2693,27 +2141,6 @@
                 41.8915756
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3757.0,
-                945.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63284875583267,
-                41.89402073692706
-              ]
-            }
           }
         ]
       }
@@ -2736,8 +2163,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2756,17 +2183,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5798,0 5798,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1578.3,5326.3 1609.7,2775.9 1868.1,2774.2 1865.7,989.9 4178.5,991.0 4175.6,7323.0 1580.5,7323.0 1587.3,5326.3 1578.3,5326.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2810,27 +2234,6 @@
                 41.8940363
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2400.5,
-                1879.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63225214782034,
-                41.89362050554815
-              ]
-            }
           }
         ]
       }
@@ -2853,8 +2256,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2873,17 +2276,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5794,0 5794,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4101.3,959.0 4121.6,6355.6 1640.9,6366.1 1639.5,962.6 4101.3,959.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0023N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2927,27 +2327,6 @@
                 41.8924393
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4122.9,
-                4535.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6296556576536,
-                41.892457820210325
-              ]
-            }
           }
         ]
       }
@@ -2967,11 +2346,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2990,17 +2369,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5798,0 5798,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1685.5,889.0 4285.2,971.2 4100.5,7323.0 1495.9,7323.0 1685.5,889.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3044,27 +2420,6 @@
                 41.8916443
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1527.3,
-                2751.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6297434540647,
-                41.89321850889849
-              ]
-            }
           }
         ]
       }
@@ -3080,15 +2435,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3107,25 +2462,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5794,0 5794,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"5047.4,6287.2 582.0,6296.6 582.0,904.8 5038.3,900.6 5047.4,6287.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2843.7,
-                2708.7
+                582.0,
+                4486.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3136,8 +2488,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6267605,
-                41.8932946
+                -87.6280935,
+                41.8924761
               ]
             }
           },
@@ -3146,7 +2498,7 @@
             "properties": {
               "resourceCoords": [
                 582.0,
-                6276.0
+                904.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3157,29 +2509,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.628071,
-                41.8916668
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                582.0,
-                2708.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62812526101742,
-                41.893268988038926
+                -87.628138,
+                41.8940776
               ]
             }
           }
@@ -3201,11 +2532,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3224,17 +2555,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5803,0 5803,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"677.1,852.7 2544.2,854.1 2542.3,1631.4 2830.5,1633.7 2832.6,860.9 5162.4,879.4 5152.1,4474.0 2803.5,4430.5 2810.3,4264.3 2517.3,4256.1 2518.1,4428.3 665.9,4414.3 677.1,852.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3278,27 +2606,6 @@
                 41.8941207
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2743.0,
-                4453.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62415676069689,
-                41.892529422192695
-              ]
-            }
           }
         ]
       }
@@ -3321,8 +2628,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3341,17 +2648,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5794,0 5794,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"851.4,962.4 4928.2,908.9 4983.3,7299.2 915.7,7322.0 851.4,962.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3395,27 +2699,6 @@
                 41.8941636
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                852.8,
-                6296.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62271136641908,
-                41.89177752266415
-              ]
-            }
           }
         ]
       }
@@ -3438,8 +2721,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3458,17 +2741,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5803,0 5803,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"325.4,954.6 4071.3,956.8 4071.6,0.0 4520.9,0.0 4561.8,4571.4 3450.9,4572.8 3439.0,7323.0 329.5,7323.0 325.4,954.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3512,27 +2792,6 @@
                 41.891803
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2040.0,
-                6323.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61920110938192,
-                41.891820125635164
-              ]
-            }
           }
         ]
       }
@@ -3548,15 +2807,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3575,17 +2834,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5753,0 5753,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4175.6 409.5,0.0 3947.6,0.0 4480.9,1557.5 4545.5,0.0 5753.0,0.0 5753.0,5062.3 4350.1,4895.2 4375.0,4672.5 -0.0,4175.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3613,8 +2869,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5424.6,
-                4583.4
+                4295.3,
+                1016.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3625,29 +2881,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6145965,
-                41.8926846
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5424.6,
-                3595.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61469909757592,
-                41.89306481917319
+                -87.6153782,
+                41.894289
               ]
             }
           }
@@ -3672,8 +2907,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3692,17 +2927,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5845,0 5845,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4136.7,6569.2 1715.4,6571.9 1714.4,6340.5 -0.0,6357.2 -0.0,0.0 3850.7,0.0 4136.7,992.1 4136.7,6569.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3746,27 +2978,6 @@
                 41.8947101
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2313.2,
-                3821.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64256482027696,
-                41.895097997987584
-              ]
-            }
           }
         ]
       }
@@ -3789,8 +3000,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3809,17 +3020,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5803,0 5803,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 5803.0,-0.0 5803.0,6347.5 -0.0,6389.1 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3863,27 +3071,6 @@
                 41.8911123
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1524.2,
-                999.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61188628128528,
-                41.89192576576524
-              ]
-            }
           }
         ]
       }
@@ -3906,8 +3093,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3926,17 +3113,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5753,0 5753,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"2792.0,6502.1 -0.0,6657.1 -0.0,1201.6 5112.9,1015.1 5301.5,6432.2 3521.6,6483.0 3593.8,7256.1 5303.4,7209.1 5315.6,7323.0 2811.5,7323.0 2792.0,6502.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0031N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3980,27 +3164,6 @@
                 41.889119
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1449.1,
-                2800.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63922929039069,
-                41.89077526633602
-              ]
-            }
           }
         ]
       }
@@ -4023,8 +3186,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4043,17 +3206,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5803,0 5803,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1662.5,1060.1 4077.2,1038.5 4163.5,4655.4 1714.8,7323.0 -0.0,7323.0 -0.0,6540.7 1662.5,1060.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0032N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4097,27 +3257,6 @@
                 41.8915431
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1662.5,
-                4655.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63701091733452,
-                41.889955908072885
-              ]
-            }
           }
         ]
       }
@@ -4137,11 +3276,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4160,17 +3299,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5825,0 5825,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4210.9,3737.4 1746.9,3890.2 1746.2,1121.5 5825.0,1164.3 5825.0,4635.3 4454.9,4718.6 4200.2,4617.9 4210.9,3737.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4214,27 +3350,6 @@
                 41.8899822
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4200.2,
-                2970.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63404085464316,
-                41.89073935573375
-              ]
-            }
           }
         ]
       }
@@ -4257,8 +3372,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4277,17 +3392,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5825,0 5825,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"3444.7,4515.2 3415.4,1003.0 4015.4,1002.8 4013.8,4515.6 3444.7,4515.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4331,27 +3443,6 @@
                 41.8899822
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3946.7,
-                4511.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63270253837042,
-                41.890001700295585
-              ]
-            }
           }
         ]
       }
@@ -4374,8 +3465,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4394,17 +3485,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5831,0 5831,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1416.8,4613.7 1409.4,2026.2 4042.3,2024.4 4042.5,2794.6 5831.0,2802.2 5831.0,4813.1 5748.0,4606.7 1416.8,4613.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4448,27 +3536,6 @@
                 41.8916211
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                452.3,
-                2814.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6332573039146,
-                41.89079477537513
-              ]
-            }
           }
         ]
       }
@@ -4484,15 +3551,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4511,17 +3578,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5825,0 5825,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1761.9,973.9 4250.5,974.7 4248.7,2770.3 3714.8,4774.5 3533.3,4774.5 3534.3,4568.0 1754.4,2748.3 1761.9,973.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0036N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4565,27 +3629,6 @@
                 41.8892182
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4240.6,
-                4554.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62959788676223,
-                41.8900491124962
-              ]
-            }
           }
         ]
       }
@@ -4605,11 +3648,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4628,17 +3671,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5831,0 5831,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1468.8,2958.9 4090.8,2915.2 4081.4,3718.1 1459.3,3690.6 1468.8,2958.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0037N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4682,27 +3722,6 @@
                 41.8916668
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4102.4,
-                5490.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62800011439573,
-                41.890082119089925
-              ]
-            }
           }
         ]
       }
@@ -4718,15 +3737,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4745,17 +3764,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5825,0 5825,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1947.4,3673.0 1937.4,1859.3 4220.4,1846.6 4222.3,3655.0 1947.4,3673.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0038N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4763,7 +3779,7 @@
             "properties": {
               "resourceCoords": [
                 1947.4,
-                3667.3
+                3673.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4784,7 +3800,7 @@
             "properties": {
               "resourceCoords": [
                 4220.4,
-                1838.0
+                1846.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4797,27 +3813,6 @@
               "coordinates": [
                 -87.6267252,
                 41.8916883
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1947.4,
-                1846.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62806444541081,
-                41.89166931866725
               ]
             }
           }
@@ -4842,8 +3837,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4862,17 +3857,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5866,0 5866,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1804.0,3489.8 1818.4,1703.8 3182.2,1705.3 3214.1,3495.4 1804.0,3489.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0039N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4916,27 +3908,6 @@
                 41.8917123
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1792.1,
-                1705.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62674009712705,
-                41.89168708953981
-              ]
-            }
           }
         ]
       }
@@ -4959,8 +3930,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4979,17 +3950,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5879,0 5879,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1684.2,1047.4 1403.9,70.8 5879.0,0.0 5879.0,723.4 4258.7,728.1 4127.2,1017.1 4148.2,6535.3 1678.1,6535.3 1684.2,1047.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5033,27 +4001,6 @@
                 41.8947101
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4141.2,
-                2956.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64002088146752,
-                41.895520636186276
-              ]
-            }
           }
         ]
       }
@@ -5076,8 +4023,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5096,17 +4043,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5820,0 5820,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"711.5,1987.5 676.6,207.2 2500.1,0.0 2652.6,0.0 2789.5,0.0 5097.8,106.1 5820.0,2842.1 5820.0,3601.3 2688.5,6217.5 711.5,1987.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5150,27 +4094,6 @@
                 41.8917508
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                -4102.8,
-                5433.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62833072403446,
-                41.89014557452253
-              ]
-            }
           }
         ]
       }
@@ -5193,8 +4116,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5213,17 +4136,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5820,0 5820,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2534.1 221.4,592.0 2829.3,780.7 2880.2,0.0 5617.4,0.0 5545.1,973.6 5820.0,1102.5 5528.5,1083.2 5016.7,7323.0 -0.0,7323.0 -0.0,2534.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5267,27 +4187,6 @@
                 41.889126
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2829.3,
-                2587.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63543690874387,
-                41.889214684733
-              ]
-            }
           }
         ]
       }
@@ -5310,8 +4209,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5330,17 +4229,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6327.0 1805.2,6207.3 1902.2,0.0 4663.3,0.0 4456.2,7278.9 -0.0,7323.0 -0.0,6327.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0043N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5384,27 +4280,6 @@
                 41.8891834
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3064.1,
-                4286.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63330573925641,
-                41.888155364686476
-              ]
-            }
           }
         ]
       }
@@ -5427,8 +4302,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5447,7 +4322,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1625.6,6817.2 1872.2,73.6 5828.0,42.8 5828.0,247.0 4142.7,199.3 4049.4,7053.7 5394.1,7094.7 5386.9,7219.8 2385.9,7122.7 2383.7,7323.0 -0.0,7323.0 -0.0,6764.5 1625.6,6817.2\" /></svg>"
         }
       },
       "body": {
@@ -5476,8 +4351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6336029212412,
-                41.88997035340453
+                -87.6336016864351,
+                41.88996998929027
               ]
             }
           },
@@ -5497,8 +4372,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63007068379076,
-                41.89005549408424
+                -87.6300711661468,
+                41.89005508875374
               ]
             }
           },
@@ -5518,8 +4393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6299269981427,
-                41.88675078724253
+                -87.62992755035009,
+                41.88675198170654
               ]
             }
           },
@@ -5539,8 +4414,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63345923559314,
-                41.886665646562825
+                -87.63345807063838,
+                41.88666688224307
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4131.2,
+                1800.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6310629,
+                41.8892182
               ]
             }
           }
@@ -5562,11 +4458,11 @@
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5585,17 +4481,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6866.4 1669.5,0.0 4113.9,0.0 5866.0,7002.9 5866.0,7002.9 5866.0,7323.0 -0.0,7323.0 -0.0,6866.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5623,7 +4516,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1890.0,
+                1676.8,
                 1561.4
               ],
               "creator": {
@@ -5637,27 +4530,6 @@
               "coordinates": [
                 -87.6310629,
                 41.8892182
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2999.3,
-                3779.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6302894981933,
-                41.888125702055
               ]
             }
           }
@@ -5682,8 +4554,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5702,17 +4574,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"413.9,7170.9 378.3,6878.7 1569.1,6889.5 1555.7,1538.3 4255.0,1538.3 4137.3,3160.9 4291.6,3114.6 4343.3,3265.0 4347.1,5412.4 5828.0,5414.5 5828.0,7323.0 413.9,7170.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5756,27 +4625,6 @@
                 41.8892418
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4255.0,
-                3462.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62799111986726,
-                41.888424456492906
-              ]
-            }
           }
         ]
       }
@@ -5796,11 +4644,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5819,17 +4667,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5251.9,3557.6 516.5,3640.4 517.9,2060.9 -0.0,2067.9 -0.0,81.9 5357.4,63.7 5388.8,3234.3 5251.9,3557.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0047N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5858,7 +4703,7 @@
             "properties": {
               "resourceCoords": [
                 518.6,
-                1846.6
+                1863.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5871,27 +4716,6 @@
               "coordinates": [
                 -87.6295984,
                 41.8900425
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3128.9,
-                3687.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62799044929865,
-                41.88924301139412
               ]
             }
           }
@@ -5913,11 +4737,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5936,17 +4760,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5828.0,7323.0 706.9,7323.0 700.4,5266.2 650.7,5122.2 503.0,5166.8 613.6,3612.5 2801.0,3490.4 2827.0,28.2 5010.9,9.1 5023.7,2948.8 5828.0,2770.3 5828.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5990,27 +4811,6 @@
                 41.8892588
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5024.2,
-                4350.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62531944567591,
-                41.88895136018735
-              ]
-            }
           }
         ]
       }
@@ -6033,8 +4833,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6053,17 +4853,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5847,0 5847,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1543.4,4790.9 743.6,4943.6 817.4,2039.4 -0.0,2023.5 -0.0,286.6 2658.0,344.4 2632.0,2054.4 2912.4,2060.5 2940.2,351.4 5242.1,406.8 5226.0,2107.5 5847.0,2123.0 5847.0,7322.0 1468.0,7322.0 1543.4,4790.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6107,27 +4904,6 @@
                 41.8909467
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                778.1,
-                2057.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62538621576536,
-                41.890907413549826
-              ]
-            }
           }
         ]
       }
@@ -6150,8 +4926,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6170,17 +4946,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5845,0 5845,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4032.4,694.5 4110.8,6545.2 1692.6,6555.2 1648.6,1001.6 1779.8,710.3 4032.4,694.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0004N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6224,27 +4997,6 @@
                 41.8939406
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1659.3,
-                2941.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64002819154724,
-                41.895526169900414
-              ]
-            }
           }
         ]
       }
@@ -6267,8 +5019,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6287,17 +5039,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5811,0 5811,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 5811.0,1.4 5811.0,7323.0 -0.0,7323.0 0.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0052N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6341,27 +5090,6 @@
                 41.8918751
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3725.1,
-                2741.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.61621310318323,
-                41.89148000284337
-              ]
-            }
           }
         ]
       }
@@ -6384,8 +5112,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6404,17 +5132,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 5813.0,9.2 5813.0,6097.4 1409.6,6060.8 2847.6,7323.0 -0.0,7323.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0056W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6458,27 +5183,6 @@
                 41.8933844
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1406.4,
-                6084.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64762898769874,
-                41.891183111826166
-              ]
-            }
           }
         ]
       }
@@ -6494,15 +5198,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6521,17 +5225,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5865,0 5865,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5468.1,0.0 5466.9,227.0 5865.0,230.3 5865.0,6043.3 1844.6,6057.1 1872.1,0.0 5468.1,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0057W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6575,27 +5276,6 @@
                 41.8912254
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2834.6,
-                3687.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64442160439545,
-                41.89230320362214
-              ]
-            }
           }
         ]
       }
@@ -6618,8 +5298,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6638,17 +5318,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"476.4,1210.0 5813.0,1154.6 5811.8,5963.8 159.5,6053.3 186.6,7323.0 -0.0,7323.0 -0.0,2456.6 1904.3,2435.0 476.4,1210.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0058W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6692,27 +5369,6 @@
                 41.8912112
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                420.8,
-                3629.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64764632084261,
-                41.89009209941024
-              ]
-            }
           }
         ]
       }
@@ -6735,8 +5391,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6755,17 +5411,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5865,0 5865,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5409.1,6002.2 5446.1,3658.6 5518.6,3657.8 5409.1,6002.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6809,27 +5462,6 @@
                 41.891194
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                242.0,
-                3675.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64758892588459,
-                41.89007153655477
-              ]
-            }
           }
         ]
       }
@@ -6849,11 +5481,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6872,17 +5504,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5879,0 5879,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1063.1,673.3 1060.3,0.0 5879.0,0.0 5879.0,659.5 4071.6,658.9 4140.7,6413.2 1752.2,6423.0 1675.0,669.0 1063.1,673.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6926,27 +5555,6 @@
                 41.8939406
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4095.1,
-                3895.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63713732598931,
-                41.895095265655314
-              ]
-            }
           }
         ]
       }
@@ -6969,8 +5577,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6989,17 +5597,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1740.2,1261.2 4267.3,1165.2 4313.4,1728.9 5813.0,1734.1 5813.0,6034.3 1755.2,6014.4 1665.7,3639.4 1740.2,1261.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0060W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7043,27 +5648,6 @@
                 41.8912254
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1709.0,
-                6000.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64436611237042,
-                41.88906045913142
-              ]
-            }
           }
         ]
       }
@@ -7086,8 +5670,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7106,17 +5690,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"941.1,1127.1 252.8,1079.4 253.4,0.0 3101.9,0.0 3075.3,1118.4 5828.0,1031.2 5828.0,4885.4 3376.4,4933.3 3416.7,6094.3 1031.7,6101.9 941.1,1127.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7160,27 +5741,6 @@
                 41.8890802
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3416.7,
-                1077.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63992643445721,
-                41.88908809273507
-              ]
-            }
           }
         ]
       }
@@ -7196,15 +5756,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7223,24 +5783,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5877,0 5877,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"5711.1,633.6 5651.4,5619.6 306.8,5480.9 310.4,4162.9 -0.0,4157.2 -0.0,602.0 5711.1,633.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                363.0,
+                3301.5,
                 4152.3
               ],
               "creator": {
@@ -7252,8 +5809,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6475357,
-                41.8873891
+                -87.6457272,
+                41.8874361
               ]
             }
           },
@@ -7261,8 +5818,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                363.0,
-                5567.1
+                3301.5,
+                590.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7273,29 +5830,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6475129,
-                41.8867958
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1777.5,
-                4859.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.646727348619,
-                41.887109423733065
+                -87.6457947,
+                41.8890393
               ]
             }
           }
@@ -7320,8 +5856,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7340,17 +5876,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"440.1,5594.7 489.7,592.0 5310.5,725.2 5290.8,5738.1 440.1,5594.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7394,27 +5927,6 @@
                 41.889054
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.4,
-                593.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64287462930757,
-                41.88908569041822
-              ]
-            }
           }
         ]
       }
@@ -7437,8 +5949,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7457,17 +5969,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5877,0 5877,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1245.0,1283.7 4155.8,1172.7 4662.6,3503.3 5877.0,3445.8 5877.0,6403.1 5194.8,6435.2 4998.1,6234.0 1527.2,6332.2 1536.9,6522.7 36.7,6603.5 154.0,7322.0 -0.0,7322.0 -0.0,0.0 1167.8,26.5 1245.0,1283.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0065W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7511,27 +6020,6 @@
                 41.8844146
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1526.9,
-                2365.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64735711124126,
-                41.886281814002736
-              ]
-            }
           }
         ]
       }
@@ -7551,11 +6039,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7574,19 +6062,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1788.8,1116.5 2380.0,1129.6 2317.9,3642.4 2180.3,3641.2 1788.8,1116.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0066W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4136.9,
+                3667.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6442408,
+                41.8857101
+              ]
+            }
+          },
           {
             "type": "Feature",
             "properties": {
@@ -7605,48 +6111,6 @@
               "coordinates": [
                 -87.644261,
                 41.8862548
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4136.9,
-                6931.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6441836,
-                41.8844246
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1766.0,
-                3667.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64553415541843,
-                41.88572094863864
               ]
             }
           }
@@ -7668,11 +6132,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7691,17 +6155,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5877,0 5877,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1839.6,6254.3 1860.2,7322.0 930.2,7322.0 914.2,6496.9 309.1,6503.8 113.3,6288.7 270.7,6019.9 1032.1,6009.1 1123.6,3441.6 -0.0,3454.1 -0.0,1029.4 4136.9,1025.8 4175.4,6230.8 1839.6,6254.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0067W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7745,27 +6206,6 @@
                 41.8868117
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4136.9,
-                3434.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64278131442829,
-                41.88571332978507
-              ]
-            }
           }
         ]
       }
@@ -7781,15 +6221,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7808,17 +6248,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5828,0 5828,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4131.3,6237.6 1744.4,6257.7 1676.7,993.9 4042.8,995.5 4131.3,6237.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0068W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7862,27 +6299,6 @@
                 41.8868117
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4116.8,
-                3422.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64131181406132,
-                41.885713957584365
-              ]
-            }
           }
         ]
       }
@@ -7898,15 +6314,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7925,17 +6341,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5877,0 5877,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4096.6,5884.1 1674.6,5798.2 1797.1,697.2 4123.9,762.4 4096.6,5884.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0069W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7979,27 +6392,6 @@
                 41.8844479
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1696.8,
-                3106.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64135811614159,
-                41.88569121250614
-              ]
-            }
           }
         ]
       }
@@ -8015,15 +6407,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8042,17 +6434,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5839,0 5839,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4133.7,6603.2 1709.0,6585.5 1708.8,712.5 3553.7,735.2 3561.8,62.2 4185.1,30.4 4133.7,6603.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0006N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8080,7 +6469,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1709.0,
+                4181.8,
                 743.2
               ],
               "creator": {
@@ -8092,29 +6481,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6371778,
-                41.8965563
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5839.0,
-                3664.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63466854249187,
-                41.89530393062021
+                -87.6357092,
+                41.8965708
               ]
             }
           }
@@ -8136,11 +6504,11 @@
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8159,17 +6527,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5813.0,7323.0 5417.5,7323.0 5421.7,6347.5 1340.8,6269.6 1291.1,0.0 5813.0,0.0 5813.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0070W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8213,27 +6578,6 @@
                 41.8868193
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                397.7,
-                3485.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6404302491575,
-                41.885722585120995
-              ]
-            }
           }
         ]
       }
@@ -8249,15 +6593,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8276,40 +6620,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5867,0 5867,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1474.9,824.2 1475.7,626.8 2688.1,654.6 2671.2,3417.6 5867.0,3432.8 5867.0,6441.9 394.2,6408.2 386.2,7322.0 -0.0,7322.0 -0.0,822.5 1474.9,824.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0071W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1475.4,
-                2097.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6474219,
-                41.8837316
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -8335,20 +6655,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5786.3,
-                4253.2
+                1475.4,
+                625.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "projected"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64477270802168,
-                41.88280256306729
+                -87.6474391,
+                41.8844146
               ]
             }
           }
@@ -8370,11 +6690,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8393,17 +6713,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4148.6,6461.6 3216.8,6459.9 3198.3,3449.8 -0.0,3454.2 -0.0,690.1 2382.9,743.6 2576.3,961.7 3183.0,962.7 3188.1,1789.6 4120.3,1801.8 4148.6,6461.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0072W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8447,27 +6764,6 @@
                 41.8818174
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2654.3,
-                5714.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64502722803708,
-                41.88214665556366
-              ]
-            }
           }
         ]
       }
@@ -8490,8 +6786,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8510,17 +6806,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5867,0 5867,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4086.2,6548.3 1751.6,6600.0 1659.8,899.0 3989.1,883.0 4086.2,6548.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8564,27 +6857,6 @@
                 41.8844246
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4086.2,
-                899.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64269277858594,
-                41.88443118174366
-              ]
-            }
           }
         ]
       }
@@ -8604,11 +6876,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8627,17 +6899,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5813,0 5813,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4200.3,840.6 4222.2,6521.2 1825.7,6516.4 1825.7,799.4 4200.3,840.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8681,27 +6950,6 @@
                 41.8844384
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4242.3,
-                3606.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64124248647066,
-                41.88319129693115
-              ]
-            }
           }
         ]
       }
@@ -8724,8 +6972,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8744,17 +6992,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5867,0 5867,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4146.7,6384.1 1720.9,6343.0 1754.5,779.1 4179.7,852.4 4054.8,1038.7 4037.5,3270.2 4176.5,3583.1 4146.7,6384.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0075W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8798,27 +7043,6 @@
                 41.8818886
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1729.0,
-                6385.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64120787602033,
-                41.88185139319912
-              ]
-            }
           }
         ]
       }
@@ -8841,8 +7065,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8861,17 +7085,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5828,0 5828,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"3917.0,7322.0 3914.3,6466.5 1647.9,6440.2 1647.9,3547.2 1500.9,3225.6 1494.2,920.8 1621.1,726.9 5828.0,785.4 5828.0,7322.0 3917.0,7322.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0076W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8915,27 +7136,6 @@
                 41.8818886
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4540.3,
-                4993.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63798493528738,
-                41.88256568608743
-              ]
-            }
           }
         ]
       }
@@ -8958,8 +7158,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8978,17 +7178,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5873,0 5873,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4322.8,7322.0 1507.6,7322.0 1492.7,921.2 4314.0,927.9 4323.5,4700.8 4321.4,7176.6 4322.8,7322.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0077W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9032,27 +7229,6 @@
                 41.8817821
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4314.0,
-                6241.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64733733848666,
-                41.880499852611415
-              ]
-            }
           }
         ]
       }
@@ -9075,8 +7251,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9095,17 +7271,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5828,0 5828,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1342.3,7322.0 1352.5,949.0 4154.2,901.9 4163.5,7322.0 1342.3,7322.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0078W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9149,27 +7322,6 @@
                 41.8792628
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4154.2,
-                6261.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64729230968119,
-                41.87922304353867
-              ]
-            }
           }
         ]
       }
@@ -9189,11 +7341,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9212,17 +7364,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5873,0 5873,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4121.1,6487.2 1741.6,6529.9 1662.8,899.8 4015.9,852.6 4121.1,6487.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0079W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9266,27 +7415,6 @@
                 41.8805412
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4069.0,
-                876.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64264057816075,
-                41.88183622900061
-              ]
-            }
           }
         ]
       }
@@ -9302,15 +7430,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9329,24 +7457,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5835,0 5835,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1676.1,6494.7 1669.8,0.0 5835.0,0.0 5835.0,696.5 4167.1,709.5 4198.0,6493.6 1676.1,6494.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0007N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4183.9,
+                1671.3,
                 4715.9
               ],
               "creator": {
@@ -9358,8 +7483,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6341577,
-                41.8947921
+                -87.6356698,
+                41.8947745
               ]
             }
           },
@@ -9368,7 +7493,7 @@
             "properties": {
               "resourceCoords": [
                 1671.3,
-                2932.7
+                702.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9379,29 +7504,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6356819,
-                41.8955757
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4183.9,
-                2932.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63417151425108,
-                41.89559018574011
+                -87.6357092,
+                41.8965708
               ]
             }
           }
@@ -9426,8 +7530,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9446,17 +7550,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5828,0 5828,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4174.3,740.5 4124.3,6567.6 1668.0,6526.7 1705.6,710.8 4174.3,740.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9500,27 +7601,6 @@
                 41.8792909
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1668.0,
-                3705.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64263567217365,
-                41.88053069993873
-              ]
-            }
           }
         ]
       }
@@ -9543,8 +7623,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9570,10 +7650,7 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9617,27 +7694,6 @@
                 41.8793273
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.8,
-                2299.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64115822431357,
-                41.88058557476099
-              ]
-            }
           }
         ]
       }
@@ -9660,8 +7716,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9680,17 +7736,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5828,0 5828,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1140.8,1155.5 5828.0,1211.1 5828.0,6825.4 1136.2,6773.0 1140.8,1155.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0082W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9734,27 +7787,6 @@
                 41.8818705
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3549.2,
-                4014.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63969405442239,
-                41.88059498413645
-              ]
-            }
           }
         ]
       }
@@ -9774,11 +7806,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9797,17 +7829,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5853,0 5853,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4273.6,7120.9 4273.8,7322.0 1462.7,7322.0 1488.0,896.3 4312.9,880.7 4273.6,7120.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0083W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9851,27 +7880,6 @@
                 41.8785826
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2873.2,
-                1123.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6441494364238,
-                41.87863293380611
-              ]
-            }
           }
         ]
       }
@@ -9891,11 +7899,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9914,17 +7922,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5868,0 5868,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1592.0,7323.0 1596.8,906.1 4377.1,889.7 4409.0,7323.0 1592.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0084W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9968,27 +7973,6 @@
                 41.8773156
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1584.4,
-                1161.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64413713128145,
-                41.8779869008678
-              ]
-            }
           }
         ]
       }
@@ -10011,8 +7995,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10031,17 +8015,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5853,0 5853,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"4131.0,850.7 4191.6,6479.1 1808.3,6462.5 1752.2,877.4 4131.0,850.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0085W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10085,27 +8066,6 @@
                 41.8767364
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1752.2,
-                6477.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6439790229228,
-                41.87671981735112
-              ]
-            }
           }
         ]
       }
@@ -10121,15 +8081,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "3"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10148,17 +8108,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5868,0 5868,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1758.3,5392.2 1739.8,826.6 4134.8,838.3 4136.3,5413.7 1758.3,5392.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10202,27 +8159,6 @@
                 41.8786453
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3168.8,
-                2961.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64168600492478,
-                41.87834157552303
-              ]
-            }
           }
         ]
       }
@@ -10245,8 +8181,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10265,17 +8201,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7322 0,0 5853,0 5853,7322 0,7322\" /></svg>"
+          "value": "<svg><polygon points=\"1723.3,887.5 4113.6,920.1 4163.7,5258.7 3983.3,7322.0 1670.3,7322.0 1723.3,887.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10319,27 +8252,6 @@
                 41.8793088
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1723.3,
-                3694.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64107659078985,
-                41.87802131523548
-              ]
-            }
           }
         ]
       }
@@ -10355,15 +8267,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10382,17 +8294,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5868,0 5868,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"5868.0,0.0 5868.0,6530.0 1356.7,6451.0 1524.3,5215.5 1503.7,858.5 3786.9,917.2 3797.8,0.0 5868.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10436,27 +8345,6 @@
                 41.8793273
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4289.4,
-                2251.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63791550524147,
-                41.87873865291959
-              ]
-            }
           }
         ]
       }
@@ -10472,15 +8360,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10499,25 +8387,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5822,0 5822,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1107.0,7323.0 1295.0,823.2 5822.0,943.3 5822.0,6300.6 5503.4,6395.1 5822.0,6488.9 5822.0,7323.0 1107.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2860.6,
-                910.3
+                1129.3,
+                6283.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10528,8 +8413,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6439182,
-                41.8759164
+                -87.647203,
+                41.8766797
               ]
             }
           },
@@ -10551,27 +8436,6 @@
               "coordinates": [
                 -87.6438986,
                 41.8752612
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3729.1,
-                2647.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64478834024801,
-                41.875574205918156
               ]
             }
           }
@@ -10596,8 +8460,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10616,17 +8480,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5839,0 5839,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4270.8,6561.1 1668.8,6559.3 1654.5,719.1 4036.1,710.4 4021.7,2962.9 4307.5,2962.3 4270.8,6561.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10670,27 +8531,6 @@
                 41.8940169
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4141.5,
-                2961.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63270386365649,
-                41.89561310302946
-              ]
-            }
           }
         ]
       }
@@ -10713,8 +8553,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10733,17 +8573,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5868,0 5868,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,7213.5 2389.2,7120.9 2357.9,6312.3 2608.5,6313.6 2045.5,6233.4 2350.9,6129.8 2149.7,936.3 5868.0,919.7 5868.0,7323.0 -0.0,7323.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10787,27 +8624,6 @@
                 41.874359
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4744.5,
-                3059.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64516886206714,
-                41.87351863311184
-              ]
-            }
           }
         ]
       }
@@ -10830,8 +8646,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10850,17 +8666,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5867,0 5867,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4123.0,4312.3 4114.0,6324.3 1711.7,6303.2 1731.7,1072.0 4120.7,1107.7 4117.9,3143.9 5029.4,3139.5 4955.4,4313.8 4123.0,4312.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0091W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10904,27 +8717,6 @@
                 41.8767364
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1711.7,
-                1106.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64395700898122,
-                41.87671179434323
-              ]
-            }
           }
         ]
       }
@@ -10940,15 +8732,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10967,17 +8759,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1714.3,0.0 4096.5,0.0 4140.0,5232.3 1765.7,5241.5 1714.3,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10985,48 +8774,6 @@
             "properties": {
               "resourceCoords": [
                 4143.1,
-                3817.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6410117,
-                41.8753051
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1728.7,
-                3817.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424471,
-                41.8752853
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1728.7,
                 6332.0
               ],
               "creator": {
@@ -11038,8 +8785,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64241939789864,
-                41.874171862437976
+                -87.6409931,
+                41.8743938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1728.7,
+                1100.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6424927,
+                41.8767364
               ]
             }
           }
@@ -11064,8 +8832,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11084,46 +8852,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5867,0 5867,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4219.4 -0.0,2952.1 1571.1,2858.8 1481.3,1563.4 4009.1,1450.8 4161.3,4875.3 1694.9,5053.1 1643.4,4124.9 -0.0,4219.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1763.6,
-                6288.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6409931,
-                41.8743938
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
                 4178.4,
-                6288.8
+                6159.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11143,20 +8887,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2971.0,
-                3874.7
+                1763.6,
+                6288.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "projected"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.64032790880725,
-                41.87541691584033
+                -87.6409931,
+                41.8743938
               ]
             }
           }
@@ -11178,11 +8922,11 @@
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11201,17 +8945,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"3044.0,6318.9 492.5,6292.3 367.1,5622.7 402.0,1239.3 476.6,1092.0 5012.9,1130.4 5002.7,0.0 5866.0,0.0 5866.0,7323.0 3058.1,7323.0 3044.0,6318.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11255,27 +8996,6 @@
                 41.8744068
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5514.5,
-                3688.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63649903274509,
-                41.8756552147224
-              ]
-            }
           }
         ]
       }
@@ -11298,8 +9018,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11318,17 +9038,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5867,0 5867,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1765.3,4008.4 1741.9,1041.4 4144.5,1043.4 4171.4,5056.8 -0.0,5116.1 -0.0,4002.8 1765.3,4008.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11372,27 +9089,6 @@
                 41.874359
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4178.4,
-                1042.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64240307709967,
-                41.87437516328598
-              ]
-            }
           }
         ]
       }
@@ -11415,8 +9111,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11435,17 +9131,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5866,0 5866,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"1800.6,5011.5 1775.0,0.0 4115.2,0.0 4114.0,1083.9 5866.0,1085.8 5866.0,6297.7 4183.4,6306.1 4166.1,5001.3 1800.6,5011.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0096W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11489,27 +9182,6 @@
                 41.8720083
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4183.4,
-                1088.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.64095054874083,
-                41.87439205109056
-              ]
-            }
           }
         ]
       }
@@ -11532,8 +9204,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11552,17 +9224,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5867,0 5867,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"2664.2,6228.6 2742.4,1140.1 1031.6,1112.0 1050.0,0.0 3272.0,0.0 3376.5,1150.5 5867.0,1191.5 5867.0,7323.0 3454.4,7323.0 3466.6,6236.9 2664.2,6228.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11606,27 +9275,6 @@
                 41.8743938
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3466.6,
-                1112.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63946394038346,
-                41.87442992560197
-              ]
-            }
           }
         ]
       }
@@ -11649,8 +9297,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:23:24Z",
-      "modified": "2026-05-25T13:23:24Z",
+      "created": "2026-06-10T19:14:36Z",
+      "modified": "2026-06-10T19:14:36Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11669,17 +9317,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5835,0 5835,7323 0,7323\" /></svg>"
+          "value": "<svg><polygon points=\"4053.3,6537.8 1723.0,6538.7 1749.7,2982.6 1467.3,2983.9 1475.6,758.1 786.9,760.6 787.0,65.7 5835.0,0.0 5835.0,742.5 4048.5,749.0 4053.3,6537.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0009N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11721,27 +9366,6 @@
               "coordinates": [
                 -87.6312427,
                 41.8966335
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4048.5,
-                4767.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63120228771334,
-                41.89483057226306
               ]
             }
           }

--- a/gallery/detroit_mich_1929_vol_11.iiif.json
+++ b/gallery/detroit_mich_1929_vol_11.iiif.json
@@ -24,8 +24,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,17 +44,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6224.2,0.0 6205.9,1634.2 6172.6,6362.9 111.8,6390.5 113.5,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0001/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -98,27 +95,6 @@
                 42.368865
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2236.6,
-                5496.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.98523425388481,
-                42.36771844736003
-              ]
-            }
           }
         ]
       }
@@ -141,8 +117,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,17 +137,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5970.7,0.0 5899.8,6367.3 2081.0,6366.4 2074.4,7224.3 108.1,7230.9 199.6,0.0 5970.7,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0010/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -215,27 +188,6 @@
                 42.37916
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3080.3,
-                6107.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95786280666938,
-                42.377415830849316
-              ]
-            }
           }
         ]
       }
@@ -258,8 +210,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,7 +230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"627.8,1941.1 624.1,675.7 920.1,678.0 925.4,0.0 1099.1,0.0 1091.4,672.6 6335.0,712.5 6335.0,7795.0 -0.0,7795.0 -0.0,1934.9 627.8,1941.1\" /></svg>"
         }
       },
       "body": {
@@ -307,8 +259,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93518589438597,
-                42.361995241266875
+                -82.93518588042195,
+                42.36199523422316
               ]
             }
           },
@@ -328,8 +280,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93173071237136,
-                42.36327498125203
+                -82.93173074152871,
+                42.363274958317156
               ]
             }
           },
@@ -349,8 +301,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.92960094317034,
-                42.36013081533523
+                -82.92960099890765,
+                42.36013083144301
               ]
             }
           },
@@ -370,8 +322,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93305612518496,
-                42.358851075350074
+                -82.93305613780089,
+                42.35885110734901
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1076.8,
+                1945.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.934067,
+                42.361428
               ]
             }
           }
@@ -396,8 +369,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,17 +389,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5896.1,7020.5 539.0,7086.0 523.3,694.5 -0.0,701.6 -0.0,-0.0 5871.9,0.0 5896.1,7020.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -470,27 +440,6 @@
                 42.378947
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5896.1,
-                1032.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95492080001743,
-                42.38136702029563
-              ]
-            }
           }
         ]
       }
@@ -513,8 +462,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -533,17 +482,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"299.3,7017.4 244.9,62.4 -0.0,-0.0 5960.4,35.6 5990.1,6897.4 299.3,7017.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -587,27 +533,6 @@
                 42.382489
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3097.6,
-                6743.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95186579496645,
-                42.37960793472309
-              ]
-            }
           }
         ]
       }
@@ -630,8 +555,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -650,17 +575,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"367.6,6902.2 421.0,0.0 6102.6,50.5 6052.0,6837.7 367.6,6902.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0013/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -704,27 +626,6 @@
                 42.383235
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2531.0,
-                1064.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95061331377391,
-                42.382896609090324
-              ]
-            }
           }
         ]
       }
@@ -747,8 +648,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -767,17 +668,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"642.2,6764.9 641.6,0.0 6447.0,0.0 6410.4,6752.3 642.2,6764.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0014/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -821,27 +719,6 @@
                 42.383591
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2298.0,
-                4394.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94685069451272,
-                42.3825531325847
-              ]
-            }
           }
         ]
       }
@@ -864,8 +741,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -884,17 +761,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6174.2,353.9 6133.6,7795.0 -0.0,7795.0 -0.0,374.4 6174.2,353.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0015/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -938,27 +812,6 @@
                 42.367779
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4111.2,
-                6268.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9822043480589,
-                42.36541074328615
-              ]
-            }
           }
         ]
       }
@@ -974,15 +827,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1001,17 +854,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6007.0,457.4 5971.3,6188.8 6400.4,6155.7 6381.2,7795.0 -0.0,7795.0 -0.0,481.5 6007.0,457.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1055,27 +905,6 @@
                 42.3623462
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2474.3,
-                5111.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9812314200344,
-                42.36266561989359
-              ]
-            }
           }
         ]
       }
@@ -1098,8 +927,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1118,17 +947,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"454.5,6914.6 415.5,966.5 5471.0,1007.4 5385.6,6865.1 454.5,6914.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0017/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1172,27 +998,6 @@
                 42.368223
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2505.8,
-                966.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9816749962542,
-                42.36865947843105
-              ]
-            }
           }
         ]
       }
@@ -1215,8 +1020,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1235,17 +1040,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5671.0,6771.7 -0.0,6913.6 -0.0,1015.1 5756.7,1101.5 5671.0,6771.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0018/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1289,27 +1091,6 @@
                 42.370004
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1706.2,
-                1076.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97912081289631,
-                42.36958321689559
-              ]
-            }
           }
         ]
       }
@@ -1332,8 +1113,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1352,17 +1133,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"3859.4,1098.7 3861.2,0.0 4660.4,0.0 4686.7,2012.1 5638.2,1999.6 5876.1,6480.5 146.5,6718.4 148.8,1099.4 3859.4,1098.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0019/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1406,27 +1184,6 @@
                 42.370726
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3859.4,
-                6623.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9734023458097,
-                42.368879735867395
-              ]
-            }
           }
         ]
       }
@@ -1449,8 +1206,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1469,17 +1226,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5212.3,6522.7 248.7,6507.4 211.7,0.0 5270.2,0.0 5212.3,6522.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0002/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1523,27 +1277,6 @@
                 42.368223
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2425.5,
-                2153.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.98284738467592,
-                42.3703993480213
-              ]
-            }
           }
         ]
       }
@@ -1566,8 +1299,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1586,17 +1319,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5146.4,6401.1 -0.0,6401.5 -0.0,2014.5 5175.9,2139.1 5146.4,6401.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0020/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1640,27 +1370,6 @@
                 42.369392
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2090.2,
-                2880.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97225380967892,
-                42.37121023579883
-              ]
-            }
           }
         ]
       }
@@ -1683,8 +1392,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1703,7 +1412,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5194.5,7741.6 5218.4,7010.5 4666.1,6738.9 4406.4,6160.3 -0.0,6157.6 -0.0,1787.7 184.7,1790.9 215.4,0.0 6447.0,0.0 6447.0,7795.0 5194.5,7741.6\" /></svg>"
         }
       },
       "body": {
@@ -1732,8 +1441,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97127384461083,
-                42.37289979568531
+                -82.97127381899593,
+                42.37289976667562
               ]
             }
           },
@@ -1753,8 +1462,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9677897345216,
-                42.374249903199654
+                -82.96778975238908,
+                42.37424985742501
               ]
             }
           },
@@ -1774,8 +1483,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96558235412532,
-                42.371135144421565
+                -82.96558239954135,
+                42.371135137324416
               ]
             }
           },
@@ -1795,8 +1504,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96906646421456,
-                42.36978503690723
+                -82.96906646614819,
+                42.36978504657503
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                576.1,
+                6148.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9692214,
+                42.3705636
               ]
             }
           }
@@ -1821,8 +1551,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1841,17 +1571,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4988.0,7203.6 420.8,7610.7 380.9,406.1 5128.2,333.1 4988.0,7203.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0023/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1895,27 +1622,6 @@
                 42.3658529
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4605.4,
-                406.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97881131379452,
-                42.36672578940403
-              ]
-            }
           }
         ]
       }
@@ -1938,8 +1644,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1958,17 +1664,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5738.7,6481.9 -0.0,7198.9 -0.0,381.3 5769.2,172.1 5738.7,6481.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2012,27 +1715,6 @@
                 42.3655229
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1885.6,
-                6907.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97574229555164,
-                42.3645788808735
-              ]
-            }
           }
         ]
       }
@@ -2048,15 +1730,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2075,66 +1757,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6188.4,6376.5 207.8,7130.0 165.3,783.4 6161.2,486.3 6188.4,6376.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3541.4,
-                6800.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.971986,
-                42.3663519
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5002.1,
-                6652.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97123,
-                42.3666969
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3541.4,
+                1866.7,
                 698.9
               ],
               "creator": {
@@ -2146,8 +1783,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97359988712752,
-                42.36880567656491
+                -82.9745042,
+                42.368471
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                207.8,
+                7130.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.973729,
+                42.3655229
               ]
             }
           }
@@ -2172,8 +1830,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2192,17 +1850,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5943.2,356.2 5820.6,6211.4 3038.8,6194.8 257.2,6418.9 384.0,467.5 5943.2,356.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2246,27 +1901,6 @@
                 42.369392
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                384.0,
-                6211.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97061412537997,
-                42.36710282847461
-              ]
-            }
           }
         ]
       }
@@ -2289,8 +1923,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2309,17 +1943,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"525.7,623.3 4420.0,476.5 4708.1,1053.9 5280.8,1307.2 5286.8,2051.4 6447.0,2053.5 6447.0,6614.2 5429.4,6419.6 570.1,6531.9 525.7,623.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2363,27 +1994,6 @@
                 42.3705636
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                525.7,
-                6494.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96771635421553,
-                42.36821084225839
-              ]
-            }
           }
         ]
       }
@@ -2406,8 +2016,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2433,10 +2043,7 @@
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0028/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2480,27 +2087,6 @@
                 42.3689608
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                3713.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96598956770167,
-                42.37152028864625
-              ]
-            }
           }
         ]
       }
@@ -2523,8 +2109,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2543,17 +2129,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6755.0 -0.0,-0.0 5982.0,0.0 5855.2,6850.4 -0.0,6755.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2597,27 +2180,6 @@
                 42.3723885
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3916.0,
-                6784.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97799413838126,
-                42.37002265282776
-              ]
-            }
           }
         ]
       }
@@ -2640,8 +2202,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2660,7 +2222,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"2687.6,6849.6 2818.3,7795.0 -0.0,7795.0 -0.0,-0.0 5478.5,0.0 5613.7,1531.7 6447.0,1444.4 6447.0,5497.8 5979.2,5562.5 6162.0,7572.1 5249.5,7382.2 2687.6,6849.6\" /></svg>"
         }
       },
       "body": {
@@ -2689,8 +2251,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9640564360491,
-                42.372227595522716
+                -82.9640564020039,
+                42.372227564541134
               ]
             }
           },
@@ -2710,8 +2272,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96037759351081,
-                42.373257202064835
+                -82.9603776053783,
+                42.37325715829812
               ]
             }
           },
@@ -2731,8 +2293,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95869422142911,
-                42.36996835446937
+                -82.95869425430541,
+                42.36996835154189
               ]
             }
           },
@@ -2752,8 +2314,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96237306396739,
-                42.36893874792725
+                -82.96237305093102,
+                42.36893875778491
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2222.5,
+                6756.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9613285,
+                42.3697326
               ]
             }
           }
@@ -2778,8 +2361,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2798,17 +2381,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1324.6,7795.0 1349.4,6280.3 -0.0,6139.0 -0.0,-0.0 1460.5,0.0 1455.6,304.0 5160.6,330.1 5040.7,7795.0 1324.6,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2852,27 +2432,6 @@
                 42.374477
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4112.8,
-                2849.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96035744798642,
-                42.37507476678681
-              ]
-            }
           }
         ]
       }
@@ -2895,8 +2454,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2915,17 +2474,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"106.4,7795.0 -0.0,7795.0 -0.0,6678.2 1180.9,6678.1 1288.1,0.0 5193.4,0.0 5081.8,7269.5 119.9,7163.7 106.4,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2969,27 +2525,6 @@
                 42.375274
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3188.9,
-                7568.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95712195198651,
-                42.37329279995454
-              ]
-            }
           }
         ]
       }
@@ -3012,8 +2547,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3032,17 +2567,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4063.7,7795.0 -0.0,6473.1 -0.0,-0.0 4968.6,0.0 5009.9,7795.0 4063.7,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3086,27 +2618,6 @@
                 42.3704972
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4333.2,
-                3560.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95558415900736,
-                42.37221831417817
-              ]
-            }
           }
         ]
       }
@@ -3129,8 +2640,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3149,17 +2660,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5241.9,1637.8 5153.2,6184.7 1312.7,6184.7 1384.3,1611.5 5241.9,1637.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3203,27 +2711,6 @@
                 42.376049
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3232.9,
-                2342.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95714538114801,
-                42.377188183615516
-              ]
-            }
           }
         ]
       }
@@ -3246,8 +2733,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3266,17 +2753,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"418.7,1685.9 5773.1,1634.0 5771.2,6114.0 410.2,6202.2 418.7,1685.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3320,27 +2804,6 @@
                 42.377876
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3988.5,
-                1687.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95430342213936,
-                42.37857483568423
-              ]
-            }
           }
         ]
       }
@@ -3363,8 +2826,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3383,17 +2846,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"6012.2,6088.4 285.4,6167.4 302.1,1694.8 6037.2,1632.3 6012.2,6088.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3437,27 +2897,6 @@
                 42.379305
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3869.4,
-                1680.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95139660515473,
-                42.379657542943846
-              ]
-            }
           }
         ]
       }
@@ -3480,8 +2919,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3500,17 +2939,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"186.7,1724.7 5841.9,1646.1 5836.7,6082.5 164.9,6150.6 186.7,1724.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0038/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3554,27 +2990,6 @@
                 42.381262
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4023.7,
-                1646.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94813725719018,
-                42.38090018224599
-              ]
-            }
           }
         ]
       }
@@ -3597,8 +3012,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3617,17 +3032,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"1136.6,6870.7 1262.5,227.8 5098.0,219.5 4984.8,7796.0 3097.7,7796.0 3113.8,6870.7 1136.6,6870.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3671,27 +3083,6 @@
                 42.372996
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2125.2,
-                4894.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95539470864183,
-                42.373585003967065
-              ]
-            }
           }
         ]
       }
@@ -3707,15 +3098,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3734,17 +3125,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"73.3,6818.8 80.6,0.0 4496.4,0.0 4579.4,5713.8 3780.9,5715.0 3780.7,6812.8 73.3,6818.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3788,27 +3176,6 @@
                 42.373522
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1756.6,
-                6812.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97599723080421,
-                42.37072595945392
-              ]
-            }
           }
         ]
       }
@@ -3831,8 +3198,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3851,17 +3218,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"1489.8,6142.8 -0.0,5647.9 1107.3,5705.0 1107.3,821.5 3072.8,790.0 3071.6,1710.1 4947.5,1680.0 4963.6,7295.3 1682.1,6206.7 1631.2,7796.0 1439.9,7796.0 1489.8,6142.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0040/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3905,27 +3269,6 @@
                 42.372996
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1105.1,
-                5976.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95402548610151,
-                42.37051286151529
-              ]
-            }
           }
         ]
       }
@@ -3948,8 +3291,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3968,17 +3311,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"500.6,387.1 4091.4,386.1 5880.3,387.4 6407.0,7523.6 6407.0,7796.0 2491.7,7796.0 381.9,7796.0 500.6,387.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4022,27 +3362,6 @@
                 42.376049
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1396.3,
-                2178.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95408897314393,
-                42.37551490449931
-              ]
-            }
           }
         ]
       }
@@ -4065,8 +3384,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4085,17 +3404,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"531.2,250.2 4154.3,304.9 4163.8,0.0 5970.0,0.0 5968.2,55.6 6407.0,63.5 6407.0,1230.1 5931.3,1243.2 5746.8,7582.2 4081.0,7476.0 359.9,6085.8 531.2,250.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4139,27 +3455,6 @@
                 42.3708449
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3730.9,
-                5300.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94999291760642,
-                42.371737891402155
-              ]
-            }
           }
         ]
       }
@@ -4175,15 +3470,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4202,19 +3497,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"93.3,7796.0 190.2,430.5 6129.8,410.2 6025.4,7796.0 93.3,7796.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2055.9,
+                415.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.951182,
+                42.377505
+              ]
+            }
+          },
           {
             "type": "Feature",
             "properties": {
@@ -4233,48 +3546,6 @@
               "coordinates": [
                 -82.950191,
                 42.377873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                273.9,
-                415.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952156,
-                42.377136
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2111.0,
-                4088.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95017582839047,
-                42.37605291514366
               ]
             }
           }
@@ -4299,8 +3570,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4319,17 +3590,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"6407.0,7339.4 163.7,7334.9 580.6,0.0 6407.0,0.0 6407.0,7339.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4373,27 +3641,6 @@
                 42.372325
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3013.0,
-                1636.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94844290027739,
-                42.37369338161156
-              ]
-            }
           }
         ]
       }
@@ -4416,8 +3663,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4436,17 +3683,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"253.0,361.6 5975.7,336.8 5916.0,7796.0 173.1,7796.0 253.0,361.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4490,27 +3734,6 @@
                 42.379455
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5061.1,
-                2165.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94594653448142,
-                42.378537732959494
-              ]
-            }
           }
         ]
       }
@@ -4533,8 +3756,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4553,17 +3776,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"5389.1,7081.5 -0.0,6814.6 -0.0,0.0 448.8,7.3 434.2,305.2 6184.6,524.3 5879.3,7030.8 5508.4,7033.8 5510.7,7248.5 5389.1,7081.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4607,27 +3827,6 @@
                 42.3733752
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3115.3,
-                5303.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94420228372375,
-                42.37390621610434
-              ]
-            }
           }
         ]
       }
@@ -4650,8 +3849,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4670,17 +3869,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"633.5,7796.0 632.8,343.1 6407.0,329.7 6407.0,7796.0 633.5,7796.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4724,27 +3920,6 @@
                 42.379455
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1476.6,
-                2030.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94503270509283,
-                42.37893968440024
-              ]
-            }
           }
         ]
       }
@@ -4760,15 +3935,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4787,17 +3962,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"912.7,7080.6 915.0,6857.4 377.7,6857.2 756.6,248.0 6407.0,567.8 6407.0,7796.0 5472.0,7796.0 5522.3,6963.5 2189.2,6843.9 2218.5,7083.2 912.7,7080.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4825,7 +3997,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                519.5,
+                5522.3,
                 6962.0
               ],
               "creator": {
@@ -4837,29 +4009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9421978,
-                42.3737775
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1361.7,
-                5278.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94225880788949,
-                42.37467435943418
+                -82.9395284,
+                42.3748856
               ]
             }
           }
@@ -4884,8 +4035,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4904,17 +4055,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"6386.5,6110.5 626.5,6127.9 626.7,1674.1 6407.0,1683.8 6386.5,6110.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4958,27 +4106,6 @@
                 42.379455
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3976.4,
-                6127.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94410595643801,
-                42.380116942371174
-              ]
-            }
           }
         ]
       }
@@ -5001,8 +4128,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5021,7 +4148,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6447.0,0.0 6447.0,7795.0 -0.0,7795.0 -0.0,-0.0 6447.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -5050,8 +4177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97631656021736,
-                42.37405932403855
+                -82.9763165537007,
+                42.37405932030927
               ]
             }
           },
@@ -5071,8 +4198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97280168342499,
-                42.3753650981416
+                -82.9728017207747,
+                42.37536507819789
               ]
             }
           },
@@ -5092,8 +4219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97066678666572,
-                42.37222283424566
+                -82.97066685065936,
+                42.37222285332098
               ]
             }
           },
@@ -5113,83 +4240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97418166345807,
-                42.37091706014261
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0050/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.98175772765508,
-                42.361948444321946
+                -82.97418168358536,
+                42.37091709543237
               ]
             }
           },
@@ -5197,62 +4249,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6407.0,
-                0.0
+                465.9,
+                979.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97804771752905,
-                42.36285789539577
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6407.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97655069246404,
-                42.35951864835932
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.98026070259007,
-                42.358609197285496
+                -82.9757944,
+                42.373759
               ]
             }
           }
@@ -5277,8 +4287,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5297,17 +4307,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"628.1,1513.0 5552.2,1063.0 5499.9,6864.3 3931.8,6859.0 2276.0,7323.7 2276.0,7796.0 592.8,7796.0 628.1,1513.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5351,27 +4358,6 @@
                 42.3630839
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3540.4,
-                6214.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97593907828961,
-                42.36181251289136
-              ]
-            }
           }
         ]
       }
@@ -5394,8 +4380,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5414,17 +4400,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"3811.4,0.0 5358.4,0.0 6407.0,805.6 6407.0,7408.1 4491.0,7376.6 4479.1,7796.0 -0.0,7796.0 0.0,0.0 516.2,0.0 512.7,932.4 3811.4,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5468,27 +4451,6 @@
                 42.357967
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1350.7,
-                5649.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9752785470465,
-                42.35881736150786
-              ]
-            }
           }
         ]
       }
@@ -5511,8 +4473,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5531,17 +4493,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"659.5,1183.1 6407.0,534.6 6407.0,4897.3 5648.2,4897.3 5635.3,7524.6 6407.0,7526.4 6407.0,7796.0 758.8,7796.0 659.5,1183.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5585,27 +4544,6 @@
                 42.362803
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                698.9,
-                1196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9762867002331,
-                42.36429941905909
-              ]
-            }
           }
         ]
       }
@@ -5628,8 +4566,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5648,17 +4586,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"128.7,7796.0 135.4,5196.3 886.2,5194.5 876.1,877.8 6075.6,284.9 6050.1,5929.9 5762.8,7796.0 128.7,7796.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5702,27 +4637,6 @@
                 42.3637904
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3242.9,
-                635.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97209903849046,
-                42.36627952777262
-              ]
-            }
           }
         ]
       }
@@ -5745,8 +4659,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5765,17 +4679,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"325.9,6880.4 438.8,399.0 3158.5,139.1 6407.0,111.3 6407.0,7377.7 154.4,7362.3 325.9,6880.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5819,27 +4730,6 @@
                 42.3650003
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2027.6,
-                277.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96977812933095,
-                42.36736093315638
-              ]
-            }
           }
         ]
       }
@@ -5862,8 +4752,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5882,17 +4772,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7554.3 23.6,0.0 6377.7,0.0 6378.7,425.1 5632.7,426.9 5610.5,7553.7 -0.0,7554.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0058/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5936,27 +4823,6 @@
                 42.362122
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2304.6,
-                3547.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96669902984195,
-                42.36309060013898
-              ]
-            }
           }
         ]
       }
@@ -5979,8 +4845,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5999,17 +4865,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5230.6,388.0 6173.9,578.4 6179.8,0.0 6346.0,0.0 6346.0,7795.0 1243.7,7795.0 1219.0,441.2 5230.6,388.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6053,27 +4916,6 @@
                 42.3689608
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                321.1,
-                5418.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96651142543112,
-                42.365987306812585
-              ]
-            }
           }
         ]
       }
@@ -6096,8 +4938,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6116,7 +4958,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"256.9,465.9 6346.0,519.1 6346.0,7795.0 -0.0,7795.0 -0.0,7569.9 170.0,7571.5 256.9,465.9\" /></svg>"
         }
       },
       "body": {
@@ -6145,8 +4987,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96597639443534,
-                42.36514518651102
+                -82.96597636757303,
+                42.36514514897063
               ]
             }
           },
@@ -6166,8 +5008,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96251051665607,
-                42.366421805865485
+                -82.9625105330486,
+                42.36642175247269
               ]
             }
           },
@@ -6187,8 +5029,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9603901563,
-                42.36327416469267
+                -82.96039019915504,
+                42.36327415038568
               ]
             }
           },
@@ -6208,8 +5050,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96385603407927,
-                42.3619975453382
+                -82.96385603367949,
+                42.36199754688362
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                170.0,
+                7571.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.963824,
+                42.362122
               ]
             }
           }
@@ -6234,8 +5097,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6254,7 +5117,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,823.8 3342.6,2015.7 3436.8,0.0 6127.2,0.0 5962.8,3014.3 5340.5,2978.3 5294.0,6990.3 -0.0,6751.6 -0.0,823.8\" /></svg>"
         }
       },
       "body": {
@@ -6283,8 +5146,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96128431375047,
-                42.3700931291083
+                -82.96128427254943,
+                42.37009312932897
               ]
             }
           },
@@ -6304,8 +5167,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95788493549914,
-                42.37146403693432
+                -82.95788493672302,
+                42.371464020131754
               ]
             }
           },
@@ -6325,8 +5188,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95560796970197,
-                42.36837678930837
+                -82.95560799934285,
+                42.36837681084168
               ]
             }
           },
@@ -6346,8 +5209,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9590073479533,
-                42.367005881482356
+                -82.95900733516926,
+                42.3670059200389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4768.9,
+                2556.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.957983,
+                42.3701109
               ]
             }
           }
@@ -6372,8 +5256,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6392,17 +5276,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,190.0 96.6,0.0 6346.0,0.0 6346.0,7329.2 -0.0,7328.1 -0.0,190.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6446,27 +5327,6 @@
                 42.36535
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3564.9,
-                4095.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95662598452323,
-                42.36633657754039
-              ]
-            }
           }
         ]
       }
@@ -6489,8 +5349,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6509,17 +5369,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7242.2 2047.5,1758.7 3715.6,1870.2 3722.6,1677.0 2119.2,1566.8 2521.8,488.8 5941.4,627.3 5713.8,7463.8 4083.2,7409.2 4070.3,7795.0 -0.0,7795.0 -0.0,7242.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0065/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6563,27 +5420,6 @@
                 42.3706179
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                5885.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95475118778104,
-                42.36797513271146
-              ]
-            }
           }
         ]
       }
@@ -6606,8 +5442,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6626,17 +5462,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7253.1 -0.0,589.8 422.1,592.8 422.4,766.5 685.8,766.1 1739.8,175.4 5676.1,133.0 5634.6,7254.1 -0.0,7253.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0066/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6680,25 +5513,97 @@
                 42.36568
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2639.1,410.2 6266.1,460.7 6264.5,642.5 4382.2,573.5 4445.0,7795.0 612.4,7795.0 2549.6,1942.2 2639.1,410.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0067/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2275.9,
-                5076.5
+                1337.8,
+                5581.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "projected"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95394431865252,
-                42.367393061040424
+                -82.951565,
+                42.3707349
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2546.6,
+                1992.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9492906,
+                42.3709414
               ]
             }
           }
@@ -6723,8 +5628,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6743,7 +5648,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5316.7,7162.2 1333.9,7199.0 266.5,7795.0 -0.0,7795.0 -0.0,985.5 5325.1,1008.4 5316.7,7162.2\" /></svg>"
         }
       },
       "body": {
@@ -6772,8 +5677,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94778554954368,
-                42.37056629302075
+                -82.9477855806799,
+                42.37056624861092
               ]
             }
           },
@@ -6793,8 +5698,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94608068909791,
-                42.36799554769931
+                -82.94608074151112,
+                42.36799553521169
               ]
             }
           },
@@ -6814,8 +5719,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95035048686186,
-                42.36644722739641
+                -82.95035048598717,
+                42.36644723413504
               ]
             }
           },
@@ -6835,8 +5740,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95205534730765,
-                42.36901797271785
+                -82.95205532515594,
+                42.369017947534275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5316.7,
+                7162.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9502804,
+                42.3669899
               ]
             }
           }
@@ -6861,8 +5787,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6881,17 +5807,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5666.1,7577.8 -0.0,7584.4 -0.0,2318.8 522.4,2316.5 479.4,4162.5 624.8,4164.5 690.1,607.9 5681.2,314.1 5666.1,7577.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6935,27 +5858,6 @@
                 42.36934
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3843.5,
-                541.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94667156618468,
-                42.37186313779504
-              ]
-            }
           }
         ]
       }
@@ -6978,8 +5880,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6998,17 +5900,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"403.7,414.4 853.9,391.0 830.2,0.0 6346.0,0.0 6346.0,161.2 5704.6,207.4 6133.0,7052.4 6346.0,7039.1 6346.0,7579.7 396.3,7576.6 403.7,414.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7052,27 +5951,6 @@
                 42.3727707
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4768.9,
-                393.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94325597517022,
-                42.373213161438095
-              ]
-            }
           }
         ]
       }
@@ -7095,8 +5973,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7115,17 +5993,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"3024.8,285.3 6346.0,414.3 6346.0,7795.0 -0.0,7795.0 -0.0,516.6 682.4,510.3 693.0,339.5 815.7,512.7 816.3,292.0 1739.3,295.6 1736.4,520.8 3053.7,526.9 3024.8,285.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7169,27 +6044,6 @@
                 42.3745709
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3969.4,
-                2269.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94023309495878,
-                42.37366483129083
-              ]
-            }
           }
         ]
       }
@@ -7212,8 +6066,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7232,17 +6086,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"645.7,51.1 6346.0,0.0 6346.0,7795.0 4834.2,7795.0 4841.3,7477.0 -0.0,7482.4 -0.0,595.7 612.4,605.0 645.7,51.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7286,27 +6137,6 @@
                 42.368594
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2976.3,
-                3746.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9382838521037,
-                42.3697309281
-              ]
-            }
           }
         ]
       }
@@ -7345,8 +6175,8 @@
           "value": "3865.0"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7365,17 +6195,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6346.0,3930.0 6346.0,7795.0 -0.0,7795.0 -0.0,4151.4 1984.9,4127.9 1979.3,3930.0 6346.0,3930.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7419,27 +6246,6 @@
                 42.359887
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                938.0,
-                7395.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.97170745012234,
-                42.35767283203848
-              ]
-            }
           }
         ]
       }
@@ -7462,8 +6268,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7482,17 +6288,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 312.8,0.0 312.8,252.5 5732.2,251.9 5734.3,476.8 6346.0,471.3 6346.0,7795.0 -0.0,7795.0 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0075/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7536,27 +6339,6 @@
                 42.362122
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3267.4,
-                5522.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9638611625024,
-                42.35946458072782
-              ]
-            }
           }
         ]
       }
@@ -7579,8 +6361,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7628,8 +6410,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96402569767709,
-                42.362198442693284
+                -82.96402569515986,
+                42.362198441744056
               ]
             }
           },
@@ -7649,8 +6431,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96055981989781,
-                42.36347506204775
+                -82.96055986063543,
+                42.36347504524611
               ]
             }
           },
@@ -7670,8 +6452,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95843945954174,
-                42.36032742087493
+                -82.95843952674187,
+                42.3603274431591
               ]
             }
           },
@@ -7691,8 +6473,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96190533732101,
-                42.35905080152046
+                -82.96190536126632,
+                42.359050839657044
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                220.3,
+                299.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.963824,
+                42.362122
               ]
             }
           }
@@ -7717,8 +6520,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7737,17 +6540,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6040.7,425.0 6020.5,7795.0 -0.0,7795.0 -0.0,0.0 898.5,0.0 898.8,427.2 6040.7,425.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7791,165 +6591,6 @@
                 42.36535
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2811.0,
-                425.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95666017305082,
-                42.36470860894979
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "1"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0008/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.90741466232187,
-                42.39860309147489
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.90493238810178,
-                42.40085945195491
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.90124331457422,
-                42.39864032419529
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.90372558879429,
-                42.396383963715266
-              ]
-            }
           }
         ]
       }
@@ -7972,8 +6613,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7992,17 +6633,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4891.5,7299.2 478.8,7314.6 482.2,446.1 4888.3,432.2 4891.5,7299.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0080/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8046,27 +6684,6 @@
                 42.36568
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5521.3,
-                7313.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95026027865724,
-                42.36354277634637
-              ]
-            }
           }
         ]
       }
@@ -8089,8 +6706,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8109,17 +6726,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5541.4,7356.6 -0.0,7359.0 -0.0,459.2 4906.8,485.7 5006.8,5375.5 5444.8,6301.7 5541.4,7356.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0081/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8163,27 +6777,6 @@
                 42.366353
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3944.2,
-                456.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95028324645936,
-                42.367003989948714
-              ]
-            }
           }
         ]
       }
@@ -8199,15 +6792,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8226,7 +6819,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"419.2,6262.4 -0.0,5327.0 -0.0,425.9 6335.0,544.1 6335.0,1457.0 5152.7,1430.7 5077.8,7071.1 446.3,6981.0 419.2,6262.4\" /></svg>"
         }
       },
       "body": {
@@ -8255,8 +6848,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94986857622622,
-                42.367356597761265
+                -82.94986854753954,
+                42.3673565624981
               ]
             }
           },
@@ -8276,8 +6869,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94642656704221,
-                42.3686556026446
+                -82.9464265813125,
+                42.36865555125106
               ]
             }
           },
@@ -8297,8 +6890,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9442647368075,
-                42.3655234238141
+                -82.94426477805784,
+                42.36552341131436
               ]
             }
           },
@@ -8318,8 +6911,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94770674599151,
-                42.36422441893077
+                -82.94770674428489,
+                42.36422442256141
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                494.3,
+                7319.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94757,
+                42.3645168
               ]
             }
           }
@@ -8344,8 +6958,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8364,17 +6978,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1163.2,415.6 5714.7,443.9 5675.5,6959.0 -0.0,6930.8 -0.0,1312.2 1175.2,1322.8 1163.2,415.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8418,27 +7029,6 @@
                 42.36934
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3863.3,
-                443.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94478283599138,
-                42.368968115051096
-              ]
-            }
           }
         ]
       }
@@ -8461,8 +7051,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8481,17 +7071,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5855.5,7344.4 396.4,7355.1 394.8,495.4 5816.1,503.7 5855.5,7344.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0084/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8535,27 +7122,6 @@
                 42.369778
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4792.2,
-                500.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94132980221517,
-                42.370211110187554
-              ]
-            }
           }
         ]
       }
@@ -8578,8 +7144,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8598,17 +7164,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,860.2 464.2,859.3 462.8,355.7 4915.6,343.7 4905.1,7795.0 -0.0,7795.0 -0.0,860.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0086/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8652,27 +7215,6 @@
                 42.362546
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2144.2,
-                5805.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95068465701027,
-                42.3606786208714
-              ]
-            }
           }
         ]
       }
@@ -8695,8 +7237,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8715,17 +7257,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5317.3,406.1 5436.5,7795.0 -0.0,7795.0 -0.0,414.5 5317.3,406.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8769,27 +7308,6 @@
                 42.3645168
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1627.8,
-                5641.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94823386004725,
-                42.361539389303935
-              ]
-            }
           }
         ]
       }
@@ -8809,11 +7327,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8832,17 +7350,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5640.5,0.0 5642.6,350.3 6335.0,350.3 6335.0,708.2 5644.9,721.6 5645.9,879.3 6335.0,875.1 6335.0,3441.5 5567.1,3441.8 5613.7,7085.8 1185.6,7077.9 1023.2,0.0 5640.5,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0088/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8886,27 +7401,6 @@
                 42.362313
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1183.9,
-                387.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94749904502733,
-                42.36451551273927
-              ]
-            }
           }
         ]
       }
@@ -8922,15 +7416,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8949,17 +7443,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1963.6,7795.0 -0.0,7795.0 -0.0,3454.0 730.9,3454.7 734.0,869.6 39.9,873.0 39.1,714.2 734.2,701.5 734.7,341.0 37.3,340.1 35.6,0.0 5769.2,0.0 5811.9,7159.4 1964.7,7196.0 1963.6,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0089/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9003,27 +7494,6 @@
                 42.364881
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5739.9,
-                5840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94047379131695,
-                42.364315608709724
-              ]
-            }
           }
         ]
       }
@@ -9046,8 +7516,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9066,17 +7536,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4050.2,7224.3 4060.9,6347.5 289.7,6334.4 293.6,6025.0 -0.0,6026.0 -0.0,-0.0 6101.6,0.0 6011.3,7217.5 4050.2,7224.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9120,27 +7587,6 @@
                 42.37916
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4138.0,
-                4231.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96100962233857,
-                42.37719010314021
-              ]
-            }
           }
         ]
       }
@@ -9163,8 +7609,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9183,17 +7629,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5256.3,391.6 5296.2,7138.4 40.7,7162.3 -0.0,403.5 5256.3,391.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9237,27 +7680,6 @@
                 42.367408
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                3112.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94116725155823,
-                42.36544442903224
-              ]
-            }
           }
         ]
       }
@@ -9280,8 +7702,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9300,17 +7722,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,380.6 4987.9,375.2 4980.6,703.1 6335.0,691.2 6252.3,7795.0 1242.4,7795.0 1245.1,7098.2 -0.0,7109.1 -0.0,380.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9354,27 +7773,6 @@
                 42.368221
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3129.7,
-                5805.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93580202145297,
-                42.366009970521375
-              ]
-            }
           }
         ]
       }
@@ -9397,8 +7795,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9417,17 +7815,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6120.4,694.9 6121.8,0.0 6335.0,0.0 6335.0,7795.0 1055.0,7795.0 1057.5,7122.3 883.8,7123.6 884.7,12.7 1081.2,0.0 1079.4,701.2 6120.4,694.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0092/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9471,165 +7866,6 @@
                 42.364666
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2948.7,
-                6674.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9336708575432,
-                42.3627760887512
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p93",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "1"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95077961920961,
-                42.36192722937796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94699134589426,
-                42.362491558294494
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94605217828239,
-                42.359044284086856
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94984045159774,
-                42.358479955170324
-              ]
-            }
           }
         ]
       }
@@ -9652,8 +7888,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9672,17 +7908,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5521.9,7795.0 -0.0,7795.0 -0.0,951.9 1145.2,952.3 1143.7,0.0 5554.4,0.0 5521.9,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0094/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9726,27 +7959,6 @@
                 42.361467
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4371.8,
-                5204.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94252793590815,
-                42.36030503826343
-              ]
-            }
           }
         ]
       }
@@ -9769,8 +7981,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9789,7 +8001,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"275.1,577.9 2230.8,596.5 2237.6,0.0 6069.7,0.0 6059.4,7795.0 150.0,7795.0 275.1,577.9\" /></svg>"
         }
       },
       "body": {
@@ -9818,8 +8030,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94339640798083,
-                42.36257391893337
+                -82.9433963573186,
+                42.36257391929449
               ]
             }
           },
@@ -9839,8 +8051,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93993919121401,
-                42.36385065060531
+                -82.93993918369854,
+                42.36385063511262
               ]
             }
           },
@@ -9860,8 +8072,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9378144285088,
-                42.36070463309328
+                -82.93781444751079,
+                42.360704656666236
               ]
             }
           },
@@ -9881,8 +8093,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9412716452756,
-                42.35942790142134
+                -82.94127162113085,
+                42.35942794084811
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5982.4,
+                2915.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.939337,
+                42.362603
               ]
             }
           }
@@ -9907,8 +8140,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9927,17 +8160,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9981,27 +8211,6 @@
                 42.363479
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3211.6,
-                5090.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93693398389654,
-                42.3623817460464
-              ]
-            }
           }
         ]
       }
@@ -10024,8 +8233,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10044,17 +8253,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5395.8,981.9 5309.1,7772.0 -0.0,7795.0 -0.0,967.1 5395.8,981.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10098,27 +8304,6 @@
                 42.358105
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3088.8,
-                4860.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94142668630255,
-                42.357445578093525
-              ]
-            }
           }
         ]
       }
@@ -10141,8 +8326,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:29:47Z",
-      "modified": "2026-05-25T13:29:47Z",
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10161,17 +8346,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6335,0 6335,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5912.2,901.3 5913.1,2175.4 6335.0,2173.5 6335.0,7795.0 -0.0,7795.0 72.4,971.2 5912.2,901.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0098/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10215,25 +8397,163 @@
                 42.360111
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p99",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-06-10T19:06:49Z",
+      "modified": "2026-06-10T19:06:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6335.0,775.9 6335.0,2041.4 5707.2,2034.1 5690.0,7795.0 -0.0,7795.0 -0.0,7527.5 477.7,7535.2 567.4,1974.8 150.0,1970.0 169.4,709.6 6335.0,775.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4892.9,
-                4215.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "projected"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93771773443595,
-                42.35909376894884
+                -82.93832411510802,
+                42.360873911993664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93487415152855,
+                42.36216124801358
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93273174098701,
+                42.3590218306008
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93618170456648,
+                42.35773449458089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                119.6,
+                3856.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.937199,
+                42.359345
               ]
             }
           }

--- a/gallery/new_orleans_la_1896_vol_2.iiif.json
+++ b/gallery/new_orleans_la_1896_vol_2.iiif.json
@@ -21,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,17 +44,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6387,0 6387,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"432.9,4482.7 627.6,2118.7 -0.0,1847.8 -0.0,1282.6 653.9,1558.1 900.1,0.0 6387.0,0.0 6387.0,6877.3 5937.1,7040.5 6068.3,7315.2 3169.7,7491.3 3178.1,7795.0 2626.5,7795.0 2540.1,7480.8 443.6,7498.4 432.9,4482.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -98,27 +95,6 @@
                 29.9500266
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                984.1,
-                1945.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06595410626768,
-                29.951083981188727
-              ]
-            }
           }
         ]
       }
@@ -141,8 +117,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,17 +137,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6428,0 6428,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5542.9,7450.2 843.2,7441.6 868.2,1905.2 1145.8,0.0 6097.6,0.0 5834.8,1519.2 5185.4,1235.0 5177.6,1799.6 5800.7,2078.9 5573.8,4437.6 5542.9,7450.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0102/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -215,27 +188,6 @@
                 29.9511568
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5293.8,
-                4239.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06670168885874,
-                29.950146327442205
-              ]
-            }
           }
         ]
       }
@@ -255,11 +207,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,25 +230,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6428,0 6428,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"173.1,7310.1 2029.2,8.9 4206.5,259.9 6428.0,1863.1 6428.0,7795.0 3539.1,7795.0 1698.6,7407.4 173.1,7310.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                760.4,
-                5047.6
+                789.1,
+                4884.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -316,8 +265,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3607.0,
-                198.1
+                5632.5,
+                3945.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -328,29 +277,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0721396,
-                29.9532842
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2418.5,
-                5047.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06982246132385,
-                29.9522131796512
+                -90.0700736,
+                29.9537006
               ]
             }
           }
@@ -372,11 +300,11 @@
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "16"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -395,17 +323,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6428,0 6428,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"851.2,7544.3 772.6,241.5 6157.1,171.8 4920.2,7535.3 851.2,7544.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -449,27 +374,6 @@
                 29.951481
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3044.7,
-                5089.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07034672105705,
-                29.950477193803746
-              ]
-            }
           }
         ]
       }
@@ -489,11 +393,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -512,17 +416,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6428,0 6428,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6428.0,7795.0 2259.3,7426.6 1614.3,3737.9 1474.2,1626.8 1217.7,1622.1 774.8,270.0 942.2,268.9 896.1,0.0 6428.0,0.0 6428.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -566,27 +467,6 @@
                 29.9543008
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1619.8,
-                3197.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07396421901613,
-                29.95419246017148
-              ]
-            }
           }
         ]
       }
@@ -609,8 +489,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -629,17 +509,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6496,0 6496,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4042.5,0.0 5923.1,824.0 6283.9,0.0 6496.0,0.0 6496.0,1663.3 6345.2,2294.9 6496.0,2367.4 6496.0,2675.8 5857.4,4248.2 4967.4,7635.5 0.0,7572.9 914.1,1972.6 542.3,1473.8 1041.6,1414.4 1269.5,0.0 4042.5,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -683,27 +560,6 @@
                 29.9541167
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2187.7,
-                3871.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07441111883745,
-                29.952463943573818
-              ]
-            }
           }
         ]
       }
@@ -719,15 +575,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -746,17 +602,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6428,0 6428,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"339.8,14.6 3990.3,625.7 3994.4,2862.5 6183.1,2854.8 6152.2,7630.8 868.6,7769.6 869.6,7643.9 361.7,7610.5 339.8,14.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -764,7 +617,7 @@
             "properties": {
               "resourceCoords": [
                 3990.3,
-                5446.9
+                7616.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -775,29 +628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0734605,
-                29.9488979
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                335.5,
-                5446.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0753256,
-                29.9493252
+                -90.073751,
+                29.9479258
               ]
             }
           },
@@ -806,7 +638,7 @@
             "properties": {
               "resourceCoords": [
                 3990.3,
-                2913.5
+                626.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -817,8 +649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07311865679448,
-                29.95001811759141
+                -90.0728094,
+                29.9510458
               ]
             }
           }
@@ -840,11 +672,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -863,17 +695,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6361,0 6361,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"954.5,7551.0 912.0,0.0 5724.3,0.0 5836.1,7492.4 954.5,7551.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0108/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -917,27 +746,6 @@
                 29.9494941
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3092.6,
-                2670.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07097830023024,
-                29.948314025534906
-              ]
-            }
           }
         ]
       }
@@ -960,8 +768,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -980,17 +788,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6350,0 6350,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5741.6,563.1 5739.0,7280.9 421.1,7325.7 -0.0,7158.6 -0.0,533.0 5741.6,563.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0109/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1034,27 +839,6 @@
                 29.944664
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3296.4,
-                3782.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07292599712258,
-                29.94620853796291
-              ]
-            }
           }
         ]
       }
@@ -1074,11 +858,11 @@
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1097,24 +881,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6488,0 6488,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"727.3,7271.0 709.2,508.0 5602.4,504.4 5646.1,7274.6 727.3,7271.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0110/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                709.2,
+                3197.7,
                 7261.5
               ],
               "creator": {
@@ -1126,8 +907,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0721429,
-                29.9443845
+                -90.0708922,
+                29.9441047
               ]
             }
           },
@@ -1149,27 +930,6 @@
               "coordinates": [
                 -90.0712549,
                 29.9473502
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3197.7,
-                3782.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0704242336181,
-                29.945628703396924
               ]
             }
           }
@@ -1194,8 +954,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1214,17 +974,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6350,0 6350,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4858.8,1008.3 5412.2,1027.6 5396.7,3270.6 6350.0,7293.8 303.8,7121.9 423.6,568.0 4783.2,690.0 4858.8,1008.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0111/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1268,27 +1025,6 @@
                 29.9484512
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6033.8,
-                5590.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06586319620655,
-                29.94614664340204
-              ]
-            }
           }
         ]
       }
@@ -1311,8 +1047,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1331,17 +1067,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6340,0 6340,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"2771.7,150.3 3035.3,138.4 3013.2,0.0 6340.0,0.0 6340.0,7795.0 3530.4,7795.0 3354.1,7090.1 975.0,7046.2 -0.0,3055.1 -0.0,523.0 2894.9,427.9 2771.7,150.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1385,27 +1118,6 @@
                 29.9484512
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                19.2,
-                3022.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06590016859766,
-                29.947254783473
-              ]
-            }
           }
         ]
       }
@@ -1428,8 +1140,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1448,17 +1160,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6356,0 6356,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5702.6,235.5 5709.1,7545.5 4815.5,7795.0 4082.2,7795.0 4084.0,6941.1 3717.0,6946.4 599.2,7795.0 551.1,4388.0 531.8,4394.7 532.0,0.0 597.3,249.2 5702.6,235.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1502,27 +1211,6 @@
                 29.9438175
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                597.3,
-                1967.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06878585504651,
-                29.943618699928393
-              ]
-            }
           }
         ]
       }
@@ -1545,8 +1233,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1565,17 +1253,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6305,0 6305,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,3437.6 798.1,3220.0 809.5,801.1 3928.4,0.0 4294.1,0.0 4280.1,850.8 5010.8,861.3 5904.8,625.5 5896.3,1799.4 5187.3,1982.9 5209.9,4815.6 6305.0,4806.9 6305.0,7795.0 1683.8,7795.0 1683.8,7795.0 0.0,7795.0 0.0,3437.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0114/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1619,27 +1304,6 @@
                 29.9428089
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                795.3,
-                913.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06578209740684,
-                29.942928877316728
-              ]
-            }
           }
         ]
       }
@@ -1662,8 +1326,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1682,17 +1346,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6349,0 6349,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"3668.2,7532.8 0.0,7563.8 0.0,3709.2 612.7,2044.6 826.8,236.1 6349.0,199.9 6349.0,6814.4 4027.9,7734.9 3668.2,7532.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1736,27 +1397,6 @@
                 29.9414266
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                370.5,
-                2692.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07043951097694,
-                29.941172049898714
-              ]
-            }
           }
         ]
       }
@@ -1776,11 +1416,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1799,17 +1439,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6349,0 6349,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"3877.6,1832.5 6349.0,1866.6 4224.1,7207.3 3411.2,7117.2 3142.7,7796.0 0.0,7796.0 0.0,4526.2 465.1,4525.3 562.1,277.7 3373.3,1413.6 3877.6,1832.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1853,13 +1490,151 @@
                 29.9423435
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p119",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6262
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6262.0,0.0 6262.0,6066.4 5988.0,7427.1 6262.0,7434.4 6262.0,7796.0 0.0,7796.0 0.0,2294.0 2280.3,2243.3 3125.3,0.0 6262.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06768210720418,
+                29.935060702188814
+              ]
+            }
           },
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2455.9,
-                4685.3
+                6262.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06806143121695,
+                29.937882704895525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6262.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06400528407559,
+                29.938292038572936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06362596006284,
+                29.935470035866224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6143.8,
+                210.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1870,8 +1645,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0658088556324,
-                29.9417166363788
+                -90.0679446,
+                29.9378405
               ]
             }
           }
@@ -1896,8 +1671,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1916,17 +1691,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6509,0 6509,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"2617.0,0.0 3765.8,0.0 6249.5,985.1 6143.2,5331.6 5667.3,5331.7 5663.3,7795.0 172.7,7795.0 177.4,7551.3 0.0,7543.2 206.7,6014.2 312.9,451.0 1811.4,893.8 2617.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0120/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1970,27 +1742,6 @@
                 29.9399818
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                239.5,
-                246.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06795517623029,
-                29.93785826060836
-              ]
-            }
           }
         ]
       }
@@ -2013,8 +1764,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2033,17 +1784,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6288,0 6288,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"2937.0,0.0 2933.2,1269.0 6288.0,1394.6 6288.0,7796.0 3158.8,7796.0 3184.4,6199.8 -0.0,4885.8 -0.0,2569.3 1300.1,3124.3 2561.7,0.0 2937.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0121/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2087,27 +1835,6 @@
                 29.9333635
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3214.3,
-                3101.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0661969853462,
-                29.934377792549988
-              ]
-            }
           }
         ]
       }
@@ -2130,8 +1857,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2150,17 +1877,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6321,0 6321,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"3572.2,6832.5 1322.6,6815.6 1319.1,546.3 4757.5,553.2 5408.2,2176.7 5532.3,2786.0 5520.8,7282.8 3572.0,7268.5 3572.2,6832.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0123/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2204,27 +1928,6 @@
                 29.9303995
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3612.5,
-                2801.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0668327662745,
-                29.932114224916685
-              ]
-            }
           }
         ]
       }
@@ -2247,8 +1950,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2267,17 +1970,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6481,0 6481,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"605.5,7230.4 631.2,2757.7 452.7,2007.9 3320.8,815.1 2981.9,0.0 6481.0,0.0 6481.0,6904.8 3235.7,6862.4 3235.7,7258.3 605.5,7230.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0124/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2321,27 +2021,6 @@
                 29.929624
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                530.2,
-                2804.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06590852044623,
-                29.93190005732464
-              ]
-            }
           }
         ]
       }
@@ -2361,11 +2040,11 @@
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2384,17 +2063,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6245,0 6245,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3088.0 -0.0,434.8 2212.7,434.7 2212.9,0.0 4454.7,0.0 4457.7,434.4 6245.0,434.0 6245.0,6964.4 4469.1,5825.8 4457.7,4870.5 2897.5,4896.4 -0.0,3088.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0125/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2438,27 +2114,6 @@
                 29.9301443
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2881.3,
-                4870.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06880891150907,
-                29.92835900901476
-              ]
-            }
           }
         ]
       }
@@ -2481,8 +2136,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2501,17 +2156,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"2871.1,399.5 2865.9,0.0 6447.0,0.0 6447.0,7795.0 204.2,7795.0 200.8,7064.9 75.9,6987.1 60.3,406.4 2871.1,399.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0126/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2555,27 +2207,6 @@
                 29.9289319
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2904.0,
-                4871.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06565226541395,
-                29.92765555967836
-              ]
-            }
           }
         ]
       }
@@ -2598,8 +2229,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2618,17 +2249,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6146,0 6146,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7796.0 -0.0,-0.0 180.3,0.0 125.6,797.0 6146.0,1112.5 6146.0,7796.0 -0.0,7796.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0127/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2672,27 +2300,6 @@
                 29.9257439
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                437.6,
-                1079.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07251983875517,
-                29.924495626313234
-              ]
-            }
           }
         ]
       }
@@ -2715,8 +2322,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2735,17 +2342,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6448,0 6448,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"2963.7,792.0 5508.4,733.8 5560.2,3487.8 4949.7,3888.6 6448.0,6194.2 6448.0,7796.0 -0.0,7796.0 -0.0,1105.4 2963.7,792.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0128/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2789,27 +2393,6 @@
                 29.927108
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5560.2,
-                402.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06840100016703,
-                29.92803351722608
-              ]
-            }
           }
         ]
       }
@@ -2832,8 +2415,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2852,17 +2435,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6335,0 6335,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,391.9 6335.0,294.4 6335.0,7324.4 -0.0,7426.9 -0.0,391.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0129/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2906,27 +2486,6 @@
                 29.9252972
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5146.6,
-                4781.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07139353660601,
-                29.9268367495783
-              ]
-            }
           }
         ]
       }
@@ -2946,11 +2505,11 @@
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "16"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2969,17 +2528,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6444,0 6444,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"4600.2,0.0 5380.6,0.0 5423.2,885.8 6444.0,885.8 6444.0,1449.0 5477.0,2100.0 5596.0,5540.4 6444.0,6866.3 5703.6,7377.6 5665.9,6897.4 3121.4,6991.2 635.9,7358.8 1260.3,409.3 3778.9,363.4 4600.2,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0130/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3023,27 +2579,6 @@
                 29.927108
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5533.5,
-                4806.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06908330599497,
-                29.92857554339433
-              ]
-            }
           }
         ]
       }
@@ -3066,8 +2601,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3086,17 +2621,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6352,0 6352,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5824.8,607.3 6037.5,7256.3 170.8,7225.6 162.9,7795.0 -0.0,7795.0 69.0,604.9 5824.8,607.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0131/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3140,27 +2672,6 @@
                 29.9287748
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3094.6,
-                5063.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0743681716842,
-                29.928628104517934
-              ]
-            }
           }
         ]
       }
@@ -3180,11 +2691,11 @@
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3203,61 +2714,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6444,0 6444,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"4909.0,407.0 6157.2,2257.9 6444.0,7796.0 4744.0,7796.0 193.1,7331.6 481.0,757.8 4909.0,407.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2463.2,
-                2941.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0730662,
-                29.9308108
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4626.1,
-                2941.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.072131,
-                29.9313235
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -3274,8 +2740,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07246585692363,
-                29.929988359580413
+                -90.0723245,
+                29.930088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2463.2,
+                7326.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0715553,
+                29.9293384
               ]
             }
           }
@@ -3300,8 +2787,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3320,17 +2807,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6358,0 6358,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"192.2,3000.2 1810.5,325.3 3800.4,316.3 3800.1,0.0 6022.1,0.0 6023.1,323.4 6358.0,323.1 6358.0,5561.9 6038.7,5563.2 6044.2,7443.2 1533.6,7446.8 1532.1,4849.8 1530.9,3005.1 192.2,3000.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3374,27 +2858,6 @@
                 29.9303995
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3802.0,
-                7446.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06827288172737,
-                29.931392977223105
-              ]
-            }
           }
         ]
       }
@@ -3414,11 +2877,11 @@
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "8"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3437,17 +2900,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6444,0 6444,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"1279.6,336.3 5509.9,348.5 5502.5,1446.2 4957.4,1446.5 4961.2,6696.7 3197.0,7456.9 938.1,7499.8 939.3,5608.1 1260.7,5607.9 1279.6,336.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0134/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3491,27 +2951,6 @@
                 29.9331684
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3172.5,
-                3743.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06958663946166,
-                29.933763220382296
-              ]
-            }
           }
         ]
       }
@@ -3534,8 +2973,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3554,17 +2993,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6321,0 6321,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5990.2,818.1 6013.7,7275.1 186.0,7289.2 188.3,6791.7 -0.0,6791.2 -0.0,2899.0 220.5,2969.8 216.6,3328.5 1071.4,805.2 5990.2,818.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0135/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3608,27 +3044,6 @@
                 29.937986
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2673.4,
-                3034.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07158557816,
-                29.937268062847316
-              ]
-            }
           }
         ]
       }
@@ -3648,11 +3063,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3671,17 +3086,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6443,0 6443,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"6443.0,7437.1 6270.2,7436.6 6270.0,7796.0 -0.0,7796.0 -0.0,831.8 1501.0,836.4 1503.4,1466.5 3326.9,1292.0 4037.3,2995.5 6365.7,2987.1 6443.0,7437.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0136/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3725,27 +3137,6 @@
                 29.9377133
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3574.5,
-                779.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06778970557782,
-                29.93749228695326
-              ]
-            }
           }
         ]
       }
@@ -3765,11 +3156,11 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3788,17 +3179,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6349,0 6349,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"2733.7,7055.2 960.1,6462.6 2185.5,2871.9 2806.6,3036.3 2802.1,4079.4 3109.5,3209.9 3097.3,1063.0 1982.7,668.9 3095.0,672.7 3092.9,303.6 4250.5,410.5 6349.0,1106.8 6349.0,7038.6 3122.2,7015.0 3122.7,6020.2 2796.6,5909.0 2733.7,7055.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3826,8 +3214,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1539.3,
-                4736.4
+                1504.2,
+                4845.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3840,27 +3228,6 @@
               "coordinates": [
                 -90.0730958,
                 29.9397251
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3123.4,
-                3066.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.072035690167,
-                29.940393654773718
               ]
             }
           }
@@ -3878,15 +3245,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3905,17 +3272,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6453,0 6453,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"1387.8,441.4 5252.9,850.1 5036.9,3217.2 5358.6,4305.9 6453.0,4844.4 6453.0,6412.5 6065.2,6519.1 6416.1,7796.0 4555.7,7796.0 4614.3,7158.8 772.5,6781.0 1387.8,441.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0138/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3959,27 +3323,6 @@
                 29.9378405
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4881.3,
-                7087.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06871099278852,
-                29.93771152989359
-              ]
-            }
           }
         ]
       }
@@ -3995,15 +3338,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4022,24 +3365,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6340,0 6340,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"227.2,3934.6 1392.1,3927.0 1388.7,3623.9 223.7,3637.0 190.8,896.6 6340.0,795.9 6340.0,3832.3 6340.0,7054.2 4221.1,7795.0 3253.8,7795.0 4286.9,7434.6 4232.3,6762.7 252.8,6806.5 227.2,3934.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4184.1,
+                1973.9,
                 862.6
               ],
               "creator": {
@@ -4051,8 +3391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.075084,
-                29.942043
+                -90.075719,
+                29.941206
               ]
             }
           },
@@ -4061,27 +3401,6 @@
             "properties": {
               "resourceCoords": [
                 223.6,
-                862.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0762294,
-                29.9405175
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4184.1,
                 3756.9
               ],
               "creator": {
@@ -4093,8 +3412,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0737977321191,
-                29.941317811362712
+                -90.0749595,
+                29.9398011
               ]
             }
           }
@@ -4116,11 +3435,11 @@
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4139,17 +3458,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6426,0 6426,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"778.9,4004.7 1679.8,1428.3 4798.5,2416.0 5818.0,0.0 6014.9,0.0 6010.8,7408.4 0.0,7421.0 0.0,6232.1 778.9,4004.7 778.9,4004.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0140/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4193,27 +3509,6 @@
                 29.9441047
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3605.8,
-                4923.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07245542785611,
-                29.94333557874561
-              ]
-            }
           }
         ]
       }
@@ -4229,15 +3524,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4256,17 +3551,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6353,0 6353,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 307.1,-0.0 301.6,1180.8 5199.9,1175.1 4869.8,-0.0 5236.1,-0.0 5576.9,1001.4 6353.0,740.6 6353.0,3407.8 6241.5,3066.5 6009.7,3070.1 6353.0,4083.6 6353.0,7795.0 6179.6,7795.0 6168.6,6763.2 339.1,6753.7 349.9,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0141/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4294,28 +3586,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3232.4,
-                6744.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0751923,
-                29.9369301
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6008.0,
+                325.8,
                 3050.9
               ],
               "creator": {
@@ -4327,8 +3598,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07292434008215,
-                29.93762122410147
+                -90.0754052,
+                29.9390424
               ]
             }
           }
@@ -4353,8 +3624,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4373,17 +3644,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"420.7,6056.4 373.9,2764.0 -0.0,2760.8 -0.0,-0.0 793.5,0.0 792.3,501.1 5567.1,469.5 5578.1,5030.6 5253.1,5032.1 5256.9,7265.6 2405.8,7261.8 420.7,6056.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0142/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4427,27 +3695,6 @@
                 29.9321959
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5574.8,
-                5063.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07159001684518,
-                29.933154356633768
-              ]
-            }
           }
         ]
       }
@@ -4467,11 +3714,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4490,17 +3737,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6364,0 6364,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7165.1 -0.0,-0.0 158.8,0.0 147.5,873.8 5510.6,910.7 5750.9,7177.2 -0.0,7165.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0143/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4544,27 +3788,6 @@
                 29.9304185
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3092.5,
-                4897.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07647429135298,
-                29.931072152931975
-              ]
-            }
           }
         ]
       }
@@ -4580,15 +3803,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "11"
         },
         {
           "label": "intersections",
-          "value": "41"
+          "value": "23"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4607,17 +3830,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6426,0 6426,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"175.8,911.1 3665.7,781.3 5417.9,249.0 5655.8,585.9 6426.0,351.6 6426.0,1256.6 6229.3,1398.1 6426.0,1706.2 3859.7,3608.5 4035.7,5867.1 4539.5,6583.0 3969.1,6925.3 160.1,7076.8 175.8,911.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4661,27 +3881,6 @@
                 29.9330997
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1980.2,
-                6715.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07402095780013,
-                29.931648417781147
-              ]
-            }
           }
         ]
       }
@@ -4704,8 +3903,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4724,17 +3923,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6372,0 6372,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"41.7,7795.0 169.4,1267.3 6036.4,756.6 6188.2,2503.4 6220.0,7795.0 41.7,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4778,27 +3974,6 @@
                 29.9325206
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3321.7,
-                2574.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0776737932825,
-                29.934211322910716
-              ]
-            }
           }
         ]
       }
@@ -4814,15 +3989,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4841,17 +4016,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6432,0 6432,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5914.9 173.2,4364.9 -0.0,4859.0 -0.0,1660.9 187.0,1660.1 172.0,621.3 5986.7,607.4 6001.9,1636.7 6174.8,1636.0 6168.2,-0.0 6432.0,-0.0 6432.0,3702.1 6034.2,3833.9 6033.5,5695.6 5588.0,7413.5 -0.0,5914.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4859,7 +4031,7 @@
             "properties": {
               "resourceCoords": [
                 3129.8,
-                4625.9
+                5028.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4870,8 +4042,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0763203,
-                29.9353676
+                -90.07643,
+                29.935226
               ]
             }
           },
@@ -4880,27 +4052,6 @@
             "properties": {
               "resourceCoords": [
                 6013.6,
-                4625.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0750408,
-                29.9346473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3129.8,
                 2437.5
               ],
               "creator": {
@@ -4912,8 +4063,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07568977609921,
-                29.936208719678486
+                -90.0744219,
+                29.9354891
               ]
             }
           }
@@ -4938,8 +4089,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4958,17 +4109,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6396,0 6396,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"472.4,977.0 4617.8,1295.7 5800.8,1184.7 5806.8,7067.4 -0.0,6868.1 -0.0,-0.0 481.7,0.0 472.4,977.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5012,27 +4160,6 @@
                 29.9341069
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                383.4,
-                2897.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08191351989528,
-                29.935595231938063
-              ]
-            }
           }
         ]
       }
@@ -5055,8 +4182,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5075,17 +4202,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6453,0 6453,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5478.7,5373.5 4266.8,5806.4 4322.8,5962.5 1538.2,6926.4 2061.5,6928.6 542.3,7271.3 529.6,7093.9 -0.0,7075.2 -0.0,1211.4 1963.9,912.9 3662.5,279.3 5478.7,5373.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5129,27 +4253,6 @@
                 29.939051
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3836.7,
-                6175.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07703664346164,
-                29.93697839345267
-              ]
-            }
           }
         ]
       }
@@ -5172,8 +4275,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5192,17 +4295,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6380,0 6380,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"932.5,7104.8 907.1,2243.8 -0.0,2242.5 -0.0,1820.0 905.9,1831.7 901.0,-0.0 5786.5,-0.0 5785.8,162.9 5368.8,161.9 5367.7,7073.7 5803.3,7073.7 5806.0,7590.3 3030.9,7592.2 932.5,7104.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5246,27 +4346,6 @@
                 29.9411788
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5785.8,
-                3923.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07847242644291,
-                29.939750466053383
-              ]
-            }
           }
         ]
       }
@@ -5289,8 +4368,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5309,17 +4388,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6453,0 6453,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"428.1,6489.3 435.1,7795.0 -0.0,7795.0 -0.0,890.5 416.5,891.4 420.5,-0.0 3121.6,-0.0 3121.2,895.6 5904.6,914.2 5854.8,7542.4 6017.6,7543.6 6014.7,7795.0 5848.1,7795.0 5850.3,6501.7 428.1,6489.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0150/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5363,27 +4439,6 @@
                 29.938387
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3124.3,
-                4680.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07729340001137,
-                29.939078052267067
-              ]
-            }
           }
         ]
       }
@@ -5406,8 +4461,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5426,17 +4481,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6380,0 6380,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1460.6,5044.6 1417.7,210.1 5282.2,173.5 5281.6,2114.0 4775.3,2118.2 4778.7,2292.0 5281.7,2288.4 5310.4,7715.3 2205.8,7717.5 2182.5,5041.5 1460.6,5044.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0151/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5480,27 +4532,6 @@
                 29.943062
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3073.4,
-                4999.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07692410944496,
-                29.94186701476472
-              ]
-            }
           }
         ]
       }
@@ -5516,15 +4547,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5543,45 +4574,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6443,0 6443,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"1909.9,0.0 6443.0,0.0 6443.0,4007.3 6014.1,4142.6 6121.0,5013.5 5977.6,5058.8 5741.8,7588.4 415.2,7574.3 493.3,2251.8 -0.0,2245.5 -0.0,2075.1 496.7,2080.8 535.2,177.9 1928.1,141.6 1909.9,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5743.4,
-                4953.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.074673,
-                29.944873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                460.0,
+                2670.5,
                 7588.4
               ],
               "creator": {
@@ -5593,8 +4600,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.075084,
-                29.942043
+                -90.0744359,
+                29.942928
               ]
             }
           },
@@ -5602,8 +4609,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                460.0,
-                4953.5
+                5743.4,
+                7588.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5614,125 +4621,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07630659636634,
-                29.94274905899993
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p153",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6380
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6380,0 6380,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2530.3,
-                2958.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0783631,
-                29.948933
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2530.3,
-                6194.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.078733,
-                29.9477565
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1073.5,
-                6194.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07934421059886,
-                29.94790077669353
+                -90.073562,
+                29.944138
               ]
             }
           }
@@ -5750,15 +4640,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5777,25 +4667,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6378,0 6378,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,117.2 -0.0,-0.0 1341.0,0.0 1284.3,400.1 5864.6,1335.5 6378.0,1430.6 6378.0,6110.3 6184.2,6121.9 6105.0,7796.0 -0.0,7796.0 -0.0,131.9 -0.0,117.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0155/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1906.7,
-                3264.0
+                137.3,
+                2963.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5806,8 +4693,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0797014,
-                29.9523614
+                -90.0805377,
+                29.9527262
               ]
             }
           },
@@ -5815,8 +4702,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1906.7,
-                412.0
+                6279.0,
+                4516.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5827,29 +4714,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0793069,
-                29.9535853
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3343.9,
-                4033.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07909604547623,
-                29.951858853682417
+                -90.0775949,
+                29.9513804
               ]
             }
           }
@@ -5871,11 +4737,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5894,17 +4760,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6398,0 6398,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7159.8 329.6,7155.4 387.1,5463.7 594.6,5414.9 519.7,723.7 744.7,762.3 1069.0,0.0 1874.3,0.0 1884.5,957.8 3316.9,1173.2 3382.3,1677.6 3882.6,1296.2 5821.4,1626.1 5824.2,6453.2 4047.7,6432.7 4062.9,7795.0 -0.0,7795.0 -0.0,7159.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0156/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5948,27 +4811,6 @@
                 29.9493252
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                392.9,
-                3568.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07759343414419,
-                29.95150614133113
-              ]
-            }
           }
         ]
       }
@@ -5991,8 +4833,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6011,7 +4853,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6425,0 6425,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1545.0,7795.0 353.1,2488.1 3252.8,1670.5 2929.9,0.0 5892.1,0.0 6125.9,0.0 6425.0,1612.3 6425.0,7795.0 1545.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -6040,8 +4882,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08078391099669,
-                29.954288331162747
+                -90.0807849763607,
+                29.954287251796703
               ]
             }
           },
@@ -6061,8 +4903,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0787381502968,
-                29.956600588852723
+                -90.07873817826332,
+                29.956600681943566
               ]
             }
           },
@@ -6082,8 +4924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07550028676553,
-                29.954449848244924
+                -90.07549867282371,
+                29.954448850777975
               ]
             }
           },
@@ -6103,8 +4945,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07754604746542,
-                29.952137590554944
+                -90.0775454709211,
+                29.952135420631112
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6166.2,
+                329.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.078683,
+                29.956417
               ]
             }
           }
@@ -6122,15 +4985,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6149,17 +5012,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6373,0 6373,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"358.9,480.0 5771.1,444.0 5780.9,0.0 6373.0,0.0 6373.0,7575.3 1392.7,7543.7 1434.1,7795.0 1277.8,7795.0 878.6,6910.0 685.5,6997.1 358.9,480.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6203,27 +5063,6 @@
                 29.957514
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1028.6,
-                5095.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07655125513071,
-                29.955357389115427
-              ]
-            }
           }
         ]
       }
@@ -6239,15 +5078,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6266,17 +5105,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6424,0 6424,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6424.0,567.1 6345.8,6961.6 3250.5,6086.7 3106.7,7795.0 439.9,7795.0 316.3,6454.4 199.2,6471.0 457.1,3722.6 -0.0,3607.2 -0.0,1327.0 6424.0,567.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6304,8 +5140,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                329.0,
-                6638.5
+                6296.2,
+                7293.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6316,29 +5152,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.080185,
-                29.953962
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3370.1,
-                3795.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08078686472089,
-                29.955761065026582
+                -90.078683,
+                29.956417
               ]
             }
           }
@@ -6363,8 +5178,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6383,17 +5198,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6423,0 6423,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6343.4,954.9 6333.4,7247.3 890.1,7286.2 -0.0,3951.8 -0.0,968.4 6343.4,954.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6437,27 +5249,6 @@
                 29.957514
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1740.7,
-                4993.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07935281725658,
-                29.9573634683325
-              ]
-            }
           }
         ]
       }
@@ -6477,11 +5268,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6500,17 +5291,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6423,0 6423,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"554.1,783.3 2838.4,1092.4 3016.0,649.9 5734.7,1296.1 5775.3,7795.0 -0.0,7795.0 -0.0,5658.5 288.0,4998.5 527.0,3200.8 554.1,783.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0162/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6554,144 +5342,6 @@
                 29.953962
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4142.5,
-                3645.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08134390047556,
-                29.95314988780794
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p164",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6432
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6432,0 6432,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4416.8,
-                1667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.078733,
-                29.9477565
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6032.8,
-                6689.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0760493,
-                29.9469191
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3784.5,
-                6689.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07679201200317,
-                29.946084853626264
-              ]
-            }
           }
         ]
       }
@@ -6714,8 +5364,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6734,17 +5384,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6414,0 6414,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4395.7,5773.6 3975.5,5776.0 3979.4,6678.3 487.9,6708.1 494.1,3799.2 -0.0,3861.6 -0.0,1330.1 389.5,1415.4 465.1,1082.9 466.9,1447.0 6058.9,1419.8 6095.3,6660.3 4389.2,6674.7 4395.7,5773.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0165/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6788,27 +5435,6 @@
                 29.9437673
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2309.4,
-                1015.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08310043798086,
-                29.942340476601856
-              ]
-            }
           }
         ]
       }
@@ -6831,8 +5457,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6851,17 +5477,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6431,0 6431,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"3937.1,6679.0 -0.0,6670.2 11.6,1187.0 5331.3,1122.6 5320.8,1599.7 6431.0,1610.6 6431.0,6479.1 3937.1,6679.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0166/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6905,27 +5528,6 @@
                 29.944275
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3939.1,
-                6708.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07840018667332,
-                29.94390787330888
-              ]
-            }
           }
         ]
       }
@@ -6945,11 +5547,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6968,17 +5570,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6474,0 6474,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"1303.6,7562.2 1226.4,3427.3 1079.2,3433.5 960.9,2586.4 3338.0,1706.7 3107.7,1264.2 5841.3,259.1 6329.8,1512.2 6474.0,3154.2 6474.0,7795.0 1993.2,7795.0 1993.5,7552.9 1303.6,7562.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0167/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7022,27 +5621,6 @@
                 29.93831
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1220.1,
-                3258.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08382209033203,
-                29.941108186485778
-              ]
-            }
           }
         ]
       }
@@ -7062,11 +5640,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7085,17 +5663,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6442,0 6442,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5589.6,207.0 6060.8,3369.8 5814.9,7543.5 4832.6,7551.7 4837.0,7795.0 1018.4,7795.0 1001.3,3143.9 850.0,1491.2 2990.0,1199.2 5589.6,207.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7139,27 +5714,6 @@
                 29.9368699
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                271.5,
-                5248.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08324074864272,
-                29.938928818032757
-              ]
-            }
           }
         ]
       }
@@ -7179,11 +5733,11 @@
         },
         {
           "label": "intersections",
-          "value": "28"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7202,17 +5756,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6474,0 6474,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 110.5,0.0 114.8,1240.1 4157.0,1212.0 4147.6,779.5 5317.8,347.3 6120.5,6698.9 4866.0,6875.5 4872.4,7022.8 736.6,7104.6 746.6,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7256,27 +5807,6 @@
                 29.9420438
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3031.0,
-                1252.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08646208618549,
-                29.942659388949124
-              ]
-            }
           }
         ]
       }
@@ -7296,11 +5826,11 @@
         },
         {
           "label": "intersections",
-          "value": "36"
+          "value": "21"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7319,17 +5849,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6407,0 6407,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 635.9,0.0 635.3,987.6 2067.3,985.9 4066.8,6425.5 4059.3,6865.4 -0.0,6879.7 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0170/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7373,27 +5900,6 @@
                 29.9447896
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3922.1,
-                4579.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08677266239492,
-                29.94376635344223
-              ]
-            }
           }
         ]
       }
@@ -7416,8 +5922,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7436,17 +5942,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6474,0 6474,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"553.1,4013.0 517.6,1236.0 -0.0,1041.3 8.7,0.0 5974.7,-0.0 5988.0,7795.0 186.5,7795.0 775.1,6187.6 502.9,6088.7 557.4,4425.9 684.8,4425.6 663.6,4011.6 553.1,4013.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0171/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7490,27 +5993,6 @@
                 29.9452046
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2373.1,
-                5756.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0871358940582,
-                29.944795777972253
-              ]
-            }
           }
         ]
       }
@@ -7533,8 +6015,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7553,17 +6035,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6476,0 6476,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"228.8,341.0 6143.5,361.7 6145.3,2183.4 6476.0,2184.9 6476.0,7795.0 212.3,6370.8 228.8,341.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7607,27 +6086,6 @@
                 29.945462
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2012.8,
-                2159.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08380629629835,
-                29.94476798731694
-              ]
-            }
           }
         ]
       }
@@ -7650,8 +6108,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7670,17 +6128,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6474,0 6474,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5800.4,-0.0 5717.4,5416.4 5913.4,5417.4 5903.6,7136.4 -0.0,7054.2 -0.0,0.0 5800.4,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7724,27 +6179,6 @@
                 29.9463455
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5889.5,
-                5408.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08345856421519,
-                29.946755856887872
-              ]
-            }
           }
         ]
       }
@@ -7760,15 +6194,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "4"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7787,25 +6221,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6421,0 6421,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"194.5,5455.2 -0.0,5457.2 -0.0,0.0 6421.0,-0.0 6421.0,4097.9 5941.7,4092.0 6046.4,7639.6 215.7,7654.6 194.5,5455.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0174/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5964.2,
-                5383.0
+                1974.2,
+                7638.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7816,8 +6247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0809002,
-                29.945289
+                -90.0832916,
+                29.945462
               ]
             }
           },
@@ -7841,27 +6272,6 @@
                 29.9444632
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3708.8,
-                6510.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08216392277498,
-                29.94541454685927
-              ]
-            }
           }
         ]
       }
@@ -7881,11 +6291,11 @@
         },
         {
           "label": "intersections",
-          "value": "35"
+          "value": "21"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7904,25 +6314,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6467,0 6467,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5375.5,7795.0 -0.0,7795.0 -0.0,3753.5 1573.5,-0.0 1837.7,-0.0 1928.8,-0.0 4367.1,-0.0 6325.1,4494.9 6352.0,7606.5 5375.5,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1382.8,
-                5370.2
+                -47.9,
+                843.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7933,8 +6340,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0898782,
-                29.9466074
+                -90.088397,
+                29.948348
               ]
             }
           },
@@ -7942,8 +6349,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5828.3,
-                3788.9
+                6352.0,
+                7606.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7954,29 +6361,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.087806,
-                29.945414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6406.3,
-                5370.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0882907402632,
-                29.94476968128739
+                -90.0892624,
+                29.9441746
               ]
             }
           }
@@ -8001,8 +6387,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8021,19 +6407,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6421,0 6421,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5591.8,1236.9 5273.9,2195.3 6421.0,2193.1 6421.0,7795.0 641.8,7795.0 643.6,6170.5 2175.4,6743.7 2165.7,2720.9 0.0,2698.8 0.0,2216.1 2159.9,2189.5 2150.6,1610.6 0.0,1186.3 45.8,273.0 2246.5,1004.9 2493.5,105.3 5591.8,1236.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                51.1,
+                6833.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0864543,
+                29.9472487
+              ]
+            }
+          },
           {
             "type": "Feature",
             "properties": {
@@ -8050,50 +6454,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0872464,
-                29.947698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                936.0,
-                6833.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.088397,
-                29.948348
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3121.1,
-                447.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08505891861017,
-                29.95060835570548
+                -90.087599,
+                29.947895
               ]
             }
           }
@@ -8118,8 +6480,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8138,17 +6500,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6537,0 6537,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 6199.9,0.0 6537.0,2996.4 6537.0,7795.0 -0.0,7795.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8192,27 +6551,6 @@
                 29.954773
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6287.8,
-                5015.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0860364855307,
-                29.95375380073279
-              ]
-            }
           }
         ]
       }
@@ -8232,11 +6570,11 @@
         },
         {
           "label": "intersections",
-          "value": "40"
+          "value": "25"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8255,17 +6593,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6537,0 6537,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"4461.5,0.0 6537.0,590.3 5947.4,7417.3 3196.3,7795.0 1007.0,7795.0 -0.0,7488.9 -0.0,4616.3 235.7,4700.5 1787.0,0.0 4461.5,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8309,160 +6644,6 @@
                 29.954773
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2881.9,
-                3996.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08492168051423,
-                29.954380182791255
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p179 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "1622.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "1481.0"
-        }
-      ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6537
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6537,0 6537,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1449.6,
-                287.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0869179,
-                29.9552827
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                191.6,
-                287.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.087376,
-                29.954773
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                820.6,
-                1481.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08658852770174,
-                29.95465109160822
-              ]
-            }
           }
         ]
       }
@@ -8485,8 +6666,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8505,17 +6686,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6461,0 6461,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6336.9,85.5 6461.0,114.6 6461.0,7146.4 6430.0,7139.0 6272.7,7795.0 5659.9,7795.0 5622.2,6817.8 -0.0,7774.9 436.8,1087.1 6204.1,2398.2 6336.9,85.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8559,27 +6737,6 @@
                 29.9558475
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                261.9,
-                3197.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08484869144915,
-                29.956042127797957
-              ]
-            }
           }
         ]
       }
@@ -8602,8 +6759,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8622,17 +6779,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6537,0 6537,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"5365.5,7188.6 5240.8,7188.7 3073.0,7190.6 527.9,7795.0 470.5,6556.1 -0.0,6524.8 -0.0,795.3 5696.0,975.0 5592.6,7188.4 5365.5,7188.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8676,27 +6830,6 @@
                 29.9578871
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                351.5,
-                4894.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08837268929702,
-                29.95534966124131
-              ]
-            }
           }
         ]
       }
@@ -8712,15 +6845,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8739,17 +6872,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6408,0 6408,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,804.0 4632.3,755.6 4848.5,765.1 4876.7,920.7 6325.4,903.6 6333.0,4765.8 5371.7,4772.5 5800.3,7094.0 -0.0,7191.4 -0.0,804.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8793,27 +6923,6 @@
                 29.960089
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5405.0,
-                4833.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08496992473957,
-                29.95918004035497
-              ]
-            }
           }
         ]
       }
@@ -8836,8 +6945,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8856,17 +6965,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6504,0 6504,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6347.5,309.9 6408.5,7795.0 283.8,7795.0 172.6,763.7 585.8,759.8 579.0,343.8 -0.0,353.3 -0.0,0.0 6343.7,-0.0 6504.0,-0.0 6504.0,377.5 6347.5,309.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8910,27 +7016,6 @@
                 29.962235
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                230.0,
-                4993.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08634242441646,
-                29.962286821333326
-              ]
-            }
           }
         ]
       }
@@ -8953,8 +7038,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8973,24 +7058,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6483,0 6483,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"62.7,7676.3 37.0,-0.0 6483.0,-0.0 6483.0,316.1 6483.0,317.4 6483.0,6150.6 62.7,7676.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0184/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                150.1,
+                31.9,
                 316.2
               ],
               "creator": {
@@ -9027,27 +7109,6 @@
                 29.9602424
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6141.3,
-                2650.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08051148283268,
-                29.959321227894204
-              ]
-            }
           }
         ]
       }
@@ -9070,8 +7131,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9090,17 +7151,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6542,0 6542,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"6374.0,-0.0 6377.4,315.8 6025.9,313.8 6157.6,7600.9 6393.7,7602.8 6395.7,7795.0 53.0,7795.0 50.4,7559.0 -0.0,7795.0 -0.0,0.0 6374.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9144,27 +7202,6 @@
                 29.9664772
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2660.9,
-                4999.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09037994807537,
-                29.964796138232362
-              ]
-            }
           }
         ]
       }
@@ -9187,8 +7224,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9207,17 +7244,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6490,0 6490,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"3596.0,7479.4 285.8,7437.3 288.2,7618.0 -0.0,7614.3 -0.0,319.7 255.4,322.4 253.5,-0.0 6490.0,-0.0 6490.0,422.4 6070.6,419.4 6092.8,7693.2 3598.8,7660.9 3596.0,7479.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9261,27 +7295,6 @@
                 29.964523
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6109.9,
-                2769.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08570740945648,
-                29.962969259288215
-              ]
-            }
           }
         ]
       }
@@ -9297,15 +7310,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9324,40 +7337,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6529,0 6529,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,433.4 5576.5,227.8 6529.0,4916.3 6529.0,7629.6 5447.0,7637.4 5446.2,7795.0 829.2,7795.0 -0.0,3230.9 -0.0,433.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                575.0,
-                5613.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0909289,
-                29.9570938
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -9383,8 +7372,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                143.7,
-                3341.6
+                6660.0,
+                5613.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9395,8 +7384,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09209071773272,
-                29.957611740577068
+                -90.088838,
+                29.959452
               ]
             }
           }
@@ -9421,8 +7410,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9441,17 +7430,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7796 0,0 6483,0 6483,7796 0,7796\" /></svg>"
+          "value": "<svg><polygon points=\"224.5,136.4 6098.7,110.3 6079.6,3242.5 5908.0,3246.2 5998.4,7796.0 4623.2,7796.0 4598.2,7648.0 4393.1,7636.6 1084.3,7630.1 1102.7,4913.6 224.5,136.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9495,27 +7481,6 @@
                 29.958988
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4659.5,
-                7629.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0868020585192,
-                29.960154621440186
-              ]
-            }
           }
         ]
       }
@@ -9538,8 +7503,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9558,17 +7523,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6500,0 6500,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"0.1,410.9 6500.0,481.3 6500.0,6517.6 3.3,7515.3 0.1,410.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9612,27 +7574,6 @@
                 29.961476
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2593.6,
-                4057.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0924063120973,
-                29.96254552780284
-              ]
-            }
           }
         ]
       }
@@ -9655,8 +7596,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:58:12Z",
-      "modified": "2026-05-25T13:58:12Z",
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9675,17 +7616,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6484,0 6484,7795 0,7795\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,1134.8 6350.6,-0.0 6484.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9729,13 +7667,64 @@
                 29.961915
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p191",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-10T19:05:39Z",
+      "modified": "2026-06-10T19:05:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5687.8,7684.7 5688.6,7795.0 -0.0,7795.0 -0.0,-0.0 5651.8,99.5 6457.5,7647.5 5687.8,7684.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2513.7,
-                3709.0
+                5675.9,
+                3233.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9746,8 +7735,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09432082649398,
-                29.960399287291327
+                -90.0920489,
+                29.9575989
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6103.9,
+                5581.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0909289,
+                29.9570938
               ]
             }
           }

--- a/gallery/new_orleans_la_1951_vol_5.iiif.json
+++ b/gallery/new_orleans_la_1951_vol_5.iiif.json
@@ -21,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,17 +44,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5700,0 5700,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 83.0,397.2 3606.0,395.8 3738.3,5792.8 5700.0,5413.9 5700.0,8150.0 -0.0,8150.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -98,27 +95,6 @@
                 29.917632
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2819.1,
-                2773.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11925213605,
-                29.91657436162915
-              ]
-            }
           }
         ]
       }
@@ -141,8 +117,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -161,17 +137,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,983.9 668.2,1000.0 4609.6,48.9 4461.6,6831.2 5637.0,6856.8 5637.0,8149.0 1904.4,8149.0 1956.6,6018.4 -0.0,6346.9 -0.0,983.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0426/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -215,27 +188,6 @@
                 29.9164473
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2776.4,
-                351.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1170281478137,
-                29.917589443046673
-              ]
-            }
           }
         ]
       }
@@ -258,8 +210,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -278,17 +230,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5681,0 5681,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1332.8 5088.2,75.2 5238.7,2488.5 5681.0,2381.0 5681.0,8150.0 -0.0,8150.0 -0.0,1332.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -332,27 +281,6 @@
                 29.9164918
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3294.0,
-                485.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11421497021388,
-                29.917596112660732
-              ]
-            }
           }
         ]
       }
@@ -375,8 +303,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -395,17 +323,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5681,0 5681,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"3481.5,484.3 3421.8,5779.3 5681.0,5804.8 5681.0,8150.0 -0.0,8150.0 -0.0,465.1 3481.5,484.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -449,27 +374,6 @@
                 29.9165542
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2797.0,
-                1855.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11022416798676,
-                29.91590787172023
-              ]
-            }
           }
         ]
       }
@@ -492,8 +396,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -512,17 +416,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5637.0,8149.0 317.2,8149.0 0.0,-0.0 5637.0,-0.0 5637.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -566,27 +467,6 @@
                 29.9165542
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1594.5,
-                5107.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10827532769851,
-                29.915980198094072
-              ]
-            }
           }
         ]
       }
@@ -609,8 +489,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -629,7 +509,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5681,0 5681,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5681.0,8150.0 -0.0,8150.0 -0.0,5985.7 564.8,6030.0 1004.9,414.4 5681.0,319.8 5681.0,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -658,8 +538,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10614710966473,
-                29.91688135087515
+                -90.1061484243011,
+                29.91688132163911
               ]
             }
           },
@@ -679,8 +559,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10317398558911,
-                29.91711617138879
+                -90.10317384240481,
+                29.917116257246178
               ]
             }
           },
@@ -700,8 +580,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10278496998248,
-                29.913420576577064
+                -90.10278463605103,
+                29.91341885109922
               ]
             }
           },
@@ -721,8 +601,122 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1057580940581,
-                29.913185756063424
+                -90.10575921794731,
+                29.91318391549215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5094.1,
+                331.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.103466,
+                29.916941
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0432/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p432",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0432/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0432/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5145.1,2565.0 5637.0,2439.8 5637.0,8149.0 -0.0,8149.0 -0.0,7715.6 1155.0,7719.8 1182.2,282.6 5151.3,286.4 5145.1,2565.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0432/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                623.2,
+                286.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.103466,
+                29.916941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5151.3,
+                286.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1009714,
+                29.917146
               ]
             }
           }
@@ -747,8 +741,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -796,8 +790,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.101303819717,
-                29.91663400169671
+                -90.10130511837345,
+                29.916634021793026
               ]
             }
           },
@@ -817,8 +811,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.098323138259,
-                29.916780221970022
+                -90.09832297538917,
+                29.91678031373381
               ]
             }
           },
@@ -838,8 +832,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.098080902317,
-                29.91307523332798
+                -90.0980806206709,
+                29.9130735091523
               ]
             }
           },
@@ -859,83 +853,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10106158377499,
-                29.912929013054665
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p434",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "1"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10192506316949,
-                29.945690591554648
+                -90.10106276365518,
+                29.912927217211518
               ]
             }
           },
@@ -943,62 +862,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5637.0,
-                0.0
+                5026.7,
+                376.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09939467973442,
-                29.94702646585548
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5637.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09716583850499,
-                29.943858793916394
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09969622194006,
-                29.942522919615563
+                -90.0986553,
+                29.916593
               ]
             }
           }
@@ -1023,8 +900,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1043,17 +920,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5693,0 5693,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"2337.0,1862.2 2432.4,418.4 3570.9,489.3 3922.9,2291.4 5693.0,2192.5 5693.0,8149.0 -0.0,8149.0 -0.0,2006.9 2337.0,1862.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1097,27 +971,6 @@
                 29.9175164
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2431.0,
-                1892.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09530899733078,
-                29.916933606638203
-              ]
-            }
           }
         ]
       }
@@ -1133,15 +986,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "2"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,37 +1013,34 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5637.0,972.8 5637.0,8149.0 655.4,8149.0 1825.1,2160.1 -0.0,1908.2 0.0,0.0 5637.0,972.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0436/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                3228.4,
+                525.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09484976045206,
-                29.917642086468394
+                -90.0931377,
+                29.9177871
               ]
             }
           },
@@ -1198,62 +1048,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5637.0,
-                0.0
+                5013.8,
+                862.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09198520743789,
-                29.91829926591112
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5637.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09088873553468,
-                29.914713262274162
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09375328854885,
-                29.91405608283144
+                -90.0922248,
+                29.9178626
               ]
             }
           }
@@ -1278,8 +1086,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1298,17 +1106,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5693,0 5693,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4206.5,2537.6 4698.8,7073.9 5693.0,6965.9 5693.0,8149.0 -0.0,8149.0 -0.0,7288.2 1222.2,7360.1 1634.5,338.7 5693.0,1361.8 5693.0,2828.4 4206.5,2537.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0437/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1352,27 +1157,6 @@
                 29.9180392
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3638.1,
-                2847.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0905027383747,
-                29.917133906597034
-              ]
-            }
           }
         ]
       }
@@ -1395,8 +1179,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1415,17 +1199,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5655,0 5655,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1137.9,3145.8 1237.0,744.2 431.6,685.9 464.9,-0.0 5655.0,-0.0 5655.0,8149.0 973.5,8149.0 1434.8,6664.4 -0.0,6508.6 1137.9,3145.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1469,27 +1250,6 @@
                 29.9183693
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4047.5,
-                2659.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "projected"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0871273527283,
-                29.917179075517193
-              ]
-            }
           }
         ]
       }
@@ -1512,8 +1272,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1532,17 +1292,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5659,0 5659,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"899.7,395.9 4625.9,353.7 4669.4,7995.0 3416.1,7768.9 922.7,7144.0 899.7,395.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0439/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1586,27 +1343,6 @@
                 29.92087
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                898.3,
-                2605.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09183711225221,
-                29.919916115555473
-              ]
-            }
           }
         ]
       }
@@ -1622,15 +1358,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1649,61 +1385,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5655,0 5655,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"2405.4,8149.0 488.1,7541.2 1149.6,20.6 5655.0,150.2 5655.0,7391.7 5086.0,7384.1 4803.7,7384.3 4780.0,8149.0 2405.4,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2611.3,
-                4554.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0887023,
-                29.9197829
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                791.8,
-                4554.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.089624,
-                29.9195269
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -1720,8 +1411,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.08906238943442,
-                29.920756820135786
+                -90.0891468,
+                29.9206984
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5031.7,
+                146.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0884285,
+                29.9220625
               ]
             }
           }
@@ -1746,8 +1458,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1766,17 +1478,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5671,0 5671,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5456.2,7258.8 654.8,7294.1 1313.0,568.3 5454.0,527.3 5456.2,7258.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0441/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1820,27 +1529,6 @@
                 29.9214099
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5457.6,
-                2824.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09107018909285,
-                29.923324612657733
-              ]
-            }
           }
         ]
       }
@@ -1863,8 +1551,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1883,17 +1571,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5655,0 5655,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1438.8,617.5 4983.0,710.8 4988.7,0.0 5655.0,0.0 5655.0,8149.0 5447.6,8149.0 5446.4,7521.6 845.3,7398.1 1438.8,617.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0442/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -1937,27 +1622,6 @@
                 29.9220625
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4807.0,
-                5256.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08889256154468,
-                29.922997542041653
-              ]
-            }
           }
         ]
       }
@@ -1980,8 +1644,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2000,17 +1664,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5686,0 5686,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"705.1,7691.3 1265.5,6.0 5021.0,186.9 5055.9,7747.6 705.1,7691.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2054,27 +1715,6 @@
                 29.9237647
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                926.6,
-                7781.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09447633169577,
-                29.923436245471805
-              ]
-            }
           }
         ]
       }
@@ -2094,11 +1734,11 @@
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "18"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2117,17 +1757,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5643,0 5643,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5643.0,0.0 5643.0,7697.9 315.8,7942.2 303.3,0.0 5643.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0444/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2155,8 +1792,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2175.8,
-                6109.0
+                314.4,
+                314.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2167,29 +1804,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.091751,
-                29.9250945
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                317.2,
-                6109.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09268129680896,
-                29.924833110964325
+                -90.0936405,
+                29.9273622
               ]
             }
           }
@@ -2214,8 +1830,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2234,17 +1850,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5686,0 5686,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"702.0,7250.4 708.6,879.4 5027.1,870.9 5048.4,7249.6 702.0,7250.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0445/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2288,27 +1901,6 @@
                 29.9230009
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                702.0,
-                3948.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09947641842967,
-                29.924501828923248
-              ]
-            }
           }
         ]
       }
@@ -2331,8 +1923,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2351,17 +1943,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5643,0 5643,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"564.3,7286.8 564.3,861.6 2719.5,887.4 4322.2,683.7 5259.4,7130.7 3548.8,7311.4 564.3,7286.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2405,27 +1994,6 @@
                 29.9240017
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2695.2,
-                3964.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09609281320466,
-                29.924766554076122
-              ]
-            }
           }
         ]
       }
@@ -2448,8 +2016,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2468,17 +2036,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5681,0 5681,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"4844.2,671.4 4920.7,7324.7 -0.0,7358.5 -0.0,709.3 4844.2,671.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0447/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2522,27 +2087,6 @@
                 29.9201345
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4920.0,
-                5120.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09572972620924,
-                29.921225738165933
-              ]
-            }
           }
         ]
       }
@@ -2565,8 +2109,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2585,17 +2129,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5643,0 5643,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"888.2,631.3 5643.0,684.4 5643.0,7407.9 1771.3,7502.9 39.6,7265.3 888.2,631.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0448/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2639,27 +2180,6 @@
                 29.9224374
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                592.4,
-                3051.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09583348467754,
-                29.92215204098111
-              ]
-            }
           }
         ]
       }
@@ -2682,8 +2202,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2702,17 +2222,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5692,0 5692,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"2311.7,1137.6 4006.9,907.1 4841.9,6867.1 554.6,6911.6 554.5,1135.6 2311.7,1137.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0449/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2756,27 +2273,6 @@
                 29.9177871
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4613.7,
-                5172.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09333202658236,
-                29.91854682567783
-              ]
-            }
           }
         ]
       }
@@ -2796,11 +2292,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2819,24 +2315,21 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5597,0 5597,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"971.9,1042.8 4210.5,886.3 4754.6,7552.2 902.4,7019.0 971.9,1042.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0450/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                917.9,
+                2644.1,
                 5081.5
               ],
               "creator": {
@@ -2848,8 +2341,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.093366,
-                29.9186607
+                -90.0924814,
+                29.9188349
               ]
             }
           },
@@ -2871,27 +2364,6 @@
               "coordinates": [
                 -90.0929817,
                 29.9206404
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2644.1,
-                5081.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09248355452995,
-                29.918844584786104
               ]
             }
           }
@@ -2916,8 +2388,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2936,17 +2408,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5692,0 5692,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"723.3,6057.5 724.1,1211.8 471.6,222.3 5692.0,249.4 5692.0,8149.0 -0.0,8149.0 -0.0,6058.8 723.3,6057.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0451/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -2990,27 +2459,6 @@
                 29.9199592
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5043.3,
-                4268.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09766567600586,
-                29.918231825830127
-              ]
-            }
           }
         ]
       }
@@ -3033,8 +2481,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3053,17 +2501,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5597,0 5597,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"2521.7,7706.0 2524.0,8150.0 1396.1,8150.0 1308.1,258.1 4966.7,241.9 4886.0,7547.4 2521.7,7706.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0452/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3107,27 +2552,6 @@
                 29.9200476
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                640.0,
-                4323.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09769344873182,
-                29.918227973125802
-              ]
-            }
           }
         ]
       }
@@ -3150,8 +2574,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3170,17 +2594,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5710,0 5710,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4982.3,1138.0 4989.7,6379.6 5137.6,6941.8 765.1,6983.9 739.8,1150.8 4982.3,1138.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0453/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3224,27 +2645,6 @@
                 29.9195986
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                718.7,
-                3369.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1047819065716,
-                29.918497470676282
-              ]
-            }
           }
         ]
       }
@@ -3260,15 +2660,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3287,17 +2687,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5597,0 5597,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"1788.4,8149.0 2371.1,5890.4 -0.0,5271.4 -0.0,4701.6 1231.3,0.0 2262.9,0.0 5597.0,881.7 5597.0,1870.0 4436.7,6413.6 3758.3,6241.8 3271.4,8150.0 1788.4,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3341,27 +2738,6 @@
                 29.9187595
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                404.2,
-                4216.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10227608069526,
-                29.917572535079067
-              ]
-            }
           }
         ]
       }
@@ -3384,8 +2760,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3404,17 +2780,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5710,0 5710,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1204.7,7325.7 1211.5,678.5 5225.9,680.2 5225.3,7341.5 1204.7,7325.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3458,27 +2831,6 @@
                 29.9227198
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2863.4,
-                5107.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10146387544337,
-                29.920795191513413
-              ]
-            }
           }
         ]
       }
@@ -3501,8 +2853,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3521,17 +2873,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5647,0 5647,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"685.5,659.6 4343.2,655.2 4295.9,7380.8 695.8,7386.1 685.5,659.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0456/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3575,27 +2924,6 @@
                 29.9230009
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4953.4,
-                5116.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09799416583424,
-                29.92107058075987
-              ]
-            }
           }
         ]
       }
@@ -3615,11 +2943,11 @@
         },
         {
           "label": "intersections",
-          "value": "24"
+          "value": "20"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3638,17 +2966,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5710,0 5710,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"618.0,7288.0 601.8,913.1 2703.0,904.1 2706.7,1953.9 4900.8,1948.4 4901.2,2423.7 5334.1,2422.6 5346.5,7273.2 618.0,7288.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0457/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3656,7 +2981,7 @@
             "properties": {
               "resourceCoords": [
                 612.0,
-                2431.8
+                5453.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3667,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1042724,
-                29.9248364
+                -90.1041314,
+                29.9234657
               ]
             }
           },
@@ -3676,7 +3001,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                614.8,
+                2725.9,
                 7281.3
               ],
               "creator": {
@@ -3688,29 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1040459,
-                29.922634
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2725.9,
-                3953.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10309373269774,
-                29.924230201719528
+                -90.1029417,
+                29.9227198
               ]
             }
           }
@@ -3735,8 +3039,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3755,17 +3059,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5647,0 5647,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"806.7,7279.8 803.6,2430.6 370.6,2430.9 372.0,908.6 5095.2,894.4 5095.3,7274.5 806.7,7279.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3809,27 +3110,6 @@
                 29.9258963
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                567.2,
-                3953.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10184566181465,
-                29.92432600065089
-              ]
-            }
           }
         ]
       }
@@ -3849,11 +3129,11 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3872,17 +3152,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5698,0 5698,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5339.1,1834.3 5343.9,7171.9 2343.8,7129.5 236.8,6872.0 869.8,1940.1 5339.1,1834.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0459/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -3926,27 +3203,6 @@
                 29.9239641
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2547.1,
-                5345.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10786540485202,
-                29.92317566720037
-              ]
-            }
           }
         ]
       }
@@ -3969,8 +3225,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3989,17 +3245,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5647,0 5647,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"630.4,7250.4 629.4,848.3 4983.7,843.4 4980.1,7250.4 630.4,7250.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0460/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4043,27 +3296,6 @@
                 29.922634
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2808.1,
-                3908.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10533442362653,
-                29.924055164830857
-              ]
-            }
           }
         ]
       }
@@ -4086,8 +3318,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4106,17 +3338,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5698,0 5698,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"701.8,7385.2 711.4,688.1 4993.5,689.0 4980.8,7383.4 701.8,7385.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0461/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4160,27 +3389,6 @@
                 29.9203581
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2819.5,
-                2953.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1062121120254,
-                29.921430375621412
-              ]
-            }
           }
         ]
       }
@@ -4203,8 +3411,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4223,17 +3431,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5647,0 5647,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5647.0,686.4 5647.0,7454.0 4872.3,7656.4 4871.5,7387.7 601.2,7390.2 608.3,689.4 5647.0,686.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0462/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4277,27 +3482,6 @@
                 29.9216042
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4886.0,
-                5150.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1027385656377,
-                29.920698021210306
-              ]
-            }
           }
         ]
       }
@@ -4320,8 +3504,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4340,17 +3524,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5645,0 5645,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5094.8,6966.8 445.6,6841.2 1202.9,878.9 3294.7,1155.2 5052.2,1132.1 5094.8,6966.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0463/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4394,27 +3575,6 @@
                 29.9174021
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                948.8,
-                3105.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10919357016745,
-                29.918280155658312
-              ]
-            }
           }
         ]
       }
@@ -4437,8 +3597,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4457,17 +3617,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5664,0 5664,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"691.0,7006.7 717.7,1128.0 4997.8,1140.6 4988.3,7008.1 691.0,7006.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0464/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4511,27 +3668,6 @@
                 29.9184957
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2813.7,
-                3375.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10590600044259,
-                29.918404756805177
-              ]
-            }
           }
         ]
       }
@@ -4554,8 +3690,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4574,17 +3710,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5645,0 5645,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4059.0,8149.0 1037.3,8149.0 1189.4,7310.7 729.8,7337.8 1422.3,823.9 4952.8,860.7 4970.8,7084.5 3988.7,7142.7 4059.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0465/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4628,27 +3761,6 @@
                 29.9183497
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2880.0,
-                3077.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1122045925936,
-                29.918393542165266
-              ]
-            }
           }
         ]
       }
@@ -4671,8 +3783,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4691,17 +3803,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5664,0 5664,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"944.7,7151.3 961.7,884.6 4593.5,859.3 4563.1,6927.6 944.7,7151.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0466/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4745,27 +3854,6 @@
                 29.9175118
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2777.2,
-                3125.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11015343819449,
-                29.918312479760356
-              ]
-            }
           }
         ]
       }
@@ -4788,8 +3876,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4808,17 +3896,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5645,0 5645,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1044.6,684.0 4649.1,656.0 4643.4,7411.3 1031.7,7437.8 1044.6,684.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0467/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4862,27 +3947,6 @@
                 29.9224148
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1038.6,
-                2976.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11095634120299,
-                29.921396385198875
-              ]
-            }
           }
         ]
       }
@@ -4905,8 +3969,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4925,17 +3989,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5664,0 5664,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"805.7,7401.3 803.2,671.6 3797.9,581.6 4660.7,7180.2 2917.6,7418.9 805.7,7401.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0468/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -4979,27 +4040,6 @@
                 29.9192585
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                791.9,
-                5158.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10911113347161,
-                29.920333842328514
-              ]
-            }
           }
         ]
       }
@@ -5022,8 +4062,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5042,17 +4082,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5645,0 5645,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"791.5,7157.6 867.4,1561.4 4756.6,1571.3 5236.5,7128.3 693.6,7303.3 791.5,7157.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0469/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5096,27 +4133,6 @@
                 29.9237625
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2933.4,
-                4880.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11364634028864,
-                29.921707433347414
-              ]
-            }
           }
         ]
       }
@@ -5139,8 +4155,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5159,17 +4175,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5673,0 5673,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4524.5,7385.9 978.1,7329.9 1680.6,574.4 4538.4,612.5 4524.5,7385.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0470/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5213,27 +4226,6 @@
                 29.922473
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1302.5,
-                5113.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11270083113072,
-                29.920454524779124
-              ]
-            }
           }
         ]
       }
@@ -5256,8 +4248,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5276,17 +4268,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5645,0 5645,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"840.0,952.0 4755.1,921.5 4807.3,6156.7 834.1,7127.7 840.0,952.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0471/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5330,27 +4319,6 @@
                 29.9175779
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4805.7,
-                4198.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11567993614076,
-                29.91842337953187
-              ]
-            }
           }
         ]
       }
@@ -5373,8 +4341,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5393,17 +4361,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5673,0 5673,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5287.4,6841.2 354.0,7879.1 476.8,539.0 4954.7,492.6 5287.4,6841.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5447,27 +4412,6 @@
                 29.9198776
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5181.8,
-                2751.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11285725167419,
-                29.91944621808551
-              ]
-            }
           }
         ]
       }
@@ -5490,8 +4434,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5510,17 +4454,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5670,0 5670,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7217.6 -0.0,939.3 948.6,950.7 2788.7,943.5 4545.3,974.2 4505.0,7105.4 4238.1,7250.3 -0.0,7217.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0473/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5564,27 +4505,6 @@
                 29.9204507
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2790.1,
-                3004.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11846460641392,
-                29.919530723837184
-              ]
-            }
           }
         ]
       }
@@ -5600,15 +4520,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5627,17 +4547,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5673,0 5673,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4569.0,1974.9 4586.7,7101.6 555.5,7108.5 559.7,8149.0 -0.0,8149.0 35.5,1961.5 4569.0,1974.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0474/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5681,27 +4598,6 @@
                 29.92391
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4586.7,
-                949.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11562128185896,
-                29.926648177136368
-              ]
-            }
           }
         ]
       }
@@ -5721,11 +4617,11 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5744,17 +4640,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5670,0 5670,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"694.3,7959.2 663.5,0.0 4779.2,0.0 4768.8,4045.8 5283.0,4049.3 5328.8,8111.4 694.3,7959.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0475/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5782,8 +4675,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5282.6,
-                4071.7
+                659.6,
+                443.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5794,29 +4687,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.116784,
-                29.922315
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                662.4,
-                4071.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11732068237087,
-                29.920257211497304
+                -90.1191767,
+                29.9206311
               ]
             }
           }
@@ -5838,11 +4710,11 @@
         },
         {
           "label": "intersections",
-          "value": "30"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5861,17 +4733,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5687,0 5687,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"4826.3,0.0 4816.9,4058.3 5398.9,4056.7 5401.4,8145.5 1260.5,8133.3 1215.4,4060.6 699.7,4057.0 711.0,0.8 4826.3,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0476/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -5915,27 +4784,6 @@
                 29.9239714
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2745.3,
-                5985.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11562123599549,
-                29.922795307123515
-              ]
-            }
           }
         ]
       }
@@ -5955,11 +4803,11 @@
         },
         {
           "label": "intersections",
-          "value": "26"
+          "value": "18"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5978,17 +4826,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5670,0 5670,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"931.2,7248.3 985.3,980.9 4792.0,1020.7 4808.4,4291.2 4985.8,4289.8 4956.3,7274.3 4757.1,7273.0 4757.0,7273.9 931.2,7248.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0477/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6032,27 +4877,6 @@
                 29.9259915
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2885.5,
-                5779.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11510765335701,
-                29.924632911461515
-              ]
-            }
           }
         ]
       }
@@ -6075,8 +4899,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6095,17 +4919,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5687,0 5687,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"773.3,4282.6 692.1,0.0 4136.0,0.0 4828.1,8150.0 957.7,8150.0 953.4,4279.3 773.3,4282.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6149,27 +4970,6 @@
                 29.9265722
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                825.3,
-                5777.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11408698781257,
-                29.924443746382867
-              ]
-            }
           }
         ]
       }
@@ -6192,8 +4992,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6212,17 +5012,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5668,0 5668,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4993.2,1161.7 4901.4,7191.9 429.7,7153.9 501.7,667.7 4993.2,1161.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0479/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6266,27 +5063,6 @@
                 29.9246322
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3789.9,
-                5380.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1098817013475,
-                29.92393826889417
-              ]
-            }
           }
         ]
       }
@@ -6309,8 +5085,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6329,17 +5105,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5687,0 5687,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,7239.8 0.0,1154.8 3754.2,1557.9 3766.9,2473.3 2914.9,2461.1 2846.4,7240.4 0.0,7239.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0480/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6383,27 +5156,6 @@
                 29.9246322
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3772.6,
-                5407.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10977626826552,
-                29.926153571603123
-              ]
-            }
           }
         ]
       }
@@ -6419,15 +5171,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "10"
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "18"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6446,17 +5198,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5668,0 5668,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 906.6,0.0 4552.1,1038.4 4584.2,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6500,27 +5249,6 @@
                 29.9269835
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2807.3,
-                3521.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11609628445643,
-                29.928416235049088
-              ]
-            }
           }
         ]
       }
@@ -6540,11 +5268,11 @@
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "18"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6563,17 +5291,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5687,0 5687,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"2864.8,1098.0 3781.5,1341.7 4870.7,1332.9 4874.1,1632.1 5687.0,1848.2 5687.0,2232.6 5119.5,2063.8 5133.0,5203.1 4882.1,5206.3 4924.2,6448.6 912.3,6469.7 876.9,975.8 2854.4,1349.1 2864.8,1098.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6617,27 +5342,6 @@
                 29.9269835
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2851.9,
-                6468.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.114587311317,
-                29.926785910434777
-              ]
-            }
           }
         ]
       }
@@ -6660,8 +5364,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6680,17 +5384,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5705,0 5705,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"393.2,5529.0 1021.5,2576.4 1520.3,2851.0 1598.8,2489.8 875.4,2138.7 1274.0,200.1 4160.6,800.5 5705.0,840.9 5705.0,7408.2 3366.4,7372.4 3478.0,6424.0 126.3,5712.0 156.8,5480.8 393.2,5529.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6734,27 +5435,6 @@
                 29.9262256
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2173.1,
-                3105.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11235471019728,
-                29.92818429884388
-              ]
-            }
           }
         ]
       }
@@ -6777,8 +5457,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6797,17 +5477,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5693,0 5693,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5574.2,6481.1 5579.8,6875.0 4681.5,6493.1 4703.0,8150.0 -0.0,8150.0 -0.0,7311.4 1425.6,7280.2 1166.6,752.8 4563.4,678.7 4672.9,6114.2 5574.2,6481.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6851,27 +5528,6 @@
                 29.9281978
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4648.7,
-                2902.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10870626470512,
-                29.92809825752205
-              ]
-            }
           }
         ]
       }
@@ -6894,8 +5550,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6914,17 +5570,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5705,0 5705,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"684.8,4208.2 1515.2,4746.2 1578.2,4351.9 742.3,3828.4 1261.6,510.1 3385.1,862.6 4730.4,860.8 4565.1,8149.0 45.8,8149.0 684.8,4208.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0485/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -6968,27 +5621,6 @@
                 29.9271541
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2698.1,
-                5155.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10770598438151,
-                29.92613256808038
-              ]
-            }
           }
         ]
       }
@@ -7011,8 +5643,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7031,17 +5663,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5693,0 5693,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"708.8,930.7 5693.0,930.7 5693.0,7131.7 711.9,7138.4 708.8,930.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0486/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7085,27 +5714,6 @@
                 29.9283389
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2891.4,
-                5474.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10554851419352,
-                29.926190918571713
-              ]
-            }
           }
         ]
       }
@@ -7128,8 +5736,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7148,17 +5756,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5681,0 5681,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"4840.5,8150.0 2651.8,8150.0 2650.7,7103.3 1200.8,7105.9 1198.4,924.8 4853.1,923.4 4849.3,3050.2 5271.7,3050.2 5272.3,5095.3 5271.6,5218.7 4845.5,5218.4 4840.5,8150.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0487/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7202,27 +5807,6 @@
                 29.9283389
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2667.8,
-                3068.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10342286200041,
-                29.927449454009448
-              ]
-            }
           }
         ]
       }
@@ -7245,8 +5829,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7265,17 +5849,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5693,0 5693,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"192.3,7379.0 195.3,5387.4 644.8,5387.7 645.5,5257.4 644.3,3099.4 198.7,3099.5 202.1,855.2 5164.5,851.6 5162.6,7365.7 192.3,7379.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7319,27 +5900,6 @@
                 29.927736
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                645.7,
-                5452.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10195199954428,
-                29.926547998332804
-              ]
-            }
           }
         ]
       }
@@ -7362,8 +5922,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7382,17 +5942,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5707,0 5707,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"701.8,925.1 5050.9,902.8 5074.9,7116.5 727.6,7147.5 701.8,925.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0489/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7436,27 +5993,6 @@
                 29.9287053
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                701.8,
-                3060.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0998118291772,
-                29.927741106419894
-              ]
-            }
           }
         ]
       }
@@ -7479,8 +6015,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7499,17 +6035,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5693,0 5693,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"927.8,7146.3 930.0,934.4 3848.4,754.2 4681.4,6952.6 3081.1,7163.0 927.8,7146.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7553,27 +6086,6 @@
                 29.929079
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                926.4,
-                1120.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09763112175969,
-                29.92879775706782
-              ]
-            }
           }
         ]
       }
@@ -7593,11 +6105,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "11"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7616,17 +6128,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5707,0 5707,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"1434.5,363.5 3926.3,590.8 3703.0,7784.3 519.6,7522.1 1434.5,363.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7670,27 +6179,6 @@
                 29.9270718
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1156.6,
-                2706.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0961063283948,
-                29.92900779177337
-              ]
-            }
           }
         ]
       }
@@ -7713,8 +6201,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7733,17 +6221,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5717,0 5717,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5303.7,0.0 5717.0,0.0 5717.0,7694.6 715.7,7702.8 729.1,8025.5 -0.0,7988.2 -0.0,834.8 5346.2,660.3 5303.7,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7787,27 +6272,6 @@
                 29.9304011
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                673.9,
-                3006.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09447010547149,
-                29.929489477125593
-              ]
-            }
           }
         ]
       }
@@ -7830,8 +6294,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7850,17 +6314,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5688,0 5688,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"924.8,3172.4 1038.6,152.3 -0.0,103.7 -0.0,-0.0 5688.0,-0.0 5688.0,349.4 5293.7,329.5 5002.2,4650.0 4478.4,7374.9 274.7,6511.7 924.8,3172.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -7904,27 +6365,6 @@
                 29.9341848
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3048.9,
-                3172.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09521166926774,
-                29.933311670319423
-              ]
-            }
           }
         ]
       }
@@ -7947,8 +6387,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7967,17 +6407,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5717,0 5717,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"405.5,7129.5 866.6,-0.0 5158.3,-0.0 5028.4,5331.2 4723.0,7778.3 405.5,7129.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8021,27 +6458,6 @@
                 29.9328246
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2959.6,
-                4475.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0951296812056,
-                29.931308356850746
-              ]
-            }
           }
         ]
       }
@@ -8064,8 +6480,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8084,25 +6500,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5688,0 5688,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"771.5,827.2 5025.3,811.2 5009.9,7169.9 2161.2,7195.8 757.9,7195.3 771.5,827.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0495/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2835.6,
-                5081.5
+                5025.4,
+                2970.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8113,29 +6526,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1000027,
-                29.9296644
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2835.6,
-                814.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1002003,
-                29.9315993
+                -90.0989693,
+                29.9307111
               ]
             }
           },
@@ -8155,8 +6547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0988569872128,
-                29.929752276294188
+                -90.0988699,
+                29.9297521
               ]
             }
           }
@@ -8181,8 +6573,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8201,17 +6593,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5717,0 5717,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"4165.2,7153.7 648.9,7166.3 600.0,1772.3 4904.6,1730.1 5702.4,6960.8 4165.2,7153.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0496/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8255,27 +6644,6 @@
                 29.9307111
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2813.6,
-                2987.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09781283502915,
-                29.930790530861405
-              ]
-            }
           }
         ]
       }
@@ -8298,8 +6666,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8318,17 +6686,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5688,0 5688,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"4956.9,837.1 4987.5,7168.8 -0.0,7220.8 -0.0,862.9 4956.9,837.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0497/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8372,27 +6737,6 @@
                 29.9316899
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2801.9,
-                7170.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10021711888413,
-                29.931607573974873
-              ]
-            }
           }
         ]
       }
@@ -8415,8 +6759,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8435,17 +6779,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5670,0 5670,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"704.9,880.7 3977.5,719.9 5021.5,8150.0 699.6,8150.0 704.9,880.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0498/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8489,27 +6830,6 @@
                 29.9316899
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4342.3,
-                3009.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09735486167259,
-                29.93374509670979
-              ]
-            }
           }
         ]
       }
@@ -8532,8 +6852,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8552,17 +6872,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5703,0 5703,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4935.2,826.6 4937.8,7163.4 -0.0,7219.7 -0.0,844.4 4935.2,826.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0499/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8606,27 +6923,6 @@
                 29.931313
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4936.4,
-                2942.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1040150306868,
-                29.933235238668793
-              ]
-            }
           }
         ]
       }
@@ -8649,8 +6945,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8669,17 +6965,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5670,0 5670,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"334.3,863.2 3432.8,847.2 4425.5,850.6 4380.4,7200.6 315.0,7201.1 334.3,863.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8723,27 +7016,6 @@
                 29.934313
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                502.4,
-                5103.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10382345416573,
-                29.932274858004625
-              ]
-            }
           }
         ]
       }
@@ -8766,8 +7038,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8786,17 +7058,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5703,0 5703,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"645.3,7200.6 641.1,826.7 4957.4,784.7 4951.9,7199.1 645.3,7200.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0501/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8840,27 +7109,6 @@
                 29.9302571
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4958.9,
-                5071.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10362586707656,
-                29.92938333788043
-              ]
-            }
           }
         ]
       }
@@ -8883,8 +7131,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8903,17 +7151,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5705,0 5705,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5144.6,861.2 5135.6,7186.4 350.7,7188.4 356.1,864.7 5144.6,861.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -8957,27 +7202,6 @@
                 29.9285309
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                527.8,
-                5105.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1035315556491,
-                29.929383554660802
-              ]
-            }
           }
         ]
       }
@@ -9000,8 +7224,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9020,17 +7244,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5703,0 5703,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4621.7,846.8 4462.4,7239.7 5131.9,7253.7 5112.7,8149.0 158.0,8149.0 1341.6,520.0 3419.9,840.2 4621.7,846.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0503/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9074,27 +7295,6 @@
                 29.9330105
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2760.2,
-                5088.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10743046324,
-                29.93198101549721
-              ]
-            }
           }
         ]
       }
@@ -9117,8 +7317,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9137,17 +7337,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5708,0 5708,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5586.2,7211.0 2126.2,7208.3 42.9,6890.4 748.0,1903.6 5638.9,1847.0 5586.2,7211.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0504/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9191,27 +7388,6 @@
                 29.928094
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3459.1,
-                3111.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10711255255933,
-                29.93003367962854
-              ]
-            }
           }
         ]
       }
@@ -9227,15 +7403,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9254,17 +7430,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5703,0 5703,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1072.9,815.7 5703.0,1694.3 5703.0,5863.1 4979.9,5860.1 4963.5,7639.3 708.3,7621.1 718.2,2703.1 1072.9,815.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0505/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9292,27 +7465,6 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2822.0,
-                4049.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1105267,
-                29.9301512
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
                 707.6,
                 4049.2
               ],
@@ -9325,8 +7477,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11057256494595,
-                29.929181832068036
+                -90.110572,
+                29.929179
               ]
             }
           }
@@ -9351,8 +7503,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9371,17 +7523,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5708,0 5708,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"689.3,5290.4 1419.5,5286.7 1373.6,297.6 5316.7,993.2 4962.0,2940.6 4965.5,7052.3 689.3,7087.6 689.3,5290.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0506/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9425,27 +7574,6 @@
                 29.9310677
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4992.0,
-                3484.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11036173501894,
-                29.933101459217177
-              ]
-            }
           }
         ]
       }
@@ -9465,11 +7593,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9488,17 +7616,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5642,0 5642,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 4530.1,143.8 4528.1,8149.0 4028.5,8149.0 734.0,7179.6 -0.0,7174.1 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9542,27 +7667,6 @@
                 29.9318113
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2868.7,
-                4251.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11526653255909,
-                29.931195056517172
-              ]
-            }
           }
         ]
       }
@@ -9578,15 +7682,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9605,17 +7709,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5708,0 5708,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"956.0,7781.8 953.2,162.9 4961.0,168.9 4958.5,1986.5 5708.0,1844.2 5708.0,6508.4 4715.8,6507.7 4720.9,8149.0 3664.4,8149.0 2830.4,7912.1 2818.7,8149.0 956.0,7781.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9623,48 +7724,6 @@
             "properties": {
               "resourceCoords": [
                 954.6,
-                4470.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1144924,
-                29.930901
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2903.1,
-                4470.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1135232,
-                29.9306535
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2903.1,
                 2285.8
               ],
               "creator": {
@@ -9676,8 +7735,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11320304360198,
-                29.931595100491627
+                -90.1142511,
+                29.9318113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                951.8,
+                162.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1139956,
+                29.9327704
               ]
             }
           }
@@ -9699,11 +7779,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "7"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9722,17 +7802,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5642,0 5642,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5642.0,7835.7 3568.0,7835.4 2799.7,7975.5 2800.1,7835.1 618.9,7833.9 769.8,0.0 5642.0,0.0 5642.0,7835.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0509/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9776,27 +7853,6 @@
                 29.9327704
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2778.9,
-                5604.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11277876423725,
-                29.933516042764293
-              ]
-            }
           }
         ]
       }
@@ -9816,11 +7872,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "10"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9839,17 +7895,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5724,0 5724,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4838.8,3671.6 5078.6,3672.1 5093.9,7727.3 2976.3,7764.2 1531.3,7763.0 1459.0,75.4 5724.0,0.0 5724.0,301.8 5055.4,314.5 4838.8,3671.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0510/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -9878,7 +7931,7 @@
             "properties": {
               "resourceCoords": [
                 5069.9,
-                1280.5
+                5593.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9889,29 +7942,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1142081,
-                29.9367638
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4907.1,
-                3675.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11302299424135,
-                29.936460083247315
+                -90.1119988,
+                29.9363451
               ]
             }
           }
@@ -9933,11 +7965,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9956,17 +7988,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5642,0 5642,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"655.8,1799.7 989.4,0.0 3147.7,0.0 3101.7,244.1 5205.3,643.3 4935.4,2440.0 4957.7,8055.7 2791.0,8042.9 2783.9,5929.6 646.4,5923.2 655.8,1799.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0511/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10010,27 +8039,6 @@
                 29.9349874
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4929.0,
-                2313.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11027705018792,
-                29.935024812549283
-              ]
-            }
           }
         ]
       }
@@ -10053,8 +8061,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10073,17 +8081,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5724,0 5724,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"779.5,1771.1 1049.1,182.4 5195.2,955.1 4958.7,2214.9 4985.7,7501.7 759.8,7499.6 779.5,1771.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0512/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10127,27 +8132,6 @@
                 29.936859
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4985.7,
-                5425.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1082863006903,
-                29.93689662620076
-              ]
-            }
           }
         ]
       }
@@ -10170,8 +8154,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10190,17 +8174,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5642,0 5642,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1656.0,879.1 4861.5,835.4 4855.7,7170.7 841.1,7226.6 1656.0,879.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0513/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10244,27 +8225,6 @@
                 29.9349198
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1437.2,
-                2976.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10720828957076,
-                29.935895436517605
-              ]
-            }
           }
         ]
       }
@@ -10287,8 +8247,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10307,17 +8267,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5724,0 5724,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5724.0,921.1 5724.0,7221.6 554.9,7140.1 686.4,864.2 5724.0,921.1\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0514/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10361,27 +8318,6 @@
                 29.9370981
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2751.1,
-                2985.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1042925596725,
-                29.936128402049683
-              ]
-            }
           }
         ]
       }
@@ -10404,8 +8340,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10424,17 +8360,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5642,0 5642,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"5066.6,946.8 5041.8,7053.7 1389.3,7039.4 1312.0,918.9 5066.6,946.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10478,27 +8411,6 @@
                 29.9363992
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5058.2,
-                5121.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10057982998609,
-                29.935395286835867
-              ]
-            }
           }
         ]
       }
@@ -10521,8 +8433,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10541,17 +8453,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5719,0 5719,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"968.1,7258.8 922.3,880.1 4079.0,890.9 4983.7,7233.9 968.1,7258.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0516/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10595,27 +8504,6 @@
                 29.937367
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                920.9,
-                5126.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10060641006876,
-                29.93544570218264
-              ]
-            }
           }
         ]
       }
@@ -10638,8 +8526,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10658,17 +8546,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5650,0 5650,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"4246.7,7228.0 -0.0,6471.1 524.2,2525.7 451.6,699.1 -0.0,674.6 0.0,-0.0 5083.0,-0.0 5074.4,2882.4 4246.7,7228.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0517/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10712,27 +8597,6 @@
                 29.9359766
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2794.1,
-                3111.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09697907952783,
-                29.9368892399886
-              ]
-            }
           }
         ]
       }
@@ -10755,8 +8619,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10775,17 +8639,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5719,0 5719,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5136.9,-0.0 5164.5,3052.7 4666.2,6452.8 2516.1,6115.2 2251.0,7560.9 121.7,7219.4 884.0,2878.9 851.2,-0.0 5136.9,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10829,27 +8690,6 @@
                 29.9357212
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5019.9,
-                4115.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09620871280825,
-                29.934065449448802
-              ]
-            }
           }
         ]
       }
@@ -10872,8 +8712,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10892,17 +8732,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5650,0 5650,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"342.1,0.0 5650.0,0.0 4678.3,282.6 5520.6,7231.3 268.8,7143.2 342.1,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0519/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -10946,27 +8783,6 @@
                 29.938318
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4566.1,
-                5071.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09974705836144,
-                29.938413956122595
-              ]
-            }
           }
         ]
       }
@@ -10989,8 +8805,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11009,17 +8825,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5719,0 5719,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"3527.3,7292.7 84.6,6909.4 952.3,0.0 5719.0,0.0 5719.0,7086.6 3527.3,7292.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11063,27 +8876,6 @@
                 29.9391971
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5469.1,
-                3394.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09708039694071,
-                29.93982201916266
-              ]
-            }
           }
         ]
       }
@@ -11106,8 +8898,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11126,17 +8918,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5664,0 5664,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"1059.9,0.0 1961.5,163.5 1979.3,0.0 5424.4,46.1 5377.5,5153.4 4989.7,5148.3 4960.9,7194.9 19.8,7203.3 1059.9,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0521/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11180,27 +8969,6 @@
                 29.937002
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3254.6,
-                2976.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10571737733326,
-                29.93890669989515
-              ]
-            }
           }
         ]
       }
@@ -11223,8 +8991,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11243,17 +9011,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5719,0 5719,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5103.9,7169.0 -0.0,7184.5 -0.0,5190.2 377.9,5189.8 353.5,213.5 -0.0,219.6 -0.0,-0.0 5719.0,0.0 5719.0,137.8 5073.8,145.5 5103.9,7169.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11297,27 +9062,6 @@
                 29.9400995
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                536.2,
-                3043.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10451238050315,
-                29.93901866219336
-              ]
-            }
           }
         ]
       }
@@ -11340,8 +9084,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11360,17 +9104,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5645,0 5645,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"850.5,491.9 3692.2,1019.5 3727.0,827.1 4520.9,1182.4 4424.4,2321.4 4813.7,3320.9 4794.3,7089.6 625.4,7057.9 610.4,1754.9 850.5,491.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0523/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11414,27 +9155,6 @@
                 29.936891
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2750.9,
-                3166.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10919962865856,
-                29.93789653836708
-              ]
-            }
           }
         ]
       }
@@ -11454,11 +9174,11 @@
         },
         {
           "label": "intersections",
-          "value": "24"
+          "value": "20"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11477,17 +9197,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5750,0 5750,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"3624.0,8149.0 3690.6,7213.5 553.1,7094.6 673.9,3192.3 297.5,2146.8 427.9,969.8 0.0,874.2 0.0,664.2 1990.2,1096.4 1926.4,1388.3 5750.0,2223.7 5750.0,8149.0 3624.0,8149.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11531,27 +9248,6 @@
                 29.9387656
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                553.1,
-                3190.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.10907818434087,
-                29.93878428424206
-              ]
-            }
           }
         ]
       }
@@ -11571,11 +9267,11 @@
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "16"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11594,17 +9290,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5634,0 5634,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"783.1,0.0 5634.0,0.0 5634.0,7351.1 681.6,7310.1 742.8,3311.2 506.4,3306.1 783.1,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11648,27 +9341,6 @@
                 29.9382721
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2801.6,
-                3341.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11273077297054,
-                29.937480406801726
-              ]
-            }
           }
         ]
       }
@@ -11688,11 +9360,11 @@
         },
         {
           "label": "intersections",
-          "value": "28"
+          "value": "13"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11711,17 +9383,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8150 0,0 5736,0 5736,8150 0,8150\" /></svg>"
+          "value": "<svg><polygon points=\"5736.0,0.0 5736.0,1649.9 4973.2,1666.9 4933.5,7185.0 1983.9,7254.6 1747.0,0.0 5736.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11729,7 +9398,7 @@
             "properties": {
               "resourceCoords": [
                 746.8,
-                3175.2
+                3380.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11740,8 +9409,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.11263,
-                29.9382948
+                -90.1125306,
+                29.9382721
               ]
             }
           },
@@ -11765,27 +9434,6 @@
                 29.9398784
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                746.8,
-                5249.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11158297855413,
-                29.93806624904358
-              ]
-            }
           }
         ]
       }
@@ -11805,11 +9453,11 @@
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "15"
         }
       ],
-      "created": "2026-05-25T13:47:23Z",
-      "modified": "2026-05-25T13:47:23Z",
+      "created": "2026-06-10T13:56:39Z",
+      "modified": "2026-06-10T13:56:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11828,17 +9476,14 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8149 0,0 5634,0 5634,8149 0,8149\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 5634.0,0.0 5634.0,8149.0 5350.3,8149.0 5349.6,7595.0 -0.0,7441.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0527/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
@@ -11880,27 +9525,6 @@
               "coordinates": [
                 -90.1110562,
                 29.9398784
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1560.8,
-                5590.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.11181412108292,
-                29.940985537094726
               ]
             }
           }


### PR DESCRIPTION
Closes #52

Not too much movement on the numbers. The fits are slightly more conservative: fewer georeferenced pages, fewer bad fits. If there were a "max RMSE" column in the table, it would show a more marked improvement.

The new IIIF files use transformation type "helmert", so they need the dev version of Allmaps for now.