### PR TITLE
Direct links in the debugger app

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.2.7"
       },
       "devDependencies": {
+        "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
@@ -2082,6 +2083,16 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -4288,6 +4299,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,18 @@ import { DetectionsTable } from './components/DetectionsTable';
 import { PanelsTable } from './components/PanelsTable';
 import { loadImage } from './loadImage';
 
+// Whether a URL/path points at an image we can load (matched by extension).
+function isImageUrl(url: string): boolean {
+  return /\.(jpe?g|png|webp|gif|tiff?)(\?.*)?$/i.test(url);
+}
+
+// Resolve a `?files=` entry to a fetchable URL, leaving absolute URLs/paths as
+// given and otherwise resolving relative to the app's base (e.g.
+// `data/streets.json` -> `/mapsnap/data/streets.json`, served by the dev server).
+function resolveDataUrl(file: string): string {
+  if (/^https?:\/\//.test(file) || file.startsWith('/')) return file;
+  return import.meta.env.BASE_URL.replace(/\/$/, '') + '/' + file;
+}
 /**
  * Debug API exposed on `window.mapsnap` so data can be injected without the UI
  * (e.g. from the browser console or automated tests). `loadJson` accepts either
@@ -138,6 +150,14 @@ export function App() {
     }
   }
 
+  // Point the viewer at a decoded image, updating its source and JSON dimensions.
+  function applyImage(el: HTMLImageElement, src: string): void {
+    setImageEl(el);
+    setImageSrc(src);
+    setJsonWidth(el.naturalWidth);
+    setJsonHeight(el.naturalHeight);
+  }
+
   // Handle files dropped onto the image column (image and/or JSON).
   async function handleFiles(files: File[]): Promise<void> {
     const imageFile = files.find((f) => f.type.startsWith('image/'));
@@ -153,12 +173,9 @@ export function App() {
       const url = URL.createObjectURL(imageFile);
       prevObjectUrlRef.current = url;
       const el = await loadImage(url);
-      setImageEl(el);
-      setImageSrc(url);
+      applyImage(el, url);
       fallbackWidth = el.naturalWidth;
       fallbackHeight = el.naturalHeight;
-      setJsonWidth(el.naturalWidth);
-      setJsonHeight(el.naturalHeight);
     }
 
     if (jsonFile) {
@@ -167,20 +184,62 @@ export function App() {
     }
   }
 
+  // Load image and/or JSON data from dev-server URLs (the `?files=` deep link).
+  // Mirrors handleFiles, but fetches served files instead of reading File blobs.
+  async function loadFromUrls(files: string[]): Promise<void> {
+    const imageFile = files.find(isImageUrl);
+    const jsonFile = files.find((f) => f.endsWith('.json'));
+
+    let fallbackWidth = jsonWidth;
+    let fallbackHeight = jsonHeight;
+
+    try {
+      if (imageFile) {
+        if (prevObjectUrlRef.current) {
+          URL.revokeObjectURL(prevObjectUrlRef.current);
+          prevObjectUrlRef.current = null;
+        }
+        const src = resolveDataUrl(imageFile);
+        const el = await loadImage(src);
+        applyImage(el, src);
+        fallbackWidth = el.naturalWidth;
+        fallbackHeight = el.naturalHeight;
+      }
+
+      if (jsonFile) {
+        const response = await fetch(resolveDataUrl(jsonFile));
+        if (!response.ok) {
+          throw new Error(`${jsonFile}: HTTP ${response.status}`);
+        }
+        processJson(await response.text(), fallbackWidth, fallbackHeight);
+      }
+    } catch (err) {
+      console.error('Failed to load files from URL:', err);
+    }
+  }
+
   // Expose a debug API on `window.mapsnap` for injecting data without the UI.
   // Re-registered each render so it always closes over the latest state.
   useEffect(() => {
     window.mapsnap = {
       loadJson: (text: string) => processJson(text, jsonWidth, jsonHeight),
-      setImage: async (url: string) => {
-        const el = await loadImage(url);
-        setImageEl(el);
-        setImageSrc(url);
-        setJsonWidth(el.naturalWidth);
-        setJsonHeight(el.naturalHeight);
-      },
+      setImage: async (url: string) => applyImage(await loadImage(url), url),
     };
   });
+
+  // On first load, honor a `?files=data/image.jpg,data/streets.json` deep link
+  // by fetching those files from the dev server and entering the matching view.
+  useEffect(() => {
+    const filesParam = new URLSearchParams(window.location.search).get('files');
+    if (!filesParam) return;
+    const files = filesParam
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    void loadFromUrls(files);
+    // Runs once on mount; loadFromUrls closes over the initial (empty) state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Cycle warped-image opacity through 0/50/100% on the 'p' key (georef mode).
   useEffect(() => {

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,10 +1,84 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const dataDir = path.join(repoRoot, 'data');
+
+// Content types for the file kinds found under data/.
+const MIME_BY_EXT: Record<string, string> = {
+  '.json': 'application/json',
+  '.geojson': 'application/geo+json',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+};
+
+// Guess a Content-Type from a file path's extension.
+function contentTypeFor(filePath: string): string {
+  return (
+    MIME_BY_EXT[path.extname(filePath).toLowerCase()] ??
+    'application/octet-stream'
+  );
+}
+
+/**
+ * Serve the repo-root `data/` directory over the dev server.
+ *
+ * Vite's root is `app/`, so `data/` (a sibling) is otherwise unreachable. This
+ * exposes it at `<base>data/...` (e.g. `/mapsnap/data/streets.json`) so test
+ * data can be loaded by URL via the app's `?files=` deep link.
+ */
+function serveDataDir(): Plugin {
+  return {
+    name: 'serve-data-dir',
+    configureServer(server) {
+      const base = server.config.base; // e.g. '/mapsnap/'
+      server.middlewares.use((req, res, next) => {
+        if (!req.url) return next();
+
+        // Custom middleware runs before Vite strips the base, but be tolerant of
+        // either form by stripping the base if present, else the leading slash.
+        let pathname = decodeURIComponent(
+          new URL(req.url, 'http://localhost').pathname,
+        );
+        pathname = pathname.startsWith(base)
+          ? pathname.slice(base.length)
+          : pathname.replace(/^\//, '');
+        if (!pathname.startsWith('data/')) return next();
+
+        const filePath = path.join(dataDir, pathname.slice('data/'.length));
+        // Refuse paths that escape data/ via `..` or symlinks.
+        if (filePath !== dataDir && !filePath.startsWith(dataDir + path.sep)) {
+          res.statusCode = 403;
+          return res.end('Forbidden');
+        }
+
+        fs.stat(filePath, (err, stat) => {
+          if (err || !stat.isFile()) return next();
+          res.setHeader('Content-Type', contentTypeFor(filePath));
+          fs.createReadStream(filePath).pipe(res);
+        });
+      });
+    },
+  };
+}
 
 export default defineConfig({
   base: '/mapsnap/',
-  plugins: [react()],
+  plugins: [react(), serveDataDir()],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
Add a `?files=image.jpg,streets.json` deep link so the debugger can be opened pointed at specific files: loadFromUrls fetches them from the dev server (resolveDataUrl resolves paths against the app base) on mount, mirroring the drag-and-drop handler. vite.config.ts serves the repo's data/ files for these links. Adds @types/node for the config's node:fs/node:path use.

Example deep link:

    http://localhost:5173/mapsnap/?files=data/chicago_il_1950_vol_1/p106W.jpg,data/chicago_il_1950_vol_1/p106W.streets.json

(Ported from interactive-ransac commit 4a06cc9; the raw cherry-pick did not apply because that commit sits on the debugger's interactive-ransac work, which is not on main. The unrelated georef_pages.csv from that commit is dropped.)