### PR TITLE
Detect multi-word streets

### DIFF
--- a/mapsnap/ctc_vocab_decode.py
+++ b/mapsnap/ctc_vocab_decode.py
@@ -148,6 +148,15 @@ def generate_vocab_strings(normalized_streets: set[str]) -> list[str]:
 
         base_name = " ".join(name_words)
 
+        # CRAFT often splits a multi-word name (e.g. "VAN BRUNT") into one box per word,
+        # especially on stretched or vertical labels. Add each individual name word so a
+        # split box decodes to itself instead of snapping to the nearest unrelated vocab
+        # word (e.g. "VAN" -> "IVAN", "DYKE" -> "DARE"); the split parts are recombined
+        # later by georef_from_labels.assemble_multiword_streets. Words shorter than 3
+        # characters are skipped to avoid adding ambiguous fragments.
+        if len(name_words) >= 2:
+            result.update(word for word in name_words if len(word) >= 3)
+
         # Also generate the numeric ordinal form so the CTC trie contains "S. 4TH ST"
         # alongside "S. FOURTH ST" — without this, the constrained decoder cannot
         # produce the abbreviated numeric label that appears on the map image.

--- a/mapsnap/ctc_vocab_decode_test.py
+++ b/mapsnap/ctc_vocab_decode_test.py
@@ -51,6 +51,22 @@ def test_generate_no_direction_bare_name_with_type():
     assert "MAGAZINE ST" in vocab
 
 
