### PR TITLE
Rework file naming & directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,5 @@ __marimo__/
 .streamlit/secrets.toml
 
 data
+backup-data
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ So depending on where you get your Sanborn maps, the next steps will be differen
 ### OldInsuranceMaps
 
 ```bash
-mapsnap run-oim sanborn03376_029 new_orleans_la_1951_vol_5 r1836428 'https://s3.us-central-1.wasabisys.com/oldinsurancemaps/uploaded/documents/new_orleans_la_1951_vol_5_'
+mapsnap run-oim sanborn03376_029 data/new_orleans_la_1951_vol_5 r1836428 'https://s3.us-central-1.wasabisys.com/oldinsurancemaps/uploaded/documents/new_orleans_la_1951_vol_5_'
 ```
 
 The four arguments here are:
 
 - sanborn03376_029: Library of Congress (LoC) Sanborn Map ID number, also in the OIM URL.
-- new_orleans_la_1951_vol_5: directory slug. Output will go in `data/new_orleans_la_1951_vol_5`.
+- data/new_orleans_la_1951_vol_5: Output directory.
 - r1836428: Relation containing this map in OSM, usually a county. This is used to download all the streets in the area of the map.
 - 'https://...': OIM S3 bucket prefix for images. You can get this by downloading a JPEG of a page from the OIM web site.
 
@@ -176,11 +176,12 @@ The four arguments here are:
 
 - `mapsnap download-oim`: Downloads manifests and images from OldInsuranceMaps.
 - `mapsnap scale-images`: reduces the size of the images by a uniform scale factor so that OCR runs faster.
+- `mapsnap split`: Split composite maps into individual images.
 - `mapsnap download-osm` + `mapsnap osm-to-geojson`: Downloads all street data in the area from OpenStreetMap.
 - `mapsnap ocr`: runs OCR over the downscaled images, saving candidate detections to `boxes.json` and `streets.json` files.
 - `mapsnap fit`: another pipeline that runs:
   - `mapsnap georef`: georeferences images based on street detections, writing out `georef.json` files where it can find a good fit.
-  - `mapsnap iiif`: produces a IIIF Georeference Extension. You can find examples of these in the `gallery` directory. View them on Allmaps.
+  - `mapsnap iiif`: produces a IIIF Georeference Extension with clipping masks. You can find examples of these in the `gallery` directory. View them on Allmaps.
   - `mapsnap compare`: compares the generated IIIF file with the human-generated one from OIM, producing a report on the accuracy of the fit.
 
 `mapsnap ocr` is typically the slowest step. The steps under `mapsnap fit` run relatively quickly. You can run `mapsnap fit` yourself to experiment.
@@ -211,10 +212,11 @@ If you have your own directory of images that you've put together in some other 
 
 - Name the images after some notion of page number, e.g. `p123.jpg`.
 - Run `mapsnap download-osm` + `mapsnap osm-to-geojson` to get OSM data for the area around your images.
+- Run `mapsnap split` to detect split maps, if needed.
 - Run `mapsnap ocr` to find street labels for all your images. Use the Mapsnap debugger app to test if it worked on a few images.
 - Run `mapsnap georef` to georeference the images. Again, you may want to spot check a few maps in the debugger app.
 
-If you have a IIIF Manifest for your images, you can then run `mapsnap iiif` to produce a Georeference AnnotationPage that you can use to look at your complete map.
+If you have a IIIF Manifest for your images, you can then run `mapsnap iiif` to produce a Georeference AnnotationPage that you can use to look at your complete map. This will also produce clipping masks.
 
 ### Multivolume Runs
 

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -44,6 +44,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     ),
     "split-twopage": ("mapsnap.split_twopage", "Split two-page images in half"),
     "split": ("mapsnap.split", "Split map pages into individual panels"),
+    "oim-split-truth": (
+        "mapsnap.oim_truth",
+        "Locate OIM's manual split regions on the canvas for comparison",
+    ),
 }
 
 _cmd_width = max(len(cmd) for cmd in SUBCOMMANDS)

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -28,11 +28,15 @@ from pathlib import Path
 
 import numpy as np
 from shapely.geometry import Polygon as ShapelyPolygon
+from shapely.geometry import box
 
 from mapsnap.utils import source_id_to_page_key
 
 GCP = tuple[tuple[float, float], tuple[float, float]]  # ((px, py), (lon, lat))
 EARTH_RADIUS_FT = 20_925_524.0
+MIN_SPLIT_IOU = (
+    0.1  # minimum panel overlap to treat a truth and generated split as the same region
+)
 
 
 def extract_metadata_int(item: dict, label: str) -> int | None:
@@ -206,11 +210,16 @@ def angle_diff(a: float, b: float) -> float:
 def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
     """Compute accuracy metrics for one page by comparing two IIIF georef annotations.
 
-    Returns a dict with keys: page_key, n_truth, n_gen, rmse_ft, max_ft, trans_ft,
-    rot_err, scale_pct, skew_deg, aniso.
+    Returns a dict with keys: page_key, gen_page_key, n_truth, n_gen, rmse_ft, max_ft,
+    trans_ft, rot_err, scale_pct, skew_deg, aniso. page_key uses the truth's split
+    numbering; gen_page_key uses the matched generated split's numbering (they can differ
+    when OIM and our splitter number panels differently).
     """
     source_id: str = truth_item["target"]["source"]["id"]
     page_key = source_id_to_page_key(source_id, truth_item["label"])
+    gen_index = annotation_split_index(gen_item)
+    base_key = source_id_to_page_key(source_id, "")
+    gen_page_key = f"{base_key}__{gen_index}" if gen_index is not None else base_key
 
     truth_gcps = extract_gcps(truth_item)
     gen_gcps = extract_gcps(gen_item)
@@ -269,6 +278,7 @@ def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
 
     return {
         "page_key": page_key,
+        "gen_page_key": gen_page_key,
         "n_truth": len(truth_gcps),
         "n_gen": len(gen_gcps),
         "n_streets": extract_metadata_int(gen_item, "streets"),
@@ -303,12 +313,23 @@ def analyze_truth_only(truth_item: dict) -> dict:
     }
 
 
+def split_numbers_disagree(row: dict) -> bool:
+    """True if a paired row's truth and generated split numbering differ."""
+    gen_page_key = row.get("gen_page_key")
+    return gen_page_key is not None and gen_page_key != row["page_key"]
+
+
+def page_label(row: dict) -> str:
+    """Page column text: the truth page key, marked '(t)' when our numbering disagrees."""
+    return f"{row['page_key']} (t)" if split_numbers_disagree(row) else row["page_key"]
+
+
 def print_table(rows: list[dict], missing: list[dict]) -> None:
     """Print paired results (sorted by RMSE desc) then missing pages, with summary stats."""
     rows_sorted = sorted(rows, key=lambda r: r["rmse_ft"], reverse=True)
 
     header = (
-        f"{'Page':<9} {'n_t':>3} {'n_g':>3} {'str':>4} {'int':>4}  "
+        f"{'Page':<13} {'n_t':>3} {'n_g':>3} {'str':>4} {'int':>4}  "
         f"{'t.px/ft':>7}  {'g.px/ft':>7}  "
         f"{'rmse_ft':>8}  {'max_ft':>8}  {'trans_ft':>9}  "
         f"{'rot_err':>8}  {'scale_%':>7}  {'skew°':>6}  {'aniso':>6}"
@@ -319,18 +340,21 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
     for r in rows_sorted:
         n_str = r["n_streets"] if r["n_streets"] is not None else "—"
         n_int = r["n_intersections"] if r["n_intersections"] is not None else "—"
+        # When the split numbers disagree, note the matched generated page in the trailing
+        # column (where missing rows show "(no fit)").
+        trailing = f"  ({r['gen_page_key']})" if split_numbers_disagree(r) else ""
         print(
-            f"{r['page_key']:<9} {r['n_truth']:>3} {r['n_gen']:>3} {n_str!s:>4} {n_int!s:>4}  "
+            f"{page_label(r):<13} {r['n_truth']:>3} {r['n_gen']:>3} {n_str!s:>4} {n_int!s:>4}  "
             f"{r['truth_px_per_ft']:>7.2f}  {r['gen_px_per_ft']:>7.2f}  "
             f"{r['rmse_ft']:>8.1f}  {r['max_ft']:>8.1f}  {r['trans_ft']:>9.1f}  "
             f"{r['rot_err']:>+8.2f}  {r['scale_pct']:>+7.2f}  "
-            f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}"
+            f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}{trailing}"
         )
     if missing:
         missing_sorted = sorted(missing, key=lambda r: r["page_key"])
         for r in missing_sorted:
             print(
-                f"{r['page_key']:<9} {r['n_truth']:>3} {'—':>3} {'—':>4} {'—':>4}  "
+                f"{r['page_key']:<13} {r['n_truth']:>3} {'—':>3} {'—':>4} {'—':>4}  "
                 f"{'—':>7}  {'—':>7}  "
                 f"{'—':>8}  {'—':>8}  {'—':>9}  "
                 f"{'—':>8}  {'—':>7}  "
@@ -472,36 +496,54 @@ def match_split_pairs(
     gen_items: list[dict],
     truth_polygons: dict[int, ShapelyPolygon],
     gen_polygons: dict[int, ShapelyPolygon],
+    canvas_polygon: ShapelyPolygon | None = None,
 ) -> tuple[list[tuple[dict, dict]], list[dict]]:
     """Associate truth and generated split annotations by panel-polygon overlap.
 
-    OIM's split numbering need not match ours, so each truth split is paired with the
-    generated split whose panel polygon has the highest IoU (greedily, each generated
-    split used once). Both sides' polygons are in canvas coordinates. Returns
-    (pairs, unmatched_truth_items).
+    OIM's split numbering need not match ours, so pairs are chosen by greatest panel IoU
+    globally: every (truth, generated) pair with IoU >= MIN_SPLIT_IOU is considered, and
+    the highest-overlap pairs are assigned first (each split used once). Choosing globally
+    rather than per-truth-in-file-order matters — a truth split that merely grazes a
+    generated panel must not claim it ahead of the truth split that actually overlaps it.
+
+    When OIM split a page but we kept it whole, the generated annotation has no split index;
+    canvas_polygon (the full page) then stands in as its panel, so it pairs with the truth
+    split it most overlaps — i.e. the largest split. Both sides' polygons are in canvas
+    coordinates. Returns (pairs, unmatched_truth_items).
     """
-    available = list(gen_items)
-    pairs: list[tuple[dict, dict]] = []
-    unmatched: list[dict] = []
-    for truth in truth_items:
+
+    def gen_polygon(gen: dict) -> ShapelyPolygon | None:
+        gen_index = annotation_split_index(gen)
+        if gen_index is not None:
+            return gen_polygons.get(gen_index)
+        return canvas_polygon  # unsplit page: one panel covering the whole canvas
+
+    candidates: list[tuple[float, int, int]] = []  # (iou, truth_idx, gen_idx)
+    for ti, truth in enumerate(truth_items):
         truth_index = label_split_index(truth)
         truth_poly = truth_polygons.get(truth_index) if truth_index else None
-        best_gen: dict | None = None
-        best_iou = 0.0
-        if truth_poly is not None:
-            for gen in available:
-                gen_index = annotation_split_index(gen)
-                gen_poly = gen_polygons.get(gen_index) if gen_index else None
-                if gen_poly is None:
-                    continue
-                iou = polygon_iou(truth_poly, gen_poly)
-                if iou > best_iou:
-                    best_iou, best_gen = iou, gen
-        if best_gen is not None:
-            pairs.append((truth, best_gen))
-            available.remove(best_gen)
-        else:
-            unmatched.append(truth)
+        if truth_poly is None:
+            continue
+        for gi, gen in enumerate(gen_items):
+            gen_poly = gen_polygon(gen)
+            if gen_poly is None:
+                continue
+            iou = polygon_iou(truth_poly, gen_poly)
+            if iou >= MIN_SPLIT_IOU:
+                candidates.append((iou, ti, gi))
+
+    candidates.sort(reverse=True)  # assign highest-overlap pairs first
+    used_truth: set[int] = set()
+    used_gen: set[int] = set()
+    pairs: list[tuple[dict, dict]] = []
+    for _iou, ti, gi in candidates:
+        if ti in used_truth or gi in used_gen:
+            continue
+        pairs.append((truth_items[ti], gen_items[gi]))
+        used_truth.add(ti)
+        used_gen.add(gi)
+
+    unmatched = [t for ti, t in enumerate(truth_items) if ti not in used_truth]
     return pairs, unmatched
 
 
@@ -563,8 +605,11 @@ def main() -> None:
         gen_polygons = load_split_polygons(
             gen_dir / f"{page_key}.panels.json", source_dims
         )
+        # If we kept the page whole, a generated annotation with no split index stands in
+        # for a panel covering the full canvas, matching the largest truth split.
+        canvas_polygon = box(0.0, 0.0, source_dims[0], source_dims[1])
         pairs, unmatched = match_split_pairs(
-            truth_splits, gen_items, truth_polygons, gen_polygons
+            truth_splits, gen_items, truth_polygons, gen_polygons, canvas_polygon
         )
         rows.extend(analyze_pair(t, g) for t, g in pairs)
         missing.extend(analyze_truth_only(t) for t in unmatched)

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -23,11 +23,14 @@ import json
 import math
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
 
 from mapsnap.utils import source_id_to_page_key
+
+Rect = tuple[float, float, float, float]  # (x, y, w, h) in canvas pixels
 
 GCP = tuple[tuple[float, float], tuple[float, float]]  # ((px, py), (lon, lat))
 EARTH_RADIUS_FT = 20_925_524.0
@@ -401,19 +404,98 @@ def print_tsv(rows: list[dict], missing: list[dict]) -> None:
         print("\t".join(row_vals[f] for f in fields))
 
 
-def load_items_by_source(path: Path) -> dict[str, dict]:
-    """Load a IIIF AnnotationPage and index items by target.source.id."""
+def annotations_by_source(path: Path) -> dict[str, list[dict]]:
+    """Load a IIIF AnnotationPage, grouping items by target.source.id.
+
+    Split pages produce several items per source id (they share the parent canvas);
+    full pages produce one. Group order follows file order.
+    """
     data: dict = json.loads(path.read_text())
-    index: dict[str, dict] = {}
+    groups: dict[str, list[dict]] = defaultdict(list)
     for item in data.get("items", []):
-        source_id: str = item["target"]["source"]["id"]
-        if item["label"].endswith("]"):
-            m = re.search(r"\[(\d+)\]$", item["label"])
-            assert m
-            split = m.group(1)
-            source_id += f"__{split}"
-        index[source_id] = item
-    return index
+        groups[item["target"]["source"]["id"]].append(item)
+    return dict(groups)
+
+
+def label_split_index(item: dict) -> int | None:
+    """Return split number N from a label ending in '[N]', or None for full pages."""
+    m = re.search(r"\[(\d+)\]$", item.get("label", ""))
+    return int(m.group(1)) if m else None
+
+
+def gen_split_region(item: dict) -> Rect | None:
+    """Return a generated annotation's split canvas region (x, y, w, h), or None."""
+    cx = extract_metadata_float(item, "split_canvas_x")
+    cy = extract_metadata_float(item, "split_canvas_y")
+    cw = extract_metadata_float(item, "split_canvas_w")
+    ch = extract_metadata_float(item, "split_canvas_h")
+    if cx is None or cy is None or cw is None or ch is None:
+        return None
+    return (cx, cy, cw, ch)
+
+
+def rect_iou(a: Rect, b: Rect) -> float:
+    """Intersection-over-union of two (x, y, w, h) rectangles."""
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    ix = max(0.0, min(ax + aw, bx + bw) - max(ax, bx))
+    iy = max(0.0, min(ay + ah, by + bh) - max(ay, by))
+    inter = ix * iy
+    union = aw * ah + bw * bh - inter
+    return inter / union if union > 0 else 0.0
+
+
+def load_truth_split_regions(oim_dir: Path, page_key: str) -> dict[int, Rect]:
+    """Load OIM split canvas regions (x, y, w, h) keyed by split index.
+
+    Reads oim/<page_key>.panels.json, written by `mapsnap oim-split-truth`, whose rings
+    are bounding rectangles in full-resolution canvas coordinates. Returns {} if absent.
+    """
+    path = oim_dir / f"{page_key}.panels.json"
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text())
+    regions: dict[int, Rect] = {}
+    for i, ring in enumerate(data["panels"], start=1):
+        xs = [pt[0] for pt in ring]
+        ys = [pt[1] for pt in ring]
+        regions[i] = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
+    return regions
+
+
+def match_split_pairs(
+    truth_items: list[dict],
+    gen_items: list[dict],
+    truth_regions: dict[int, Rect],
+) -> tuple[list[tuple[dict, dict]], list[dict]]:
+    """Associate truth and generated split annotations by canvas-region overlap.
+
+    OIM's split numbering need not match ours, so each truth split is paired with the
+    generated split whose split_canvas region has the highest IoU (greedily, each
+    generated split used once). Returns (pairs, unmatched_truth_items).
+    """
+    available = list(gen_items)
+    pairs: list[tuple[dict, dict]] = []
+    unmatched: list[dict] = []
+    for truth in truth_items:
+        truth_index = label_split_index(truth)
+        truth_rect = truth_regions.get(truth_index) if truth_index else None
+        best_gen: dict | None = None
+        best_iou = 0.0
+        if truth_rect is not None:
+            for gen in available:
+                gen_rect = gen_split_region(gen)
+                if gen_rect is None:
+                    continue
+                iou = rect_iou(truth_rect, gen_rect)
+                if iou > best_iou:
+                    best_iou, best_gen = iou, gen
+        if best_gen is not None:
+            pairs.append((truth, best_gen))
+            available.remove(best_gen)
+        else:
+            unmatched.append(truth)
+    return pairs, unmatched
 
 
 def main() -> None:
