### PR TITLE
Default value for `--centerlines` flag

### DIFF
--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from mapsnap.ctc_vocab_decode import HINT_STRINGS, generate_vocab_strings
 from mapsnap.streets import build_block_index, polygon_side_lengths
-from mapsnap.utils import image_stem
+from mapsnap.utils import default_centerlines, image_stem
 
 # Non-street text that appears on Sanborn maps and should be recognized but
 # excluded from georeferencing.
@@ -436,11 +436,11 @@ def main() -> None:
     parser.add_argument(
         "--centerlines",
         metavar="GEOJSON",
-        required=True,
         help=(
             "Centerlines GeoJSON file. Used to build a vocabulary of known street-name "
             "forms for prefix-constrained CTC decoding, which substantially improves "
-            "recall on abbreviated and direction-prefixed labels."
+            "recall on abbreviated and direction-prefixed labels. Defaults to a "
+            "centerlines.geojson next to the input images (or their parent directory)."
         ),
     )
     parser.add_argument(
@@ -506,6 +506,16 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    if args.centerlines is None:
+        centerlines = default_centerlines(Path(args.images[0]).parent)
+        if centerlines is None:
+            sys.exit(
+                "No --centerlines given and no centerlines.geojson found next to the "
+                "input images."
+            )
+        args.centerlines = str(centerlines)
+        print(f"Using centerlines: {args.centerlines}", file=sys.stderr)
 
     geojson = json.load(open(args.centerlines))
     block_index = build_block_index(geojson)

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -7,18 +7,15 @@ import sys
 from pathlib import Path
 
 from mapsnap import experiments
-from mapsnap.utils import list_pages, run_cmd
+from mapsnap.utils import default_centerlines, list_pages, run_cmd
 
 
 def find_centerlines(dir_path: Path) -> Path:
     """Return the centerlines GeoJSON, checking dir then parent dir."""
-    for candidate in (
-        dir_path / "centerlines.geojson",
-        dir_path.parent / "centerlines.geojson",
-    ):
-        if candidate.exists():
-            return candidate
-    sys.exit(f"centerlines.geojson not found in {dir_path} or {dir_path.parent}")
+    centerlines = default_centerlines(dir_path)
+    if centerlines is None:
+        sys.exit(f"centerlines.geojson not found in {dir_path} or {dir_path.parent}")
+    return centerlines
 
 
 def find_input_images(dir_path: Path) -> list[str]:

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -40,7 +40,7 @@ from mapsnap.streets import (
     is_number_only,
     normalize_street,
 )
-from mapsnap.utils import image_stem
+from mapsnap.utils import default_centerlines, image_stem
 
 
 @dataclass
@@ -1722,7 +1722,12 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--centerlines", required=True, metavar="FILE", help="centerlines.geojson"
+        "--centerlines",
+        metavar="FILE",
+        help=(
+            "centerlines.geojson (defaults to one next to the input images or their "
+            "parent directory)"
+        ),
     )
     parser.add_argument(
         "--min-confidence",
@@ -1873,6 +1878,16 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    if args.centerlines is None:
+        centerlines = default_centerlines(Path(args.images[0]).parent)
+        if centerlines is None:
+            sys.exit(
+                "No --centerlines given and no centerlines.geojson found next to the "
+                "input images."
+            )
+        args.centerlines = str(centerlines)
+        print(f"Using centerlines: {args.centerlines}", file=sys.stderr)
 
     # A key-map index page (one with a sibling <stem>.keymap.json) has no streets to fit, so
     # ignore it for georeferencing. Other images still require a <stem>.streets.json downstream.

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -38,7 +38,7 @@ from shapely.geometry import mapping as geom_mapping
 
 from mapsnap.clip_masks import compute_all_clip_masks, geo_polygon_to_svg
 from mapsnap.split import panels_json_path, read_panels_json
-from mapsnap.utils import jpeg_dimensions
+from mapsnap.utils import default_centerlines, jpeg_dimensions
 
 # Page images are stored at 25% scale, so the full-resolution canvas is 4× larger.
 FULL_RES_FACTOR = 4
@@ -639,6 +639,8 @@ def main() -> None:
     result_id = ""
     label = ""
     n_georef_files = 0
+    # Glob patterns whose directory is used to locate a default centerlines.geojson.
+    georef_globs: list[str] = []
 
     if args.image_base_url:
         # Plain-image (S3) mode: no manifest needed.
@@ -652,6 +654,7 @@ def main() -> None:
                 )
             base = args.image_base_url.rstrip("/")
             for s3_glob, vol_suffix in args.volume:
+                georef_globs.append(s3_glob)
                 vol_base_url = base + "/" + vol_suffix.lstrip("/")
                 vol_items, vol_result_id, _ = _load_s3_items(
                     s3_glob, vol_base_url, args.image_source_type
@@ -670,6 +673,7 @@ def main() -> None:
                     "Provide a georef glob pattern as a positional argument "
                     "when using --image-base-url."
                 )
+            georef_globs.append(s3_glob)
             vol_items, result_id, label = _load_s3_items(
                 s3_glob, args.image_base_url, args.image_source_type
             )
@@ -694,6 +698,7 @@ def main() -> None:
             )
 
         for iiif_path, georef_glob in volume_specs:
+            georef_globs.append(georef_glob)
             vol_items, vol_result_id, vol_label = _load_volume_items(
                 iiif_path, georef_glob
             )
@@ -702,6 +707,14 @@ def main() -> None:
             if not result_id:
                 result_id = vol_result_id
                 label = vol_label
+
+    # Clipping masks are optional here, so fall back to a centerlines.geojson next to the
+    # georef files only if one exists; absence simply means no block-based clipping.
+    if args.centerlines is None and georef_globs:
+        centerlines = default_centerlines(Path(georef_globs[0]).parent)
+        if centerlines is not None:
+            args.centerlines = str(centerlines)
+            print(f"Using centerlines: {args.centerlines}", file=sys.stderr)
 
     # Compute block-based clipping masks when a centerlines file is provided.
     # All volumes' pages are passed together so blocks at volume boundaries are

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -125,6 +125,22 @@ def image_stem(image_path: str) -> str:
     return Path(image_path).name.split(".")[0]
 
 
+def default_centerlines(dir_path: Path) -> Path | None:
+    """Return the ``centerlines.geojson`` next to the inputs, or None if absent.
+
+    Checks ``dir_path`` then its parent (so it is found whether commands are run on a
+    volume directory or on split panels in a subdirectory). Returns None rather than
+    exiting so callers can decide whether the file is required.
+    """
+    for candidate in (
+        dir_path / "centerlines.geojson",
+        dir_path.parent / "centerlines.geojson",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def list_pages(dir_path: Path) -> list[Path]:
     """Return the effective page images in dir_path, splits superseding their parent.
 

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -1,6 +1,30 @@
 """Tests for mapsnap.utils."""
 
-from mapsnap.utils import image_stem, list_pages, source_id_to_page_key
+from mapsnap.utils import (
+    default_centerlines,
+    image_stem,
+    list_pages,
+    source_id_to_page_key,
+)
+
+
+def test_default_centerlines_in_same_dir(tmp_path):
+    centerlines = tmp_path / "centerlines.geojson"
+    centerlines.touch()
+    assert default_centerlines(tmp_path) == centerlines
+
+
+def test_default_centerlines_in_parent_dir(tmp_path):
+    # Split panels live in a subdirectory; the file sits in the volume (parent) dir.
+    centerlines = tmp_path / "centerlines.geojson"
+    centerlines.touch()
+    panels_dir = tmp_path / "panels"
+    panels_dir.mkdir()
+    assert default_centerlines(panels_dir) == centerlines
+
+
+def test_default_centerlines_missing_returns_none(tmp_path):
+    assert default_centerlines(tmp_path) is None
 
 
 def test_list_pages_splits_supersede_parent(tmp_path):


### PR DESCRIPTION
CLI ergonomics: `mapsnap fit` has a default value for `--centerlines`. Now the individual commands (`ocr`, `georef`, `iiif`) do as well.