### PR TITLE
Normalize 21 ST and 21ST the same

### DIFF
--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -193,6 +193,24 @@ def normalize_street(text: str) -> str:
     words = text.split()
     if not words:
         return ""
+    # Merge a bare digit token with a following ordinal-suffix token ("21", "ST" → "21ST").
+    # Sanborn maps sometimes print a typographic gap between digit and suffix, causing the
+    # CTC decoder to emit "21 ST" instead of "21ST". Merging must precede STREET_ABBREVS
+    # expansion so that "ST" is not consumed as "STREET" before the ordinal is recognised.
+    merged: list[str] = []
+    i = 0
+    while i < len(words):
+        if (
+            i + 1 < len(words)
+            and words[i].isdigit()
+            and words[i + 1] in ("ST", "ND", "RD", "TH")
+        ):
+            merged.append(words[i] + words[i + 1])
+            i += 2
+        else:
+            merged.append(words[i])
+            i += 1
+    words = merged
     # Expand numeric ordinals; may expand one token to two ("21ST" → ["TWENTY", "FIRST"]).
     words = [w for token in words for w in _ORDINALS.get(token, token).split()]
     words[0] = DIRECTION_ABBREVS.get(words[0], words[0])

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -81,6 +81,26 @@ def test_normalize_ordinal_does_not_expand_non_ordinal_numbers():
     assert normalize_street("Route 66") == "ROUTE 66"
 
 
+def test_normalize_spaced_ordinal_suffix():
+    # "21 ST" (CTC gap between digit and suffix) should match "21ST" form.
+    assert normalize_street("21 ST") == normalize_street("21ST")
+    assert normalize_street("5 TH") == normalize_street("5TH")
+    assert normalize_street("2 ND") == normalize_street("2ND")
+    assert normalize_street("3 RD") == normalize_street("3RD")
+
+
+def test_normalize_spaced_ordinal_with_street_type():
+    # "21 ST ST" → "TWENTY FIRST STREET" (ordinal merged, then trailing ST→STREET)
+    assert normalize_street("21 ST ST") == "TWENTY FIRST STREET"
+    assert normalize_street("S 4 TH ST") == "SOUTH FOURTH STREET"
+
+
+def test_normalize_spaced_ordinal_does_not_merge_non_digit():
+    # Only bare digit tokens trigger the merge; letters must be left alone.
+    assert normalize_street("N ST") == normalize_street("N STREET")  # "N STREET"
+    assert normalize_street("K ST") == normalize_street("K STREET")
+
+
 # --- canonical_street_matches / canonical_street_match: direction-suffixed type keys ---
 
 _DC_STREETS = {


### PR DESCRIPTION
This is a fix for Queens. "21 ST" (with a space) was handled as "21 STREET", not "21ST STREET", whereas "21ST" was handled as "21ST STREET". Now they're consistent.