@@ -441,23 +523,36 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    truth_items = load_items_by_source(Path(args.truth))
-    gen_items = load_items_by_source(Path(args.generated))
+    truth_by_source = annotations_by_source(Path(args.truth))
+    gen_by_source = annotations_by_source(Path(args.generated))
+    oim_dir = Path(args.truth).parent / "oim"
 
-    n_truth_total = len(truth_items)
+    n_truth_total = sum(len(items) for items in truth_by_source.values())
+    n_gen_total = sum(len(items) for items in gen_by_source.values())
     print(
-        f"Truth: {n_truth_total} pages  |  Generated: {len(gen_items)} pages",
+        f"Truth: {n_truth_total} pages  |  Generated: {n_gen_total} pages",
         file=sys.stderr,
     )
 
     rows: list[dict] = []
     missing: list[dict] = []
-    for source_id, truth_item in sorted(truth_items.items()):
-        gen_item = gen_items.get(source_id)
-        if gen_item is None:
-            missing.append(analyze_truth_only(truth_item))
-        else:
-            rows.append(analyze_pair(truth_item, gen_item))
+    for source_id, truth_items in sorted(truth_by_source.items()):
+        gen_items = gen_by_source.get(source_id, [])
+        truth_splits = [t for t in truth_items if label_split_index(t) is not None]
+        if not truth_splits:
+            # Full page: pair the single truth and generated annotations directly.
+            gen_item = gen_items[0] if gen_items else None
+            if gen_item is None:
+                missing.append(analyze_truth_only(truth_items[0]))
+            else:
+                rows.append(analyze_pair(truth_items[0], gen_item))
+            continue
+        # Split page: associate by canvas-region overlap (numbering may differ).
+        page_key = source_id_to_page_key(source_id, "")
+        truth_regions = load_truth_split_regions(oim_dir, page_key)
+        pairs, unmatched = match_split_pairs(truth_splits, gen_items, truth_regions)
+        rows.extend(analyze_pair(t, g) for t, g in pairs)
+        missing.extend(analyze_truth_only(t) for t in unmatched)
 
     if args.omit_missing:
         missing = []

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -27,10 +27,9 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
+from shapely.geometry import Polygon as ShapelyPolygon
 
 from mapsnap.utils import source_id_to_page_key
-
-Rect = tuple[float, float, float, float]  # (x, y, w, h) in canvas pixels
 
 GCP = tuple[tuple[float, float], tuple[float, float]]  # ((px, py), (lon, lat))
 EARTH_RADIUS_FT = 20_925_524.0
@@ -423,71 +422,79 @@ def label_split_index(item: dict) -> int | None:
     return int(m.group(1)) if m else None
 
 
-def gen_split_region(item: dict) -> Rect | None:
-    """Return a generated annotation's split canvas region (x, y, w, h), or None."""
-    cx = extract_metadata_float(item, "split_canvas_x")
-    cy = extract_metadata_float(item, "split_canvas_y")
-    cw = extract_metadata_float(item, "split_canvas_w")
-    ch = extract_metadata_float(item, "split_canvas_h")
-    if cx is None or cy is None or cw is None or ch is None:
-        return None
-    return (cx, cy, cw, ch)
+def annotation_split_index(item: dict) -> int | None:
+    """Return split number N from a generated annotation id like '...__N/georef'."""
+    m = re.search(r"__(\d+)/", item.get("id", ""))
+    return int(m.group(1)) if m else None
 
 
-def rect_iou(a: Rect, b: Rect) -> float:
-    """Intersection-over-union of two (x, y, w, h) rectangles."""
-    ax, ay, aw, ah = a
-    bx, by, bw, bh = b
-    ix = max(0.0, min(ax + aw, bx + bw) - max(ax, bx))
-    iy = max(0.0, min(ay + ah, by + bh) - max(ay, by))
-    inter = ix * iy
-    union = aw * ah + bw * bh - inter
+def ring_to_polygon(ring: list[list[float]]) -> ShapelyPolygon:
+    """A panels.json ring as a valid Shapely polygon (buffer(0) repairs self-intersection)."""
+    polygon = ShapelyPolygon(ring)
+    return polygon if polygon.is_valid else polygon.buffer(0)
+
+
+def polygon_iou(a: ShapelyPolygon, b: ShapelyPolygon) -> float:
+    """Intersection-over-union of two polygons; 0 if disjoint or empty."""
+    if a.is_empty or b.is_empty:
+        return 0.0
+    inter = a.intersection(b).area
+    union = a.area + b.area - inter
     return inter / union if union > 0 else 0.0
 
 
-def load_truth_split_regions(oim_dir: Path, page_key: str) -> dict[int, Rect]:
-    """Load OIM split canvas regions (x, y, w, h) keyed by split index.
+def load_split_polygons(
+    path: Path, source_dims: tuple[float, float] | None = None
+) -> dict[int, ShapelyPolygon]:
+    """Load panels.json rings as polygons keyed by 1-based split index.
 
-    Reads oim/<page_key>.panels.json, written by `mapsnap oim-split-truth`, whose rings
-    are bounding rectangles in full-resolution canvas coordinates. Returns {} if absent.
+    OIM truth panels (oim/pN.panels.json) are already in canvas coordinates, so pass
+    source_dims=None. Our generated panels (pN.panels.json) are in the 25%-scale page
+    frame; pass the canvas (source) width/height to scale them up to canvas coordinates.
+    Returns {} if the file is absent.
     """
-    path = oim_dir / f"{page_key}.panels.json"
     if not path.exists():
         return {}
     data = json.loads(path.read_text())
-    regions: dict[int, Rect] = {}
-    for i, ring in enumerate(data["panels"], start=1):
-        xs = [pt[0] for pt in ring]
-        ys = [pt[1] for pt in ring]
-        regions[i] = (min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys))
-    return regions
+    if source_dims is not None:
+        scale_x = source_dims[0] / data["width"]
+        scale_y = source_dims[1] / data["height"]
+    else:
+        scale_x = scale_y = 1.0
+    return {
+        i: ring_to_polygon([[x * scale_x, y * scale_y] for x, y in ring])
+        for i, ring in enumerate(data["panels"], start=1)
+    }
 
 
 def match_split_pairs(
     truth_items: list[dict],
     gen_items: list[dict],
-    truth_regions: dict[int, Rect],
+    truth_polygons: dict[int, ShapelyPolygon],
+    gen_polygons: dict[int, ShapelyPolygon],
 ) -> tuple[list[tuple[dict, dict]], list[dict]]:
-    """Associate truth and generated split annotations by canvas-region overlap.
+    """Associate truth and generated split annotations by panel-polygon overlap.
 
     OIM's split numbering need not match ours, so each truth split is paired with the
-    generated split whose split_canvas region has the highest IoU (greedily, each
-    generated split used once). Returns (pairs, unmatched_truth_items).
+    generated split whose panel polygon has the highest IoU (greedily, each generated
+    split used once). Both sides' polygons are in canvas coordinates. Returns
+    (pairs, unmatched_truth_items).
     """
     available = list(gen_items)
     pairs: list[tuple[dict, dict]] = []
     unmatched: list[dict] = []
     for truth in truth_items:
         truth_index = label_split_index(truth)
-        truth_rect = truth_regions.get(truth_index) if truth_index else None
+        truth_poly = truth_polygons.get(truth_index) if truth_index else None
         best_gen: dict | None = None
         best_iou = 0.0
-        if truth_rect is not None:
+        if truth_poly is not None:
             for gen in available:
-                gen_rect = gen_split_region(gen)
-                if gen_rect is None:
+                gen_index = annotation_split_index(gen)
+                gen_poly = gen_polygons.get(gen_index) if gen_index else None
+                if gen_poly is None:
                     continue
-                iou = rect_iou(truth_rect, gen_rect)
+                iou = polygon_iou(truth_poly, gen_poly)
                 if iou > best_iou:
                     best_iou, best_gen = iou, gen
         if best_gen is not None:
@@ -526,6 +533,7 @@ def main() -> None:
     truth_by_source = annotations_by_source(Path(args.truth))
     gen_by_source = annotations_by_source(Path(args.generated))
     oim_dir = Path(args.truth).parent / "oim"
+    gen_dir = Path(args.generated).parent
 
     n_truth_total = sum(len(items) for items in truth_by_source.values())
     n_gen_total = sum(len(items) for items in gen_by_source.values())
@@ -547,10 +555,17 @@ def main() -> None:
             else:
                 rows.append(analyze_pair(truth_items[0], gen_item))
             continue
-        # Split page: associate by canvas-region overlap (numbering may differ).
+        # Split page: associate by panel-polygon overlap (numbering may differ).
         page_key = source_id_to_page_key(source_id, "")
-        truth_regions = load_truth_split_regions(oim_dir, page_key)
-        pairs, unmatched = match_split_pairs(truth_splits, gen_items, truth_regions)
+        source = truth_items[0]["target"]["source"]
+        source_dims = (float(source["width"]), float(source["height"]))
+        truth_polygons = load_split_polygons(oim_dir / f"{page_key}.panels.json")
+        gen_polygons = load_split_polygons(
+            gen_dir / f"{page_key}.panels.json", source_dims
+        )
+        pairs, unmatched = match_split_pairs(
+            truth_splits, gen_items, truth_polygons, gen_polygons
+        )
         rows.extend(analyze_pair(t, g) for t, g in pairs)
         missing.extend(analyze_truth_only(t) for t in unmatched)
 

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -1,0 +1,60 @@
+"""Tests for split association in mapsnap.compare_iiif_georef."""
+
+from mapsnap.compare_iiif_georef import (
+    gen_split_region,
+    match_split_pairs,
+    rect_iou,
+)
+
+
+def test_rect_iou_identical_and_disjoint():
+    assert rect_iou((0, 0, 10, 10), (0, 0, 10, 10)) == 1.0
+    assert rect_iou((0, 0, 10, 10), (20, 20, 10, 10)) == 0.0
+
+
+def test_rect_iou_partial_overlap():
+    # Two 10×10 squares overlapping in a 5×5 corner: inter=25, union=175.
+    assert rect_iou((0, 0, 10, 10), (5, 5, 10, 10)) == 25 / 175
+
+
+def _gen_item(label: str, region: tuple[float, float, float, float]) -> dict:
+    x, y, w, h = region
+    return {
+        "label": label,
+        "metadata": [
+            {"label": "split_canvas_x", "value": str(x)},
+            {"label": "split_canvas_y", "value": str(y)},
+            {"label": "split_canvas_w", "value": str(w)},
+            {"label": "split_canvas_h", "value": str(h)},
+        ],
+    }
+
+
+def test_gen_split_region_reads_metadata():
+    assert gen_split_region(_gen_item("p4 [1]", (1, 2, 3, 4))) == (1.0, 2.0, 3.0, 4.0)
+    assert gen_split_region({"label": "p4", "metadata": []}) is None
+
+
+def test_match_split_pairs_associates_by_overlap_ignoring_numbering():
+    # OIM truth: split 1 is the left region, split 2 the right.
+    truth_regions = {1: (0.0, 0.0, 100.0, 200.0), 2: (100.0, 0.0, 100.0, 200.0)}
+    truth_items = [{"label": "P [1]"}, {"label": "P [2]"}]
+    # Our numbering is reversed: gen "[1]" sits on the right, "[2]" on the left.
+    gen_items = [
+        _gen_item("P [1]", (100, 0, 100, 200)),
+        _gen_item("P [2]", (0, 0, 100, 200)),
+    ]
+
+    pairs, unmatched = match_split_pairs(truth_items, gen_items, truth_regions)
+
+    assert unmatched == []
+    paired = {t["label"]: g["label"] for t, g in pairs}
+    assert paired == {"P [1]": "P [2]", "P [2]": "P [1]"}
+
+
+def test_match_split_pairs_unmatched_when_no_gen_region():
+    truth_regions = {1: (0.0, 0.0, 100.0, 200.0)}
+    truth_items = [{"label": "P [1]"}]
+    pairs, unmatched = match_split_pairs(truth_items, [], truth_regions)
+    assert pairs == []
+    assert unmatched == truth_items

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -1,60 +1,81 @@
 """Tests for split association in mapsnap.compare_iiif_georef."""
 
+import json
+
+from shapely.geometry import Polygon as ShapelyPolygon
+
 from mapsnap.compare_iiif_georef import (
-    gen_split_region,
+    annotation_split_index,
+    load_split_polygons,
     match_split_pairs,
-    rect_iou,
+    polygon_iou,
 )
 
 
-def test_rect_iou_identical_and_disjoint():
-    assert rect_iou((0, 0, 10, 10), (0, 0, 10, 10)) == 1.0
-    assert rect_iou((0, 0, 10, 10), (20, 20, 10, 10)) == 0.0
+def _square(x: float, y: float, side: float) -> ShapelyPolygon:
+    return ShapelyPolygon([(x, y), (x + side, y), (x + side, y + side), (x, y + side)])
 
 
-def test_rect_iou_partial_overlap():
+def test_polygon_iou_identical_and_disjoint():
+    a = _square(0, 0, 10)
+    assert polygon_iou(a, a) == 1.0
+    assert polygon_iou(a, _square(20, 20, 10)) == 0.0
+
+
+def test_polygon_iou_partial_overlap():
     # Two 10×10 squares overlapping in a 5×5 corner: inter=25, union=175.
