### PR TITLE
Fixes for Washington, D.C.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ There are cases where this breaks down, though. If the streets in a large area h
 
 If the streets have all been renamed, this can also throw off georeferencing. For example, the borough of Queens in New York City systematically renamed all its streets in 1911. Mapsnap does well on 1945 Queens maps, but it does terribly on the [1898 maps][queens1898].
 
+Mapsnap also has trouble in places where the street names are all very short, for example "AVENUE T" or "K ST" or "1ST ST". This is because the underlying OCR library, EasyOCR, works better with longer runs of text. The orientation of  a single letter like O, X or M/W is ambiguous. Washington, D.C. is a nightmare scenario for Mapsnap, and it does pretty poorly there.
+
 [queens1898]: https://www.loc.gov/item/sanborn06198_001
 
 ### How I developed this model

--- a/app/index.html
+++ b/app/index.html
@@ -58,7 +58,7 @@
           </div>
           <div class="filter-row">
             <label for="filter-long-side"
-              >Min long side: <span id="filter-long-side-value">60</span></label
+              >Min long side: <span id="filter-long-side-value">20</span></label
             >
             <input
               type="range"
@@ -66,7 +66,7 @@
               min="0"
               max="200"
               step="1"
-              value="60"
+              value="20"
             />
           </div>
           <div class="filter-row">

