### PR TITLE
Be more cautious about single-letter street names

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -35,6 +35,8 @@ from mapsnap.streets import (
     build_block_index,
     canonical_street_matches,
     deduplicate_detections,
+    hint_type_word,
+    is_bare_letter,
     is_number_only,
     normalize_street,
 )
@@ -737,6 +739,16 @@ def _are_quadrant_siblings(matches: list[str]) -> bool:
     return len(bases) == 1
 
 
+def reading_vector(polygon: list[list[float]]) -> tuple[float, float]:
+    """Directed reading vector (top-left → top-right edge) of a text polygon.
+
+    detect_text builds polygons from EasyOCR's TL,TR,BR,BL corner order (preserved through the
+    90°/270° remaps), so the first edge points in the direction the text is read. This gives an
+    unambiguous before/after ordering of a letter and a type-word hint along the label.
+    """
+    return (polygon[1][0] - polygon[0][0], polygon[1][1] - polygon[0][1])
+
+
 def promote_avenue_letters(
     hint_detections: list[dict],
     all_detections: list[dict],
@@ -827,6 +839,20 @@ def promote_avenue_letters(
             det_perp = -det_cx * sin_d + det_cy * cos_d
             if abs(det_perp - hint_perp) > perp_tolerance_px:
                 continue
+
+            # Enforce the letter/type-word order along the reading direction: "<letter> STREET"
+            # (the ST hint must follow the letter) vs "AVENUE <letter>" (the AVE hint must
+            # precede it). proj is the letter's offset from the hint along the reading vector.
+            htype = hint_type_word(hint.get("text", ""))
+            if htype is not None:
+                rvx, rvy = reading_vector(hint_poly)
+                proj = (det_cx - hint_cx) * rvx + (det_cy - hint_cy) * rvy
+                # proj<0: letter precedes hint (… "K" before "STREET"); proj>0: letter follows
+                # hint ("AVENUE" before "Q" …). Reject the wrong order for each type.
+                if (htype == "STREET" and proj >= 0) or (
+                    htype == "AVENUE" and proj <= 0
+                ):
+                    continue
 
             matches = canonical_street_matches(text, normalized_streets)
             if len(matches) != 1:
@@ -1201,6 +1227,10 @@ def process_image(
                 and det.get("long_side", float("inf"))
                 >= min_aspect_ratio * det.get("short_side", 1.0)
                 and not is_number_only(det["text"])
+                # Bare single letters are accepted only via promotion (the is_promoted
+                # branch above); an unpromoted "M"/"W" is almost always a rotated misread of
+                # a quadrant/type box, so reject it here.
+                and not is_bare_letter(det["text"])
                 and (
                     normalize_street(det["text"]) not in DIRECTION_WORDS
                     or det["text"].upper().strip() in normalized_streets
@@ -1719,6 +1749,18 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    # A key-map index page (one with a sibling <stem>.keymap.json) has no streets to fit, so
+    # ignore it for georeferencing. Other images still require a <stem>.streets.json downstream.
+    kept_images = []
+    for image_path in args.images:
+        stem = image_stem(str(image_path))
+        keymap_path = os.path.join(os.path.dirname(image_path), f"{stem}.keymap.json")
+        if os.path.exists(keymap_path):
+            print(f"Skipping {image_path}: key-map page", file=sys.stderr)
+        else:
+            kept_images.append(image_path)
+    args.images = kept_images
 
     force_intersection: tuple[int, int] | None = None
     if args.force_intersection is not None:

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -36,16 +36,23 @@ def _make_det(
     angle: int = 0,
     hint: bool = False,
 ) -> dict:
-    """Build a mock detection dict with a horizontal bounding polygon."""
-    half_long = long_side / 2.0
-    half_short = short_side / 2.0
+    """Build a mock detection whose polygon is oriented along ``dir_pix``.
+
+    The first edge (polygon[0] → polygon[1]) points in the reading direction (+dir_pix), as a
+    real detect_text polygon does, so reading_vector / the letter-ordering check behave as in
+    production.
+    """
+    ux, uy = math.cos(dir_pix), math.sin(dir_pix)  # reading (long-axis) direction
+    px, py = -uy, ux  # perpendicular
+    hl, hs = long_side / 2.0, short_side / 2.0
+    corners = [
+        (cx - hl * ux - hs * px, cy - hl * uy - hs * py),  # start, near edge
+        (cx + hl * ux - hs * px, cy + hl * uy - hs * py),  # end, near edge
+        (cx + hl * ux + hs * px, cy + hl * uy + hs * py),  # end, far edge
+        (cx - hl * ux + hs * px, cy - hl * uy + hs * py),  # start, far edge
+    ]
     return {
-        "polygon": [
-            [int(cx - half_long), int(cy - half_short)],
-            [int(cx + half_long), int(cy - half_short)],
-            [int(cx + half_long), int(cy + half_short)],
-            [int(cx - half_long), int(cy + half_short)],
-        ],
+        "polygon": [[round(x), round(y)] for x, y in corners],
         "text": text,
         "confidence": confidence,
         "angle": angle,
@@ -63,16 +70,18 @@ def _make_det(
 
 def test_promote_single_char_near_avenue_hint():
     # "X" in the same vertical column as an "AVENUE" hint → promoted with corrected dir_pix.
-    # Both share dir_pix=π/2 (vertical), as in the real p88 data where detect_text.py
-    # already computes dir_pix correctly from the CRAFT polygon even for square boxes.
+    # Both share dir_pix=π/2 (vertical, reading downward); for "AVENUE X" the AVENUE hint must
+    # precede the letter, so the hint is above (smaller cy) and "X" below.
     streets = {"AVENUE X", "X"}
     hints = [
         _make_det(
-            "AVENUE", cx=193, cy=1544, long_side=120, hint=True, dir_pix=math.pi / 2
+            "AVENUE", cx=193, cy=274, long_side=120, hint=True, dir_pix=math.pi / 2
         )
     ]
     dets = [
-        _make_det("X", cx=192, cy=274, long_side=24, short_side=24, dir_pix=math.pi / 2)
+        _make_det(
+            "X", cx=192, cy=1544, long_side=24, short_side=24, dir_pix=math.pi / 2
+        )
     ]
     result = promote_avenue_letters(hints, dets, streets)
     assert len(result) == 1
@@ -100,11 +109,13 @@ def test_promote_no_matching_street():
     streets = {"AVENUE X", "X"}
     hints = [
         _make_det(
-            "AVENUE", cx=193, cy=1544, long_side=120, hint=True, dir_pix=math.pi / 2
+            "AVENUE", cx=193, cy=274, long_side=120, hint=True, dir_pix=math.pi / 2
         )
     ]
     dets = [
-        _make_det("Q", cx=192, cy=274, long_side=24, short_side=24, dir_pix=math.pi / 2)
+        _make_det(
+            "Q", cx=192, cy=1544, long_side=24, short_side=24, dir_pix=math.pi / 2
+        )
     ]
     result = promote_avenue_letters(hints, dets, streets)
     assert result == []
@@ -158,15 +169,15 @@ def test_promote_correct_letter_wins_over_misread():
     streets = {"AVENUE W", "W", "AVENUE M", "M"}
     hints = [
         _make_det(
-            "AVENUE", cx=1164, cy=1566, long_side=120, hint=True, dir_pix=math.pi / 2
+            "AVENUE", cx=1164, cy=268, long_side=120, hint=True, dir_pix=math.pi / 2
         ),
     ]
     dets = [
         _make_det(
-            "W", cx=1163, cy=268, long_side=28, short_side=26, dir_pix=math.pi / 2
+            "W", cx=1163, cy=1566, long_side=28, short_side=26, dir_pix=math.pi / 2
         ),
         _make_det(
-            "M", cx=1162, cy=270, long_side=28, short_side=26, dir_pix=math.pi / 2
+            "M", cx=1162, cy=1568, long_side=28, short_side=26, dir_pix=math.pi / 2
         ),
     ]
     result = promote_avenue_letters(hints, dets, streets)
@@ -180,18 +191,52 @@ def test_promote_letter_in_column_with_avenue():
     streets = {"AVENUE W", "W"}
     hints = [
         _make_det(
-            "AVENUE", cx=193, cy=1544, long_side=120, hint=True, dir_pix=math.pi / 2
+            "AVENUE", cx=193, cy=274, long_side=120, hint=True, dir_pix=math.pi / 2
         ),
     ]
     dets = [
         _make_det(
-            "W", cx=192, cy=274, long_side=18, short_side=12, dir_pix=math.pi / 2
+            "W", cx=192, cy=1544, long_side=18, short_side=12, dir_pix=math.pi / 2
         ),
     ]
     result = promote_avenue_letters(hints, dets, streets)
     assert len(result) == 1
     assert result[0]["text"] == "W"
     assert result[0]["promoted"] is True
+
+
+def test_promote_street_letter_must_follow_hint():
+    # "K STREET": reading left→right, the "ST" hint must come AFTER the K. K left, ST right → OK.
+    streets = {"K STREET", "K"}
+    hints = [_make_det("ST", cx=200, cy=300, hint=True, dir_pix=0.0)]
+    dets = [_make_det("K", cx=100, cy=300, long_side=24, short_side=24, dir_pix=0.0)]
+    result = promote_avenue_letters(hints, dets, streets)
+    assert len(result) == 1 and result[0]["text"] == "K"
+
+
+def test_promote_street_letter_before_hint_rejected():
+    # K to the RIGHT of "ST" (reads "ST K") → wrong order for "K STREET" → not promoted.
+    streets = {"K STREET", "K"}
+    hints = [_make_det("ST", cx=100, cy=300, hint=True, dir_pix=0.0)]
+    dets = [_make_det("K", cx=200, cy=300, long_side=24, short_side=24, dir_pix=0.0)]
+    assert promote_avenue_letters(hints, dets, streets) == []
+
+
+def test_promote_avenue_letter_must_follow_hint():
+    # "AVENUE Q": the "AV" hint must come BEFORE the Q. AV left, Q right → OK.
+    streets = {"AVENUE Q", "Q"}
+    hints = [_make_det("AV", cx=100, cy=300, hint=True, dir_pix=0.0)]
+    dets = [_make_det("Q", cx=200, cy=300, long_side=24, short_side=24, dir_pix=0.0)]
+    result = promote_avenue_letters(hints, dets, streets)
+    assert len(result) == 1 and result[0]["text"] == "Q"
+
+
+def test_promote_avenue_letter_after_hint_rejected():
+    # Q to the LEFT of "AV" (reads "Q AV") → wrong order for "AVENUE Q" → not promoted.
+    streets = {"AVENUE Q", "Q"}
+    hints = [_make_det("AV", cx=200, cy=300, hint=True, dir_pix=0.0)]
+    dets = [_make_det("Q", cx=100, cy=300, long_side=24, short_side=24, dir_pix=0.0)]
+    assert promote_avenue_letters(hints, dets, streets) == []
 
 
 # ---------------------------------------------------------------------------

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -224,6 +224,30 @@ def is_number_only(text: str) -> bool:
     return not bool(re.search(r"[a-zA-Z]", text))
 
 
+def hint_type_word(text: str) -> str | None:
+    """Map a type-word hint to 'STREET' or 'AVENUE', else None.
+
+    Handles dotted/spaced abbreviation forms ('ST', 'ST.', 'S T', 'AVE', 'AV', 'A V', ...) as
+    well as the full words. Quadrant and other hints return None — only STREET/AVENUE have a
+    letter-ordering convention ("K STREET" vs "AVENUE Q").
+    """
+    compact = text.upper().replace(".", "").replace(" ", "")
+    if compact in ("STREET", "AVENUE"):
+        return compact
+    full = STREET_ABBREVS.get(compact)
+    return full if full in ("STREET", "AVENUE") else None
+
+
+def is_bare_letter(text: str) -> bool:
+    """Return True if text is a single letter (e.g. "M", "W").
+
+    Bare single letters are too easily produced by misreading a rotated quadrant/type box
+    (e.g. an "N.W." box read as "M" at the opposite rotation), so the georeferencer only
+    trusts them when promoted by a correctly-oriented type-word hint (see promote_avenue_letters).
+    """
+    return len(text.strip()) == 1 and text.strip().isalpha()
+
+
 def _match_candidates(s: str) -> list[str]:
     """Return the candidate forms to compare against when prefix-matching street key s.
 

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -5,8 +5,20 @@ from mapsnap.streets import (
     _num_to_ordinal_word,
     canonical_street_match,
     canonical_street_matches,
+    is_bare_letter,
     normalize_street,
 )
+
+
+def test_is_bare_letter():
+    assert is_bare_letter("M")
+    assert is_bare_letter("W")
+    assert is_bare_letter(" M ")  # surrounding whitespace ignored
+    assert not is_bare_letter("M.")  # has punctuation -> not bare
+    assert not is_bare_letter("MAIN")
+    assert not is_bare_letter("5")  # a digit is not a letter
+    assert not is_bare_letter("")
+
 
 # --- _num_to_ordinal_word ---
 


### PR DESCRIPTION
Single-letter street names require a "hint" like "AVE" or "ST" in the same orientation and on the correct side of the street name. So if the street name is "K STREET," we'd better find "K ST" and not "ST K". This has mostly-positive effects on volumes with lots of these, e.g. Brooklyn 1905 vol 14.