+def test_generate_includes_individual_words_of_multiword_name():
+    # CRAFT splits "VAN BRUNT" into separate boxes; each word must be recognizable on its
+    # own (not just the combined form) so a split box does not snap to an unrelated street.
+    vocab = generate_vocab_strings({"VAN BRUNT STREET", "VAN DYKE STREET"})
+    assert "VAN BRUNT" in vocab  # combined form still present
+    assert "VAN" in vocab
+    assert "BRUNT" in vocab
+    assert "DYKE" in vocab
+
+
+def test_generate_single_word_name_adds_no_fragments():
+    # A single-word base name has no parts to split, so nothing extra is added.
+    vocab = generate_vocab_strings({"MAGAZINE STREET"})
+    assert "MAGAZIN" not in vocab  # no spurious sub-word fragments
+
+
 def test_generate_saint_prefix():
     vocab = generate_vocab_strings({"SAINT CHARLES AVENUE"})
     assert "SAINT CHARLES" in vocab

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -880,6 +880,119 @@ def promote_avenue_letters(
     return promoted
 
 
+def _assembled_detection(first: dict, second: dict, text: str) -> dict:
+    """One detection spanning two word-part detections, tagged ``assembled=True``.
+
+    The polygon is the oriented box containing both parts, expressed in the reading frame of
+    ``first`` (the earlier word along the reading direction) so its corner order and dir_pix
+    stay consistent with ordinary detections.
+    """
+    rvx, rvy = reading_vector(first["polygon"])
+    norm = math.hypot(rvx, rvy) or 1.0
+    rvx, rvy = rvx / norm, rvy / norm
+    pvx, pvy = -rvy, rvx  # perpendicular (across the text)
+    corners = first["polygon"] + second["polygon"]
+    along = [px * rvx + py * rvy for px, py in corners]
+    across = [px * pvx + py * pvy for px, py in corners]
+    r0, r1, p0, p1 = min(along), max(along), min(across), max(across)
+    box = [
+        (r0 * rvx + p0 * pvx, r0 * rvy + p0 * pvy),
+        (r1 * rvx + p0 * pvx, r1 * rvy + p0 * pvy),
+        (r1 * rvx + p1 * pvx, r1 * rvy + p1 * pvy),
+        (r0 * rvx + p1 * pvx, r0 * rvy + p1 * pvy),
+    ]
+    return {
+        "polygon": [[round(x), round(y)] for x, y in box],
+        "text": text,
+        "confidence": min(first.get("confidence", 0.0), second.get("confidence", 0.0)),
+        "angle": first.get("angle"),
+        "dir_pix": round(first.get("dir_pix", 0.0) % math.pi, 4),
+        "long_side": round(r1 - r0, 1),
+        "short_side": round(p1 - p0, 1),
+        "assembled": True,
+    }
+
+
+def assemble_multiword_streets(
+    detections: list[dict],
+    normalized_streets: set[str],
+    perp_tolerance_px: float = 20.0,
+    max_word_gap_frac: float = 0.7,
+    min_confidence: float = 0.5,
+) -> tuple[list[dict], list[dict]]:
+    """Combine adjacent single-word detections into a multi-word street name.
+
+    CRAFT often splits a label like "VAN BRUNT" into one box per word; once the parts are
+    recognized (the individual name words are in the OCR vocabulary), this pairs two collinear,
+    adjacent word detections whose concatenation is a known street name and emits one assembled
+    detection (text "VAN BRUNT", ``assembled=True``) spanning both, so the georeferencer sees
+    the whole street. This is the name-portion counterpart to promote_avenue_letters.
+
+    Two parts pair when they share an EasyOCR ``angle`` and dir_pix bucket, lie on the same
+    line (perpendicular offset ≤ perp_tolerance_px), and are adjacent along the reading
+    direction (gap between boxes ≤ max_word_gap_frac of the larger box's length). Both reading
+    orders are tried; the order whose concatenation matches a street wins. Returns
+    (assembled detections, the source parts that were consumed) so the caller can drop the
+    parts — a lone "VAN" is ambiguous on its own.
+    """
+    bucket_size = math.pi / 12.0
+    parts = [
+        d
+        for d in detections
+        if d.get("confidence", 0.0) >= min_confidence
+        and not d.get("assembled")
+        and (text := d.get("text", "").strip()).isalpha()
+        and len(text) >= 3
+    ]
+    parts.sort(key=lambda d: d.get("confidence", 0.0), reverse=True)
+
+    def center(poly: list[list[float]]) -> tuple[float, float]:
+        return sum(p[0] for p in poly) / 4.0, sum(p[1] for p in poly) / 4.0
+
+    assembled: list[dict] = []
+    consumed: list[dict] = []
+    used: set[int] = set()
+    for i, a in enumerate(parts):
+        if i in used:
+            continue
+        a_dir = a.get("dir_pix", 0.0)
+        a_bucket = int(round(a_dir / bucket_size)) % 12
+        cos_d, sin_d = math.cos(a_dir), math.sin(a_dir)
+        a_cx, a_cy = center(a["polygon"])
+        a_perp = -a_cx * sin_d + a_cy * cos_d
+        a_long = a.get("long_side", 0.0)
+        for j, b in enumerate(parts):
+            if j == i or j in used:
+                continue
+            b_dir = b.get("dir_pix", 0.0)
+            if int(round(b_dir / bucket_size)) % 12 != a_bucket:
+                continue
+            angle_a, angle_b = a.get("angle"), b.get("angle")
+            if angle_a is not None and angle_b is not None and angle_a != angle_b:
+                continue
+            b_cx, b_cy = center(b["polygon"])
+            if abs((-b_cx * sin_d + b_cy * cos_d) - a_perp) > perp_tolerance_px:
+                continue
+            b_long = b.get("long_side", 0.0)
+            edge_gap = math.hypot(b_cx - a_cx, b_cy - a_cy) - (a_long + b_long) / 2.0
+            if edge_gap > max_word_gap_frac * max(a_long, b_long):
+                continue
+            ordered = None
+            for first, second in ((a, b), (b, a)):
+                text = f"{first['text'].strip()} {second['text'].strip()}"
+                if canonical_street_matches(text, normalized_streets):
+                    ordered = (text, first, second)
+                    break
+            if ordered is None:
+                continue
+            text, first, second = ordered
+            assembled.append(_assembled_detection(first, second, text))
+            consumed.extend([a, b])
+            used.update([i, j])
+            break
+    return assembled, consumed
+
+
 def correct_square_feature_dirs(
     features: list[LabelFeature],
     hint_detections: list[dict],
@@ -1201,6 +1314,17 @@ def process_image(
             file=sys.stderr,
         )
         all_detections = promoted + all_detections
+    assembled, consumed = assemble_multiword_streets(all_detections, normalized_streets)
+    if assembled:
+        print(
+            f"Assembled multi-word detections ({len(assembled)}): "
+            + ", ".join(d["text"] for d in assembled),
+            file=sys.stderr,
+        )
+        consumed_ids = {id(d) for d in consumed}
+        all_detections = assembled + [
+            d for d in all_detections if id(d) not in consumed_ids
+        ]
     all_detections = deduplicate_detections(
         all_detections, normalized_streets=normalized_streets
     )

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -10,6 +10,7 @@ from mapsnap.georef_from_labels import (
     _angle_diff_abs,
     _cluster_geo_coords,
     _rotation_from_neighbors,
+    assemble_multiword_streets,
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
@@ -61,6 +62,60 @@ def _make_det(
         "dir_pix": dir_pix,
         **({"hint": True} if hint else {}),
     }
+
+
+# ---------------------------------------------------------------------------
+# assemble_multiword_streets
+# ---------------------------------------------------------------------------
+
+_VAN_STREETS = {"VAN BRUNT STREET", "VAN BUREN STREET"}
+
+
+def test_assemble_adjacent_words_into_street():
+    # "VAN" and "BRUNT" detected as separate, collinear, adjacent boxes -> "VAN BRUNT".
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22)
+    brunt = _make_det("BRUNT", cx=760, cy=1000, long_side=80, short_side=22)
+    assembled, consumed = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert len(assembled) == 1
+    assert assembled[0]["text"] == "VAN BRUNT"
+    assert assembled[0]["assembled"] is True
+    assert (
+        len(consumed) == 2
+    )  # both parts consumed so a lone ambiguous "VAN" doesn't remain
+
+
+def test_assemble_resolves_reading_order():
+    # Spatial order doesn't matter: only "VAN BRUNT" matches a street, not "BRUNT VAN".
+    brunt = _make_det("BRUNT", cx=700, cy=1000, long_side=80, short_side=22)
+    van = _make_det("VAN", cx=770, cy=1000, long_side=50, short_side=22)
+    assembled, _ = assemble_multiword_streets([brunt, van], _VAN_STREETS)
+    assert len(assembled) == 1
+    assert assembled[0]["text"] == "VAN BRUNT"
+
+
+def test_assemble_skips_far_apart_words():
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22)
+    brunt = _make_det("BRUNT", cx=1300, cy=1000, long_side=80, short_side=22)
+    assembled, consumed = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert assembled == [] and consumed == []
+
+
+def test_assemble_skips_non_street_combination():
+    # Adjacent words whose concatenation is not a street are left alone.
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22)
+    other = _make_det("PARK", cx=760, cy=1000, long_side=70, short_side=22)
+    assembled, _ = assemble_multiword_streets([van, other], _VAN_STREETS)
+    assert assembled == []
+
+
+def test_assemble_skips_different_orientation():
+    # Words on perpendicular lines (different dir_pix bucket) are not combined.
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22, dir_pix=0.0)
+    brunt = _make_det(
+        "BRUNT", cx=760, cy=1000, long_side=80, short_side=22, dir_pix=math.pi / 2
+    )
+    assembled, _ = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert assembled == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #65 