-    assert rect_iou((0, 0, 10, 10), (5, 5, 10, 10)) == 25 / 175
+    assert polygon_iou(_square(0, 0, 10), _square(5, 5, 10)) == 25 / 175
 
 
-def _gen_item(label: str, region: tuple[float, float, float, float]) -> dict:
-    x, y, w, h = region
-    return {
-        "label": label,
-        "metadata": [
-            {"label": "split_canvas_x", "value": str(x)},
-            {"label": "split_canvas_y", "value": str(y)},
-            {"label": "split_canvas_w", "value": str(w)},
-            {"label": "split_canvas_h", "value": str(h)},
-        ],
-    }
+def test_annotation_split_index_parses_id():
+    assert annotation_split_index({"id": "http://x/p4__2/georef"}) == 2
+    assert annotation_split_index({"id": "http://x/p4/georef"}) is None
+    assert annotation_split_index({}) is None
 
 
-def test_gen_split_region_reads_metadata():
-    assert gen_split_region(_gen_item("p4 [1]", (1, 2, 3, 4))) == (1.0, 2.0, 3.0, 4.0)
-    assert gen_split_region({"label": "p4", "metadata": []}) is None
+def _write_panels(path, width, height, rings):
+    path.write_text(
+        json.dumps(
+            {"image": "p.jpg", "width": width, "height": height, "panels": rings}
+        )
+    )
 
 
-def test_match_split_pairs_associates_by_overlap_ignoring_numbering():
-    # OIM truth: split 1 is the left region, split 2 the right.
-    truth_regions = {1: (0.0, 0.0, 100.0, 200.0), 2: (100.0, 0.0, 100.0, 200.0)}
+def test_load_split_polygons_scales_generated_panels(tmp_path):
+    # A 50×100 ring in a 100×200 (25%) frame scales ×4 to an 800×1600 canvas.
+    panels = tmp_path / "p4.panels.json"
+    _write_panels(panels, 100, 200, [[[0, 0], [50, 0], [50, 100], [0, 100]]])
+
+    truth = load_split_polygons(panels)  # no scaling
+    assert truth[1].bounds == (0.0, 0.0, 50.0, 100.0)
+
+    gen = load_split_polygons(panels, source_dims=(800.0, 1600.0))  # ×8, ×8
+    assert gen[1].bounds == (0.0, 0.0, 400.0, 800.0)
+
+
+def test_match_split_pairs_associates_by_polygon_overlap_ignoring_numbering():
+    # Truth split 1 is the left half, split 2 the right half (canvas coords).
+    truth_polygons = {1: _square(0, 0, 100), 2: _square(100, 0, 100)}
     truth_items = [{"label": "P [1]"}, {"label": "P [2]"}]
-    # Our numbering is reversed: gen "[1]" sits on the right, "[2]" on the left.
+    # Our numbering is reversed: gen __1 sits on the right, __2 on the left.
     gen_items = [
-        _gen_item("P [1]", (100, 0, 100, 200)),
-        _gen_item("P [2]", (0, 0, 100, 200)),
+        {"id": "http://x/p__1/georef"},
+        {"id": "http://x/p__2/georef"},
     ]
+    gen_polygons = {1: _square(100, 0, 100), 2: _square(0, 0, 100)}
 
-    pairs, unmatched = match_split_pairs(truth_items, gen_items, truth_regions)
+    pairs, unmatched = match_split_pairs(
+        truth_items, gen_items, truth_polygons, gen_polygons
+    )
 
     assert unmatched == []
-    paired = {t["label"]: g["label"] for t, g in pairs}
-    assert paired == {"P [1]": "P [2]", "P [2]": "P [1]"}
+    paired = {t["label"]: g["id"] for t, g in pairs}
+    assert paired == {"P [1]": "http://x/p__2/georef", "P [2]": "http://x/p__1/georef"}
 
 
-def test_match_split_pairs_unmatched_when_no_gen_region():
-    truth_regions = {1: (0.0, 0.0, 100.0, 200.0)}
+def test_match_split_pairs_unmatched_when_no_gen_polygon():
+    truth_polygons = {1: _square(0, 0, 100)}
     truth_items = [{"label": "P [1]"}]
-    pairs, unmatched = match_split_pairs(truth_items, [], truth_regions)
+    pairs, unmatched = match_split_pairs(truth_items, [], truth_polygons, {})
     assert pairs == []
     assert unmatched == truth_items

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -8,8 +8,27 @@ from mapsnap.compare_iiif_georef import (
     annotation_split_index,
     load_split_polygons,
     match_split_pairs,
+    page_label,
     polygon_iou,
+    split_numbers_disagree,
 )
+
+
+def test_split_numbering_annotations():
+    # Numbers agree → plain key, no disagreement.
+    agree = {"page_key": "p13__1", "gen_page_key": "p13__1"}
+    assert split_numbers_disagree(agree) is False
+    assert page_label(agree) == "p13__1"
+
+    # Numbers disagree → '(t)' marker on the truth key.
+    disagree = {"page_key": "p13__1", "gen_page_key": "p13__2"}
+    assert split_numbers_disagree(disagree) is True
+    assert page_label(disagree) == "p13__1 (t)"
+
+    # Full pages (no gen_page_key, e.g. missing rows) are never flagged.
+    full = {"page_key": "p13"}
+    assert split_numbers_disagree(full) is False
+    assert page_label(full) == "p13"
 
 
 def _square(x: float, y: float, side: float) -> ShapelyPolygon:
@@ -73,9 +92,56 @@ def test_match_split_pairs_associates_by_polygon_overlap_ignoring_numbering():
     assert paired == {"P [1]": "http://x/p__2/georef", "P [2]": "http://x/p__1/georef"}
 
 
+def test_match_split_pairs_unsplit_page_matches_largest_truth_split():
+    # OIM split the page into 3 panels of different sizes; we kept it whole, so the
+    # generated annotation has no split index and stands in as the full canvas.
+    truth_polygons = {
+        1: _square(0, 0, 100),  # area 10_000
+        2: _square(0, 0, 200),  # area 40_000 — largest
+        3: _square(0, 0, 50),  # area 2_500 — below MIN_SPLIT_IOU vs the canvas
+    }
+    truth_items = [{"label": "P [3]"}, {"label": "P [2]"}, {"label": "P [1]"}]
+    gen_items = [{"id": "http://x/p3/georef"}]  # no __N → unsplit page
+    canvas = _square(0, 0, 300)  # area 90_000
+
+    pairs, unmatched = match_split_pairs(
+        truth_items, gen_items, truth_polygons, {}, canvas_polygon=canvas
+    )
+
+    assert len(pairs) == 1
+    truth, gen = pairs[0]
+    assert truth["label"] == "P [2]"  # the largest split
+    assert gen["id"] == "http://x/p3/georef"
+    assert {t["label"] for t in unmatched} == {"P [1]", "P [3]"}
+
+
 def test_match_split_pairs_unmatched_when_no_gen_polygon():
     truth_polygons = {1: _square(0, 0, 100)}
     truth_items = [{"label": "P [1]"}]
     pairs, unmatched = match_split_pairs(truth_items, [], truth_polygons, {})
     assert pairs == []
     assert unmatched == truth_items
+
+
+def test_match_split_pairs_picks_best_overlap_not_file_order():
+    # The single generated panel overlaps truth [1] strongly; truth [3], listed first,
+    # only grazes it. The grazing split must not claim the generated panel ahead of the
+    # real match (regression for the champaign p4__3 mismatch).
+    truth_polygons = {
+        1: _square(0, 0, 100),
+        2: _square(200, 0, 100),
+        3: _square(99, 0, 2),  # tiny overlap with the generated panel's right edge
+    }
+    truth_items = [{"label": "P [3]"}, {"label": "P [2]"}, {"label": "P [1]"}]
+    gen_items = [{"id": "http://x/p__1/georef"}]
+    gen_polygons = {1: _square(0, 0, 100)}
+
+    pairs, unmatched = match_split_pairs(
+        truth_items, gen_items, truth_polygons, gen_polygons
+    )
+
+    assert len(pairs) == 1
+    truth, gen = pairs[0]
+    assert truth["label"] == "P [1]"
+    assert gen["id"] == "http://x/p__1/georef"
+    assert {t["label"] for t in unmatched} == {"P [2]", "P [3]"}

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -100,6 +100,18 @@ def _streets_path(image_path: str) -> str:
     return str(Path(image_path).parent / (stem + ".streets.json"))
 
 
+def has_split_panels(image_path: str) -> bool:
+    """True if image_path is a whole page already split into <stem>__N.jpg panels.
+
+    Such a parent page is superseded by its panels and should not be OCR'd; the panels
+    are processed instead. Returns False for the panels themselves (stems with '__').
+    """
+    stem = image_stem(image_path)
+    if "__" in stem:
+        return False
+    return any(Path(image_path).parent.glob(f"{stem}__*.jpg"))
+
+
 def _craft_detect_all_angles(
     img: Image.Image,
     reader: easyocr.Reader,
@@ -503,7 +515,19 @@ def main() -> None:
         file=sys.stderr,
     )
 
+    # Never OCR a page that has been split into panels; OCR its panels instead. This
+    # mirrors mapsnap.utils.list_pages so the rule holds however ocr is invoked (pipeline
+    # or a raw shell glob that happens to include the parent).
     images = args.images
