### PR TITLE
Admit smaller, higher-confidence detections (issue #78)

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -977,6 +977,31 @@ def compute_auto_min_short_side(
     return quantiles[index]
 
 
+def confidence_relaxed_threshold(
+    confidence: float,
+    min_confidence: float,
+    base_threshold: float,
+    high_confidence_floor: float,
+) -> float:
+    """Compute the size threshold required for a detection at a given confidence.
+
+    A detection right at min_confidence must meet base_threshold; one at confidence
+    1.0 only needs to meet high_confidence_floor. Confidence values in between are
+    interpolated via a power law (linear in log-confidence vs. log-threshold), so a
+    smaller-than-base_threshold detection can still be admitted if it's proportionally
+    more confident than min_confidence (see issue #78). Returns base_threshold
+    unchanged if confidence <= min_confidence or high_confidence_floor >=
+    base_threshold (i.e. relaxation is disabled).
+    """
+    if confidence <= min_confidence or high_confidence_floor >= base_threshold:
+        return base_threshold
+    confidence = min(confidence, 1.0)
+    exponent = math.log(high_confidence_floor / base_threshold) / math.log(
+        min_confidence
+    )
+    return base_threshold * (min_confidence / confidence) ** exponent
+
+
 class _Tee:
     """File-like object that writes to multiple streams (used to mirror logs under --debug)."""
 
@@ -1028,6 +1053,7 @@ def _init_worker(
     one_gcp_fits: bool,
     debug: bool,
     parameters: dict,
+    high_confidence_size_fraction: float,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
@@ -1043,6 +1069,7 @@ def _init_worker(
         one_gcp_fits=one_gcp_fits,
         debug=debug,
         parameters=parameters,
+        high_confidence_size_fraction=high_confidence_size_fraction,
     )
 
 
@@ -1083,6 +1110,9 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             one_gcp_fits=_worker_state["one_gcp_fits"],
             debug=_worker_state["debug"],
             parameters=_worker_state["parameters"],
+            high_confidence_size_fraction=_worker_state[
+                "high_confidence_size_fraction"
+            ],
         )
     if result.deferred is not None:
         result.deferred["log_path"] = log_path
@@ -1105,6 +1135,7 @@ def process_image(
     one_gcp_fits: bool = False,
     debug: bool = False,
     parameters: dict | None = None,
+    high_confidence_size_fraction: float = 0.7,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -1155,19 +1186,27 @@ def process_image(
             # Promoted single-char avenue letters bypass size/aspect checks; confidence only.
             if det["confidence"] < min_confidence or is_number_only(det["text"]):
                 continue
-        elif not (
-            det["confidence"] >= min_confidence
-            and det.get("long_side", float("inf")) >= min_long_side
-            and det.get("short_side", float("inf")) >= min_short_side
-            and det.get("long_side", float("inf"))
-            >= min_aspect_ratio * det.get("short_side", 1.0)
-            and not is_number_only(det["text"])
-            and (
-                normalize_street(det["text"]) not in DIRECTION_WORDS
-                or det["text"].upper().strip() in normalized_streets
+        else:
+            required_short_side = confidence_relaxed_threshold(
+                det["confidence"],
+                min_confidence,
+                min_short_side,
+                min_short_side * high_confidence_size_fraction,
             )
-        ):
-            continue
+            required_long_side = min_long_side * (required_short_side / min_short_side)
+            if not (
+                det["confidence"] >= min_confidence
+                and det.get("long_side", float("inf")) >= required_long_side
+                and det.get("short_side", float("inf")) >= required_short_side
+                and det.get("long_side", float("inf"))
+                >= min_aspect_ratio * det.get("short_side", 1.0)
+                and not is_number_only(det["text"])
+                and (
+                    normalize_street(det["text"]) not in DIRECTION_WORDS
+                    or det["text"].upper().strip() in normalized_streets
+                )
+            ):
+                continue
         if edge_margin > 0 and not is_promoted:
             poly = np.array(det["polygon"], dtype=float)
             cx, cy = float(poly[:, 0].mean()), float(poly[:, 1].mean())
@@ -1595,6 +1634,19 @@ def main() -> None:
         help="Minimum long/short side ratio for a text polygon (default: %(default)s)",
     )
     parser.add_argument(
+        "--high-confidence-size-fraction",
+        type=float,
+        default=0.7,
+        metavar="FRACTION",
+        help=(
+            "Smaller detections are admitted if they're proportionally more "
+            "confident than --min-confidence: a detection at confidence 1.0 only "
+            "needs to meet this fraction of min-long-side/min-short-side, with "
+            "confidences in between interpolated on a power-law curve. Set to 1.0 "
+            "to disable (default: %(default)s)"
+        ),
+    )
+    parser.add_argument(
         "--scale",
         type=float,
         default=None,
@@ -1732,6 +1784,7 @@ def main() -> None:
         "auto_threshold_confidence": args.auto_threshold_confidence,
         "auto_threshold_percentile": args.auto_threshold_percentile,
         "auto_threshold_include_hints": auto_threshold_include_hints,
+        "high_confidence_size_fraction": args.high_confidence_size_fraction,
     }
 
     n_success = 0
@@ -1758,6 +1811,7 @@ def main() -> None:
         not args.disable_one_gcp_fits,
         args.debug,
         parameters,
+        args.high_confidence_size_fraction,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -11,6 +11,7 @@ from mapsnap.georef_from_labels import (
     _cluster_geo_coords,
     _rotation_from_neighbors,
     compute_auto_min_short_side,
+    confidence_relaxed_threshold,
     correct_square_feature_dirs,
     label_features,
     promote_avenue_letters,
@@ -545,3 +546,73 @@ def test_compute_auto_min_short_side_skips_missing_labels_file(tmp_path):
         [image_path], min_confidence=0.3, percentile=25
     )
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# confidence_relaxed_threshold
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_relaxed_threshold_at_min_confidence():
+    # At min_confidence, the full base_threshold is required (no relaxation).
+    result = confidence_relaxed_threshold(
+        confidence=0.15,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=12.6,
+    )
+    assert result == 18.0
+
+
+def test_confidence_relaxed_threshold_below_min_confidence():
+    # Below min_confidence, still returns base_threshold (this detection wouldn't
+    # pass the confidence check anyway).
+    result = confidence_relaxed_threshold(
+        confidence=0.1,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=12.6,
+    )
+    assert result == 18.0
+
+
+def test_confidence_relaxed_threshold_at_max_confidence():
+    # At confidence 1.0, the relaxed floor applies exactly.
+    result = confidence_relaxed_threshold(
+        confidence=1.0,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=12.6,
+    )
+    assert math.isclose(result, 12.6)
+
+
+def test_confidence_relaxed_threshold_interpolates_between_endpoints():
+    # Matches the schedule from issue #78: as confidence rises from min_confidence
+    # towards 1.0, the required short side relaxes from 18px towards ~12.6px (0.7x).
+    result_mid_low = confidence_relaxed_threshold(
+        confidence=0.3,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=12.6,
+    )
+    result_mid_high = confidence_relaxed_threshold(
+        confidence=0.6,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=12.6,
+    )
+    assert 12.6 < result_mid_high < result_mid_low < 18.0
+    assert math.isclose(result_mid_low, 15.8, abs_tol=0.1)
+    assert math.isclose(result_mid_high, 13.9, abs_tol=0.1)
+
+
+def test_confidence_relaxed_threshold_disabled_when_floor_not_below_base():
+    # high_confidence_floor >= base_threshold disables relaxation entirely.
+    result = confidence_relaxed_threshold(
+        confidence=1.0,
+        min_confidence=0.15,
+        base_threshold=18.0,
+        high_confidence_floor=18.0,
+    )
+    assert result == 18.0


### PR DESCRIPTION
Fixes #78

## Summary

#77 set `--min-short-side`/`--min-long-side`/`--min-confidence` as flat, volume-wide cutoffs. That's too coarse: issue #78 points out that some volumes (e.g. Brooklyn) have small but extremely high-confidence street labels that get rejected by the flat size floor, while other volumes (e.g. Detroit) have larger, lower-confidence noise that the size floor correctly screens out. The fix is to admit a detection that's smaller than `min_short_side`/`min_long_side` *if* it's proportionally more confident than `min_confidence`.

## Design

Added `confidence_relaxed_threshold()` in `mapsnap/georef_from_labels.py`. It interpolates the required size threshold between two anchor points using a power law (linear in log-confidence vs. log-threshold):

- at `confidence = min_confidence`: the full `base_threshold` is required (today's behavior, unchanged)
- at `confidence = 1.0`: only `base_threshold * high_confidence_size_fraction` is required

```python
exponent = log(high_confidence_floor / base_threshold) / log(min_confidence)
required = base_threshold * (min_confidence / confidence) ** exponent
```

This is wired into `process_image()`'s per-detection filter for both `short_side` and `long_side` (scaled by the same ratio, so the existing aspect-ratio check stays meaningful), gated by a new `--high-confidence-size-fraction` flag (default `0.7`). Setting it to `1.0` disables relaxation entirely and recovers the exact old behavior.

I picked `0.7` because it closely reproduces the illustrative schedule from issue #78 (which anchors on Brooklyn's calibrated `min-short-side` of 18px):

| confidence | issue's schedule | this PR's formula (fraction=0.7) |
|---|---|---|
| 0.150 (min_confidence) | 18.0px | 18.0px |
| 0.300 | 16.0px | 15.8px |
| 0.600 | 14.0px | 13.9px |
| 0.990 | 13.0px | 12.6px |
| 1.000 | — | 12.6px (floor) |

## Before/after results

Ran `mapsnap fit` on the 5 truth-data volumes, comparing `--high-confidence-size-fraction 1.0` (A, disabled — equivalent to pre-#78 behavior) against the new default `0.7` (B). (`champaign_ill_1915` needs `--scale-outlier-threshold 0` in both runs, per its existing test-data notes.)

| volume | scenario | fit rate | RMSE mean/median/max | trans mean/median | rot mean |
|---|---|---|---|---|---|
| new orleans 1951 | A (disabled) | 99/109 (90.8%) | 17 / 12 / 112 ft | 12 / 8 ft | 0.8° |
| new orleans 1951 | B (0.7) | **100**/109 (91.7%) | 17 / 12 / 112 ft | 12 / 8 ft | 0.8° |
| detroit | A (disabled) | 82/103 (79.6%) | 44 / 14 / 914 ft | 38 / 10 ft | 1.4° |
| detroit | B (0.7) | 81/103 (78.6%) | **33** / 14 / **901** ft | **28** / 10 ft | 1.3° |
| chicago | A (disabled) | 98/111 (88.3%) | 114 / 10 / 6735 ft | 109 / 6 ft | 1.8° |
| chicago | B (0.7) | 98/111 (88.3%) | 114 / 10 / 6735 ft | 110 / 6 ft | 1.9° (identical fit count) |
| champaign | A (disabled) | 27/33 (81.8%) | 12 / 10 / 62 ft | 15 / 5 ft | 0.4° |
| champaign | B (0.7) | 27/33 (81.8%) | 12 / 10 / 62 ft | 15 / 6 ft | 0.4° (identical) |
| brooklyn | A (disabled) | 47/62 (75.8%) | 21 / 8 / 234 ft | 15 / 5 ft | 0.7° |
| brooklyn | B (0.7) | **49**/62 (79.0%) | 20 / 8 / 234 ft | 15 / 5 ft | 0.7° |

Brooklyn (the volume that motivated #78) gains 2 fits, New Orleans gains 1, and Detroit's RMSE improves further (44 → 33 ft mean) at the cost of 1 fit there. Chicago and Champaign are unchanged. No volume regresses meaningfully, so `0.7` becomes the new default rather than a purely opt-in flag.

## Verification

- `uv run ruff format` / `uv run ruff check --fix`: clean
- `uv run pyright`: 0 errors
- `uv run pytest`: 279 passed (5 new unit tests for `confidence_relaxed_threshold`)
- Live smoke test on `brooklyn_ny_1939_vol_1/p28.jpg` (the issue's second motivating example) confirmed the new thresholds apply and the page still georeferences successfully
- Full before/after `mapsnap fit` comparison above on all 5 truth-data volumes
