### PR TITLE
Set short-side and long-side using high-confidence distribution

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -11,17 +11,22 @@ which can be pasted into the textarea to preview the warped image on a MapLibre 
 """
 
 import argparse
+import contextlib
+import io
 import json
 import math
+import multiprocessing
 import os
 import statistics
 import sys
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from PIL import Image
+from tqdm import tqdm
 
 from mapsnap.streets import (
     DIRECTION_WORDS,
@@ -902,16 +907,20 @@ def correct_square_feature_dirs(
             feat.dir_pix = round(best_dir % math.pi, 4)
 
 
-def derive_paths(image_path: str) -> tuple[str, str]:
-    """Derive labels and output paths from an image path.
+def derive_paths(image_path: str) -> tuple[str, str, str]:
+    """Derive labels, output, and per-page log paths from an image path.
 
     Strips everything after the first '.' in the filename to form the stem:
-      p123.2048px.jpg → (p123.streets.json, p123.georef.json)
+      p123.2048px.jpg → (p123.streets.json, p123.georef.json, p123.txt)
     """
     p = Path(image_path)
     stem = image_stem(image_path)
     base = p.parent / stem
-    return str(base) + ".streets.json", str(base) + ".georef.json"
+    return (
+        str(base) + ".streets.json",
+        str(base) + ".georef.json",
+        str(base) + ".txt",
+    )
 
 
 def load_detections(labels_path: str) -> list[dict]:
@@ -941,7 +950,7 @@ def compute_auto_min_short_side(
     """
     short_sides: list[float] = []
     for image_path in images:
-        labels_path, _ = derive_paths(image_path)
+        labels_path, _, _ = derive_paths(image_path)
         if not os.path.exists(labels_path):
             continue
         for det in load_detections(labels_path):
@@ -961,6 +970,118 @@ def compute_auto_min_short_side(
     index = round(percentile) - 1
     index = max(0, min(len(quantiles) - 1, index))
     return quantiles[index]
+
+
+class _Tee:
+    """File-like object that writes to multiple streams (used to mirror logs under --debug)."""
+
+    def __init__(self, *streams: Any) -> None:
+        self.streams = streams
+
+    def write(self, s: str) -> int:
+        for stream in self.streams:
+            stream.write(s)
+        return len(s)
+
+    def flush(self) -> None:
+        for stream in self.streams:
+            stream.flush()
+
+
+@contextlib.contextmanager
+def _captured_page_log(log_path: str, debug: bool, append: bool = False):
+    """Redirect stdout/stderr to log_path for the duration of the block.
+
+    Under --debug, output is also mirrored to the real stderr in addition to being
+    written to log_path. append=True is used for the second (deferred-image) pass so
+    its output joins the page's first-pass log rather than overwriting it.
+    """
+    buf = io.StringIO()
+    target = _Tee(buf, sys.stderr) if debug else buf
+    with contextlib.redirect_stdout(target), contextlib.redirect_stderr(target):
+        yield
+    with open(log_path, "a" if append else "w") as f:
+        f.write(buf.getvalue())
+
+
+# Module-level state populated by _init_worker, used by _process_one_image. Each
+# multiprocessing worker process gets its own copy; with --num-workers=1 this is
+# populated directly in the main process instead of spawning a pool.
+_worker_state: dict[str, Any] = {}
+
+
+def _init_worker(
+    block_index: dict[str, list[Block]],
+    cos_phi: float,
+    centerlines_path: str,
+    min_confidence: float,
+    min_long_side: float,
+    min_short_side: float,
+    min_aspect_ratio: float,
+    edge_margin: float,
+    force_intersection: tuple[int, int] | None,
+    one_gcp_fits: bool,
+    debug: bool,
+    parameters: dict,
+) -> None:
+    """Populate _worker_state once per worker process (or once in the main process)."""
+    _worker_state.update(
+        block_index=block_index,
+        cos_phi=cos_phi,
+        centerlines_path=centerlines_path,
+        min_confidence=min_confidence,
+        min_long_side=min_long_side,
+        min_short_side=min_short_side,
+        min_aspect_ratio=min_aspect_ratio,
+        edge_margin=edge_margin,
+        force_intersection=force_intersection,
+        one_gcp_fits=one_gcp_fits,
+        debug=debug,
+        parameters=parameters,
+    )
+
+
+def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
+    """Georeference one image using _worker_state, capturing its log to a <stem>.txt sidecar.
+
+    Runs the same way whether dispatched to a multiprocessing worker (--num-workers > 1)
+    or called directly in the main process (--num-workers == 1), so a page's output and
+    log file are identical either way.
+    """
+    labels_path, output_path, log_path = derive_paths(image_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+    for stale_suffix in (
+        ".georef-misscale.json",
+        ".georef-outlier.json",
+        ".georef-1gcp.json",
+    ):
+        stale_path = output_path.replace(".georef.json", stale_suffix)
+        if os.path.exists(stale_path):
+            os.remove(stale_path)
+
+    with _captured_page_log(log_path, _worker_state["debug"]):
+        print(f"--- {image_path} ---")
+        result = process_image(
+            image_path=image_path,
+            labels_path=labels_path,
+            output_path=output_path,
+            block_index=_worker_state["block_index"],
+            cos_phi=_worker_state["cos_phi"],
+            centerlines_path=_worker_state["centerlines_path"],
+            min_confidence=_worker_state["min_confidence"],
+            min_long_side=_worker_state["min_long_side"],
+            min_short_side=_worker_state["min_short_side"],
+            min_aspect_ratio=_worker_state["min_aspect_ratio"],
+            edge_margin=_worker_state["edge_margin"],
+            force_intersection=_worker_state["force_intersection"],
+            one_gcp_fits=_worker_state["one_gcp_fits"],
+            debug=_worker_state["debug"],
+            parameters=_worker_state["parameters"],
+        )
+    if result.deferred is not None:
+        result.deferred["log_path"] = log_path
+    return image_path, result
 
 
 def process_image(
@@ -1522,6 +1643,16 @@ def main() -> None:
     parser.add_argument(
         "--debug", action="store_true", help="Print additional debug information"
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Number of worker processes for the per-image fitting pass "
+            "(default: %(default)s, sequential)"
+        ),
+    )
     args = parser.parse_args()
 
     force_intersection: tuple[int, int] | None = None
@@ -1594,39 +1725,39 @@ def main() -> None:
     ] = []  # (center, rotation)
     deferred_list: list[dict] = []
 
-    for image_path in args.images:
-        if len(args.images) > 1:
-            print(f"\n--- {image_path} ---", file=sys.stderr)
-        labels_path, output_path = derive_paths(image_path)
-        # Delete stale georef file before attempting a new fit so a failed run
-        # doesn't leave a previous result in place.
-        if os.path.exists(output_path):
-            os.remove(output_path)
-        for stale_suffix in (
-            ".georef-misscale.json",
-            ".georef-outlier.json",
-            ".georef-1gcp.json",
-        ):
-            stale_path = output_path.replace(".georef.json", stale_suffix)
-            if os.path.exists(stale_path):
-                os.remove(stale_path)
-        result = process_image(
-            image_path=image_path,
-            labels_path=labels_path,
-            output_path=output_path,
-            block_index=block_index,
-            cos_phi=cos_phi,
-            centerlines_path=args.centerlines,
-            min_confidence=args.min_confidence,
-            min_long_side=min_long_side,
-            min_short_side=min_short_side,
-            min_aspect_ratio=args.min_aspect_ratio,
-            edge_margin=args.edge_margin,
-            force_intersection=force_intersection,
-            one_gcp_fits=not args.disable_one_gcp_fits,
-            debug=args.debug,
-            parameters=parameters,
-        )
+    worker_initargs = (
+        block_index,
+        cos_phi,
+        args.centerlines,
+        args.min_confidence,
+        min_long_side,
+        min_short_side,
+        args.min_aspect_ratio,
+        args.edge_margin,
+        force_intersection,
+        not args.disable_one_gcp_fits,
+        args.debug,
+        parameters,
+    )
+    if args.num_workers > 1:
+        with multiprocessing.Pool(
+            args.num_workers, initializer=_init_worker, initargs=worker_initargs
+        ) as pool:
+            page_results = list(
+                tqdm(
+                    pool.imap_unordered(_process_one_image, args.images),
+                    total=len(args.images),
+                    smoothing=0,
+                )
+            )
+    else:
+        _init_worker(*worker_initargs)
+        page_results = [
+            _process_one_image(image_path)
+            for image_path in tqdm(args.images, smoothing=0)
+        ]
+
+    for image_path, result in page_results:
         if result.success:
             n_success += 1
             if result.scale_deg_per_px is not None:
@@ -1667,17 +1798,15 @@ def main() -> None:
             scale_deg_per_px = px_per_ft_to_deg_per_px(ref_scale_px_per_ft)
             for deferred in deferred_list:
                 deferred_image_path: str = deferred["image_path"]
-                if len(args.images) > 1:
-                    print(
-                        f"\n--- {deferred_image_path} (deferred) ---", file=sys.stderr
+                with _captured_page_log(deferred["log_path"], args.debug, append=True):
+                    print(f"\n--- {deferred_image_path} (deferred) ---")
+                    deferred_result = process_deferred_image(
+                        deferred=deferred,
+                        scale_deg_per_px=scale_deg_per_px,
+                        block_index=block_index,
+                        cos_phi=cos_phi,
+                        neighbor_rotations=neighbor_rotations,
                     )
-                deferred_result = process_deferred_image(
-                    deferred=deferred,
-                    scale_deg_per_px=scale_deg_per_px,
-                    block_index=block_index,
-                    cos_phi=cos_phi,
-                    neighbor_rotations=neighbor_rotations,
-                )
                 if deferred_result.success:
                     n_success += 1
                     if deferred_result.center is not None:
@@ -1691,7 +1820,7 @@ def main() -> None:
         for img_path, px_per_ft in scale_records:
             ratio = px_per_ft / ref_scale_px_per_ft
             if abs(ratio - 1.0) > args.scale_outlier_threshold:
-                _, out_path = derive_paths(img_path)
+                _, out_path, _ = derive_paths(img_path)
                 misscale_path = out_path.replace(
                     ".georef.json", ".georef-misscale.json"
                 )
@@ -1719,7 +1848,7 @@ def main() -> None:
             other_centers = [c for p, c in active if p != img_path]
             min_dist_km = min(_dist_km(center, other) for other in other_centers)
             if min_dist_km > args.min_distance_for_outlier_km:
-                _, out_path = derive_paths(img_path)
+                _, out_path, _ = derive_paths(img_path)
                 outlier_path = out_path.replace(".georef.json", ".georef-outlier.json")
                 os.rename(out_path, outlier_path)
                 n_success -= 1

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -938,15 +938,18 @@ FALLBACK_MIN_SHORT_SIDE = 20.0
 
 
 def compute_auto_min_short_side(
-    images: list[str], min_confidence: float, percentile: float
+    images: list[str],
+    min_confidence: float,
+    percentile: float,
+    include_hints: bool = False,
 ) -> float | None:
     """Derive a volume-wide min_short_side floor from the volume's own detections.
 
     Collects short_side values from confident (>= min_confidence) street detections
-    (non-hint, non-ignored, with at least 2 letters in the detected text) across every
-    image's cached <stem>.streets.json, then returns the given percentile of that
-    distribution. Returns None if no qualifying detections are found anywhere in the
-    volume.
+    (non-ignored, with at least 2 letters in the detected text; hint detections are
+    excluded unless include_hints is set) across every image's cached
+    <stem>.streets.json, then returns the given percentile of that distribution.
+    Returns None if no qualifying detections are found anywhere in the volume.
     """
     short_sides: list[float] = []
     for image_path in images:
@@ -954,7 +957,7 @@ def compute_auto_min_short_side(
         if not os.path.exists(labels_path):
             continue
         for det in load_detections(labels_path):
-            if det.get("ignore") or det.get("hint"):
+            if det.get("ignore") or (not include_hints and det.get("hint")):
                 continue
             text = det.get("text", "")
             n_letters = sum(1 for c in text if c.isalpha())
@@ -1575,6 +1578,14 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--auto-threshold-include-hints",
+        action="store_true",
+        help=(
+            "Include hint (type-word) detections, not just street-name detections, "
+            "in the automatic min-short-side calculation"
+        ),
+    )
+    parser.add_argument(
         "--min-aspect-ratio",
         type=float,
         default=1.75,
@@ -1679,7 +1690,10 @@ def main() -> None:
         min_short_side = args.min_short_side
     else:
         auto_min_short_side = compute_auto_min_short_side(
-            args.images, args.auto_threshold_confidence, args.auto_threshold_percentile
+            args.images,
+            args.auto_threshold_confidence,
+            args.auto_threshold_percentile,
+            args.auto_threshold_include_hints,
         )
         if auto_min_short_side is None:
             min_short_side = FALLBACK_MIN_SHORT_SIDE
@@ -1712,6 +1726,7 @@ def main() -> None:
         "min_aspect_ratio": args.min_aspect_ratio,
         "auto_threshold_confidence": args.auto_threshold_confidence,
         "auto_threshold_percentile": args.auto_threshold_percentile,
+        "auto_threshold_include_hints": args.auto_threshold_include_hints,
     }
 
     n_success = 0

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -969,6 +969,8 @@ def compute_auto_min_short_side(
 
     if not short_sides:
         return None
+    if len(short_sides) == 1:
+        return short_sides[0]
     quantiles = statistics.quantiles(short_sides, n=100, method="inclusive")
     index = round(percentile) - 1
     index = max(0, min(len(quantiles) - 1, index))

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1560,7 +1560,7 @@ def main() -> None:
     parser.add_argument(
         "--auto-threshold-confidence",
         type=float,
-        default=0.3,
+        default=0.5,
         metavar="THRESHOLD",
         help=(
             "Minimum OCR confidence for a detection to count towards the automatic "
@@ -1573,16 +1573,16 @@ def main() -> None:
         default=25.0,
         metavar="PCT",
         help=(
-            "Percentile of confident street-detection short sides used as the "
-            "automatic min-short-side floor (default: %(default)s)"
+            "Percentile of confident detection short sides used as the automatic "
+            "min-short-side floor (default: %(default)s)"
         ),
     )
     parser.add_argument(
-        "--auto-threshold-include-hints",
+        "--auto-threshold-exclude-hints",
         action="store_true",
         help=(
-            "Include hint (type-word) detections, not just street-name detections, "
-            "in the automatic min-short-side calculation"
+            "Only count street-name detections (not hint/type-word detections) "
+            "towards the automatic min-short-side calculation"
         ),
     )
     parser.add_argument(
@@ -1686,6 +1686,7 @@ def main() -> None:
         file=sys.stderr,
     )
 
+    auto_threshold_include_hints = not args.auto_threshold_exclude_hints
     if args.min_short_side is not None:
         min_short_side = args.min_short_side
     else:
@@ -1693,14 +1694,16 @@ def main() -> None:
             args.images,
             args.auto_threshold_confidence,
             args.auto_threshold_percentile,
-            args.auto_threshold_include_hints,
+            auto_threshold_include_hints,
+        )
+        detection_kind = (
+            "detections" if auto_threshold_include_hints else "street detections"
         )
         if auto_min_short_side is None:
             min_short_side = FALLBACK_MIN_SHORT_SIDE
             print(
-                f"No confident (>= {args.auto_threshold_confidence:g}) street "
-                f"detections found; falling back to min-short-side="
-                f"{min_short_side:g}px.",
+                f"No confident (>= {args.auto_threshold_confidence:g}) {detection_kind} "
+                f"found; falling back to min-short-side={min_short_side:g}px.",
                 file=sys.stderr,
             )
         else:
@@ -1708,7 +1711,7 @@ def main() -> None:
             print(
                 f"Auto min-short-side: {min_short_side:.1f}px "
                 f"(p{args.auto_threshold_percentile:g} of confidence>="
-                f"{args.auto_threshold_confidence:g} street detections)",
+                f"{args.auto_threshold_confidence:g} {detection_kind})",
                 file=sys.stderr,
             )
     min_long_side = (
@@ -1726,7 +1729,7 @@ def main() -> None:
         "min_aspect_ratio": args.min_aspect_ratio,
         "auto_threshold_confidence": args.auto_threshold_confidence,
         "auto_threshold_percentile": args.auto_threshold_percentile,
-        "auto_threshold_include_hints": args.auto_threshold_include_hints,
+        "auto_threshold_include_hints": auto_threshold_include_hints,
     }
 
     n_success = 0

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import math
 import os
+import statistics
 import sys
 from dataclasses import dataclass
 from itertools import combinations
@@ -614,6 +615,7 @@ def _finalize_georef(
     centerlines_path: str,
     initial_pair: tuple[int, int] | None = None,
     extra_fields: dict | None = None,
+    parameters: dict | None = None,
 ) -> tuple[float, tuple[float, float]]:
     """Print fit stats, write georef JSON, and return (scale_deg_per_px, page_center)."""
 
@@ -693,6 +695,7 @@ def _finalize_georef(
             "labels": labels_path,
             "centerlines": centerlines_path,
             "image": image_path,
+            "parameters": parameters,
         },
         "streets": streets_out,
         "intersections": intersections_out,
@@ -911,6 +914,55 @@ def derive_paths(image_path: str) -> tuple[str, str]:
     return str(base) + ".streets.json", str(base) + ".georef.json"
 
 
+def load_detections(labels_path: str) -> list[dict]:
+    """Load cached label detections from a <stem>.streets.json file."""
+    labels_raw = json.load(open(labels_path))
+    if isinstance(labels_raw, dict):
+        return labels_raw.get(
+            "streets", labels_raw.get("detections", labels_raw.get("accepted", []))
+        )
+    return labels_raw
+
+
+# Used when a volume has no detections confident enough to derive an auto threshold.
+FALLBACK_MIN_SHORT_SIDE = 20.0
+
+
+def compute_auto_min_short_side(
+    images: list[str], min_confidence: float, percentile: float
+) -> float | None:
+    """Derive a volume-wide min_short_side floor from the volume's own detections.
+
+    Collects short_side values from confident (>= min_confidence) street detections
+    (non-hint, non-ignored, with at least 2 letters in the detected text) across every
+    image's cached <stem>.streets.json, then returns the given percentile of that
+    distribution. Returns None if no qualifying detections are found anywhere in the
+    volume.
+    """
+    short_sides: list[float] = []
+    for image_path in images:
+        labels_path, _ = derive_paths(image_path)
+        if not os.path.exists(labels_path):
+            continue
+        for det in load_detections(labels_path):
+            if det.get("ignore") or det.get("hint"):
+                continue
+            text = det.get("text", "")
+            n_letters = sum(1 for c in text if c.isalpha())
+            if det.get("confidence", 0.0) < min_confidence or n_letters < 2:
+                continue
+            short_side = det.get("short_side")
+            if short_side is not None:
+                short_sides.append(float(short_side))
+
+    if not short_sides:
+        return None
+    quantiles = statistics.quantiles(short_sides, n=100, method="inclusive")
+    index = round(percentile) - 1
+    index = max(0, min(len(quantiles) - 1, index))
+    return quantiles[index]
+
+
 def process_image(
     image_path: str,
     labels_path: str,
@@ -926,6 +978,7 @@ def process_image(
     force_intersection: tuple[int, int] | None = None,
     one_gcp_fits: bool = False,
     debug: bool = False,
+    parameters: dict | None = None,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -939,13 +992,7 @@ def process_image(
     with Image.open(image_path) as pil_img:
         img_w, img_h = pil_img.size
 
-    labels_raw = json.load(open(labels_path))
-    if isinstance(labels_raw, dict):
-        all_detections: list[dict] = labels_raw.get(
-            "streets", labels_raw.get("detections", labels_raw.get("accepted", []))
-        )
-    else:
-        all_detections = labels_raw
+    all_detections = load_detections(labels_path)
 
     print(f"All detections: {len(all_detections)}")
     all_detections = [d for d in all_detections if not d.get("ignore")]
@@ -1059,6 +1106,7 @@ def process_image(
                 "gcps": gcps,
                 "img_w": img_w,
                 "img_h": img_h,
+                "parameters": parameters,
             },
         )
 
@@ -1099,6 +1147,7 @@ def process_image(
         labels_path,
         centerlines_path,
         initial_pair=seed_pair,
+        parameters=parameters,
     )
     rotation = math.atan2(float(A[1, 0]), float(-A[1, 1]))
     return ProcessResult(
@@ -1257,6 +1306,7 @@ def process_deferred_image(
     gcps: list[IntersectionGCP] = deferred["gcps"]
     img_w: int = deferred["img_w"]
     img_h: int = deferred["img_h"]
+    parameters: dict | None = deferred["parameters"]
     gcp = gcps[0]
 
     undirected = _rotation_from_gcp_features(gcp, block_index)
@@ -1329,6 +1379,7 @@ def process_deferred_image(
         labels_path,
         centerlines_path,
         extra_fields=one_gcp_extra,
+        parameters=parameters,
     )
     return ProcessResult(
         success=decision.confirmed, scale_deg_per_px=scale, center=center
@@ -1364,16 +1415,43 @@ def main() -> None:
     parser.add_argument(
         "--min-long-side",
         type=float,
-        default=40.0,
+        default=None,
         metavar="PX",
-        help="Minimum long side of a text polygon to accept (default: %(default)s)",
+        help=(
+            "Minimum long side of a text polygon to accept. If not given, defaults to "
+            "2x the (auto or explicit) min-short-side."
+        ),
     )
     parser.add_argument(
         "--min-short-side",
         type=float,
-        default=20.0,
+        default=None,
         metavar="PX",
-        help="Minimum short side of a text polygon to accept (default: %(default)s)",
+        help=(
+            "Minimum short side of a text polygon to accept. If not given, it is "
+            "derived automatically from this volume's own detections (see "
+            "--auto-threshold-confidence and --auto-threshold-percentile)."
+        ),
+    )
+    parser.add_argument(
+        "--auto-threshold-confidence",
+        type=float,
+        default=0.3,
+        metavar="THRESHOLD",
+        help=(
+            "Minimum OCR confidence for a detection to count towards the automatic "
+            "min-short-side calculation (default: %(default)s)"
+        ),
+    )
+    parser.add_argument(
+        "--auto-threshold-percentile",
+        type=float,
+        default=25.0,
+        metavar="PCT",
+        help=(
+            "Percentile of confident street-detection short sides used as the "
+            "automatic min-short-side floor (default: %(default)s)"
+        ),
     )
     parser.add_argument(
         "--min-aspect-ratio",
@@ -1466,6 +1544,45 @@ def main() -> None:
         file=sys.stderr,
     )
 
+    if args.min_short_side is not None:
+        min_short_side = args.min_short_side
+    else:
+        auto_min_short_side = compute_auto_min_short_side(
+            args.images, args.auto_threshold_confidence, args.auto_threshold_percentile
+        )
+        if auto_min_short_side is None:
+            min_short_side = FALLBACK_MIN_SHORT_SIDE
+            print(
+                f"No confident (>= {args.auto_threshold_confidence:g}) street "
+                f"detections found; falling back to min-short-side="
+                f"{min_short_side:g}px.",
+                file=sys.stderr,
+            )
+        else:
+            min_short_side = auto_min_short_side
+            print(
+                f"Auto min-short-side: {min_short_side:.1f}px "
+                f"(p{args.auto_threshold_percentile:g} of confidence>="
+                f"{args.auto_threshold_confidence:g} street detections)",
+                file=sys.stderr,
+            )
+    min_long_side = (
+        args.min_long_side if args.min_long_side is not None else 2 * min_short_side
+    )
+    print(
+        f"Thresholds: min_confidence={args.min_confidence:g} "
+        f"min_long_side={min_long_side:.1f}px min_short_side={min_short_side:.1f}px",
+        file=sys.stderr,
+    )
+    parameters = {
+        "min_confidence": args.min_confidence,
+        "min_long_side": min_long_side,
+        "min_short_side": min_short_side,
+        "min_aspect_ratio": args.min_aspect_ratio,
+        "auto_threshold_confidence": args.auto_threshold_confidence,
+        "auto_threshold_percentile": args.auto_threshold_percentile,
+    }
+
     n_success = 0
     scales: list[float] = []
     scale_records: list[
@@ -1501,13 +1618,14 @@ def main() -> None:
             cos_phi=cos_phi,
             centerlines_path=args.centerlines,
             min_confidence=args.min_confidence,
-            min_long_side=args.min_long_side,
-            min_short_side=args.min_short_side,
+            min_long_side=min_long_side,
+            min_short_side=min_short_side,
             min_aspect_ratio=args.min_aspect_ratio,
             edge_margin=args.edge_margin,
             force_intersection=force_intersection,
             one_gcp_fits=not args.disable_one_gcp_fits,
             debug=args.debug,
+            parameters=parameters,
         )
         if result.success:
             n_success += 1

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1,5 +1,6 @@
 """Tests for georef_from_labels helpers."""
 
+import json
 import math
 
 import numpy as np
@@ -9,6 +10,7 @@ from mapsnap.georef_from_labels import (
     _angle_diff_abs,
     _cluster_geo_coords,
     _rotation_from_neighbors,
+    compute_auto_min_short_side,
     correct_square_feature_dirs,
     label_features,
     promote_avenue_letters,
@@ -473,3 +475,59 @@ def test_rotation_from_neighbors_adjacency_boundary():
     )
     assert result.confirmed is True
     assert result.n_agree == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_auto_min_short_side
+# ---------------------------------------------------------------------------
+
+
+def _write_streets_json(path, detections: list[dict]) -> None:
+    """Write a minimal <stem>.streets.json fixture file."""
+    path.write_text(json.dumps({"streets": detections}))
+
+
+def test_compute_auto_min_short_side_basic_percentile(tmp_path):
+    dets = [_make_det(f"MAIN ST {i}", 0, 0, short_side=float(i)) for i in range(1, 101)]
+    _write_streets_json(tmp_path / "p1.streets.json", dets)
+    image_path = str(tmp_path / "p1.2048px.jpg")
+
+    result = compute_auto_min_short_side(
+        [image_path], min_confidence=0.3, percentile=25
+    )
+    assert result == 25.75
+
+
+def test_compute_auto_min_short_side_excludes_hints_and_low_confidence(tmp_path):
+    dets = [
+        _make_det("MAIN STREET", 0, 0, short_side=10.0, confidence=0.9),
+        _make_det("LOW CONFIDENCE", 0, 0, short_side=1000.0, confidence=0.1),
+        _make_det("N", 0, 0, short_side=1000.0, confidence=0.9, hint=True),
+        _make_det("A", 0, 0, short_side=1000.0, confidence=0.9),  # < 2 letters
+    ]
+    _write_streets_json(tmp_path / "p1.streets.json", dets)
+    image_path = str(tmp_path / "p1.2048px.jpg")
+
+    result = compute_auto_min_short_side(
+        [image_path], min_confidence=0.3, percentile=25
+    )
+    assert result == 10.0
+
+
+def test_compute_auto_min_short_side_no_qualifying_detections(tmp_path):
+    dets = [_make_det("A", 0, 0, confidence=0.9)]  # < 2 letters
+    _write_streets_json(tmp_path / "p1.streets.json", dets)
+    image_path = str(tmp_path / "p1.2048px.jpg")
+
+    result = compute_auto_min_short_side(
+        [image_path], min_confidence=0.3, percentile=25
+    )
+    assert result is None
+
+
+def test_compute_auto_min_short_side_skips_missing_labels_file(tmp_path):
+    image_path = str(tmp_path / "p1.2048px.jpg")  # no p1.streets.json written
+    result = compute_auto_min_short_side(
+        [image_path], min_confidence=0.3, percentile=25
+    )
+    assert result is None

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -514,6 +514,20 @@ def test_compute_auto_min_short_side_excludes_hints_and_low_confidence(tmp_path)
     assert result == 10.0
 
 
+def test_compute_auto_min_short_side_include_hints(tmp_path):
+    dets = [
+        _make_det("MAIN STREET", 0, 0, short_side=10.0, confidence=0.9),
+        _make_det("EAST", 0, 0, short_side=1000.0, confidence=0.9, hint=True),
+    ]
+    _write_streets_json(tmp_path / "p1.streets.json", dets)
+    image_path = str(tmp_path / "p1.2048px.jpg")
+
+    result = compute_auto_min_short_side(
+        [image_path], min_confidence=0.3, percentile=25, include_hints=True
+    )
+    assert result == 257.5
+
+
 def test_compute_auto_min_short_side_no_qualifying_detections(tmp_path):
     dets = [_make_det("A", 0, 0, confidence=0.9)]  # < 2 letters
     _write_streets_json(tmp_path / "p1.streets.json", dets)


### PR DESCRIPTION
Fixes #68
Fixes #72

## Summary

Replaces the fixed `--min-long-side`/`--min-short-side` defaults with a value derived automatically from each volume's own OCR detections, parallelizes the per-image georeferencing loop, and cleans up terminal output.

- **Automatic thresholds.** `--min-short-side` now defaults to the Nth percentile of `short_side` across confident detections (2+ letters) in the volume's own `<stem>.streets.json` files, instead of a single hard-coded pixel value across all volumes. `--min-long-side` defaults to 2x that. The constants are exposed as `--auto-threshold-confidence` (default `0.5`) and `--auto-threshold-percentile` (default `25`), and whether hint (type-word) detections count towards the calculation is controlled by `--auto-threshold-exclude-hints` (off by default). The resolved thresholds are logged and written into each `<stem>.georef.json`'s new `inputs.parameters` section for reproducibility.
- **Parallelization.** Added `--num-workers` to georeference images concurrently (process-based, via `multiprocessing.Pool`), since the per-image loop is embarrassingly parallel.
- **Cleaner terminal output.** Per-page output (previously dumped to stderr for every image) is now written to a `<stem>.txt` sidecar file next to each image's output, and only echoed to the terminal under `--debug`. A `tqdm` progress bar tracks overall progress over the volume instead.

## Choosing the auto-threshold defaults

To pick `--auto-threshold-confidence` and whether to include hint detections, I compared the current/candidate behavior across all 8 combinations of {confidence 0.3, 0.5} x {hints excluded, included} x {p25, median} on the 7 volumes used for testing:

| volume | 0.3/no-hints/p25 | 0.3/+hints/p25 | 0.3/no-hints/median | 0.3/+hints/median | 0.5/no-hints/p25 | 0.5/+hints/p25 | 0.5/no-hints/median | 0.5/+hints/median |
|---|---|---|---|---|---|---|---|---|
| detroit | 12.0 | 14.0 | 20.0 | 20.0 | 18.0 | 18.0 | 24.0 | 20.0 |
| chicago | 12.0 | 12.0 | 16.0 | 16.0 | 14.0 | 14.0 | 16.0 | 16.0 |
| brooklyn | 16.0 | 16.1 | 24.0 | 24.0 | 18.0 | 18.0 | 24.0 | 24.0 |
| queens_vol2 | 18.0 | 19.1 | 24.0 | 24.0 | 20.0 | 20.0 | 24.0 | 24.0 |
| queens_vol5 | 14.0 | 14.0 | 16.0 | 16.0 | 14.0 | 14.0 | 16.0 | 16.0 |
| champaign | 20.0 | 20.0 | 24.0 | 24.0 | 20.0 | 20.0 | 24.0 | 24.0 |
| new_orleans_1951 | 17.3 | 18.0 | 24.0 | 24.0 | 21.8 | 20.0 | 24.0 | 24.0 |

(`0.3/no-hints/p25` is the threshold the original implementation in this PR used; `0.5/+hints/p25` is what the PR settles on as the new default.) Including hints barely moves p25 anywhere (≤1.1px difference); median is consistently 1.3–1.7x p25.

I then ran `mapsnap fit` end-to-end on the volumes with reference (truth) georeferencing to compare `0.3/no-hints/p25` (scenario A, the original default) against `0.5/+hints/p25` (scenario B, the new default):

| volume | scenario | fit rate | RMSE mean / median / max | trans mean / median | rot mean |
|---|---|---|---|---|---|
| detroit | A | 82/103 (79.6%) | 144 / 14 / 9163 ft | 140 / 10 ft | 1.4° |
| detroit | B | 82/103 (79.6%) | **44** / 14 / **914** ft | **38** / 10 ft | 1.4° |
| chicago | A | 97/111 (87.4%) | 115 / 10 / 6735 ft | 110 / 6 ft | 1.9° |
| chicago | B | **98**/111 (88.3%) | 114 / 10 / 6735 ft | 109 / 6 ft | 1.8° |
| brooklyn | A | **48**/62 (77.4%) | 21 / 8 / 234 ft | 15 / 5 ft | 0.7° |
| brooklyn | B | 47/62 (75.8%) | 21 / 8 / 234 ft | 15 / 5 ft | 0.7° |
| champaign | A | 18/33 (54.6%) | 13 / 8 / 62 ft | 18 / 5 ft | 0.4° |
| champaign | B | 18/33 (54.6%) | 13 / 8 / 62 ft | 18 / 5 ft | 0.4° (identical) |
| new orleans 1951 | A | **101**/109 (92.7%) | 17 / 12 / 112 ft | 13 / 8 ft | 0.9° |
| new orleans 1951 | B | 99/109 (90.8%) | 17 / 12 / 112 ft | **12** / 8 ft | 0.8° |

Detroit is the standout: scenario B fixes some severe outlier fits (max RMSE 9163 → 914 ft, mean 144 → 44 ft) with no change in fit count. Chicago gains 1 fit; Brooklyn and New Orleans each lose 1-2 fits with otherwise near-identical accuracy; Champaign is unaffected. I also checked the two volumes without reference data, where only fit count is measurable:

| volume | scenario A (0.3, no hints, p25) | scenario B (0.5, +hints, p25) |
|---|---|---|
| queens vol2 | **65**/88 | 64/88 |
| queens vol5 | 50/68 | 50/68 |

No scenario dominates outright, but B's fix to Detroit's worst outliers, plus a small win on Chicago, outweighed the 1-2 fit regressions elsewhere, so this PR makes B (`--auto-threshold-confidence 0.5`, hints included) the new default.

## Prompts used to produce this branch

In rough chronological order (some exploratory; only the ones that changed code are reflected in the commits above):

1. "I've switched to `main` to roll back all the adaptive threshold changes from earlier. I'd like to implement a new automatic threshold based on this analysis. min-confidence can be set explicitly via command-line flag, as it is now. No change there. But min-short-side should be set to the 25th percentile of confident (>=0.3) street detections that are 2+ letters. min-long-side can default to double that value. These values should be logged, and should be included in the generated georef.json files in a new `input.parameters` section. The constants (0.3 and 25) can be new command line flags." → `1d1df3a`
2. "How would the 25th percentile value for min-short-side change on each of the seven test volumes if you included high-confidence hint detections as well as street detections?" (exploratory, no code change)
3. "The main step in `mapsnap/georef_from_labels.py`, the iteration over each image, is embarassingly parallel. Add a `--num-workers` flag and make this parallelizable. In addition to this change, reroute the per-page output that's currently written to stderr. Put it in a sidecar text file instead (e.g. p527.txt). Only print it to stderr if `--debug` is set. With the cleaner terminal output, set up a tqdm progress bar to track progress over the volume's images." → `08fe9f9`
4. "Give me another table for the seven test volumes showing what the min-short-side value would be for a few different scenarios: confidence 0.3/0.5, with/without hints, p25 vs. median." (exploratory, no code change)
5. "Using `mapsnap fit`, compare the performance on the volumes with truth data (Detroit, Chicago, Brooklyn, Champaign, New Orleans) for these two scenarios: conf=0.3/no-hints/p25 (current behavior) vs. conf=0.5/+hints/p25. This might take a little while. You can either pass `--num-workers 2` to `mapsnap fit` or kick off a few of the (location, configuration) pairs in parallel." → `23e8b16` (adds the include/exclude-hints flag needed to run the comparison)
6. "How many fits do we get under both scenarios for queens_vol2 and queens_vol5? There's no truth data here, I just want to know the number of images fit." (exploratory, no code change)
7. "Go ahead and make B the default." → `3164330`
8. "Fill in the PR description for https://github.com/danvk/mapsnap/pull/77. Include all the tables you generated, as well as a list of the prompts use to produce the changes in this branch." (this PR description)
9. "pytest passes locally but fails on the PR branch ... Figure out why." → `98062a0`