+    superseded = [p for p in images if has_split_panels(p)]
+    if superseded:
+        images = [p for p in images if p not in superseded]
+        print(
+            f"Skipping {len(superseded)} split parent page(s): "
+            + ", ".join(Path(p).name for p in superseded),
+            file=sys.stderr,
+        )
+
     if args.resume:
         images = [
             p

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -2,12 +2,33 @@
 
 import numpy as np
 
-from mapsnap.detect_text import NON_STREET_TEXT, _erase_underlines, filter_args
+from mapsnap.detect_text import (
+    NON_STREET_TEXT,
+    _erase_underlines,
+    filter_args,
+    has_split_panels,
+)
 from mapsnap.streets import (
     canonical_street_match,
     matches_any_street,
     normalize_street,
 )
+
+
+def test_has_split_panels(tmp_path):
+    (tmp_path / "p428.jpg").touch()
+    (tmp_path / "p428__1.jpg").touch()
+    (tmp_path / "p428__2.jpg").touch()
+    (tmp_path / "p528.jpg").touch()  # unsplit page, no panels
+
+    # Parent with panels is superseded; panels and unsplit pages are not.
+    assert has_split_panels(str(tmp_path / "p428.jpg")) is True
+    assert has_split_panels(str(tmp_path / "p428__1.jpg")) is False
+    assert has_split_panels(str(tmp_path / "p528.jpg")) is False
+    # The "p4__" prefix must not match "p428__N" (delimiter-aware).
+    (tmp_path / "p4.jpg").touch()
+    assert has_split_panels(str(tmp_path / "p4.jpg")) is False
+
 
 # ---------------------------------------------------------------------------
 # normalize_street

--- a/mapsnap/download_loc_iiif.py
+++ b/mapsnap/download_loc_iiif.py
@@ -51,7 +51,7 @@ def process_canvas(
     page_key = canvas_to_page_key(canvas_id, label)
     assert page_key != "iiif", f"Could not extract valid page key from {canvas_id}"
     image_url = f"{canvas_id}/full/{scale}/0/default.jpg"
-    image_path = output_dir / f"{page_key}.raw.jpg"
+    image_path = output_dir / f"{page_key}.jpg"
 
     if image_path.exists():
         print(f"  Already done: {image_path.name}", file=sys.stderr)
@@ -76,7 +76,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Download LOC images from a local IIIF Presentation manifest. "
-            "Saves one .raw.jpg per canvas alongside the IIIF file."
+            "Saves one <page_key>.jpg per canvas alongside the IIIF file."
         )
     )
     parser.add_argument(

--- a/mapsnap/download_oim_iiif.py
+++ b/mapsnap/download_oim_iiif.py
@@ -76,31 +76,18 @@ def download_oim_image(url: str, dest: Path) -> None:
         download_with_retry(actual_url, dest)
 
 
-def _download_unsplit_image(
-    base_key: str,
-    output_dir: Path,
-    oim_url_prefix: str,
-    dry_run: bool,
-) -> None:
-    """Download the un-split version of a split page (e.g. p4 for p4__2).
-
-    Saves to <base_key>.unsplit.jpg. Skips if the file already exists.
-    """
-    unsplit_path = output_dir / f"{base_key}.unsplit.jpg"
-    if unsplit_path.exists():
-        print(f"    Unsplit already done: {unsplit_path.name}", file=sys.stderr)
+def _download_if_missing(url: str, dest: Path, dry_run: bool) -> None:
+    """Download url to dest unless dest already exists. Creates parent dirs."""
+    if dest.exists():
+        print(f"    Already done: {dest.name}", file=sys.stderr)
         return
-
-    unsplit_url = f"{oim_url_prefix}{base_key}.jpg"
-    print(f"    Unsplit URL: {unsplit_url}", file=sys.stderr)
-
+    print(f"    {url} → {dest}", file=sys.stderr)
     if dry_run:
         return
-
-    print(f"    Downloading unsplit → {unsplit_path.name} ...", file=sys.stderr)
-    download_oim_image(unsplit_url, unsplit_path)
-    dl_width, dl_height = jpeg_dimensions(unsplit_path)
-    print(f"    Unsplit downloaded: {dl_width}×{dl_height}", file=sys.stderr)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    download_oim_image(url, dest)
+    dl_width, dl_height = jpeg_dimensions(dest)
+    print(f"    Downloaded: {dl_width}×{dl_height}", file=sys.stderr)
 
 
 def process_annotation(
@@ -109,11 +96,14 @@ def process_annotation(
     oim_url_prefix: str,
     dry_run: bool,
 ) -> bool:
-    """Download the image for one annotation item.
+    """Download the images for one annotation item into the canonical layout.
 
-    Returns True on success, False if the item was skipped or failed.
-    For split page keys (ending in __N), also downloads the un-split image
-    as <base_key>.unsplit.jpg so it can serve as a reference for sub-image bounds.
+    The full-resolution unsplit page goes to raw/<base_key>.jpg (the pipeline input).
+    For split annotations (page key ending in __N), OIM's manually-generated split
+    region also goes to oim/<page_key>.jpg as comparison ground truth; the unsplit
+    raw/<base_key>.jpg serves as the template-matching reference.
+
+    Returns True on success, False if the item was skipped.
     """
     label: str = item.get("label", "unknown")
     page_key = label_to_page_key(label)
@@ -121,35 +111,23 @@ def process_annotation(
         print(f"  Skipping '{label}': could not extract page key.", file=sys.stderr)
         return False
 
-    target = item.get("target", {})
-    source = target.get("source", {})
-    full_width: int = source.get("width", 0)
-    full_height: int = source.get("height", 0)
+    print(f"  {label}", file=sys.stderr)
+    base_key = page_key.split("__")[0]
 
-    if not full_width or not full_height:
-        print(f"  Skipping '{label}': missing source dimensions.", file=sys.stderr)
-        return False
+    # Full-resolution unsplit page → raw/ (downloaded once per page).
+    _download_if_missing(
+        f"{oim_url_prefix}{base_key}.jpg",
+        output_dir / "raw" / f"{base_key}.jpg",
+        dry_run,
+    )
 
-    image_url = f"{oim_url_prefix}{page_key}.jpg"
-    image_path = output_dir / f"{page_key}.raw.jpg"
-
-    if image_path.exists():
-        print(f"  Already done: {image_path.name}", file=sys.stderr)
-    else:
-        print(f"  {label}", file=sys.stderr)
-        print(f"    Image: {image_url}", file=sys.stderr)
-        print(f"    Source: {full_width}×{full_height}", file=sys.stderr)
-
-        if not dry_run:
-            print(f"    Downloading → {image_path.name} ...", file=sys.stderr)
-            download_oim_image(image_url, image_path)
-            dl_width, dl_height = jpeg_dimensions(image_path)
-            print(f"    Downloaded: {dl_width}×{dl_height}", file=sys.stderr)
-
-    # For split pages, also fetch the un-split original.
+    # OIM's manual split region → oim/ (ground truth for comparison).
     if "__" in page_key:
-        base_key = page_key.split("__")[0]
-        _download_unsplit_image(base_key, output_dir, oim_url_prefix, dry_run)
+        _download_if_missing(
+            f"{oim_url_prefix}{page_key}.jpg",
+            output_dir / "oim" / f"{page_key}.jpg",
+            dry_run,
+        )
 
     return True
 
@@ -158,7 +136,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Download OIM images from a local IIIF AnnotationPage. "
-            "Saves one .raw.jpg per annotation item alongside the IIIF file."
+            "Saves full-resolution pages to raw/ and OIM split regions to oim/."
         )
     )
     parser.add_argument(

--- a/mapsnap/download_osm.py
+++ b/mapsnap/download_osm.py
@@ -8,11 +8,16 @@ Usage:
 import argparse
 import json
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
 OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+
+MAX_ATTEMPTS = 5  # total Overpass attempts before giving up
+INITIAL_RETRY_DELAY = 2.0  # seconds before the first retry; doubles each attempt
+MAX_RETRY_DELAY = 60.0  # cap on the exponential backoff delay
 
 
 def form_osm_query_bbox(sw: tuple[float, float], ne: tuple[float, float]) -> str:
@@ -48,30 +53,54 @@ out skel qt;
 """
 
 
-def download_osm(query: str) -> dict:
-    """Submit an Overpass query and return the parsed JSON response."""
+def download_osm(
+    query: str,
+    max_attempts: int = MAX_ATTEMPTS,
+    initial_delay: float = INITIAL_RETRY_DELAY,
+) -> dict:
+    """Submit an Overpass query and return the parsed JSON response.
 
+    Retries with exponential backoff on transient errors: HTTP 429 (Overpass rate-limits
+    when busy) and 5xx (e.g. 504 when overloaded), and network/timeout errors. Exits with
+    an error message on a non-transient HTTP error or once all attempts are exhausted.
+    """
     data = urllib.parse.urlencode({"data": query}).encode()
-    req = urllib.request.Request(
-        OVERPASS_URL,
-        data=data,
-        method="get",
-        headers={
-            "User-Agent": "mapsnap/0.1",
-            "Accept": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=90) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as exc:
-        print(
-            f"Error: Overpass returned HTTP {exc.code}: {exc.reason}", file=sys.stderr
+    delay = initial_delay
+    for attempt in range(1, max_attempts + 1):
+        req = urllib.request.Request(
+            OVERPASS_URL,
+            data=data,
+            method="get",
+            headers={
+                "User-Agent": "mapsnap/0.1",
+                "Accept": "application/json",
+            },
         )
-        sys.exit(1)
-    except urllib.error.URLError as exc:
-        print(f"Error: {exc.reason}", file=sys.stderr)
-        sys.exit(1)
+        try:
+            with urllib.request.urlopen(req, timeout=90) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            transient = exc.code == 429 or 500 <= exc.code < 600
+            if not transient or attempt == max_attempts:
+                sys.exit(f"Error: Overpass returned HTTP {exc.code}: {exc.reason}")
+            print(
+                f"  Overpass HTTP {exc.code} ({exc.reason}); retrying in {delay:.0f}s "
+                f"(attempt {attempt}/{max_attempts})",
+                file=sys.stderr,
+            )
+        except urllib.error.URLError as exc:
+            if attempt == max_attempts:
+                sys.exit(f"Error: {exc.reason}")
+            print(
+                f"  Overpass request failed ({exc.reason}); retrying in {delay:.0f}s "
+                f"(attempt {attempt}/{max_attempts})",
+                file=sys.stderr,
+            )
+        time.sleep(delay)
+        delay = min(delay * 2, MAX_RETRY_DELAY)
+
+    # Unreachable: the final attempt always returns or exits above.
+    sys.exit("Error: exhausted Overpass retries")
 
 
 def main() -> None:

--- a/mapsnap/download_osm_test.py
+++ b/mapsnap/download_osm_test.py
@@ -1,0 +1,72 @@
+"""Tests for mapsnap.download_osm retry behavior."""
+
+import io
+import urllib.error
+
+import pytest
+
+from mapsnap import download_osm as dl
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for urlopen's response."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return io.BytesIO(self._body)
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(dl.OVERPASS_URL, code, "boom", {}, None)  # type: ignore[arg-type]
+
+
+def test_retries_then_succeeds_on_transient_error(monkeypatch):
+    # 429, then 504, then a successful JSON response.
+    attempts: list[None] = []
+    responses = [_http_error(429), _http_error(504), _FakeResp(b'{"elements": [1, 2]}')]
+
+    def fake_urlopen(req, timeout=0):
+        result = responses[len(attempts)]
+        attempts.append(None)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(dl.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(dl.time, "sleep", lambda _s: None)
+
+    result = dl.download_osm("query", max_attempts=5, initial_delay=0.01)
+    assert result == {"elements": [1, 2]}
+    assert len(attempts) == 3
+
+
+def test_exits_after_exhausting_retries(monkeypatch):
+    def always_429(req, timeout=0):
+        raise _http_error(429)
+
+    monkeypatch.setattr(dl.urllib.request, "urlopen", always_429)
+    monkeypatch.setattr(dl.time, "sleep", lambda _s: None)
+
+    with pytest.raises(SystemExit):
+        dl.download_osm("query", max_attempts=3, initial_delay=0.01)
+
+
+def test_exits_immediately_on_non_transient_error(monkeypatch):
+    calls: list[None] = []
+
+    def http_400(req, timeout=0):
+        calls.append(None)
+        raise _http_error(400)
+
+    monkeypatch.setattr(dl.urllib.request, "urlopen", http_400)
+    monkeypatch.setattr(dl.time, "sleep", lambda _s: None)
+
+    with pytest.raises(SystemExit):
+        dl.download_osm("query", max_attempts=5, initial_delay=0.01)
+    # A client error (400) is not retried.
+    assert len(calls) == 1

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from mapsnap.utils import run_cmd
+from mapsnap.utils import list_pages, run_cmd
 
 
 def find_centerlines(dir_path: Path) -> Path:
@@ -21,12 +21,11 @@ def find_centerlines(dir_path: Path) -> Path:
 
 
 def find_input_images(dir_path: Path) -> list[str]:
-    """Return image paths, preferring p*.scaled.jpg over p*.raw.jpg."""
-    for pattern in ("p*.scaled.jpg", "p*.raw.jpg", "p*.jpg"):
-        images = sorted(glob.glob(str(dir_path / pattern)))
-        if images:
-            return images
-    sys.exit(f"No p*.scaled.jpg, p*.raw.jpg, or p*.jpg found in {dir_path}")
+    """Return the effective page images (split panels supersede their parent page)."""
+    images = [str(p) for p in list_pages(dir_path)]
+    if not images:
+        sys.exit(f"No p*.jpg found in {dir_path}")
+    return images
 
 
 def find_ref_iiif(dir_path: Path) -> Path | None:

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1364,7 +1364,7 @@ def main() -> None:
     parser.add_argument(
         "--min-long-side",
         type=float,
-        default=45.0,
+        default=40.0,
         metavar="PX",
         help="Minimum long side of a text polygon to accept (default: %(default)s)",
     )

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -4,22 +4,20 @@ Accepts two input formats for the source IIIF file:
 
   OIM AnnotationPage (type: AnnotationPage)
     Each item has a label, target.source.{id,width,height}, and body.features (GCPs).
-    Split pages (labels ending in "[N]") are supported: the unsplit original is located
-    via template matching to determine a non-circular canvas placement.
 
   LOC sc:Manifest (@type: sc:Manifest)
-    Each canvas has a label like "Page 8" and an image service URL. No split pages;
-    the script asserts that all matching georef page keys are unsplit.
+    Each canvas has a label like "Page 8" and an image service URL.
 
-For images where the raw file covers the full source canvas (raw_dims ≈ source_dims),
-resource coordinates are computed by simple proportional scaling:
+Georefs are computed in the 25%-scale page-image pixel frame (pN.jpg). Resource
+coordinates are mapped into the full source canvas by proportional scaling:
 
     resourceCoords = georef_pixel × source_dim / georef_dim
 
-For OIM split sub-images (raw_dims << source_dims), the unsplit original (e.g.
-p4.unsplit.jpg) is located via template matching to determine the sub-image's pixel
-offset within the full canvas. Raises an error and skips the page if the unsplit file
-is absent or the match score is too low.
+Split pages (georef key pN__i) are placed within the parent page's canvas using the
+panel polygon recorded in pN.panels.json: the panel's bounding box (in the pN.jpg frame)
+is scaled to canvas coordinates to give the sub-image's offset and extent. The split
+panels of a page all share the parent page's full canvas (matching how OIM expresses
+split annotations).
 
 Usage:
     python make_iiif_georef.py <main.iiif.json> <georef_glob> [--output FILE] [--creator URL]
@@ -34,109 +32,16 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-import cv2
 import numpy as np
-from PIL import Image
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import mapping as geom_mapping
 
 from mapsnap.clip_masks import compute_all_clip_masks, geo_polygon_to_svg
+from mapsnap.split import panels_json_path, read_panels_json
 from mapsnap.utils import jpeg_dimensions
 
-
-def _replace_white(arr: np.ndarray, white_threshold: int = 250) -> np.ndarray:
-    """Replace pure-white pixels with the mean of non-white pixels.
-
-    White pixels (≥ white_threshold) are masked-out regions on Sanborn map splits
-    that share no content with the corresponding area in the unsplit image.
-    Replacing them with the template mean gives zero contribution to TM_CCOEFF_NORMED,
-    preventing them from pulling the match towards the wrong location.
-    """
-    non_white = arr < white_threshold
-    if not non_white.any():
-        return arr
-    mean_val = int(round(float(arr[non_white].mean())))
-    out = arr.copy()
-    out[~non_white] = mean_val
-    return out
-
-
-def locate_split_in_unsplit(
-    split_path: Path,
-    unsplit_path: Path,
-    min_score: float = 0.90,
-    coarse_downsample: int = 4,
-    refine_margin: int = 20,
-) -> tuple[int, int]:
-    """Find the pixel offset of a split sub-image within its unsplit original.
-
-    Uses a two-stage search: coarse normalized cross-correlation at downsampled
-    resolution to find the rough location, then full-resolution refinement in a
-    small window around that estimate. Pure-white pixels in the split (masked-out
-    regions) are replaced with the template mean so they contribute nothing to the
-    correlation score.
-
-    Raises ValueError if the refined match score is below min_score (uncertain
-    placement) or if the located region overflows the unsplit image bounds.
-
-    Returns (offset_x, offset_y) in unsplit image pixel coordinates (top-left corner).
-    """
-    split_arr = _replace_white(
-        np.array(Image.open(split_path).convert("L"), dtype=np.uint8)
-    )
-    unsplit_arr = np.array(Image.open(unsplit_path).convert("L"), dtype=np.uint8)
-
-    ds = coarse_downsample
-    split_small = split_arr[::ds, ::ds]
-    unsplit_small = unsplit_arr[::ds, ::ds]
-
-    if (
-        split_small.shape[0] > unsplit_small.shape[0]
-        or split_small.shape[1] > unsplit_small.shape[1]
-    ):
-        raise ValueError(
-            f"Split ({split_arr.shape[1]}×{split_arr.shape[0]}) is larger than "
-            f"unsplit ({unsplit_arr.shape[1]}×{unsplit_arr.shape[0]}) at coarse resolution"
-        )
-
-    coarse_result = cv2.matchTemplate(unsplit_small, split_small, cv2.TM_CCOEFF_NORMED)
-    _, _, _, coarse_loc = cv2.minMaxLoc(coarse_result)
-    coarse_x = coarse_loc[0] * ds
-    coarse_y = coarse_loc[1] * ds
-
-    # Refine at full resolution within a small window around the coarse estimate.
-    sh, sw = split_arr.shape
-    uh, uw = unsplit_arr.shape
-    x1 = max(0, coarse_x - refine_margin)
-    x2 = min(uw, coarse_x + sw + refine_margin)
-    y1 = max(0, coarse_y - refine_margin)
-    y2 = min(uh, coarse_y + sh + refine_margin)
-
-    if x2 - x1 < sw or y2 - y1 < sh:
-        raise ValueError(
-            f"Refinement window too small ({x2 - x1}×{y2 - y1}) for template ({sw}×{sh})"
-        )
-
-    region = unsplit_arr[y1:y2, x1:x2]
-    result = cv2.matchTemplate(region, split_arr, cv2.TM_CCOEFF_NORMED)
-    _, max_score, _, max_loc = cv2.minMaxLoc(result)
-
-    if max_score < min_score:
-        raise ValueError(
-            f"Template match score {max_score:.3f} < threshold {min_score} "
-            f"({split_path.name} in {unsplit_path.name})"
-        )
-
-    offset_x = x1 + max_loc[0]
-    offset_y = y1 + max_loc[1]
-
-    if offset_x + sw > uw or offset_y + sh > uh:
-        raise ValueError(
-            f"Located position ({offset_x}, {offset_y}) + {sw}×{sh} overflows "
-            f"unsplit bounds {uw}×{uh}"
-        )
-
-    return offset_x, offset_y
+# Page images are stored at 25% scale, so the full-resolution canvas is 4× larger.
+FULL_RES_FACTOR = 4
 
 
 def georef_path_to_page_key(path: str) -> str | None:
@@ -180,11 +85,13 @@ def _service_url_to_page_key(url: str) -> str | None:
 
 
 def _load_oim_index(data: dict) -> dict[str, dict]:
-    """Build page_key → item dict from an OIM IIIF AnnotationPage.
+    """Build parent-page_key → item dict from an OIM IIIF AnnotationPage.
 
-    Labels ending with "[N]" (e.g. "Page 4 [1]") denote split sub-images; the
-    split number is appended to the page key as "__N" (e.g. "p4__1") to match
-    the naming convention used by georef_path_to_page_key.
+    Items are keyed by the unsplit page key (e.g. "p4"), dropping any "[N]" split
+    suffix in the label. OIM expresses each split annotation in the parent page's full
+    canvas (all splits of a page share the same source id and width/height), so a single
+    full-canvas item per page is all make_annotation needs; our own splits are placed
+    within it via panels.json.
     """
     index: dict[str, dict] = {}
     for item in data.get("items", []):
@@ -192,22 +99,19 @@ def _load_oim_index(data: dict) -> dict[str, dict]:
         page_key = _service_url_to_page_key(source_id)
         if page_key is None:
             continue
-        label: str = item.get("label", "")
-        m = re.search(r"\[(\d+)\]$", label)
-        if m:
-            page_key += f"__{m.group(1)}"
         index[page_key] = item
     return index
 
 
-def _load_loc_index(data: dict, raw_dir: Path) -> dict[str, dict]:
+def _load_loc_index(data: dict) -> dict[str, dict]:
     """Build page_key → normalized item dict from a LOC sc:Manifest.
 
     Normalizes each canvas into the same shape make_annotation expects:
       {"label": str, "target": {"source": {"id": str, "width": int, "height": int}}}
 
-    Full image dimensions come from the raw.jpg on disk when present; otherwise the
-    pct thumbnail scale factor is parsed from the resource URL and applied.
+    The manifest's resource dimensions are at the requested pct scale (we download at
+    pct:25), so the full-resolution source dimensions are recovered by scaling up by
+    100/pct (e.g. ×4 for pct:25).
     """
     manifest_label: str = data.get("label", "")
     canvases: list[dict] = data["sequences"][0]["canvases"]
@@ -220,22 +124,11 @@ def _load_loc_index(data: dict, raw_dir: Path) -> dict[str, dict]:
         if page_key is None:
             continue
 
-        raw_path = raw_dir / f"{page_key}.raw.jpg"
+        # Resource URL contains e.g. "/full/pct:25/0/default.jpg"; scale up to full res.
         pct_m = re.search(r"/pct:(\d+)/", resource.get("@id", ""))
         scale = 100.0 / int(pct_m.group(1)) if pct_m else 1.0
-        if raw_path.exists():
-            raw_w, raw_h = jpeg_dimensions(raw_path)
-            # raw.jpg may be the pct thumbnail (raw_w ≈ resource["width"]) or the
-            # full-resolution image (raw_w ≈ resource["width"] * scale). Only apply
-            # scale if the raw image is at thumbnail resolution.
-            res_w = resource.get("width", 0)
-            effective_scale = 1.0 if (res_w > 0 and raw_w > res_w * 1.5) else scale
-            source_width = int(round(raw_w * effective_scale))
-            source_height = int(round(raw_h * effective_scale))
-        else:
-            # Resource URL contains e.g. "/full/pct:25/0/default.jpg"; scale up.
-            source_width = int(round(resource["width"] * scale))
-            source_height = int(round(resource["height"] * scale))
+        source_width = int(round(resource["width"] * scale))
+        source_height = int(round(resource["height"] * scale))
 
         index[page_key] = {
             "label": f"{manifest_label} | {canvas_label}",
@@ -258,7 +151,7 @@ def _georef_metadata(
     """Build IIIF metadata entries for streets, intersections, and split canvas bounds.
 
     split_canvas, when present, gives the sub-image region within the full canvas as
-    (x, y, w, h) in canvas pixel coordinates, derived via template matching.
+    (x, y, w, h) in canvas pixel coordinates, derived from the panel polygon.
     """
     n_streets = len(
         set(s["street"] for s in georef.get("streets", []) if s.get("inlier"))
@@ -347,7 +240,8 @@ def georef_gcp_points(georef: dict) -> list[GcpPoint]:
 def make_annotation(
     item: dict,
     georef: dict,
-    raw_path: Path,
+    page_key: str,
+    image_path: Path,
     creator_url: str,
     now: str,
     geo_mask: ShapelyPolygon | None = None,
@@ -355,13 +249,17 @@ def make_annotation(
     """Build a IIIF georeferencing annotation for one page.
 
     item must have {"label": str, "target": {"source": {"id", "width", "height"}}};
-    both OIM AnnotationPage items and normalized LOC canvas items satisfy this.
+    both OIM AnnotationPage items and normalized LOC canvas items satisfy this. source
+    width/height are the full-resolution canvas dimensions.
 
-    For full-canvas images (raw_dims ≈ source_dims), resource coords are computed
-    by simple proportional scaling. For split sub-images, the unsplit original
-    (e.g. p4.unsplit.jpg) is located via template matching to determine the non-circular
-    canvas placement. Raises ValueError if the unsplit file is missing or the match
-    is too uncertain.
+    page_key is the georef page key (e.g. "p4" or split "p4__2"). The georef ran on the
+    25%-scale page image, so full-page coordinates are scaled up to the full canvas. For
+    split pages, the parent page's pN.panels.json is read and panel N's bounding box (in
+    the pN.jpg frame) is scaled to canvas coordinates to place the sub-image. Raises
+    ValueError if the panels.json is missing or has too few panels.
+
+    image_path is the georeferenced image (e.g. dir/p4__2.jpg); its directory is used to
+    locate the parent panels.json.
 
     geo_mask, when provided, is a Shapely Polygon in geographic (lon/lat) space used
     as the SvgSelector clipping polygon. Falls back to the full-page rectangle if None.
@@ -373,36 +271,22 @@ def make_annotation(
     source_height: int = source["height"]
     label: str = item["label"]
 
-    # Derive a unique canvas ID from the source URL; append split number if present.
-    canvas_id = source_id.removesuffix("/info.json")
-    m = re.search(r"\[(\d+)\]$", label)
-    if m:
-        canvas_id += f"__{m.group(1)}"
-
     creator = {"id": creator_url, "type": "Person"}
     georef_width = georef["width"]
     georef_height = georef["height"]
 
-    if not raw_path.exists():
-        raise ValueError(f"raw image not found: {raw_path}")
-    raw_width, raw_height = jpeg_dimensions(raw_path)
-
-    # Full canvas: raw covers the complete canvas extent, possibly at lower resolution
-    # (e.g. a pct:25 download). Split sub-images (OIM only) have "__" in the filename
-    # and are routed to template matching regardless of size ratios.
-    is_split_raw = "__" in raw_path.name
-    is_full_canvas = (
-        abs(raw_width - source_width) <= 2 and abs(raw_height - source_height) <= 2
-    ) or (
-        not is_split_raw
-        and source_width > 0
-        and abs(raw_width / source_width - raw_height / source_height) <= 0.01
-    )
-    split_canvas: tuple[float, float, float, float] | None = None
+    # Derive a unique canvas ID from the source URL; append split number if present.
+    canvas_id = source_id.removesuffix("/info.json")
+    split_index: int | None = None
+    if "__" in page_key:
+        split_index = int(page_key.split("__")[1])
+        canvas_id += f"__{split_index}"
 
     gcp_pts = georef_gcp_points(georef)
+    split_canvas: tuple[float, float, float, float] | None = None
 
-    if is_full_canvas:
+    if split_index is None:
+        # Full page: scale 25%-page coordinates up to the full canvas.
         scale_x = source_width / georef_width
         scale_y = source_height / georef_height
         resource_coords_list = [
@@ -410,32 +294,30 @@ def make_annotation(
             for (px, py), _, _ in gcp_pts
         ]
     else:
-        # True sub-image: locate via template matching for a non-circular placement.
-        page_key_from_raw = raw_path.name.removesuffix(".raw.jpg")
-        if "__" in page_key_from_raw:
-            base_key = page_key_from_raw.split("__")[0]
-            unsplit_path = raw_path.parent / f"{base_key}.unsplit.jpg"
-        else:
-            unsplit_path = None
-
-        if unsplit_path is None or not unsplit_path.exists():
-            missing = unsplit_path.name if unsplit_path else "unsplit file"
+        # Split page: place the panel within the parent canvas using panels.json.
+        parent_key = page_key.split("__")[0]
+        panels_path = panels_json_path(image_path.parent / f"{parent_key}.jpg")
+        if not panels_path.exists():
+            raise ValueError(f"panels.json not found: {panels_path}")
+        panels_data = read_panels_json(panels_path)
+        panels = panels_data["panels"]
+        if not (1 <= split_index <= len(panels)):
             raise ValueError(
-                f"{missing} not found; cannot place sub-image non-circularly"
+                f"split index {split_index} out of range for {panels_path.name} "
+                f"({len(panels)} panels)"
             )
+        ring = panels[split_index - 1]
+        xs = [pt[0] for pt in ring]
+        ys = [pt[1] for pt in ring]
+        minx, miny, maxx, maxy = min(xs), min(ys), max(xs), max(ys)
 
-        # locate_split_in_unsplit raises ValueError if the match is uncertain.
-        offset_x_px, offset_y_px = locate_split_in_unsplit(raw_path, unsplit_path)
-        unsplit_width, unsplit_height = jpeg_dimensions(unsplit_path)
-
-        # Scale from unsplit pixel coordinates to canvas coordinates.
-        scale_x = source_width / unsplit_width
-        scale_y = source_height / unsplit_height
-
-        split_cx = offset_x_px * scale_x
-        split_cy = offset_y_px * scale_y
-        split_cw = raw_width * scale_x
-        split_ch = raw_height * scale_y
+        # panels.json records polygons in the pN.jpg (25%) frame; scale to full canvas.
+        page_scale_x = source_width / panels_data["width"]
+        page_scale_y = source_height / panels_data["height"]
+        split_cx = minx * page_scale_x
+        split_cy = miny * page_scale_y
+        split_cw = (maxx - minx) * page_scale_x
+        split_ch = (maxy - miny) * page_scale_y
         split_canvas = (
             round(split_cx, 1),
             round(split_cy, 1),
@@ -516,16 +398,16 @@ def _load_s3_items(
 ) -> tuple[list[tuple[str, dict, dict, Path, Path]], str, str]:
     """Load volume items for self-hosted images (no IIIF manifest needed).
 
-    Constructs canvas items directly from raw.jpg dimensions on disk and a
-    base URL, so no LOC or OIM manifest file is required. Resource coordinates
-    are in the raw.jpg pixel space (scale factor 1.0 — no rescaling needed).
+    Constructs canvas items directly from the 25%-scale page image dimensions on disk
+    and a base URL, so no LOC or OIM manifest file is required. The full-resolution
+    canvas dimensions are 4× the page image; split pages share their parent's canvas.
 
     source_type should match the image server in use:
       'ImageService3' — IIIF Image API v3 (e.g. serverless-iiif v3 on Lambda)
       'ImageService2' — IIIF Image API v2
       'Image'         — plain static JPEG (no tile server; limited viewer support)
 
-    The image URL for each page is: {image_base_url}/{page_key}.raw.jpg
+    The image URL for each page is: {image_base_url}/{parent_key}.jpg
     """
     georef_paths = sorted(glob.glob(georef_glob_pattern))
     if not georef_paths:
@@ -539,24 +421,30 @@ def _load_s3_items(
         if not page_key:
             print(f"Warning: could not parse page key from '{path}'", file=sys.stderr)
             continue
-        raw_path = Path(path).parent / f"{page_key}.raw.jpg"
-        if not raw_path.exists():
-            print(f"Warning: raw image not found: {raw_path}", file=sys.stderr)
+        # Splits share their parent page's full canvas.
+        parent_key = page_key.split("__")[0]
+        image_path = Path(path).parent / f"{page_key}.jpg"
+        parent_image = Path(path).parent / f"{parent_key}.jpg"
+        if not parent_image.exists():
+            print(f"Warning: page image not found: {parent_image}", file=sys.stderr)
             continue
-        raw_w, raw_h = jpeg_dimensions(raw_path)
+        # The page image is at 25% scale; the full-resolution canvas is 4× larger.
+        page_w, page_h = jpeg_dimensions(parent_image)
+        source_width = page_w * FULL_RES_FACTOR
+        source_height = page_h * FULL_RES_FACTOR
         canvas_item = {
             "label": page_key,
             "target": {
                 "source": {
-                    "id": f"{base_url}/{page_key}.raw.jpg",
+                    "id": f"{base_url}/{parent_key}.jpg",
                     "type": source_type,
-                    "width": raw_w,
-                    "height": raw_h,
+                    "width": source_width,
+                    "height": source_height,
                 }
             },
         }
         georef = json.load(open(path))
-        valid_items.append((page_key, canvas_item, georef, raw_path, Path(path)))
+        valid_items.append((page_key, canvas_item, georef, image_path, Path(path)))
 
     # Drop skeleton pages within this volume.
     non_skeleton_keys = {pk for pk, _, _, _, _ in valid_items if not pk.endswith("s")}
@@ -600,17 +488,14 @@ def _load_volume_items(
     if not georef_paths:
         print(f"Error: no files matched '{georef_glob_pattern}'.", file=sys.stderr)
         sys.exit(1)
-    raw_dir = Path(georef_paths[0]).parent
 
     if source_data.get("type") == "AnnotationPage":
         items_by_key = _load_oim_index(source_data)
         result_id = source_data.get("id", "") + "/generated"
-        is_loc = False
         print(f"Loaded {len(items_by_key)} OIM annotations.", file=sys.stderr)
     elif source_data.get("@type") == "sc:Manifest":
-        items_by_key = _load_loc_index(source_data, raw_dir)
+        items_by_key = _load_loc_index(source_data)
         result_id = source_data.get("@id", "") + "/generated"
-        is_loc = True
         print(f"Loaded {len(items_by_key)} LOC canvases.", file=sys.stderr)
     else:
         print(
@@ -628,20 +513,18 @@ def _load_volume_items(
         if not page_key:
             print(f"Warning: could not parse page key from '{path}'", file=sys.stderr)
             continue
-        if is_loc:
-            assert "__" not in page_key, (
-                f"LOC manifests have no split pages; found split key '{page_key}' in {path}"
-            )
-        canvas_item = items_by_key.get(page_key)
+        # Splits (pN__i) share their parent page's canvas item.
+        parent_key = page_key.split("__")[0]
+        canvas_item = items_by_key.get(parent_key)
         if not canvas_item:
             print(
-                f"Warning: no canvas for page key '{page_key}' ({path})",
+                f"Warning: no canvas for page key '{parent_key}' ({path})",
                 file=sys.stderr,
             )
             continue
         georef = json.load(open(path))
-        raw_path = Path(path).parent / f"{page_key}.raw.jpg"
-        valid_items.append((page_key, canvas_item, georef, raw_path, Path(path)))
+        image_path = Path(path).parent / f"{page_key}.jpg"
+        valid_items.append((page_key, canvas_item, georef, image_path, Path(path)))
 
     # Drop skeleton pages (key ends in 's') when a full-color counterpart exists
     # within this volume. Scoped per-volume so skeletons in one volume are never
@@ -690,7 +573,7 @@ def main() -> None:
         help=(
             "Add a volume. Without --image-base-url: ARG1=IIIF manifest, ARG2=georef glob. "
             "With --image-base-url: ARG1=georef glob, ARG2=path suffix appended to the base URL "
-            "(e.g. 'vol1' gives {base_url}/vol1/{page}.raw.jpg). "
+            "(e.g. 'vol1' gives {base_url}/vol1/{page}.jpg). "
             "Repeatable for multi-volume output."
         ),
     )
@@ -721,8 +604,8 @@ def main() -> None:
         help=(
             "Base URL for plain-image hosting (e.g. an S3 bucket). "
             "When set, no IIIF manifest is needed: canvas items are built directly "
-            "from the raw.jpg files on disk. The URL for each page is "
-            "{URL}/{page_key}.raw.jpg. Provide the georef glob as the sole "
+            "from the page images on disk. The URL for each page is "
+            "{URL}/{parent_key}.jpg. Provide the georef glob as the sole "
             "positional argument."
         ),
     )
@@ -827,7 +710,7 @@ def main() -> None:
             all_georefs,
             centerlines_geojson,
             debug_blocks_out=debug_blocks,
-            raw_paths=[raw_path for _, _, _, raw_path, _ in all_valid_items],
+            raw_paths=[image_path for _, _, _, image_path, _ in all_valid_items],
         )
         n_masked = sum(m is not None for m in geo_masks)
         print(
@@ -862,13 +745,19 @@ def main() -> None:
     # Pass 2: build annotations with the per-page geo mask.
     annotations: list[dict] = []
     annotation_georef_paths: list[Path] = []
-    for (page_key, canvas_item, georef, raw_path, georef_path), geo_mask in zip(
+    for (page_key, canvas_item, georef, image_path, georef_path), geo_mask in zip(
         all_valid_items, geo_masks
     ):
         try:
             annotations.append(
                 make_annotation(
-                    canvas_item, georef, raw_path, args.creator, now, geo_mask
+                    canvas_item,
+                    georef,
+                    page_key,
+                    image_path,
+                    args.creator,
+                    now,
+                    geo_mask,
                 )
             )
             annotation_georef_paths.append(georef_path)

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -1,12 +1,16 @@
 """Unit tests for make_iiif_georef helpers."""
 
+from shapely.geometry import box
+
 from mapsnap.make_iiif_georef import (
     GcpPoint,
     _load_oim_index,
     _service_url_to_page_key,
     georef_gcp_points,
     georef_path_to_page_key,
+    make_annotation,
 )
+from mapsnap.split import write_panels_json
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -285,17 +289,92 @@ def test_load_oim_index_simple():
     assert list(index.keys()) == ["p6n"]
 
 
-def test_load_oim_index_split_label():
-    # Label " [1]" suffix → page key gets "__1" appended.
+def test_load_oim_index_split_label_keys_by_parent():
+    # Split labels are keyed by the unsplit parent page; the "[N]" suffix is dropped.
     data = {"items": [_make_oim_item(_BASE_URL, "Page 6 [1]")]}
     index = _load_oim_index(data)
-    assert list(index.keys()) == ["p6n__1"]
+    assert list(index.keys()) == ["p6n"]
 
 
-def test_load_oim_index_split_label_second_half():
-    data = {"items": [_make_oim_item(_BASE_URL, "Page 6 [2]")]}
+def test_load_oim_index_splits_share_one_parent_entry():
+    # Both halves of a split page collapse to a single parent canvas entry.
+    data = {
+        "items": [
+            _make_oim_item(_BASE_URL, "Page 6 [1]"),
+            _make_oim_item(_BASE_URL, "Page 6 [2]"),
+        ]
+    }
     index = _load_oim_index(data)
-    assert list(index.keys()) == ["p6n__2"]
+    assert list(index.keys()) == ["p6n"]
+
+
+def _metadata_value(annotation: dict, label: str) -> str | None:
+    for entry in annotation["metadata"]:
+        if entry["label"] == label:
+            return entry["value"]
+    return None
+
+
+def test_make_annotation_split_uses_panels_json(tmp_path):
+    # Parent page is 200×400 at 25%; the full canvas is 4× larger (800×1600).
+    write_panels_json(
+        tmp_path / "p4.jpg", [box(10, 20, 60, 120)], width=200, height=400
+    )
+    item = {
+        "label": "P4",
+        "target": {
+            "source": {
+                "id": "http://example/p4/info.json",
+                "type": "ImageService3",
+                "width": 800,
+                "height": 1600,
+            }
+        },
+    }
+    georef = make_georef(width=50, height=100, intersections=[])
+
+    annotation = make_annotation(
+        item,
+        georef,
+        "p4__1",
+        tmp_path / "p4__1.jpg",
+        creator_url="http://example/me",
+        now="2026-01-01T00:00:00Z",
+    )
+
+    # Panel bbox (10,20)-(60,120) in the 25% frame scales ×4 to the full canvas.
+    assert _metadata_value(annotation, "split_canvas_x") == "40.0"
+    assert _metadata_value(annotation, "split_canvas_y") == "80.0"
+    assert _metadata_value(annotation, "split_canvas_w") == "200.0"
+    assert _metadata_value(annotation, "split_canvas_h") == "400.0"
+    assert annotation["id"] == "http://example/p4__1/georef"
+    # The first corner GCP (pixel 0,0) maps to the panel's top-left on the canvas.
+    assert annotation["body"]["features"][0]["properties"]["resourceCoords"] == [
+        40.0,
+        80.0,
+    ]
+
+
+def test_make_annotation_split_missing_panels_raises(tmp_path):
+    item = {
+        "label": "P4",
+        "target": {
+            "source": {
+                "id": "http://example/p4/info.json",
+                "width": 800,
+                "height": 1600,
+            }
+        },
+    }
+    georef = make_georef(width=50, height=100, intersections=[])
+    try:
+        make_annotation(
+            item, georef, "p4__1", tmp_path / "p4__1.jpg", "http://x", "now"
+        )
+    except ValueError as exc:
+        assert "panels.json" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing panels.json")
 
 
 def test_load_oim_index_non_sheet_skipped():

--- a/mapsnap/oim_truth.py
+++ b/mapsnap/oim_truth.py
@@ -27,6 +27,27 @@ from mapsnap.utils import label_to_page_key
 
 
 WHITE_THRESHOLD = 250  # pixels at or above this are masked-out (not part of the panel)
+CLOSE_KERNEL_PX = 25  # close small holes/noise in the panel mask before contouring
+APPROX_EPS_FRAC = 0.003  # Douglas-Peucker tolerance as a fraction of contour perimeter
+
+
+def panel_polygon(split_gray: np.ndarray) -> np.ndarray | None:
+    """Largest non-white region of a split image as an (N, 2) [x, y] polygon.
+
+    Pure-white pixels are masked-out (not part of the panel), so the remaining shape is
+    the panel's true, possibly non-rectangular outline, in the split image's own pixel
+    frame. Returns None if the image has no non-white content.
+    """
+    mask = ((split_gray < WHITE_THRESHOLD).astype(np.uint8)) * 255
+    closed = cv2.morphologyEx(
+        mask, cv2.MORPH_CLOSE, np.ones((CLOSE_KERNEL_PX, CLOSE_KERNEL_PX), np.uint8)
+    )
+    contours, _ = cv2.findContours(closed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+    contour = max(contours, key=cv2.contourArea)
+    eps = APPROX_EPS_FRAC * cv2.arcLength(contour, True)
+    return cv2.approxPolyDP(contour, eps, closed=True).reshape(-1, 2).astype(float)
 
 
 def _masked_match(
@@ -131,9 +152,12 @@ def locate_oim_splits(
     """Build a canvas-coordinate panels.json for one page's OIM split regions.
 
     Template-matches each OIM split region oim/<parent>__<i>.jpg against the unsplit
-    full-resolution page raw/<parent>.jpg, recording the located rectangle as a polygon
-    ring in canvas (full-resolution) pixel coordinates. Panels are ordered by OIM split
-    index. Raises ValueError if a required image is missing or a match is too uncertain.
+    full-resolution page raw/<parent>.jpg, then extracts the region's non-white panel
+    polygon and translates it by the matched offset into canvas (full-resolution) pixel
+    coordinates. This captures the true split shape (e.g. when OIM serves a full-canvas
+    image with the other panels masked white) rather than just a bounding box. Panels are
+    ordered by OIM split index. Raises ValueError if a required image is missing or a
+    match is too uncertain.
     """
     unsplit_path = raw_dir / f"{parent_key}.jpg"
     if not unsplit_path.exists():
@@ -146,11 +170,19 @@ def locate_oim_splits(
         split_path = oim_dir / f"{parent_key}__{i}.jpg"
         if not split_path.exists():
             raise ValueError(f"OIM split region not found: {split_path}")
+        split_gray = np.array(Image.open(split_path).convert("L"))
         offset_x, offset_y = locate_split_in_unsplit(split_path, unsplit_path)
-        split_w, split_h = Image.open(split_path).size
-        x0, y0 = float(offset_x), float(offset_y)
-        x1, y1 = float(offset_x + split_w), float(offset_y + split_h)
-        rings.append([[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]])
+
+        poly = panel_polygon(split_gray)
+        if poly is None:
+            # No masked-out pixels: fall back to the full region rectangle.
+            split_h, split_w = split_gray.shape
+            poly = np.array(
+                [[0, 0], [split_w, 0], [split_w, split_h], [0, split_h]], dtype=float
+            )
+        ring = [[round(x + offset_x, 1), round(y + offset_y, 1)] for x, y in poly]
+        ring.append(ring[0])  # close the ring
+        rings.append(ring)
 
     return {
         "image": f"{parent_key}.jpg",

--- a/mapsnap/oim_truth.py
+++ b/mapsnap/oim_truth.py
@@ -26,21 +26,21 @@ from mapsnap.split import PanelsJson, panels_json_path
 from mapsnap.utils import label_to_page_key
 
 
-def _replace_white(arr: np.ndarray, white_threshold: int = 250) -> np.ndarray:
-    """Replace pure-white pixels with the mean of non-white pixels.
+WHITE_THRESHOLD = 250  # pixels at or above this are masked-out (not part of the panel)
 
-    White pixels (≥ white_threshold) are masked-out regions on Sanborn map splits
-    that share no content with the corresponding area in the unsplit image.
-    Replacing them with the template mean gives zero contribution to TM_CCOEFF_NORMED,
-    preventing them from pulling the match towards the wrong location.
+
+def _masked_match(
+    image: np.ndarray, template: np.ndarray, mask: np.ndarray
+) -> np.ndarray:
+    """Masked normalized cross-correlation of template (with mask) over image.
+
+    Pure-white masked-out pixels are excluded from the correlation entirely, rather
+    than merely zeroed, so a non-rectangular panel matches its true location even when
+    the unsplit page has unrelated content in the masked area. Returns the score map
+    with any NaN/inf (from degenerate, fully-masked windows) replaced by 0.
     """
-    non_white = arr < white_threshold
-    if not non_white.any():
-        return arr
-    mean_val = int(round(float(arr[non_white].mean())))
-    out = arr.copy()
-    out[~non_white] = mean_val
-    return out
+    result = cv2.matchTemplate(image, template, cv2.TM_CCORR_NORMED, mask=mask)
+    return np.nan_to_num(result, nan=0.0, posinf=0.0, neginf=0.0)
 
 
 def locate_split_in_unsplit(
@@ -52,24 +52,25 @@ def locate_split_in_unsplit(
 ) -> tuple[int, int]:
     """Find the pixel offset of a split sub-image within its unsplit original.
 
-    Uses a two-stage search: coarse normalized cross-correlation at downsampled
-    resolution to find the rough location, then full-resolution refinement in a
-    small window around that estimate. Pure-white pixels in the split (masked-out
-    regions) are replaced with the template mean so they contribute nothing to the
-    correlation score.
+    Uses a two-stage search: coarse masked normalized cross-correlation at downsampled
+    resolution to find the rough location, then full-resolution refinement in a small
+    window around that estimate. Pure-white pixels in the split are masked-out regions
+    that share no content with the unsplit page, so they are excluded from the match via
+    an OpenCV mask (without this, the unsplit content under those pixels suppresses the
+    correlation score of an otherwise correct match).
 
     Raises ValueError if the refined match score is below min_score (uncertain
     placement) or if the located region overflows the unsplit image bounds.
 
     Returns (offset_x, offset_y) in unsplit image pixel coordinates (top-left corner).
     """
-    split_arr = _replace_white(
-        np.array(Image.open(split_path).convert("L"), dtype=np.uint8)
-    )
+    split_arr = np.array(Image.open(split_path).convert("L"), dtype=np.uint8)
     unsplit_arr = np.array(Image.open(unsplit_path).convert("L"), dtype=np.uint8)
+    mask = ((split_arr < WHITE_THRESHOLD).astype(np.uint8)) * 255
 
     ds = coarse_downsample
     split_small = split_arr[::ds, ::ds]
+    mask_small = mask[::ds, ::ds]
     unsplit_small = unsplit_arr[::ds, ::ds]
 
     if (
@@ -81,7 +82,7 @@ def locate_split_in_unsplit(
             f"unsplit ({unsplit_arr.shape[1]}×{unsplit_arr.shape[0]}) at coarse resolution"
         )
 
-    coarse_result = cv2.matchTemplate(unsplit_small, split_small, cv2.TM_CCOEFF_NORMED)
+    coarse_result = _masked_match(unsplit_small, split_small, mask_small)
     _, _, _, coarse_loc = cv2.minMaxLoc(coarse_result)
     coarse_x = coarse_loc[0] * ds
     coarse_y = coarse_loc[1] * ds
@@ -100,7 +101,7 @@ def locate_split_in_unsplit(
         )
 
     region = unsplit_arr[y1:y2, x1:x2]
-    result = cv2.matchTemplate(region, split_arr, cv2.TM_CCOEFF_NORMED)
+    result = _masked_match(region, split_arr, mask)
     _, max_score, _, max_loc = cv2.minMaxLoc(result)
 
     if max_score < min_score:

--- a/mapsnap/oim_truth.py
+++ b/mapsnap/oim_truth.py
@@ -1,0 +1,214 @@
+"""Locate OIM's manually-generated split regions on their parent canvas (ground truth).
+
+OIM publishes split map pages as separate IIIF annotations whose SVG selectors fuse
+splitting and content masking, so they do not expose a clean split rectangle. This command
+template-matches each downloaded OIM split region (oim/pN__i.jpg) against the full-resolution
+unsplit page (raw/pN.jpg) to recover the split's rectangular placement on the parent canvas,
+then writes oim/pN.panels.json with the regions as rings in canvas (full-resolution) pixel
+coordinates. The mapsnap compare command uses these regions to associate OIM's splits with
+our own, whose numbering need not agree.
+
+Usage:
+    mapsnap oim-split-truth <main.iiif.json>
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from mapsnap.split import PanelsJson, panels_json_path
+from mapsnap.utils import label_to_page_key
+
+
+def _replace_white(arr: np.ndarray, white_threshold: int = 250) -> np.ndarray:
+    """Replace pure-white pixels with the mean of non-white pixels.
+
+    White pixels (≥ white_threshold) are masked-out regions on Sanborn map splits
+    that share no content with the corresponding area in the unsplit image.
+    Replacing them with the template mean gives zero contribution to TM_CCOEFF_NORMED,
+    preventing them from pulling the match towards the wrong location.
+    """
+    non_white = arr < white_threshold
+    if not non_white.any():
+        return arr
+    mean_val = int(round(float(arr[non_white].mean())))
+    out = arr.copy()
+    out[~non_white] = mean_val
+    return out
+
+
+def locate_split_in_unsplit(
+    split_path: Path,
+    unsplit_path: Path,
+    min_score: float = 0.90,
+    coarse_downsample: int = 4,
+    refine_margin: int = 20,
+) -> tuple[int, int]:
+    """Find the pixel offset of a split sub-image within its unsplit original.
+
+    Uses a two-stage search: coarse normalized cross-correlation at downsampled
+    resolution to find the rough location, then full-resolution refinement in a
+    small window around that estimate. Pure-white pixels in the split (masked-out
+    regions) are replaced with the template mean so they contribute nothing to the
+    correlation score.
+
+    Raises ValueError if the refined match score is below min_score (uncertain
+    placement) or if the located region overflows the unsplit image bounds.
+
+    Returns (offset_x, offset_y) in unsplit image pixel coordinates (top-left corner).
+    """
+    split_arr = _replace_white(
+        np.array(Image.open(split_path).convert("L"), dtype=np.uint8)
+    )
+    unsplit_arr = np.array(Image.open(unsplit_path).convert("L"), dtype=np.uint8)
+
+    ds = coarse_downsample
+    split_small = split_arr[::ds, ::ds]
+    unsplit_small = unsplit_arr[::ds, ::ds]
+
+    if (
+        split_small.shape[0] > unsplit_small.shape[0]
+        or split_small.shape[1] > unsplit_small.shape[1]
+    ):
+        raise ValueError(
+            f"Split ({split_arr.shape[1]}×{split_arr.shape[0]}) is larger than "
+            f"unsplit ({unsplit_arr.shape[1]}×{unsplit_arr.shape[0]}) at coarse resolution"
+        )
+
+    coarse_result = cv2.matchTemplate(unsplit_small, split_small, cv2.TM_CCOEFF_NORMED)
+    _, _, _, coarse_loc = cv2.minMaxLoc(coarse_result)
+    coarse_x = coarse_loc[0] * ds
+    coarse_y = coarse_loc[1] * ds
+
+    # Refine at full resolution within a small window around the coarse estimate.
+    sh, sw = split_arr.shape
+    uh, uw = unsplit_arr.shape
+    x1 = max(0, coarse_x - refine_margin)
+    x2 = min(uw, coarse_x + sw + refine_margin)
+    y1 = max(0, coarse_y - refine_margin)
+    y2 = min(uh, coarse_y + sh + refine_margin)
+
+    if x2 - x1 < sw or y2 - y1 < sh:
+        raise ValueError(
+            f"Refinement window too small ({x2 - x1}×{y2 - y1}) for template ({sw}×{sh})"
+        )
+
+    region = unsplit_arr[y1:y2, x1:x2]
+    result = cv2.matchTemplate(region, split_arr, cv2.TM_CCOEFF_NORMED)
+    _, max_score, _, max_loc = cv2.minMaxLoc(result)
+
+    if max_score < min_score:
+        raise ValueError(
+            f"Template match score {max_score:.3f} < threshold {min_score} "
+            f"({split_path.name} in {unsplit_path.name})"
+        )
+
+    offset_x = x1 + max_loc[0]
+    offset_y = y1 + max_loc[1]
+
+    if offset_x + sw > uw or offset_y + sh > uh:
+        raise ValueError(
+            f"Located position ({offset_x}, {offset_y}) + {sw}×{sh} overflows "
+            f"unsplit bounds {uw}×{uh}"
+        )
+
+    return offset_x, offset_y
+
+
+def locate_oim_splits(
+    parent_key: str,
+    split_indices: list[int],
+    raw_dir: Path,
+    oim_dir: Path,
+) -> PanelsJson:
+    """Build a canvas-coordinate panels.json for one page's OIM split regions.
+
+    Template-matches each OIM split region oim/<parent>__<i>.jpg against the unsplit
+    full-resolution page raw/<parent>.jpg, recording the located rectangle as a polygon
+    ring in canvas (full-resolution) pixel coordinates. Panels are ordered by OIM split
+    index. Raises ValueError if a required image is missing or a match is too uncertain.
+    """
+    unsplit_path = raw_dir / f"{parent_key}.jpg"
+    if not unsplit_path.exists():
+        raise ValueError(f"unsplit page not found: {unsplit_path}")
+    unsplit_arr = np.array(Image.open(unsplit_path).convert("L"))
+    canvas_height, canvas_width = unsplit_arr.shape
+
+    rings: list[list[list[float]]] = []
+    for i in sorted(split_indices):
+        split_path = oim_dir / f"{parent_key}__{i}.jpg"
+        if not split_path.exists():
+            raise ValueError(f"OIM split region not found: {split_path}")
+        offset_x, offset_y = locate_split_in_unsplit(split_path, unsplit_path)
+        split_w, split_h = Image.open(split_path).size
+        x0, y0 = float(offset_x), float(offset_y)
+        x1, y1 = float(offset_x + split_w), float(offset_y + split_h)
+        rings.append([[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]])
+
+    return {
+        "image": f"{parent_key}.jpg",
+        "width": canvas_width,
+        "height": canvas_height,
+        "panels": rings,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Locate OIM's manually-generated split regions on their parent canvas, "
+            "writing oim/pN.panels.json (rings in full-resolution canvas coordinates)."
+        )
+    )
+    parser.add_argument(
+        "iiif_file", metavar="FILE", help="Local OIM IIIF AnnotationPage JSON file"
+    )
+    args = parser.parse_args()
+
+    iiif_path = Path(args.iiif_file)
+    base_dir = iiif_path.parent
+    raw_dir = base_dir / "raw"
+    oim_dir = base_dir / "oim"
+    data: dict = json.load(iiif_path.open())
+
+    # Group split indices by parent page key.
+    splits_by_parent: dict[str, list[int]] = defaultdict(list)
+    for item in data.get("items", []):
+        page_key = label_to_page_key(item.get("label", ""))
+        if page_key is None or "__" not in page_key:
+            continue
+        parent_key, split_str = page_key.split("__")
+        splits_by_parent[parent_key].append(int(split_str))
+
+    if not splits_by_parent:
+        print("No split pages found in IIIF file.", file=sys.stderr)
+        return
+
+    written = 0
+    for parent_key, split_indices in sorted(splits_by_parent.items()):
+        try:
+            panels = locate_oim_splits(parent_key, split_indices, raw_dir, oim_dir)
+        except ValueError as exc:
+            print(f"Warning: skipping {parent_key}: {exc}", file=sys.stderr)
+            continue
+        out_path = panels_json_path(oim_dir / f"{parent_key}.jpg")
+        out_path.write_text(json.dumps(panels, indent=2))
+        print(
+            f"{parent_key}: located {len(panels['panels'])} OIM split(s) → {out_path.name}"
+        )
+        written += 1
+
+    print(
+        f"\nWrote {written}/{len(splits_by_parent)} OIM truth panels.json files.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/oim_truth_test.py
+++ b/mapsnap/oim_truth_test.py
@@ -49,6 +49,8 @@ def test_locate_oim_splits_writes_canvas_rings(tmp_path):
 
     assert (panels["width"], panels["height"]) == (160, 200)
     assert len(panels["panels"]) == 2
-    # Second region starts at y≈120 (top-left corner of the ring).
+    # Second region's polygon spans the bottom strip y≈[120, 200] on the canvas.
     second_ring = panels["panels"][1]
-    assert abs(second_ring[0][1] - 120) <= 1
+    ys = [pt[1] for pt in second_ring]
+    assert abs(min(ys) - 120) <= 4
+    assert abs(max(ys) - 200) <= 4

--- a/mapsnap/oim_truth_test.py
+++ b/mapsnap/oim_truth_test.py
@@ -1,0 +1,54 @@
+"""Tests for mapsnap.oim_truth."""
+
+import numpy as np
+from PIL import Image
+
+from mapsnap.oim_truth import locate_oim_splits, locate_split_in_unsplit
+
+
+def _save(path, arr):
+    Image.fromarray(arr).save(path, quality=95)
+
+
+def _smooth_page(height: int, width: int, seed: int) -> np.ndarray:
+    """A smooth, non-periodic grayscale page that survives JPEG and localizes uniquely.
+
+    Built by bilinearly upscaling coarse random noise so it has low spatial frequency
+    (JPEG-robust) yet a single sharp template-match peak.
+    """
+    rng = np.random.default_rng(seed)
+    coarse = rng.integers(0, 255, size=(height // 10, width // 10), dtype=np.uint8)
+    resized = Image.fromarray(coarse).resize((width, height), Image.Resampling.BILINEAR)
+    return np.array(resized)
+
+
+def test_locate_split_in_unsplit_finds_offset(tmp_path):
+    unsplit = _smooth_page(200, 160, seed=0)
+    # The split is a sub-window of the unsplit page at a known offset.
+    split = unsplit[40:140, 30:110].copy()
+    _save(tmp_path / "u.jpg", unsplit)
+    _save(tmp_path / "s.jpg", split)
+
+    offset_x, offset_y = locate_split_in_unsplit(tmp_path / "s.jpg", tmp_path / "u.jpg")
+    assert abs(offset_x - 30) <= 1
+    assert abs(offset_y - 40) <= 1
+
+
+def test_locate_oim_splits_writes_canvas_rings(tmp_path):
+    raw_dir = tmp_path / "raw"
+    oim_dir = tmp_path / "oim"
+    raw_dir.mkdir()
+    oim_dir.mkdir()
+
+    unsplit = _smooth_page(200, 160, seed=1)
+    _save(raw_dir / "p4.jpg", unsplit)
+    _save(oim_dir / "p4__1.jpg", unsplit[0:120, 0:160].copy())
+    _save(oim_dir / "p4__2.jpg", unsplit[120:200, 0:160].copy())
+
+    panels = locate_oim_splits("p4", [1, 2], raw_dir, oim_dir)
+
+    assert (panels["width"], panels["height"]) == (160, 200)
+    assert len(panels["panels"]) == 2
+    # Second region starts at y≈120 (top-left corner of the ring).
+    second_ring = panels["panels"][1]
+    assert abs(second_ring[0][1] - 120) <= 1

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -5,7 +5,7 @@ import glob
 import sys
 from pathlib import Path
 
-from mapsnap.utils import run_cmd
+from mapsnap.utils import list_pages, run_cmd, write_run_record
 
 
 def main() -> None:
@@ -34,6 +34,10 @@ def main() -> None:
 
     run_cmd(["mapsnap", "download-loc", "--scale", "pct:25", str(manifest)])
 
+    # Detect and write split panels (pN__i.jpg + pN.panels.json) for pages that split.
+    page_images = sorted(glob.glob(str(dir_path / "p*.jpg")))
+    run_cmd(["mapsnap", "split", *page_images])
+
     run_cmd(
         [
             "mapsnap",
@@ -54,18 +58,22 @@ def main() -> None:
         ]
     )
 
-    raw_images = sorted(glob.glob(str(dir_path / "p*.raw.jpg")))
+    ocr_images = [str(p) for p in list_pages(dir_path)]
     run_cmd(
         [
             "mapsnap",
             "ocr",
             "--centerlines",
             str(dir_path / "centerlines.geojson"),
-            *raw_images,
+            *ocr_images,
         ]
     )
 
     run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
+
+    write_run_record(
+        dir_path, "loc", {"manifest": str(manifest), "relation": args.relation}
+    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -31,6 +31,9 @@ def main() -> None:
 
     print(args.dir)
     print(args.relation)
+    write_run_record(
+        dir_path, "loc", {"manifest": str(manifest), "relation": args.relation}
+    )
 
     run_cmd(["mapsnap", "download-loc", "--scale", "pct:25", str(manifest)])
 
@@ -70,10 +73,6 @@ def main() -> None:
     )
 
     run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
-
-    write_run_record(
-        dir_path, "loc", {"manifest": str(manifest), "relation": args.relation}
-    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -42,6 +42,15 @@ def main() -> None:
 
     dir_path = Path(args.dir)
     dir_path.mkdir(parents=True, exist_ok=True)
+    write_run_record(
+        dir_path,
+        "oim",
+        {
+            "sanborn_slug": args.sanborn_slug,
+            "relation": args.relation,
+            "oim_prefix": args.oim_prefix,
+        },
+    )
 
     base_url = f"https://oldinsurancemaps.net/iiif/mosaic/{args.sanborn_slug}"
     download_file(f"{base_url}/main-content/?trim=true", dir_path / "main.iiif.json")
@@ -100,16 +109,6 @@ def main() -> None:
     run_cmd(["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")])
 
     run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
-
-    write_run_record(
-        dir_path,
-        "oim",
-        {
-            "sanborn_slug": args.sanborn_slug,
-            "relation": args.relation,
-            "oim_prefix": args.oim_prefix,
-        },
-    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -5,7 +5,7 @@ import glob
 import urllib.request
 from pathlib import Path
 
-from mapsnap.utils import run_cmd
+from mapsnap.utils import list_pages, run_cmd, write_run_record
 
 
 def download_file(url: str, dest: Path) -> None:
@@ -57,8 +57,13 @@ def main() -> None:
         ]
     )
 
-    raw_images = sorted(glob.glob(str(dir_path / "*.raw.jpg")))
-    run_cmd(["mapsnap", "scale", *raw_images])
+    # Downscale the full-resolution raw/ pages to 25% top-level pN.jpg images.
+    raw_images = sorted(glob.glob(str(dir_path / "raw" / "*.jpg")))
+    run_cmd(["mapsnap", "scale", *raw_images, "--output-dir", str(dir_path)])
+
+    # Detect and write split panels (pN__i.jpg + pN.panels.json) for pages that split.
+    page_images = sorted(glob.glob(str(dir_path / "p*.jpg")))
+    run_cmd(["mapsnap", "split", *page_images])
 
     run_cmd(
         [
@@ -80,18 +85,31 @@ def main() -> None:
         ]
     )
 
-    scaled_images = sorted(glob.glob(str(dir_path / "*.scaled.jpg")))
+    ocr_images = [str(p) for p in list_pages(dir_path)]
     run_cmd(
         [
             "mapsnap",
             "ocr",
             "--centerlines",
             str(dir_path / "centerlines.geojson"),
-            *scaled_images,
+            *ocr_images,
         ]
     )
 
+    # Locate OIM's manual split regions on the canvas (ground truth for compare).
+    run_cmd(["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")])
+
     run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
+
+    write_run_record(
+        dir_path,
+        "oim",
+        {
+            "sanborn_slug": args.sanborn_slug,
+            "relation": args.relation,
+            "oim_prefix": args.oim_prefix,
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/scale_images.py
+++ b/mapsnap/scale_images.py
@@ -1,8 +1,8 @@
 """Rescale a collection of images by a uniform factor.
 
 Scales every image by --percent (default 25%), the same factor for all of them, so pixel
-measurements stay consistent across the collection. Outputs color JPEGs with a .scaled.jpg
-suffix. Unsplit originals (template-matching references) are skipped.
+measurements stay consistent across the collection. Outputs color JPEGs named <stem>.jpg
+into --output-dir (default: each image's own directory).
 """
 
 import argparse
@@ -17,8 +17,8 @@ from mapsnap.utils import image_stem
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Rescale all images by a uniform factor derived from the largest image, "
-            "so pixel measurements are consistent across the collection."
+            "Rescale all images by a uniform --percent factor, so pixel measurements "
+            "are consistent across the collection. Writes <stem>.jpg to --output-dir."
         )
     )
     parser.add_argument("images", nargs="+", metavar="IMAGE", help="Input image files.")
@@ -28,33 +28,32 @@ def main() -> None:
         default=25.0,
         help="Percent to scale images to (25.0 = quarter size; must be in (0, 100)).",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory to write scaled <stem>.jpg files to. Defaults to each input "
+        "image's own directory.",
+    )
     args = parser.parse_args()
-
-    args.images = [p for p in args.images if "unsplit" not in Path(p).name]
-    if not args.images:
-        print(
-            "Error: no images to process (all inputs were filtered as unsplit originals).",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     scale = args.percent / 100.0
     if not (0.0 < scale < 1.0):
-        print(f"Error: {args.percent} must be in (0, 100)")
-        sys.exit(1)
-    print(
-        f"Scale factor: {scale:.6f}",
-        file=sys.stderr,
-    )
+        parser.error(f"--percent {args.percent} must be in (0, 100)")
+    print(f"Scale factor: {scale:.6f}", file=sys.stderr)
+
+    if args.output_dir is not None:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
 
     # Resize and save each image in color.
-    for image_path in args.images:
+    for image in args.images:
+        image_path = Path(image)
         with Image.open(image_path) as img:
             w, h = img.size
         new_w = round(w * scale)
         new_h = round(h * scale)
-        stem = image_stem(image_path)
-        output_path = Path(image_path).parent / (stem + ".scaled.jpg")
+        out_dir = args.output_dir if args.output_dir is not None else image_path.parent
+        output_path = out_dir / (image_stem(image) + ".jpg")
         with Image.open(image_path) as img:
             out = img.convert("RGB").resize((new_w, new_h), Image.Resampling.LANCZOS)
             out.save(output_path, "JPEG", quality=95)

--- a/mapsnap/scale_images_test.py
+++ b/mapsnap/scale_images_test.py
@@ -1,0 +1,22 @@
+"""Tests for mapsnap.scale_images."""
+
+from PIL import Image
+
+from mapsnap import scale_images
+
+
+def test_scale_writes_quarter_size_to_output_dir(tmp_path, monkeypatch):
+    src = tmp_path / "p5.jpg"
+    Image.new("RGB", (400, 200), "white").save(src)
+    out_dir = tmp_path / "scaled"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["mapsnap scale", str(src), "--output-dir", str(out_dir)],
+    )
+    scale_images.main()
+
+    out_path = out_dir / "p5.jpg"
+    assert out_path.exists()
+    with Image.open(out_path) as img:
+        assert img.size == (100, 50)

--- a/mapsnap/split.py
+++ b/mapsnap/split.py
@@ -14,7 +14,9 @@ Usage:
 """
 
 import argparse
+import json
 from pathlib import Path
+from typing import TypedDict
 
 import cv2
 import numpy as np
@@ -22,6 +24,23 @@ from PIL import Image, ImageDraw
 from shapely.geometry import LineString, Point, Polygon, box
 from shapely.ops import polygonize, unary_union
 from skimage.morphology import medial_axis
+
+from mapsnap.utils import image_stem
+
+
+class PanelsJson(TypedDict):
+    """Contents of a <stem>.panels.json sidecar.
+
+    panels is a list of polygon rings (one per panel) in the pixel frame of the named
+    image, recorded via width/height. Panels are in reading order so panels[i-1]
+    corresponds to <base>__i.jpg.
+    """
+
+    image: str
+    width: int
+    height: int
+    panels: list[list[list[float]]]
+
 
 # Front-end that turns the binary ink mask into candidate divider segments:
 #   "skeleton"  - light close → medial-axis centerlines → thickness filter → Hough
@@ -737,14 +756,46 @@ def draw_panels(rgb: np.ndarray, panels: list) -> np.ndarray:
 
 
 def panel_basename(image_path: Path) -> str:
-    """Base name for outputs: the stem with any .raw/.scaled qualifier removed.
+    """Base name for split outputs: the stem with all extensions stripped.
 
-    e.g. p45.raw.jpg → p45, p195.scaled.jpg → p195, champaign-p20.jpg → champaign-p20.
+    e.g. p45.jpg → p45, champaign-p20.jpg → champaign-p20. Legacy multi-extension names
+    like p195.scaled.jpg also collapse to p195 via image_stem.
     """
-    base = image_path.stem
-    for suffix in (".raw", ".scaled"):
-        base = base.removesuffix(suffix)
-    return base
+    return image_stem(str(image_path))
+
+
+def panels_json_path(image_path: Path) -> Path:
+    """Path to the panels.json sidecar (<stem>.panels.json) beside image_path."""
+    return image_path.parent / f"{panel_basename(image_path)}.panels.json"
+
+
+def read_panels_json(path: Path) -> PanelsJson:
+    """Load a panels.json sidecar; see PanelsJson for the shape."""
+    return json.loads(path.read_text())
+
+
+def write_panels_json(
+    image_path: Path, ordered_panels: list[Polygon], width: int, height: int
+) -> Path:
+    """Write ordered panel polygons to <stem>.panels.json beside image_path.
+
+    Rings are in image_path's pixel frame (recorded via width/height) and ordered to
+    match the __i.jpg numbering: ordered_panels[i-1] corresponds to <base>__i.jpg.
+    Returns the written path.
+    """
+    rings = [
+        [[round(x, 1), round(y, 1)] for x, y in panel.exterior.coords]
+        for panel in ordered_panels
+    ]
+    data: PanelsJson = {
+        "image": image_path.name,
+        "width": width,
+        "height": height,
+        "panels": rings,
+    }
+    out_path = panels_json_path(image_path)
+    out_path.write_text(json.dumps(data, indent=2))
+    return out_path
 
 
 def detect_downscale(
@@ -917,7 +968,8 @@ def write_panels(image_path: Path, panels: list, base: str) -> list[Path]:
 
     A panel is cropped to its bounding box, with any pixels outside its (possibly
     non-rectangular) polygon set to white. Panels are numbered in reading order: top to
-    bottom, then left to right.
+    bottom, then left to right. Also writes <base>.panels.json recording the panel
+    polygons in image_path's pixel frame, in the same order as the numbering.
     """
     rgb = load_rgb(image_path)
     h, w = rgb.shape[:2]
@@ -938,13 +990,29 @@ def write_panels(image_path: Path, panels: list, base: str) -> list[Path]:
         out_path = image_path.parent / f"{base}__{i}.jpg"
         Image.fromarray(masked[y0:y1, x0:x1]).save(out_path, quality=92)
         out_paths.append(out_path)
+    write_panels_json(image_path, ordered, w, h)
     return out_paths
+
+
+def remove_split_outputs(image_path: Path) -> None:
+    """Delete any existing <base>__N.jpg panels and <base>.panels.json for image_path.
+
+    Called before re-splitting so outputs always reflect the current code and settings.
+    """
+    base = panel_basename(image_path)
+    for stale in image_path.parent.glob(f"{base}__*.jpg"):
+        stale.unlink()
+    panels_path = panels_json_path(image_path)
+    panels_path.unlink(missing_ok=True)
 
 
 def process_image(image_path: Path, debug: bool = False) -> None:
     """Split one image into panel files, writing per-stage debug PNGs when debug is set."""
     base = panel_basename(image_path)
     out_dir = image_path.parent
+
+    # Regenerate from scratch: drop any stale panels from a previous run.
+    remove_split_outputs(image_path)
 
     rgb = crop_border(load_rgb(image_path))
     gray = crop_border(load_gray(image_path))
@@ -1005,6 +1073,9 @@ def main() -> None:
     )
     args = parser.parse_args()
     for image_path in args.images:
+        # Skip panels themselves (e.g. p2__1.jpg); only split whole pages.
+        if "__" in panel_basename(image_path):
+            continue
         process_image(image_path, debug=args.debug)
 
 

--- a/mapsnap/split_test.py
+++ b/mapsnap/split_test.py
@@ -1,5 +1,7 @@
 """Unit tests for the geometry helpers in mapsnap.split."""
 
+from pathlib import Path
+
 import cv2
 import numpy as np
 import pytest
@@ -12,20 +14,56 @@ from mapsnap.split import (
     merge_collinear,
     panel_basename,
     panel_compactness,
+    panels_json_path,
+    read_panels_json,
+    remove_split_outputs,
     seg_angle_deg,
     segment_thickness,
+    write_panels_json,
 )
 
 # --- panel_basename ---
 
 
 def test_panel_basename_strips_raw_and_scaled():
-    from pathlib import Path
-
     assert panel_basename(Path("p45.raw.jpg")) == "p45"
     assert panel_basename(Path("p195.scaled.jpg")) == "p195"
     assert panel_basename(Path("dir/champaign-p20.jpg")) == "champaign-p20"
     assert panel_basename(Path("p8.jpg")) == "p8"
+
+
+# --- panels.json round-trip and cleanup ---
+
+
+def test_write_panels_json_records_ordered_rings(tmp_path):
+    image_path = tmp_path / "p7.jpg"
+    panels = [box(0, 0, 50, 100), box(50, 0, 120, 100)]
+    out_path = write_panels_json(image_path, panels, width=120, height=100)
+
+    assert out_path == panels_json_path(image_path) == tmp_path / "p7.panels.json"
+    data = read_panels_json(out_path)
+    assert data["image"] == "p7.jpg"
+    assert (data["width"], data["height"]) == (120, 100)
+    assert len(data["panels"]) == 2
+    # First ring is the left panel; rings are closed (first point repeats).
+    xs = [pt[0] for pt in data["panels"][0]]
+    assert min(xs) == 0 and max(xs) == 50
+    assert data["panels"][0][0] == data["panels"][0][-1]
+
+
+def test_remove_split_outputs_deletes_panels_and_json(tmp_path):
+    (tmp_path / "p2__1.jpg").touch()
+    (tmp_path / "p2__2.jpg").touch()
+    (tmp_path / "p2.panels.json").touch()
+    # An unrelated page must be left alone.
+    (tmp_path / "p3__1.jpg").touch()
+
+    remove_split_outputs(tmp_path / "p2.jpg")
+
+    assert not (tmp_path / "p2__1.jpg").exists()
+    assert not (tmp_path / "p2__2.jpg").exists()
+    assert not (tmp_path / "p2.panels.json").exists()
+    assert (tmp_path / "p3__1.jpg").exists()
 
 
 # --- crop_border ---

--- a/mapsnap/split_twopage.py
+++ b/mapsnap/split_twopage.py
@@ -3,8 +3,8 @@
 Uses the filename numbering scheme — no OCR needed.
 
 Filename format:
-  sb000NNN0.raw.jpg  →  left page = NNN  (e.g. sb000060 → page 6, sb000570 → page 57)
-  sb00001d.raw.jpg   →  left page = 1    (special first-page naming)
+  sb000NNN0.jpg  →  left page = NNN  (e.g. sb000060 → page 6, sb000570 → page 57)
+  sb00001d.jpg   →  left page = 1    (special first-page naming)
 
 Content type is determined by the difference between consecutive page numbers:
   diff = 1 (file increment  10):  both halves show the same page number —
@@ -24,6 +24,8 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 
+from mapsnap.utils import image_stem
+
 # RGB spread threshold for color detection: max(R,G,B) - min(R,G,B) > this value.
 _COLOR_SPREAD = 50
 
@@ -38,12 +40,13 @@ def color_fraction(img: Image.Image) -> float:
 def parse_page_number(filename: str) -> int | None:
     """Extract the left-page number from a two-page filename.
 
-    sb00001d.raw.jpg → 1   (special first-page case)
-    sb000060.raw.jpg → 6
-    sb000570.raw.jpg → 57
-    Returns None for unrecognized patterns (e.g. sb00001a/b/c).
+    sb00001d.jpg → 1   (special first-page case)
+    sb000060.jpg → 6
+    sb000570.jpg → 57
+    Returns None for unrecognized patterns (e.g. sb00001a/b/c). Legacy ``.raw.jpg``
+    names are accepted too, since image_stem strips all extensions.
     """
-    stem = filename.removesuffix(".raw.jpg")
+    stem = image_stem(filename)
     if re.fullmatch(r"sb0+1d", stem):
         return 1
     m = re.fullmatch(r"sb(\d+)", stem)
@@ -55,7 +58,7 @@ def parse_page_number(filename: str) -> int | None:
 
 
 def page_filename(page_num: int, skeleton: bool) -> str:
-    return f"p{page_num}{'s' if skeleton else ''}.raw.jpg"
+    return f"p{page_num}{'s' if skeleton else ''}.jpg"
 
 
 def save_half(
@@ -105,9 +108,9 @@ def main() -> None:
     in_dir = Path(args.input_dir)
     out_dir = Path(args.output_dir)
 
-    all_files = sorted(in_dir.glob("*.raw.jpg"))
+    all_files = sorted(in_dir.glob("*.jpg"))
     if not all_files:
-        print(f"No .raw.jpg files in {in_dir}", file=sys.stderr)
+        print(f"No .jpg files in {in_dir}", file=sys.stderr)
         sys.exit(1)
 
     # Parse page numbers; skip files with unrecognised names.

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -1,9 +1,11 @@
 """Shared utilities for mapsnap scripts."""
 
+import json
 import re
 import struct
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -13,6 +15,23 @@ def run_cmd(cmd: list[str]) -> None:
     result = subprocess.run(cmd)
     if result.returncode != 0:
         sys.exit(result.returncode)
+
+
+def write_run_record(dir_path: Path, source: str, params: dict[str, str]) -> None:
+    """Record the pipeline invocation in dir_path/mapsnap.json for reproducibility.
+
+    source is the pipeline kind ("loc" or "oim"); params holds the volume-specific
+    arguments (slug/manifest, relation, etc.). The command line and a UTC timestamp are
+    added automatically.
+    """
+    # cli.py rewrites argv[0] to "mapsnap <subcommand>"; split it back into tokens.
+    record = {
+        "source": source,
+        "command": [*sys.argv[0].split(), *sys.argv[1:]],
+        "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "params": params,
+    }
+    (dir_path / "mapsnap.json").write_text(json.dumps(record, indent=2))
 
 
 def jpeg_dimensions(path: Path) -> tuple[int, int]:
@@ -104,3 +123,19 @@ def image_stem(image_path: str) -> str:
     ``p50n.2048px.jpg`` become ``p50n`` rather than ``p50n.2048px``.
     """
     return Path(image_path).name.split(".")[0]
+
+
+def list_pages(dir_path: Path) -> list[Path]:
+    """Return the effective page images in dir_path, splits superseding their parent.
+
+    Globs top-level ``p*.jpg`` (ignoring the ``raw/`` and ``oim/`` subdirectories). A
+    whole-page ``pN.jpg`` is dropped when any of its panels ``pN__*.jpg`` is present, so
+    callers operate on the split panels instead. Returns paths sorted by name.
+    """
+    images = sorted(dir_path.glob("p*.jpg"))
+    split_parents = {p.stem.split("__")[0] for p in images if "__" in p.stem}
+    return [
+        p
+        for p in images
+        if "__" in p.stem or p.stem.split("__")[0] not in split_parents
+    ]

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -1,6 +1,21 @@
 """Tests for mapsnap.utils."""
 
-from mapsnap.utils import image_stem, source_id_to_page_key
+from mapsnap.utils import image_stem, list_pages, source_id_to_page_key
+
+
+def test_list_pages_splits_supersede_parent(tmp_path):
+    for name in ("p1.jpg", "p2.jpg", "p2__1.jpg", "p2__2.jpg", "p3.jpg"):
+        (tmp_path / name).touch()
+    # raw/ and oim/ subdirectories are ignored.
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "raw" / "p1.jpg").touch()
+
+    names = [p.name for p in list_pages(tmp_path)]
+    assert names == ["p1.jpg", "p2__1.jpg", "p2__2.jpg", "p3.jpg"]
+
+
+def test_list_pages_empty_dir(tmp_path):
+    assert list_pages(tmp_path) == []
 
 
 def test_single_extension():

--- a/scripts/make_panel_truth.py
+++ b/scripts/make_panel_truth.py
@@ -28,7 +28,7 @@ import cv2
 import numpy as np
 from PIL import Image
 
-from mapsnap.make_iiif_georef import locate_split_in_unsplit
+from mapsnap.oim_truth import locate_split_in_unsplit
 
 WHITE_THRESHOLD = 250  # pixels at or above this are masked-out (not part of the panel)
 CLOSE_KERNEL_PX = 25  # close small holes/noise in the panel mask before contouring

--- a/scripts/migrate_loc_layout.py
+++ b/scripts/migrate_loc_layout.py
@@ -1,0 +1,62 @@
+"""Migrate Library of Congress data directories to the suffix-free layout.
+
+LoC pages were downloaded at pct:25 into ``<page_key>.raw.jpg``; that file is already at
+25% scale, so the new canonical layout just drops the ``.raw`` qualifier:
+``<page_key>.raw.jpg`` → ``<page_key>.jpg``. Sidecars (``.boxes.json``, ``.streets.json``,
+``.georef.json``) are keyed by the bare stem and need no renaming, and there is no
+full-resolution ``raw/`` directory for migrated LoC volumes.
+
+Recurses into each given directory (covering multivolume ``vol*/`` subdirectories). Skips a
+rename when the destination already exists. Run ``mapsnap split`` afterwards to generate
+panels for any pages that split.
+
+Usage:
+    uv run scripts/migrate_loc_layout.py DIR [DIR ...] [--dry-run]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+RAW_SUFFIX = ".raw.jpg"
+
+
+def migrate_dir(dir_path: Path, dry_run: bool) -> int:
+    """Rename every *.raw.jpg under dir_path to *.jpg. Returns the number renamed."""
+    renamed = 0
+    for src in sorted(dir_path.rglob(f"*{RAW_SUFFIX}")):
+        dest = src.with_name(src.name[: -len(RAW_SUFFIX)] + ".jpg")
+        if dest.exists():
+            print(f"  skip (exists): {dest}", file=sys.stderr)
+            continue
+        print(f"  {src.name} → {dest.name}  ({src.parent})")
+        if not dry_run:
+            src.rename(dest)
+        renamed += 1
+    return renamed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dirs", nargs="+", type=Path, metavar="DIR", help="LoC data directories"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the renames without performing them.",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for dir_path in args.dirs:
+        if not dir_path.is_dir():
+            sys.exit(f"Not a directory: {dir_path}")
+        total += migrate_dir(dir_path, args.dry_run)
+
+    verb = "would rename" if args.dry_run else "renamed"
+    print(f"\nDone: {verb} {total} file(s).", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #74.

(Using 25% instead of the ~30-35% scale changes the OCR feature sizes. I'll recalibrate those in a followup via #68.)

`run-oim` and `run-loc` produced different, ambiguous directory layouts — most confusingly, `pN.raw.jpg` meant full-resolution under OIM but already-25%-scaled under LoC. This reworks both pipelines onto a single canonical layout so downstream processing (and the new splitter) can treat them identically.

## Canonical layout

```
pN.jpg            # 25% scale, full page (what OCR/georef/iiif consume)
pN__1.jpg         # 25% scale panel 1 (only when the page splits)
pN__2.jpg         # 25% scale panel 2
pN.panels.json    # panel polygons in the pN.jpg frame (only when split)
mapsnap.json      # records the command + params used to generate the dir
raw/              # full-resolution pages (OIM only; LoC downloads 25% directly)
oim/              # OIM-only ground-truth: manual split regions + derived panels.json
```

The 25%→full-res factor is hard-coded (×4). The `.raw`/`.scaled`/`.unsplit` suffixes are gone; sidecars (`.boxes.json`, `.streets.json`, `.georef.json`) are unaffected since they're keyed by the bare stem.

## What changed

- **Single source of split geometry.** `mapsnap split` now writes `pN.panels.json` (polygons in reading order, matching the `pN__i.jpg` numbering), skips inputs that are themselves panels, and regenerates idempotently (stale panels removed first).
- **One page-discovery rule.** New `list_pages()` returns the effective pages with split panels superseding their parent; `fit` and both pipelines use it. `mapsnap ocr` also skips superseded parents however it's invoked, so OCR never runs on a page that's been split.
- **`mapsnap scale`** takes an input glob + `--output-dir`, writes `pN.jpg`, and drops the old `.scaled`-suffix / unsplit-filter behavior.
- **`mapsnap iiif`** places split sub-images via `pN.panels.json` (scaled to the parent canvas) instead of template matching; the template-matching path and its `.unsplit.jpg` dependency are removed from this module.
- **OIM ground truth moved off the fit path.** New `mapsnap oim-split-truth` command (`oim_truth.py`) template-matches OIM's manually-split regions against the unsplit page and writes `oim/pN.panels.json` in canvas coordinates. It uses an OpenCV **mask** (not white-pixel substitution) so masked-out regions don't suppress the match score, and extracts the true non-white **panel polygon** rather than a bounding box.
- **`mapsnap compare`** associates our splits with OIM's by panel-**polygon** IoU (numbering need not agree) rather than by `__N` index.
- **Pipelines** converge: LoC downloads 25% directly; OIM downloads full-res to `raw/` + OIM splits to `oim/`, scales, splits, then runs `oim-split-truth`. Both write a `mapsnap.json` run record.
- **`mapsnap download-osm`** now retries with exponential backoff on transient errors (HTTP 429/5xx, network/timeout), matching the other download scripts.
- **Migration:** `scripts/migrate_loc_layout.py` renames existing LoC `*.raw.jpg` → `*.jpg` in place (OIM dirs are recreated via `run-oim`).

## Testing

Added unit tests for `list_pages`, `panels.json` round-trip, `scale`, split-page `make_annotation`, polygon-IoU split association, `oim-split-truth` placement, OCR parent-skipping, and OSM retry/backoff. Full suite passes (266 tests); ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