This adds "VAN" and "BRUNT" to the OCR vocabulary when "VAN BRUNT" is a street name. The georef step then attempts to stitch these together when appropriate.

I used the new experiment system (#90) to test this:

## main vs van-dyke across the six README volumes

Methodology: for each arm I checked out the branch, re-OCR'd every page (reusing CRAFT boxes), ran `mapsnap fit`, and archived the run. Then `mapsnap experiments diff` per volume. Both arms used identical inputs; only the code differs.

### Coverage + accuracy (per-volume diff)

| Volume | Δ placed | newly placed | mean RMSE (main→vd) | net per-page |
|---|---|---|---|---|
| **Brooklyn 1939 v1** | **+3** | **p1, p6, p7** | 20.4 → 20.8 ft | 2 better / 4 worse (all ≤4 ft) |
| **New Orleans 1951 v5** | **+1** | **p436** | 16.5 → 17.0 ft | 6 better / 3 worse |
| New Orleans 1896 v2 | 0 | — | 65.2 → 65.1 ft | 2 better / 1 worse |
| Detroit 1929 v11 | 0 | — | 32.8 → 32.8 ft | 1 worse (0.1 ft) |
| Chicago 1950 v1 | 0 | — | 114.3 → 114.1 ft | 2 better / 2 worse |
| Champaign 1915 | 0 | — | 12.4 → 12.4 ft | identical |

**Verdict: exactly as you predicted.** A clear win for Brooklyn (+3 waterfront sheets, placed via VAN BRUNT / VAN DYKE / and p7), a modest bonus on New Orleans 1951 (+1 page, and more improvements than regressions), and **no meaningful effect on the other four** — every mean-RMSE move is ≤0.5 ft, i.e. noise from the broader vocab nudging a few detections. No volume regressed in coverage.

A couple of non-van-dyke notes: Chicago's mean (114 ft) is dominated by one pre-existing blow-up fit (p53N ≈ 6735 ft in *both* arms); the Detroit/Chicago "misscale ↔ deferred ±1" lines are status reshuffles with zero net coverage change.

### Timing (wall clock, MPS, sequential)

| Volume | pages | main OCR+fit | van-dyke OCR+fit |
|---|---|---|---|
| Champaign | 31 | 58 + 37s | 58 + 37s |
| Brooklyn | 64 | 191 + 40s | 195 + 41s |
| New Orleans 1896 | 91 | 365 + 47s | 366 + 49s |
| Detroit | 107 | 331 + 73s | 308 + 83s |
| New Orleans 1951 | 109 | 264 + 71s | 249 + 81s |
| Chicago | 112 | 680 + 343s | 676 + 334s |
| **Total per arm** | | **~41.6 min** | **~41.2 min** |

OCR (reusing boxes) dominates; Chicago's fit is the outlier (~340s) because of its larger street network. Full experiment ≈ **83 min** of compute across both arms.