--- a/gallery/washington_dc_1916_vol_2.iiif.json
+++ b/gallery/washington_dc_1916_vol_2.iiif.json
@@ -1,0 +1,5974 @@
+{
+  "id": "https://www.loc.gov/item/sanborn01227_003/manifest.json/generated",
+  "type": "AnnotationPage",
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld"
+  ],
+  "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia.",
+  "items": [
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 6",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
+          "type": "ImageService2",
+          "height": 8372,
+          "width": 5948
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3350.0,121.5 2758.8,218.6 4104.7,8372.0 -0.0,8372.0 0.0,-0.0 3329.2,-0.0 3350.0,121.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01835353048378,
+                38.921125554284565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5948.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01857997414172,
+                38.91788392815186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5948.0,
+                8372.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02444372196494,
+                38.91813193537031
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8372.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.02421727830699,
+                38.92137356150302
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4180.0,
+                6340.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0229532,
+                38.9190353
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 7",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/info.json",
+          "type": "ImageService2",
+          "height": 8408,
+          "width": 6032
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 574.3,-0.0 582.6,725.0 5211.7,670.3 5252.8,3758.1 5978.7,4229.5 4337.3,6574.9 3829.3,7620.1 3745.4,8141.7 -0.0,8408.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4428.0,
+                6440.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0229461,
+                38.9167239
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3792.0,
+                7756.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0239542,
+                38.9170044
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 8",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/info.json",
+          "type": "ImageService2",
+          "height": 8416,
+          "width": 6004
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6004.0,858.0 6004.0,8416.0 363.4,8416.0 384.8,7870.7 776.1,6736.1 2168.4,4128.0 1365.8,3734.6 941.0,573.7 4300.9,131.7 3926.3,832.0 6004.0,858.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2168.0,
+                4128.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.021215,
+                38.915983
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3928.0,
+                832.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0188942,
+                38.9149924
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 10",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/info.json",
+          "type": "ImageService2",
+          "height": 8492,
+          "width": 6008
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"656.7,4779.0 653.1,4443.5 511.4,4453.7 468.1,0.0 5200.1,0.0 5278.4,1087.1 6008.0,1794.5 6008.0,8492.0 5379.4,8492.0 5371.7,7793.2 5191.0,7793.7 5172.1,7617.3 2964.1,7641.8 2828.5,7808.3 690.1,7838.3 512.9,4781.6 656.7,4779.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                604.0,
+                6308.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.994977,
+                38.8764944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                604.0,
+                568.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9995209,
+                38.8765331
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 11",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/info.json",
+          "type": "ImageService2",
+          "height": 8424,
+          "width": 5968
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8424.0 -0.0,665.6 5968.0,837.9 5968.0,8424.0 -0.0,8424.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2824.0,
+                7788.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.023969,
+                38.907247
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2824.0,
+                536.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.018937,
+                38.9072367
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 13",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/info.json",
+          "type": "ImageService2",
+          "height": 8452,
+          "width": 6036
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6036.0,8452.0 -0.0,8452.0 -0.0,0.0 6036.0,-0.0 6036.0,8452.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2656.0,
+                1980.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199058,
+                38.9014723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3292.0,
+                576.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0189285,
+                38.9011315
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 18",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/info.json",
+          "type": "ImageService2",
+          "height": 8444,
+          "width": 5964
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 595.4,0.0 638.2,4462.4 781.8,4452.1 784.7,4672.5 785.3,4791.9 639.7,4794.5 819.2,7889.5 512.1,7886.8 518.2,8444.0 0.0,8444.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                732.0,
+                528.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9995209,
+                38.8765331
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                732.0,
+                6340.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.994977,
+                38.8764944
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/info.json",
+          "type": "ImageService2",
+          "height": 8488,
+          "width": 6104
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2796.7,6851.9 1157.6,6954.7 784.0,581.1 1662.3,530.8 1724.4,0.0 6104.0,0.0 6104.0,3993.0 5046.0,4055.0 5171.6,6634.8 4943.5,6732.0 4848.4,6931.3 2796.7,6851.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0196671433179,
+                38.91954401976712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6104.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01539384273677,
+                38.91975075422094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6104.0,
+                8488.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01502439091952,
+                38.91512694200843
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8488.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01929769150065,
+                38.91492020755461
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                996.0,
+                4308.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.018782,
+                38.917231
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 22",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/info.json",
+          "type": "ImageService2",
+          "height": 8396,
+          "width": 5924
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"679.4,8396.0 677.3,7172.3 454.3,7104.3 339.9,6903.8 417.6,6643.8 631.2,6540.7 396.0,4081.8 1403.9,3975.3 1225.5,160.6 -0.0,218.0 -0.0,-0.0 5924.0,0.0 5924.0,7951.6 5521.3,7937.3 5517.4,8396.0 679.4,8396.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                396.0,
+                4080.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.015958,
+                38.917506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3736.0,
+                1208.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.013541,
+                38.9191751
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/info.json",
+          "type": "ImageService2",
+          "height": 8468,
+          "width": 5980
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5980.0,0.0 5980.0,6208.7 4907.3,6226.4 4934.2,8137.7 3902.4,7572.1 38.5,7645.1 -0.0,490.7 475.6,473.7 462.7,0.0 5980.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5064.0,
+                8204.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090081,
+                38.9107672
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5064.0,
+                872.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089024,
+                38.9148176
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/info.json",
+          "type": "ImageService2",
+          "height": 8460,
+          "width": 6020
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8460.0 -0.0,5171.2 291.5,5174.8 326.3,3120.5 1046.4,3464.3 829.9,1608.2 3111.9,1318.4 4510.7,1358.8 4606.2,1605.6 4872.8,1702.5 4893.7,2981.2 6020.0,2964.8 6020.0,8460.0 -0.0,8460.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4224.0,
+                6216.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0161698,
+                38.9132801
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                344.0,
+                3076.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0188942,
+                38.9149924
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/info.json",
+          "type": "ImageService2",
+          "height": 8440,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8440.0 -0.0,0.0 5996.0,0.0 5996.0,8440.0 -0.0,8440.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                352.0,
+                3324.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.002032,
+                38.914822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                352.0,
+                6020.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.002036,
+                38.9133386
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/info.json",
+          "type": "ImageService2",
+          "height": 8400,
+          "width": 5948
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 5948.0,10.8 5948.0,4878.6 5648.0,4888.0 5591.0,5902.3 5750.7,6856.4 5615.6,6987.4 5648.0,7800.0 5948.0,7789.6 5948.0,8400.0 -0.0,8400.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5648.0,
+                4888.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.015164,
+                38.907236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5648.0,
+                7800.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0152276,
+                38.9056651
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/info.json",
+          "type": "ImageService2",
+          "height": 8428,
+          "width": 6000
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5076.7,0.0 5075.7,4956.0 977.7,4956.0 1132.6,0.0 5076.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2888.0,
+                4956.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.013655,
+                38.9072357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                672.0,
+                4956.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.015164,
+                38.907236
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/info.json",
+          "type": "ImageService2",
+          "height": 8460,
+          "width": 6088
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8460.0 -0.0,-0.0 6088.0,0.0 6088.0,8460.0 -0.0,8460.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4728.0,
+                6332.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0152099,
+                38.8915437
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4728.0,
+                1732.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0151834,
+                38.8947127
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/info.json",
+          "type": "ImageService2",
+          "height": 8488,
+          "width": 6020
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"704.3,3081.4 -0.0,3113.9 -0.0,708.2 4031.6,527.0 5261.3,1156.3 5402.3,4268.2 5532.8,4693.3 6020.0,4673.8 6020.0,5113.7 5580.1,5133.7 5662.4,6901.8 884.8,7026.2 704.3,3081.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5244.0,
+                6588.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091908,
+                38.9078971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5244.0,
+                668.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090045,
+                38.9110257
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 43",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/info.json",
+          "type": "ImageService2",
+          "height": 8420,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"636.4,4578.2 546.0,0.0 5201.3,0.0 5212.0,904.0 5088.7,899.4 5081.4,556.0 4821.2,675.5 5080.9,7322.1 5207.3,7317.1 5228.5,8420.0 -0.0,8420.0 -0.0,4571.1 636.4,4578.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5212.0,
+                3820.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089631,
+                38.9056466
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5212.0,
+                904.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089218,
+                38.90723
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/info.json",
+          "type": "ImageService2",
+          "height": 8496,
+          "width": 5988
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"350.3,705.4 614.1,590.8 614.4,935.8 738.1,942.9 738.6,737.8 2407.2,0.0 5988.0,0.0 5988.0,3842.7 5288.1,3874.0 5107.0,8496.0 601.7,8496.0 602.8,7384.1 475.8,7386.5 350.3,705.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                740.0,
+                3872.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089205,
+                38.9056464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                740.0,
+                2396.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089205,
+                38.9064444
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 45",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/info.json",
+          "type": "ImageService2",
+          "height": 8428,
+          "width": 5964
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1807.3 5964.0,1920.4 5964.0,8428.0 -0.0,8428.0 -0.0,1807.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5132.0,
+                3092.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090179,
+                38.9025148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5132.0,
+                7356.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090153,
+                38.9002174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/info.json",
+          "type": "ImageService2",
+          "height": 8480,
+          "width": 6032
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8480.0 -0.0,-0.0 6032.0,-0.0 6032.0,1284.8 3572.5,1286.3 3576.1,6884.4 2470.6,6858.0 2431.8,8480.0 -0.0,8480.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3192.0,
+                8004.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091866,
+                38.9148214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3192.0,
+                6444.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.007895,
+                38.914825
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/info.json",
+          "type": "ImageService2",
+          "height": 8424,
+          "width": 6004
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6518.4 -0.0,-0.0 6004.0,-0.0 6004.0,1606.4 4928.0,1367.9 4908.3,6638.7 -0.0,6518.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2228.0,
+                7700.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.009092,
+                38.9133406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4928.0,
+                1368.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00458,
+                38.911861
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/info.json",
+          "type": "ImageService2",
+          "height": 8380,
+          "width": 5972
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5972.0,-0.0 5972.0,7482.3 5565.7,7589.4 2622.4,7604.8 2554.1,7732.0 668.0,7732.0 630.3,1463.3 1696.4,1687.9 1679.8,100.1 -0.0,117.7 0.0,0.0 5972.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                668.0,
+                7732.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090908,
+                38.9118619
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2556.0,
+                7732.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090993,
+                38.9108059
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/info.json",
+          "type": "ImageService2",
+          "height": 8448,
+          "width": 5992
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5180.4 137.0,5171.0 -0.0,3180.9 -0.0,510.9 697.1,461.9 665.3,0.0 5827.0,0.0 5836.5,124.7 5344.2,152.5 5923.5,8448.0 -0.0,8448.0 -0.0,5180.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5836.0,
+                7180.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.002038,
+                38.901853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3880.0,
+                264.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0030622,
+                38.9056508
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/info.json",
+          "type": "ImageService2",
+          "height": 8452,
+          "width": 6016
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"373.1,3820.4 2475.7,3835.5 2473.5,322.4 5887.6,319.7 5013.6,8452.0 384.9,8452.0 373.1,3820.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3984.0,
+                6044.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9995097,
+                38.9025203
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5500.0,
+                320.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.998443,
+                38.9056458
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 59",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/info.json",
+          "type": "ImageService2",
+          "height": 8428,
+          "width": 6024
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5207.3,782.1 5287.7,8428.0 -0.0,8428.0 -0.0,0.0 4800.5,-0.0 4800.9,241.4 5341.0,536.4 5207.3,782.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2564.0,
+                5764.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.990183,
+                38.902739
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4752.0,
+                1636.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9874083,
+                38.9015712
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 60",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/info.json",
+          "type": "ImageService2",
+          "height": 8432,
+          "width": 5984
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5984.0,8432.0 -0.0,8432.0 0.0,0.0 5984.0,0.0 5984.0,8432.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5000.0,
+                7892.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9808896,
+                38.9039887
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5000.0,
+                1252.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9782803,
+                38.9081126
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 63",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/info.json",
+          "type": "ImageService2",
+          "height": 8440,
+          "width": 5948
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5948.0,7723.6 -0.0,7713.7 -0.0,359.9 491.4,359.1 491.5,0.0 5948.0,0.0 5948.0,7723.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                488.0,
+                6240.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.998455,
+                38.89814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                488.0,
+                2420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984507,
+                38.9002082
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 65",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/info.json",
+          "type": "ImageService2",
+          "height": 8464,
+          "width": 6032
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"64.7,416.4 5320.4,421.4 5324.1,7725.7 3218.5,7724.5 2816.2,7544.3 1053.4,8464.0 739.7,8464.0 732.3,7726.6 42.0,7722.0 -0.0,-0.0 64.7,416.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5328.0,
+                3664.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.988305,
+                38.89955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2568.0,
+                1440.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.990242,
+                38.900763
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 66",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/info.json",
+          "type": "ImageService2",
+          "height": 8492,
+          "width": 5976
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"848.8,419.7 2954.2,390.5 3190.5,519.6 3475.3,0.0 5976.0,0.0 5976.0,4795.3 4886.5,4805.6 4907.9,8492.0 914.8,8492.0 848.8,419.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                904.0,
+                6228.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883032,
+                38.8981486
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                904.0,
+                -712.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9882671,
+                38.9019364
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/info.json",
+          "type": "ImageService2",
+          "height": 8472,
+          "width": 5988
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4286.3,6728.8 -0.0,6618.4 -0.0,0.0 5760.9,-0.0 4528.9,4994.1 4309.3,5318.2 4286.3,6728.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4424.0,
+                5092.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9836408,
+                38.898855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1884.0,
+                4664.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9833845,
+                38.900182
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 68",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/info.json",
+          "type": "ImageService2",
+          "height": 8536,
+          "width": 6020
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3788.7,5518.8 3860.2,7653.6 1047.7,7751.2 957.6,5381.3 1145.0,5069.6 2106.0,-0.0 4270.8,-0.0 4994.9,353.9 6020.0,312.6 6020.0,2386.7 5840.0,2392.7 5861.7,3011.1 4886.6,3046.2 4952.7,5029.8 3444.1,5091.6 3451.6,5315.1 3788.7,5518.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                372.0,
+                7776.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9855028,
+                38.899288
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3128.0,
+                5108.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.983653,
+                38.897692
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/info.json",
+          "type": "ImageService2",
+          "height": 8492,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"428.5,7583.6 462.6,5350.8 2638.0,5370.6 2882.8,5482.8 3773.2,5022.2 3748.0,4171.7 465.6,4150.9 488.3,1720.5 -0.0,1779.0 -0.0,684.7 5923.4,744.9 5996.0,1060.7 5486.0,1121.8 5437.2,7628.0 428.5,7583.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5464.0,
+                4216.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949624,
+                38.8954393
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                488.0,
+                1828.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984577,
+                38.8967215
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 73",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/info.json",
+          "type": "ImageService2",
+          "height": 8444,
+          "width": 6000
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"691.7,459.8 700.3,1361.5 2780.0,280.0 3182.9,461.1 5292.6,465.3 5289.1,1234.7 6000.0,1241.4 6000.0,6616.7 -0.0,6703.9 -0.0,454.2 691.7,459.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2516.0,
+                3944.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.990245,
+                38.895435
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5280.0,
+                3944.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.98831,
+                38.895438
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 75",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/info.json",
+          "type": "ImageService2",
+          "height": 8480,
+          "width": 6024
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6581.9 -0.0,1138.3 659.6,1141.5 659.8,341.2 2866.7,341.1 3088.7,0.0 3319.8,0.0 3331.5,1559.9 5382.1,1560.3 5384.7,2568.3 6024.0,2567.3 6024.0,6776.4 682.6,6784.9 681.6,6597.6 -0.0,6581.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                668.0,
+                3904.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9855056,
+                38.8953987
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5392.0,
+                3768.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.982211,
+                38.895466
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 76",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/info.json",
+          "type": "ImageService2",
+          "height": 8400,
+          "width": 6024
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"564.5,0.0 6024.0,0.0 6024.0,8400.0 1819.0,8400.0 2014.0,482.7 566.2,481.9 564.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                572.0,
+                7412.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9855001,
+                38.8898107
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5276.0,
+                7412.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9822175,
+                38.8898083
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 78",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/info.json",
+          "type": "ImageService2",
+          "height": 8424,
+          "width": 5972
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"349.5,3291.7 783.0,3282.0 349.5,3158.1 349.4,2367.1 -0.0,2392.7 -0.0,-0.0 5526.5,0.0 5527.8,6397.0 352.5,6406.2 349.5,3291.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2472.0,
+                7364.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.000571,
+                38.8898167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5528.0,
+                7364.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984548,
+                38.8898152
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 79",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/info.json",
+          "type": "ImageService2",
+          "height": 8400,
+          "width": 5988
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5493.7,6480.1 5496.0,7388.0 488.0,7388.0 458.7,433.3 5988.0,439.0 5988.0,6480.0 5493.7,6480.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5496.0,
+                7388.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949654,
+                38.8898131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                488.0,
+                7388.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984548,
+                38.8898152
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 81",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/info.json",
+          "type": "ImageService2",
+          "height": 8436,
+          "width": 5976
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5236.1,2774.9 5013.4,3456.6 5256.3,3459.7 5223.0,5934.1 4366.5,6408.8 713.0,6406.4 712.2,6525.8 -0.0,6525.3 -0.0,-0.0 5215.7,0.0 5236.1,2774.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5296.0,
+                3084.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9882495,
+                38.8922151
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3188.0,
+                6408.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9897535,
+                38.8903694
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 82",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/info.json",
+          "type": "ImageService2",
+          "height": 8436,
+          "width": 5988
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"916.0,5894.6 886.7,3482.5 649.9,3485.6 849.8,2815.7 760.7,112.0 4590.8,0.0 4608.8,637.4 5988.0,604.2 5988.0,8436.0 963.5,8436.0 941.8,7695.0 1111.2,7438.8 1467.0,7325.6 1013.5,7153.1 752.3,6409.6 93.2,6378.6 916.0,5894.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                916.0,
+                5896.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883015,
+                38.8906327
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                916.0,
+                3116.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9882495,
+                38.8922151
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 84",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/info.json",
+          "type": "ImageService2",
+          "height": 8432,
+          "width": 6012
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4312.5 401.5,4323.8 408.8,0.0 5597.3,0.0 5590.4,7182.7 5315.9,7064.3 2828.2,7129.9 2530.9,6974.4 2530.1,7981.6 1899.1,7983.4 1759.1,8432.0 -0.0,8432.0 -0.0,4312.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2532.0,
+                964.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.000571,
+                38.8898167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                408.0,
+                964.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0020381,
+                38.8898157
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 85",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/info.json",
+          "type": "ImageService2",
+          "height": 8384,
+          "width": 5964
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5384.9,7703.4 469.9,7696.6 472.0,868.0 5385.0,871.9 5388.9,4342.3 4894.2,4602.7 4894.1,4868.3 5388.6,4866.1 5384.9,7703.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                472.0,
+                6912.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984547,
+                38.8864758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                472.0,
+                868.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984548,
+                38.8898152
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 86",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/info.json",
+          "type": "ImageService2",
+          "height": 8404,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"501.9,4958.0 -0.0,4960.4 -0.0,4690.9 501.9,4426.3 493.9,0.0 5416.8,0.0 5413.9,508.7 4968.5,907.3 5242.9,963.7 5421.2,1202.2 5410.6,7823.8 4821.3,7826.4 4887.5,8404.0 3697.6,8404.0 3697.3,7826.9 499.7,7837.7 501.9,4958.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2216.0,
+                904.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9937618,
+                38.8898126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                496.0,
+                904.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949654,
+                38.8898131
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 87",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/info.json",
+          "type": "ImageService2",
+          "height": 8452,
+          "width": 6056
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"722.3,7890.8 737.9,1297.9 560.5,1060.4 287.3,1004.0 731.0,607.5 735.0,0.0 5077.0,0.0 5226.8,170.2 5383.9,814.2 5851.7,1006.2 5478.0,1114.5 5294.7,1376.9 5297.4,2149.3 6056.0,2168.8 6056.0,8452.0 5854.8,8452.0 5844.9,7859.3 5298.5,8042.6 5247.6,7818.8 722.3,7890.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5296.0,
+                6488.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883146,
+                38.8868115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5296.0,
+                2028.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883153,
+                38.8892506
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 88",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5680
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8160.0 -0.0,1003.2 5130.9,1010.2 5128.0,1239.1 5680.0,1064.1 5680.0,8160.0 -0.0,8160.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2356.0,
+                2148.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9902407,
+                38.8854417
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5128.0,
+                1240.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883126,
+                38.8859613
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 89",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/info.json",
+          "type": "ImageService2",
+          "height": 8228,
+          "width": 5704
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1312.5,0.0 5704.0,0.0 5704.0,8228.0 0.0,8228.0 0.0,5676.9 1312.5,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1624.0,
+                1288.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984492,
+                38.8940911
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3148.0,
+                5664.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949624,
+                38.8954393
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 92",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/info.json",
+          "type": "ImageService2",
+          "height": 8212,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,5568.5 1082.8,1468.3 2625.1,1468.0 5285.4,5578.5 5292.9,8212.0 0.0,8212.0 0.0,5568.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5288.0,
+                4152.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9961774,
+                38.8860395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5288.0,
+                6996.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.993761,
+                38.8860394
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 95",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/info.json",
+          "type": "ImageService2",
+          "height": 8204,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5724.0,8204.0 -0.0,8204.0 0.0,0.0 5724.0,-0.0 5724.0,8204.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2372.0,
+                7432.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199088,
+                38.8839411
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                -104.0,
+                7432.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199096,
+                38.8850455
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 99",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
+          "type": "ImageService2",
+          "height": 8244,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5692.0,8244.0 0.0,8244.0 0.0,2454.7 5692.0,2887.7 5692.0,8244.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2356.0,
+                2316.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0030622,
+                38.9056508
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                592.0,
+                2316.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0020424,
+                38.9056565
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 101",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/info.json",
+          "type": "ImageService2",
+          "height": 8208,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8208.0 0.0,0.0 4843.9,0.0 4863.7,746.2 5294.7,857.3 4867.2,878.1 5063.8,8208.0 -0.0,8208.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00543413270151,
+                38.89256352454368
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0014430557772,
+                38.892478822302046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5692.0,
+                8208.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00160002751292,
+                38.88800057106304
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8208.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00559110443722,
+                38.888085273304675
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2756.0,
+                1004.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0035209,
+                38.8919748
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 107",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/info.json",
+          "type": "ImageService2",
+          "height": 8220,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2322.6,2595.5 -0.0,2590.7 0.0,-0.0 1617.0,-0.0 1617.7,1004.5 2322.6,2595.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                156.0,
+                2592.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089178,
+                38.908569
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5312.0,
+                2592.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089205,
+                38.9056464
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 109",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/info.json",
+          "type": "ImageService2",
+          "height": 8188,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8188.0 -0.0,-0.0 5293.6,0.0 5296.2,4191.1 4968.0,4188.0 4968.7,8188.0 -0.0,8188.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2720.0,
+                4188.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0106533,
+                38.8746432
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4968.0,
+                4188.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091579,
+                38.8746424
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 110",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/info.json",
+          "type": "ImageService2",
+          "height": 8208,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"429.6,7428.8 428.9,4201.5 743.5,4204.5 743.1,187.8 -0.0,187.4 0.0,-0.0 5692.0,0.0 5692.0,8208.0 -0.0,8208.0 -0.0,8034.9 427.7,8035.1 429.6,7428.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2868.0,
+                4204.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.007465,
+                38.8746408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2868.0,
+                808.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0074646,
+                38.8764749
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 111",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/info.json",
+          "type": "ImageService2",
+          "height": 8224,
+          "width": 5684
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5145.3,3.9 5145.3,672.1 5496.0,660.0 5533.8,1609.9 5376.0,1763.1 5578.8,2779.0 5496.0,4064.0 444.8,4221.8 314.5,-0.0 5153.5,-0.0 5145.3,3.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5496.0,
+                4064.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.015164,
+                38.907236
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5496.0,
+                660.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0152276,
+                38.9056651
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 112",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/info.json",
+          "type": "ImageService2",
+          "height": 8208,
+          "width": 5684
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"954.7,0.0 5684.0,0.0 5684.0,7732.3 5343.7,7733.1 5344.4,8067.4 541.0,8080.6 504.0,636.0 954.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                504.0,
+                636.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0020424,
+                38.9056565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5320.0,
+                636.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.998443,
+                38.9056458
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 114",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/info.json",
+          "type": "ImageService2",
+          "height": 8200,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,2495.9 641.8,2293.5 322.6,1267.8 674.6,1331.6 3186.6,474.1 3503.8,507.4 5262.3,6223.3 -0.0,7836.6 -0.0,2495.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5396.0,
+                6604.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984578,
+                38.8832594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3864.0,
+                7160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.999512,
+                38.8832215
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 115",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/info.json",
+          "type": "ImageService2",
+          "height": 8208,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"365.7,8208.0 353.9,5649.1 368.7,743.4 5535.5,748.8 5534.0,4046.9 3746.3,3113.0 3747.9,3541.3 5528.5,4472.3 5524.4,8208.0 365.7,8208.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                368.0,
+                6036.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984578,
+                38.8832594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                368.0,
+                1776.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984569,
+                38.8854988
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 117",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/info.json",
+          "type": "ImageService2",
+          "height": 8180,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5408.4,0.0 5433.9,2431.4 5692.0,2429.9 5692.0,6524.4 5416.1,6461.0 4570.2,7365.4 -0.0,7599.3 0.0,0.0 5408.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                408.0,
+                5920.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0020474,
+                38.880205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5424.0,
+                368.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9984578,
+                38.8832594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 121",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/info.json",
+          "type": "ImageService2",
+          "height": 8180,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8180.0 -0.0,4621.1 5696.0,4978.6 5696.0,8180.0 -0.0,8180.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5320.0,
+                2432.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9981661,
+                38.8765348
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                -800.0,
+                5488.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0005737,
+                38.8797767
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 123",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/info.json",
+          "type": "ImageService2",
+          "height": 8184,
+          "width": 5644
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5644.0,7996.8 2879.3,7997.2 2723.8,8184.0 223.7,8184.0 204.6,7984.1 -0.0,7982.4 0.0,-0.0 5644.0,-0.0 5644.0,7996.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1864.0,
+                2960.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.990248,
+                38.8784074
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1864.0,
+                196.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9883153,
+                38.8784076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 133",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/info.json",
+          "type": "ImageService2",
+          "height": 8180,
+          "width": 5648
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5648.0,-0.0 5648.0,8180.0 0.0,8180.0 0.0,0.0 5648.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                292.0,
+                3176.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0281054,
+                38.9056616
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2880.0,
+                3176.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0296282,
+                38.9056671
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 135",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3264.0,
+                1728.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.008984,
+                38.9245149
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3264.0,
+                7636.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089922,
+                38.9213036
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 136",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-06-12T14:50:49Z",
+      "modified": "2026-06-12T14:50:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6414.0 389.6,5717.3 405.7,5647.3 497.3,3373.6 105.1,3284.0 58.9,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,6414.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                704.0,
+                4348.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.979804,
+                38.897644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4728.0,
+                5860.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.977061,
+                38.896853
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/mapsnap/ctc_vocab_decode.py
+++ b/mapsnap/ctc_vocab_decode.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from mapsnap.streets import (
     DIRECTION_ABBREVS,
+    HINT_STRINGS,
     ORDINAL_WORD_TO_NUM,
     STREET_ABBREVS,
 )
@@ -54,22 +55,8 @@ for _abbrev, _full in STREET_ABBREVS.items():
         _TYPE_TO_ABBREVS[_full] = [_full]
     _TYPE_TO_ABBREVS[_full].append(_abbrev)
 
-# Hint strings are marked "hint" in streets.json and are not used as standalone GCPs.
-# They serve as anchors for promote_avenue_letters (recovering single-letter avenue
-# names like "X" or "W" from "AVENUE X" labels that CRAFT splits into two boxes).
-# AVENUE and STREET (and their abbreviations) are hints; "K STREET" in Washington DC
-# is the same pattern. All other type words (COURT, BOULEVARD, …) and direction
-# words remain regular detections.
-_LETTERED_TYPE_ABBREVS: frozenset[str] = frozenset(
-    k for k, v in STREET_ABBREVS.items() if v in ("AVENUE", "STREET")
-)
-HINT_STRINGS: frozenset[str] = frozenset(
-    {"AVENUE", "STREET"}
-    | _LETTERED_TYPE_ABBREVS  # AVE, AV, ST
-    | {a + "." for a in _LETTERED_TYPE_ABBREVS}  # AVE., AV., ST.
-    # Spaced forms: Sanborn typography sometimes gaps characters (e.g. "A V", "S T").
-    | {" ".join(a) for a in _LETTERED_TYPE_ABBREVS if len(a) > 1}  # A V, A V E, S T
-)
+# HINT_STRINGS is defined in streets.py (alongside STREET_TYPES) and re-exported here
+# for callers that import from ctc_vocab_decode.
 
 
 def generate_vocab_strings(normalized_streets: set[str]) -> list[str]:

--- a/mapsnap/ctc_vocab_decode.py
+++ b/mapsnap/ctc_vocab_decode.py
@@ -106,6 +106,12 @@ def generate_vocab_strings(normalized_streets: set[str]) -> list[str]:
         if not body:
             continue
 
+        # Strip a trailing direction word (e.g. "NORTHEAST" in "EIGHTH STREET NORTHEAST").
+        # DC-style centerline names carry the quadrant as a suffix, but map labels omit
+        # it; stripping here lets the trie emit "EIGHTH", "8TH", "EIGHTH ST", etc.
+        if len(body) >= 2 and body[-1] in _DIR_TO_ABBREVS:
+            body = body[:-1]
+
         # --- Determine street-type suffix variants ---
         last = body[-1]
         if last in _TYPE_TO_ABBREVS:

--- a/mapsnap/ctc_vocab_decode_test.py
+++ b/mapsnap/ctc_vocab_decode_test.py
@@ -132,6 +132,33 @@ def test_generate_west_street():
     assert "W ST" in vocab
 
 
+def test_generate_direction_suffix_numbered():
+    # DC-style names like "EIGHTH STREET NORTHEAST": quadrant suffix omitted on map labels.
+    vocab = set(generate_vocab_strings({"EIGHTH STREET NORTHEAST"}))
+    assert "EIGHTH" in vocab
+    assert "8TH" in vocab
+    assert "8 TH" in vocab
+    assert "EIGHTH ST" in vocab
+    assert "EIGHTH STREET" in vocab
+    # Full form with quadrant suffix is NOT required (map labels never show it).
+
+
+def test_generate_direction_suffix_lettered():
+    # "A STREET NORTHEAST": map label is just "A" or "A ST".
+    vocab = set(generate_vocab_strings({"A STREET NORTHEAST"}))
+    assert "A" in vocab
+    assert "A ST" in vocab
+    assert "A STREET" in vocab
+
+
+def test_generate_direction_suffix_avenue():
+    # "MASSACHUSETTS AVENUE NORTHEAST": labels omit quadrant.
+    vocab = set(generate_vocab_strings({"MASSACHUSETTS AVENUE NORTHEAST"}))
+    assert "MASSACHUSETTS" in vocab
+    assert "MASSACHUSETTS AVE" in vocab
+    assert "MASSACHUSETTS AVENUE" in vocab
+
+
 def test_generate_includes_hint_strings():
     # AVENUE- and STREET-family hints appear in every vocab regardless of streets present.
     vocab = set(generate_vocab_strings({"MAGAZINE STREET"}))

--- a/mapsnap/ctc_vocab_decode_test.py
+++ b/mapsnap/ctc_vocab_decode_test.py
@@ -167,7 +167,7 @@ def test_generate_includes_hint_strings():
 
 
 def test_hint_strings_constant():
-    # HINT_STRINGS contains AVENUE and STREET families only.
+    # HINT_STRINGS contains AVENUE/STREET families and quadrant abbreviations.
     assert "AVENUE" in HINT_STRINGS
     assert "AVE" in HINT_STRINGS
     assert "AV" in HINT_STRINGS
@@ -177,7 +177,13 @@ def test_hint_strings_constant():
     assert "ST" in HINT_STRINGS
     assert "ST." in HINT_STRINGS
     assert "S T" in HINT_STRINGS
-    # Other type words and direction words are no longer hints.
+    # Quadrant abbreviations in all four forms.
+    for q in ("NW", "NE", "SE", "SW"):
+        assert q in HINT_STRINGS, f"{q} missing"
+        assert " ".join(q) in HINT_STRINGS, f"{' '.join(q)} missing"
+        assert f"{q[0]}.{q[1]}." in HINT_STRINGS, f"{q[0]}.{q[1]}. missing"
+        assert f"{q[0]}. {q[1]}." in HINT_STRINGS, f"{q[0]}. {q[1]}. missing"
+    # Other type words and full direction words remain non-hints.
     assert "COURT" not in HINT_STRINGS
     assert "NORTH" not in HINT_STRINGS
     assert "N." not in HINT_STRINGS

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -51,13 +51,15 @@ def main() -> None:
     parser.add_argument(
         "tag", metavar="TAG", help="Tag for output files (e.g. 'init' or YYYY-MM-DD)"
     )
-    args = parser.parse_args()
+    args, georef_extra = parser.parse_known_args()
 
     dir_path = Path(args.dir)
     centerlines = find_centerlines(dir_path)
     images = find_input_images(dir_path)
 
-    run_cmd(["mapsnap", "georef", *images, "--centerlines", str(centerlines)])
+    run_cmd(
+        ["mapsnap", "georef", *images, "--centerlines", str(centerlines), *georef_extra]
+    )
 
     ref_iiif = find_ref_iiif(dir_path)
     if ref_iiif is None:

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 from mapsnap.streets import (
     DIRECTION_WORDS,
-    STREET_TYPES,
+    HINT_STRINGS,
     Block,
     build_block_index,
     canonical_street_matches,
@@ -713,6 +713,22 @@ def _finalize_georef(
     return affine_scale_deg_per_px(A), center
 
 
+def _are_quadrant_siblings(matches: list[str]) -> bool:
+    """Return True if all matches share the same base name differing only in trailing direction suffix.
+
+    e.g. ["NORTH STREET NORTHEAST", "NORTH STREET NORTHWEST", ...] → True
+    ["NORTH PLACE", "NORTH STREET NORTHEAST"] → False
+    """
+    if not matches:
+        return False
+    bases: set[str] = set()
+    for m in matches:
+        parts = m.rsplit(" ", 1)
+        base = parts[0] if (len(parts) == 2 and parts[1] in DIRECTION_WORDS) else m
+        bases.add(base)
+    return len(bases) == 1
+
+
 def promote_avenue_letters(
     hint_detections: list[dict],
     all_detections: list[dict],
@@ -735,12 +751,16 @@ def promote_avenue_letters(
     The parallel (along-street) gap is unconstrained.
     """
     type_hints = [
-        h for h in hint_detections if h.get("text", "").upper().strip() in STREET_TYPES
+        h for h in hint_detections if h.get("text", "").upper().strip() in HINT_STRINGS
     ]
     if not type_hints:
         return []
 
-    candidates = list(all_detections)
+    # Sort by confidence descending so the highest-quality reading of each physical
+    # box wins the promotion slot when multiple OCR readings overlap the same position.
+    candidates = sorted(
+        all_detections, key=lambda d: d.get("confidence", 0.0), reverse=True
+    )
 
     if not candidates:
         return []
@@ -789,7 +809,18 @@ def promote_avenue_letters(
 
             matches = canonical_street_matches(text, normalized_streets)
             if len(matches) != 1:
-                continue
+                # Bare letter is ambiguous. Try "N ST" style: combining the letter
+                # with the hint type disambiguates lettered streets (e.g. "N STREET")
+                # from direction abbreviations (e.g. "NORTH"). Allow promotion when
+                # all combined matches are quadrant siblings of the same street.
+                hint_type_text = hint.get("text", "").strip()
+                combined_matches = canonical_street_matches(
+                    f"{text} {hint_type_text}", normalized_streets
+                )
+                if combined_matches and _are_quadrant_siblings(combined_matches):
+                    matches = combined_matches
+                else:
+                    continue
 
             promoted_centers.append((det_cx, det_cy))
             # Strip "hint" so the promoted detection is treated as a regular detection
@@ -820,7 +851,7 @@ def correct_square_feature_dirs(
     column hint during promotion and must not be overwritten by a different nearby hint.
     """
     type_hints = [
-        h for h in hint_detections if h.get("text", "").upper().strip() in STREET_TYPES
+        h for h in hint_detections if h.get("text", "").upper().strip() in HINT_STRINGS
     ]
     if not type_hints:
         return

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -952,9 +952,12 @@ def process_image(
     hint_detections = [d for d in all_detections if d.get("hint")]
     all_detections = [d for d in all_detections if not d.get("hint")]
     if hint_detections:
+        confident_hints = [
+            d for d in hint_detections if d.get("confidence", 0) >= min_confidence
+        ]
         print(
-            f"Hint detections ({len(hint_detections)}): "
-            + ", ".join(d["text"] for d in hint_detections),
+            f"Hint detections ({len(confident_hints)}): "
+            + ", ".join(d["text"] for d in confident_hints),
             file=sys.stderr,
         )
     normalized_streets = set(block_index.keys())

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -792,6 +792,19 @@ def promote_avenue_letters(
             if det_bucket != hint_bucket:
                 continue
 
+            # dir_pix is mod π, so angle=90 and angle=270 share the same bucket.
+            # Require the EasyOCR `angle` to also match so a box read in the
+            # opposite direction (e.g. angle=90 vs angle=270) is not promoted.
+            # This uses the orientation of the "ST" hint to distinguish "M" from "W".
+            hint_angle = hint.get("angle")
+            det_angle = det.get("angle")
+            if (
+                hint_angle is not None
+                and det_angle is not None
+                and hint_angle != det_angle
+            ):
+                continue
+
             det_poly = det["polygon"]
             det_cx = sum(p[0] for p in det_poly) / 4.0
             det_cy = sum(p[1] for p in det_poly) / 4.0

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -158,10 +158,21 @@ def _service_url_to_page_key(url: str) -> str | None:
       "...:01790_01N_1950-0103W"           → "p103w"
       "...:05791_02_1939-0027s"            → "p27s"
 
+    Sanborn sb-format (e.g. Washington DC 1916):
+      "...:sb001250"                        → "p125"
+      "...:sb00154s"                        → "p154s"
+
     Non-sheet URLs (covers, indexes: "...-covr", "...-titl", etc.) start with a
     letter after the "-" and return None.
     """
     url = url.removesuffix("/info.json")
+    # Sanborn sb-format: service:...:sb{5-digit page}{suffix char}
+    m = re.search(r":sb(\d{5})([a-z0-9])$", url, re.IGNORECASE)
+    if m:
+        page_num = int(m.group(1))
+        suffix_char = m.group(2).lower()
+        suffix = "" if suffix_char == "0" else suffix_char
+        return f"p{page_num}{suffix}"
     m = re.search(r"-0*(\d+)([a-z]*)$", url, re.IGNORECASE)
     if m is None:
         return None

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -220,6 +220,17 @@ def test_service_url_non_sheet_returns_none():
     assert _service_url_to_page_key("...-titl") is None
 
 
+_DC = "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003"
+
+
+def test_service_url_sb_format():
+    # Washington DC 1916 uses sb-format: sb{5-digit page}{suffix char}
+    assert _service_url_to_page_key(f"{_DC}:sb001250") == "p125"
+    assert _service_url_to_page_key(f"{_DC}:sb002160") == "p216"
+    assert _service_url_to_page_key(f"{_DC}:sb00154s") == "p154s"
+    assert _service_url_to_page_key(f"{_DC}:sb00001a") == "p1a"
+
+
 # ---------------------------------------------------------------------------
 # georef_path_to_page_key
 # ---------------------------------------------------------------------------

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -440,6 +440,19 @@ def build_block_index(geojson: dict) -> dict[str, list[Block]]:
             # Same list object as the full-name entry; see comment above.
             index[stripped] = index[full_names[0]]
 
+    # Build aliases with direction suffix stripped for unambiguous cases.
+    # e.g. "MAIN STREET NORTHEAST" → also index under "MAIN STREET" (then "MAIN" via
+    # bare-name alias) when only one direction of that street exists.
+    # Iterating list(index.keys()) captures both original keys and aliases added above.
+    dir_suffix_stripped_to_full: dict[str, list[str]] = defaultdict(list)
+    for key in list(index.keys()):
+        parts = key.rsplit(" ", 1)
+        if len(parts) == 2 and parts[1] in DIRECTION_WORDS and parts[0] not in index:
+            dir_suffix_stripped_to_full[parts[0]].append(key)
+    for stripped, full_names in dir_suffix_stripped_to_full.items():
+        if len(full_names) == 1:
+            index[stripped] = index[full_names[0]]
+
     # Build aliases with leading type word stripped for unambiguous cases.
     # e.g. "AVENUE X" → also index under "X".
     # Iterating list(index.keys()) captures all aliases added so far.

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -59,6 +59,22 @@ STRIPPABLE_PREFIXES: frozenset[str] = DIRECTION_WORDS | {"SAINT"}
 # Full street-type words (STREET, AVENUE, …); used to identify bare-name aliases in build_block_index.
 STREET_TYPES: frozenset[str] = frozenset(STREET_ABBREVS.values())
 
+# Abbreviations of AVENUE and STREET (the two types used as "hints" in Sanborn maps).
+_LETTERED_TYPE_ABBREVS: frozenset[str] = frozenset(
+    k for k, v in STREET_ABBREVS.items() if v in ("AVENUE", "STREET")
+)
+
+# All hint string forms: full names, abbreviations, dotted, and spaced variants.
+# Used by detect_text.py to mark detections as hints and by georef_from_labels.py
+# to identify which hint detections are type-word anchors for promote_avenue_letters.
+HINT_STRINGS: frozenset[str] = frozenset(
+    {"AVENUE", "STREET"}
+    | _LETTERED_TYPE_ABBREVS  # AVE, AV, ST
+    | {a + "." for a in _LETTERED_TYPE_ABBREVS}  # AVE., AV., ST.
+    # Spaced forms: Sanborn typography sometimes gaps characters (e.g. "A V", "S T").
+    | {" ".join(a) for a in _LETTERED_TYPE_ABBREVS if len(a) > 1}  # A V, A V E, S T
+)
+
 # Irregular ordinal words for 1–19.
 _ORDINAL_ONES = [
     "",
@@ -235,16 +251,19 @@ def canonical_street_match(
     if raw != normalized and raw in normalized_streets:
         return raw
     if normalized in DIRECTION_WORDS:
-        # Bare direction word (e.g. "EAST", "WEST"): only match exact key aliases
-        # or two-word "DIRECTION TYPE" keys (e.g. "EAST STREET", "WEST AVENUE").
-        # Prevents "EAST" from prefix-matching all "EAST 103RD STREET",
-        # "EAST FOURTH STREET", etc. via candidate.startswith("EAST ").
+        # Bare direction word (e.g. "N", "EAST"): only match exact key aliases or
+        # keys where the word immediately after the direction prefix is a street type
+        # (e.g. "NORTH STREET NORTHWEST", "EAST AVENUE", "WEST PLACE SOUTHEAST").
+        # Prevents "EAST" from prefix-matching "EAST 103RD STREET", "EAST GRAND AVENUE",
+        # etc., while still matching DC-style "NORTH STREET NORTHWEST" (the leading N
+        # is a lettered street, not a direction prefix for a named/numbered street).
+        prefix_len = len(normalized) + 1
         for s in normalized_streets:
             if s == normalized:
                 return s
             if (
                 s.startswith(normalized + " ")
-                and s[len(normalized) + 1 :] in STREET_TYPES
+                and s[prefix_len:].split(" ", 1)[0] in STREET_TYPES
             ):
                 return s
         return None
@@ -278,22 +297,25 @@ def canonical_street_matches(
     raw text is itself a known alias (e.g. "W" for "AVENUE W"), only that alias is
     returned — preventing "W" from matching all 70+ "WEST X" streets.
 
-    Bare direction words (e.g. "EAST", "WEST") only match exact key aliases or
-    two-word "DIRECTION TYPE" keys (e.g. "EAST STREET") — not direction-prefixed
-    named/numbered streets like "EAST 103RD STREET".
+    Bare direction words (e.g. "N", "EAST") match exact key aliases or keys where
+    the word immediately after the direction prefix is a street type — including
+    direction-suffixed forms like "NORTH STREET NORTHWEST" — but not
+    direction-prefixed named/numbered streets like "EAST 103RD STREET" or
+    "NORTH CAROLINA AVENUE NORTHEAST".
     """
     normalized = normalize_street(text)
     raw = text.upper().strip()
     if raw != normalized and raw in normalized_streets:
         return [raw]
     if normalized in DIRECTION_WORDS:
+        prefix_len = len(normalized) + 1
         matches = []
         for s in normalized_streets:
             if s == normalized:
                 matches.append(s)
             elif (
                 s.startswith(normalized + " ")
-                and s[len(normalized) + 1 :] in STREET_TYPES
+                and s[prefix_len:].split(" ", 1)[0] in STREET_TYPES
             ):
                 matches.append(s)
         return matches

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -64,6 +64,11 @@ _LETTERED_TYPE_ABBREVS: frozenset[str] = frozenset(
     k for k, v in STREET_ABBREVS.items() if v in ("AVENUE", "STREET")
 )
 
+# Two-letter quadrant abbreviations that appear as standalone labels on Sanborn maps
+# (e.g. "N.W." printed at a street corner). All four forms per quadrant are included
+# so the CTC decoder can output them instead of falling back to a look-alike letter.
+_QUADRANT_ABBREVS: frozenset[str] = frozenset({"NE", "NW", "SE", "SW"})
+
 # All hint string forms: full names, abbreviations, dotted, and spaced variants.
 # Used by detect_text.py to mark detections as hints and by georef_from_labels.py
 # to identify which hint detections are type-word anchors for promote_avenue_letters.
@@ -73,6 +78,11 @@ HINT_STRINGS: frozenset[str] = frozenset(
     | {a + "." for a in _LETTERED_TYPE_ABBREVS}  # AVE., AV., ST.
     # Spaced forms: Sanborn typography sometimes gaps characters (e.g. "A V", "S T").
     | {" ".join(a) for a in _LETTERED_TYPE_ABBREVS if len(a) > 1}  # A V, A V E, S T
+    # Quadrant labels: NW / N W / N.W. / N. W.  (and NE, SE, SW equivalents).
+    | _QUADRANT_ABBREVS  # NE, NW, SE, SW
+    | {" ".join(q) for q in _QUADRANT_ABBREVS}  # N E, N W, S E, S W
+    | {f"{q[0]}.{q[1]}." for q in _QUADRANT_ABBREVS}  # N.E., N.W., S.E., S.W.
+    | {f"{q[0]}. {q[1]}." for q in _QUADRANT_ABBREVS}  # N. E., N. W., S. E., S. W.
 )
 
 # Irregular ordinal words for 1–19.

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -1,6 +1,12 @@
 """Tests for mapsnap.streets."""
 
-from mapsnap.streets import _ORDINALS, _num_to_ordinal_word, normalize_street
+from mapsnap.streets import (
+    _ORDINALS,
+    _num_to_ordinal_word,
+    canonical_street_match,
+    canonical_street_matches,
+    normalize_street,
+)
 
 # --- _num_to_ordinal_word ---
 
@@ -73,3 +79,67 @@ def test_normalize_no_ordinal_unchanged():
 def test_normalize_ordinal_does_not_expand_non_ordinal_numbers():
     # Bare numbers (no suffix) should not be altered.
     assert normalize_street("Route 66") == "ROUTE 66"
+
+
+# --- canonical_street_matches / canonical_street_match: direction-suffixed type keys ---
+
+_DC_STREETS = {
+    "NORTH STREET NORTHEAST",
+    "NORTH STREET NORTHWEST",
+    "NORTH STREET SOUTHEAST",
+    "NORTH STREET SOUTHWEST",
+    "NORTH PLACE",
+    "NORTH PLACE SOUTHEAST",
+    "NORTH ROAD",
+    "NORTH CAROLINA AVENUE NORTHEAST",
+    "NORTH DAKOTA AVENUE NORTHWEST",
+    "NORTH CAPITOL STREET NORTHWEST",
+    "EAST STREET NORTHEAST",
+    "EAST GRAND AVENUE",
+}
+
+
+def test_direction_word_matches_suffixed_type_key():
+    # "N" → "NORTH": should match "NORTH STREET NORTHWEST" (first word of remainder is STREET).
+    matches = canonical_street_matches("N", _DC_STREETS)
+    assert "NORTH STREET NORTHEAST" in matches
+    assert "NORTH STREET NORTHWEST" in matches
+    assert "NORTH STREET SOUTHEAST" in matches
+    assert "NORTH STREET SOUTHWEST" in matches
+
+
+def test_direction_word_still_matches_plain_type_key():
+    # Two-word "NORTH PLACE" still works after the fix.
+    matches = canonical_street_matches("N", _DC_STREETS)
+    assert "NORTH PLACE" in matches
+    assert "NORTH PLACE SOUTHEAST" in matches
+    assert "NORTH ROAD" in matches
+
+
+def test_direction_word_does_not_match_named_streets():
+    # "N" must NOT match streets where the word after the direction is not a type word.
+    matches = canonical_street_matches("N", _DC_STREETS)
+    assert "NORTH CAROLINA AVENUE NORTHEAST" not in matches
+    assert "NORTH DAKOTA AVENUE NORTHWEST" not in matches
+    assert "NORTH CAPITOL STREET NORTHWEST" not in matches
+
+
+def test_direction_word_does_not_match_east_grand_avenue():
+    # "E" must NOT match "EAST GRAND AVENUE" (GRAND is not a street type).
+    matches = canonical_street_matches("E", _DC_STREETS)
+    assert "EAST GRAND AVENUE" not in matches
+    assert "EAST STREET NORTHEAST" in matches
+
+
+def test_canonical_street_match_direction_suffixed():
+    # canonical_street_match (singular) is consistent with canonical_street_matches.
+    result = canonical_street_match("N", _DC_STREETS)
+    assert result in {
+        "NORTH STREET NORTHEAST",
+        "NORTH STREET NORTHWEST",
+        "NORTH STREET SOUTHEAST",
+        "NORTH STREET SOUTHWEST",
+        "NORTH PLACE",
+        "NORTH PLACE SOUTHEAST",
+        "NORTH ROAD",
+    }


### PR DESCRIPTION
DC is a nightmare scenario for Mapsnap: lots of short, lettered and numbered streets with quadrant ambiguity.

Fixes #63 

- Supports "sb000..."-style page keys from IIIF files (needed to generate a Washington, D.C. IIIF file).
- Pick the highest-confidence hint for a location, not an arbitrary one.
- Detect quadrant words ("NW", "SE") as hints.
- Pass CLI flags from `fit` -> `georef`, e.g. `--min-long-side`.

Washington, D.C. 1916 Vol. 2 goes from 36 -> 61/136 georeferenced images with this change, though some of these are very far off. This has minimal effect on the other maps.