### PR TITLE
Escape hatch for O(n^2) georef on key maps; --geocode_keymaps flag

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -521,6 +521,56 @@ def find_intersection_gcps(
     return sorted(gcps, key=lambda g: g.pixel_dist)
 
 
+# Above this many candidate GCPs, ransac_hybrid's exhaustive C(n, 2) pairing is too slow (a
+# key-map index page can yield hundreds of intersections). A fast robust affine RANSAC over the
+# GCP correspondences first discards gross outliers so the label-scored search runs only over
+# the consensus inliers.
+ROBUST_PREFILTER_MIN_GCPS = 100
+# Even after the pre-filter the consensus can be large, and each pair costs a full label scoring
+# (~tens of ms). The consensus is geometrically clean, so only a handful of well-separated pairs
+# are needed to recover the transform; pair just the best (lowest-pixel-distance) GCPs up to this
+# cap. Bounds a many-GCP page to C(cap, 2) label scorings (seconds) instead of minutes.
+MAX_PREFILTER_PAIRING_GCPS = 30
+_M_PER_DEG_LAT: float = 111_320.0
+
+
+def _robust_affine_inlier_indices(
+    gcps: list[IntersectionGCP], reproj_threshold_m: float = 30.0
+) -> list[int]:
+    """Indices of GCPs consistent with a robust 6-parameter affine (pixel → local metres).
+
+    Fits a full affine to the pixel↔geo correspondences with cv2.estimateAffine2D's RANSAC
+    (milliseconds even for hundreds of points) and returns its inlier set. Geo is projected to
+    a local equirectangular metre frame so the reprojection threshold is in metres. Used only
+    to prune gross outliers before the slower label-scored similarity search; returns all
+    indices if the robust fit fails to converge.
+    """
+    import cv2  # lazy: heavy import, only needed for many-GCP pages
+
+    pixels = np.array([g.pixel for g in gcps], dtype=np.float64)
+    geo = np.array([g.geo for g in gcps], dtype=np.float64)
+    lon0, lat0 = float(geo[:, 0].mean()), float(geo[:, 1].mean())
+    cos0 = math.cos(math.radians(lat0))
+    metres = np.stack(
+        [
+            (geo[:, 0] - lon0) * cos0 * _M_PER_DEG_LAT,
+            (geo[:, 1] - lat0) * _M_PER_DEG_LAT,
+        ],
+        axis=1,
+    )
+    _, mask = cv2.estimateAffine2D(
+        pixels.reshape(-1, 1, 2),
+        metres.reshape(-1, 1, 2),
+        method=cv2.RANSAC,
+        ransacReprojThreshold=reproj_threshold_m,
+        maxIters=5000,
+        confidence=0.999,
+    )
+    if mask is None:
+        return list(range(len(gcps)))
+    return [i for i, keep in enumerate(mask.ravel()) if keep]
+
+
 def ransac_hybrid(
     gcps: list[IntersectionGCP],
     features: list[LabelFeature],
@@ -550,6 +600,23 @@ def ransac_hybrid(
     if n < 2:
         return None, [], None
 
+    # For pages with very many candidate GCPs (key-map index pages), the exhaustive C(n, 2)
+    # pairing is prohibitively slow. Prune gross outliers with a fast robust affine first and
+    # search only over the consensus inliers; the final fit is still the label-scored similarity.
+    candidate_indices = list(range(n))
+    if n > ROBUST_PREFILTER_MIN_GCPS:
+        consensus = _robust_affine_inlier_indices(gcps)
+        if len(consensus) >= 2:
+            # gcps are sorted by pixel_dist ascending, so consensus[:cap] keeps the most
+            # reliable intersection estimates.
+            candidate_indices = consensus[:MAX_PREFILTER_PAIRING_GCPS]
+            kept = len(candidate_indices)
+            print(
+                f"Robust-affine pre-filter: {len(consensus)} / {n} GCP inliers; pairing the "
+                f"best {kept} ({kept * (kept - 1) // 2} pairs vs {n * (n - 1) // 2})",
+                file=sys.stderr,
+            )
+
     best_A: np.ndarray | None = None
     best_inliers: list[int] = []
     best_score = -float("inf")
@@ -559,7 +626,7 @@ def ransac_hybrid(
     for a in gcps:
         print(f"  {a.label_a} x {a.label_b}")
 
-    for pair_idx in combinations(range(n), 2):
+    for pair_idx in combinations(candidate_indices, 2):
         i1, i2 = pair_idx
         a, b = gcps[i1], gcps[i2]
         # Skip pairs that map to the same OSM intersection — singular by construction.
@@ -1863,6 +1930,11 @@ def main() -> None:
         "--debug", action="store_true", help="Print additional debug information"
     )
     parser.add_argument(
+        "--geocode_keymaps",
+        action="store_true",
+        help="Geocode key maps in addition to regular pages.",
+    )
+    parser.add_argument(
         "--num-workers",
         type=int,
         default=1,
@@ -1880,8 +1952,11 @@ def main() -> None:
     for image_path in args.images:
         stem = image_stem(str(image_path))
         keymap_path = os.path.join(os.path.dirname(image_path), f"{stem}.keymap.json")
-        if os.path.exists(keymap_path):
-            print(f"Skipping {image_path}: key-map page", file=sys.stderr)
+        if os.path.exists(keymap_path) and not args.geocode_keymaps:
+            print(
+                f"Skipping {image_path}: key-map page (pass --geocode_keymaps to geocode)",
+                file=sys.stderr,
+            )
         else:
             kept_images.append(image_path)
     args.images = kept_images

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -9,16 +9,25 @@ from mapsnap.georef_from_labels import (
     _FT_PER_DEG_LAT,
     _angle_diff_abs,
     _cluster_geo_coords,
+    _robust_affine_inlier_indices,
     _rotation_from_neighbors,
     assemble_multiword_streets,
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
+    IntersectionGCP,
     label_features,
+    LabelFeature,
     promote_avenue_letters,
     project_to_polyline,
 )
 from mapsnap.streets import Block
+
+
+def _make_gcp(pixel: tuple[float, float], geo: tuple[float, float]) -> IntersectionGCP:
+    """Minimal IntersectionGCP for grouping tests (only pixel/geo matter)."""
+    feat = LabelFeature("A", "A", (0.0, 0.0), 0.0, 1.0, 1.0)
+    return IntersectionGCP("A", "B", pixel, geo, 0.0, feat, feat)
 
 
 # ---------------------------------------------------------------------------
@@ -716,3 +725,33 @@ def test_confidence_relaxed_threshold_disabled_when_floor_not_below_base():
         high_confidence_floor=18.0,
     )
     assert result == 18.0
+
+
+# ---------------------------------------------------------------------------
+# _robust_affine_inlier_indices — many-GCP pre-filter
+# ---------------------------------------------------------------------------
+
+
+def test_robust_affine_inlier_indices_drops_gross_outliers():
+    # 120 GCPs consistent with a known affine (pixel → lon/lat) plus 8 gross outliers.
+    # The robust affine RANSAC should keep the inliers and reject the outliers.
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    inliers = []
+    for _ in range(120):
+        px, py = rng.uniform(0, 4000), rng.uniform(0, 4000)
+        lon = -90.0 + 1e-4 * px
+        lat = 30.0 - 1e-4 * py
+        inliers.append(_make_gcp((px, py), (lon, lat)))
+    outliers = [
+        _make_gcp((rng.uniform(0, 4000), rng.uniform(0, 4000)), (-95.0, 35.0))
+        for _ in range(8)
+    ]
+    gcps = inliers + outliers
+    outlier_indices = set(range(120, 128))
+
+    kept = set(_robust_affine_inlier_indices(gcps))
+    # No gross outlier survives, and the large majority of true inliers are kept.
+    assert not (kept & outlier_indices)
+    assert len(kept & set(range(120))) >= 110


### PR DESCRIPTION
A key-map index page can yield hundreds of intersection GCPs, making ransac_hybrid's exhaustive C(n, 2) label-scored pairing prohibitively slow. When there are many GCPs, first prune gross outliers with a fast robust affine RANSAC (cv2.estimateAffine2D) and search only over the consensus inliers (capped to the best few by pixel distance); the final fit is still the label-scored similarity. No effect on ordinary pages (<100 GCPs).

Also add `--geocode_keymaps` so key-map pages, normally skipped, can be georeferenced; the skip message now points at the flag.

Some keymaps work better with six-parameter affine models, but that's out of scope here.

(Ported from interactive-ransac commits c759e19 + 24a34d7; the raw cherry-pick did not apply because main lacks intervening branch helpers.)

Fixes #92 