### PR TITLE
Debugger app improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ From there, the pipeline is very similar to OldInsuranceMaps. The end result is 
 
 If you have your own directory of images that you've put together in some other way, Mapsnap should also be able to run over it.
 
-- Name the images after some notion of page number, e.g. `p123.jpg`.
+- Name the images after some notion of page number, e.g. `p123.jpg`. These should be scaled to 25% of full LoC resolution. Use `mapsnap scale` to do this.
 - Run `mapsnap download-osm` + `mapsnap osm-to-geojson` to get OSM data for the area around your images.
 - Run `mapsnap split` to detect split maps, if needed.
 - Run `mapsnap ocr` to find street labels for all your images. Use the Mapsnap debugger app to test if it worked on a few images.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -51,6 +51,9 @@ export function App() {
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
   const [detections, setDetections] = useState<Detection[]>([]);
   const [panels, setPanels] = useState<PanelPolygon[]>([]);
+  const [panelLabels, setPanelLabels] = useState<string[] | undefined>(
+    undefined,
+  );
   const [selectedIndices, setSelectedIndices] = useState<Set<number>>(
     new Set(),
   );
@@ -114,12 +117,14 @@ export function App() {
       setSelectedIndices(new Set());
       setDetections(result.detections);
       setPanels([]);
+      setPanelLabels(undefined);
       setJsonWidth(result.width);
       setJsonHeight(result.height);
     } else if (result.kind === 'panels') {
       setMode('panels');
       setSelectedIndices(new Set());
       setPanels(result.panels);
+      setPanelLabels(result.labels);
       setDetections([]);
       setJsonWidth(result.width);
       setJsonHeight(result.height);
@@ -128,6 +133,7 @@ export function App() {
       setSelectedIndices(new Set());
       setDetections([]);
       setPanels([]);
+      setPanelLabels(undefined);
       applyGeorefJson(result.text);
     }
   }
@@ -191,7 +197,9 @@ export function App() {
   }, [mode]);
 
   return (
-    <div className="container">
+    <div
+      className={mode === 'panels' ? 'container container-panels' : 'container'}
+    >
       <ImageColumn
         mode={mode}
         imageSrc={imageSrc}
@@ -201,6 +209,7 @@ export function App() {
         intersections={intersections}
         filteredDetections={filteredDetections}
         panels={panels}
+        panelLabels={panelLabels}
         selectedIndices={selectedIndices}
         onSelectIndices={setSelectedIndices}
         showStreetsOnImage={showStreetsOnImage}
@@ -273,6 +282,7 @@ export function App() {
         {mode === 'panels' && (
           <PanelsTable
             panels={panels}
+            panelLabels={panelLabels}
             selectedIndices={selectedIndices}
             onSelect={(index) => setSelectedIndices(new Set([index]))}
             jsonWidth={jsonWidth}

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -18,6 +18,7 @@ interface ImageColumnProps {
   intersections: IntersectionPoint[];
   filteredDetections: IndexedDetection[];
   panels: PanelPolygon[];
+  panelLabels?: string[];
   selectedIndices: Set<number>;
   onSelectIndices: (indices: Set<number>) => void;
   showStreetsOnImage: boolean;
@@ -47,6 +48,7 @@ export function ImageColumn(props: ImageColumnProps) {
     intersections,
     filteredDetections,
     panels,
+    panelLabels,
     selectedIndices,
     onSelectIndices,
     showStreetsOnImage,
@@ -131,6 +133,7 @@ export function ImageColumn(props: ImageColumnProps) {
           {panelsMode && (
             <PanelsOverlay
               panels={panels}
+              labels={panelLabels}
               selectedIndices={selectedIndices}
               displayWidth={imgSize.width}
               displayHeight={imgSize.height}

--- a/app/src/components/MapView.tsx
+++ b/app/src/components/MapView.tsx
@@ -54,7 +54,7 @@ export function MapView(props: MapViewProps) {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
-  const lastWarpedUrlRef = useRef('');
+  const lastFittedCornersRef = useRef('');
   const [mapReady, setMapReady] = useState(false);
 
   useEffect(() => {
@@ -110,8 +110,13 @@ export function MapView(props: MapViewProps) {
       });
     }
 
-    if (imageSrc !== lastWarpedUrlRef.current) {
-      lastWarpedUrlRef.current = imageSrc;
+    // Fit the view whenever the corners change (i.e. a new image/georef is
+    // loaded). The image src and corners can arrive in separate renders, so we
+    // key on corners — the value that actually determines the view — rather
+    // than on imageSrc.
+    const cornersKey = JSON.stringify(corners);
+    if (cornersKey !== lastFittedCornersRef.current) {
+      lastFittedCornersRef.current = cornersKey;
       const lons = corners.map((c) => c[0]);
       const lats = corners.map((c) => c[1]);
       const minLon = Math.min(...lons);

--- a/app/src/components/PanelsOverlay.tsx
+++ b/app/src/components/PanelsOverlay.tsx
@@ -2,6 +2,8 @@ import type { PanelPolygon } from '../types';
 
 interface PanelsOverlayProps {
   panels: PanelPolygon[];
+  /** Optional per-panel display label (e.g. page number); defaults to the 1-based index. */
+  labels?: string[];
   selectedIndices: Set<number>;
   /** Rendered image size in CSS pixels. */
   displayWidth: number;
@@ -23,6 +25,7 @@ export function panelColor(index: number): string {
 export function PanelsOverlay(props: PanelsOverlayProps) {
   const {
     panels,
+    labels,
     selectedIndices,
     displayWidth,
     displayHeight,
@@ -76,7 +79,7 @@ export function PanelsOverlay(props: PanelsOverlayProps) {
               strokeWidth={3}
               paintOrder="stroke"
             >
-              {i + 1}
+              {labels?.[i] ?? i + 1}
             </text>
           </g>
         );

--- a/app/src/components/PanelsTable.tsx
+++ b/app/src/components/PanelsTable.tsx
@@ -3,6 +3,8 @@ import type { PanelPolygon } from '../types';
 
 interface PanelsTableProps {
   panels: PanelPolygon[];
+  /** Optional per-panel label (e.g. page number); shown in a "Page" column when present. */
+  panelLabels?: string[];
   selectedIndices: Set<number>;
   onSelect: (index: number) => void;
   jsonWidth: number;
@@ -10,12 +12,21 @@ interface PanelsTableProps {
 }
 
 /**
- * Table of panels in reading order, showing each panel's 1-based index and its
- * area as a percentage of the full image. Clicking a row selects that panel.
+ * Table of panels in reading order, showing each panel's 1-based index, an
+ * optional page-number label, and its area as a percentage of the full image.
+ * Clicking a row selects that panel.
  */
 export function PanelsTable(props: PanelsTableProps) {
-  const { panels, selectedIndices, onSelect, jsonWidth, jsonHeight } = props;
+  const {
+    panels,
+    panelLabels,
+    selectedIndices,
+    onSelect,
+    jsonWidth,
+    jsonHeight,
+  } = props;
   const imageArea = jsonWidth * jsonHeight;
+  const hasLabels = panelLabels !== undefined;
 
   return (
     <div id="detections-panel">
@@ -23,6 +34,7 @@ export function PanelsTable(props: PanelsTableProps) {
         <thead>
           <tr>
             <th>Index</th>
+            {hasLabels && <th>Page</th>}
             <th>Area</th>
           </tr>
         </thead>
@@ -38,6 +50,7 @@ export function PanelsTable(props: PanelsTableProps) {
                 onClick={() => onSelect(i)}
               >
                 <td>{i + 1}</td>
+                {hasLabels && <td>{panelLabels?.[i]}</td>}
                 <td>{areaPercent.toFixed(1)}%</td>
               </tr>
             );

--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -111,6 +111,28 @@ describe('parseDroppedJson', () => {
       expect(result.panels).toHaveLength(2);
       expect(result.width).toBe(1417);
       expect(result.height).toBe(2038);
+      expect(result.labels).toBeUndefined();
+    }
+  });
+
+  it('passes through panel labels when present', () => {
+    const text = JSON.stringify({
+      image: 'p0b.jpg',
+      width: 5866,
+      height: 7323,
+      panels: [
+        [
+          [0, 0],
+          [10, 0],
+          [10, 10],
+        ],
+      ],
+      labels: ['55'],
+    });
+    const result = parseDroppedJson(text, fallback);
+    expect(result.kind).toBe('panels');
+    if (result.kind === 'panels') {
+      expect(result.labels).toEqual(['55']);
     }
   });
 

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -20,6 +20,7 @@ export type ParsedJson =
       kind: 'panels';
       text: string;
       panels: PanelPolygon[];
+      labels?: string[];
       width: number;
       height: number;
     };
@@ -78,6 +79,7 @@ export function parseDroppedJson(
       kind: 'panels',
       text,
       panels: parsed.panels,
+      labels: parsed.labels,
       width: parsed.width || fallback.width || 1,
       height: parsed.height || fallback.height || 1,
     };

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -85,6 +85,41 @@
   gap: 8px;
 }
 
+/*
+ * Panels mode: page-region boxes are tiny, so give the image the bulk of the width and let it
+ * scroll vertically with the page; the Index/Page/Area table needs only a narrow strip.
+ */
+.container-panels {
+  align-items: flex-start;
+}
+
+.container-panels .image-column {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.container-panels .image-wrapper {
+  display: block;
+  width: 100%;
+}
+
+.container-panels .image-wrapper img {
+  width: 100%;
+  max-width: none;
+  max-height: none;
+}
+
+.container-panels .map-column {
+  flex: 0 0 220px;
+  min-width: 0;
+}
+
+.container-panels #detections-panel {
+  height: auto;
+  position: sticky;
+  top: 16px;
+}
+
 #map {
   height: 90vh;
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -68,6 +68,10 @@ export type PanelPolygon = [number, number][];
 /**
  * panels.json sidecar: panel polygons in reading order in the named image's
  * pixel frame. `panels[i - 1]` corresponds to the page's `__i.jpg` split.
+ *
+ * `labels`, when present, is parallel to `panels` and gives a display label for
+ * each polygon (e.g. the page number for key-map page regions); the app shows it
+ * instead of the positional index.
  */
 export interface PanelsJsonData {
   image: string;
@@ -75,4 +79,5 @@ export interface PanelsJsonData {
   height: number;
   manual?: boolean;
   panels: PanelPolygon[];
+  labels?: string[];
 }


### PR DESCRIPTION
Split off from #87

- Fixes a bug where it wouldn't zoom to a new location after drag & drop of a page.
- Supports parallel `labels` array in panels view (useful for keymaps).
- Makes the panels image big, so you can see details (also useful for keymaps).