### PR TITLE
Place sole-intersection jog pages via 1-GCP fit instead of failing

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -521,6 +521,61 @@ def find_intersection_gcps(
     return sorted(gcps, key=lambda g: g.pixel_dist)
 
 
+# GCPs whose pixel crossings fall within this many pixels are treated as one image
+# intersection with several world candidates (a jogging street's two crossings, or a
+# divided road's two carriageways), not as independent control points.
+SAME_PIXEL_TOL_PX = 5.0
+
+
+def _distinct_pixel_gcps(
+    gcps: list[IntersectionGCP],
+) -> list[list[IntersectionGCP]]:
+    """Group GCPs by near-coincident pixel crossing.
+
+    Each group is a set of GCPs sharing one image point, whose geo locations are therefore
+    alternatives (e.g. the two crossings of a jogging street). The number of groups is the
+    number of independent control points available to fit an affine.
+    """
+    groups: list[list[IntersectionGCP]] = []
+    for gcp in gcps:
+        for group in groups:
+            if (
+                math.hypot(
+                    gcp.pixel[0] - group[0].pixel[0], gcp.pixel[1] - group[0].pixel[1]
+                )
+                <= SAME_PIXEL_TOL_PX
+            ):
+                group.append(gcp)
+                break
+        else:
+            groups.append([gcp])
+    return groups
+
+
+def _inlier_residuals(
+    features: list[LabelFeature],
+    block_index: dict[str, list[Block]],
+    A: np.ndarray,
+    inlier_feat_indices: list[int],
+) -> list[float]:
+    """Per-inlier distance (degrees) from each mapped label to its nearest street polyline."""
+    residuals: list[float] = []
+    for i in inlier_feat_indices:
+        feat = features[i]
+        blocks = block_index.get(feat.text)
+        if not blocks:
+            continue
+        lon, lat = apply_affine(A, *feat.center)
+        snap = project_to_polyline(lon, lat, blocks)
+        if snap is None:
+            continue
+        nearest_lon, nearest_lat, _ = snap
+        residuals.append(
+            float(np.linalg.norm(np.array([lon - nearest_lon, lat - nearest_lat])))
+        )
+    return residuals
+
+
 def ransac_hybrid(
     gcps: list[IntersectionGCP],
     features: list[LabelFeature],
@@ -1402,16 +1457,27 @@ def process_image(
     if len(gcps) == 0:
         print("No intersection GCPs found.", file=sys.stderr)
         return ProcessResult(success=False)
-    if len(gcps) == 1:
+
+    # GCPs sharing one pixel are the same image intersection with alternative world
+    # locations (a jogging street crosses its cross-street twice a few metres apart, or a
+    # divided road has two carriageway crossings). They cannot pair with each other to fix
+    # an affine, so when every GCP collapses onto a single image point there is just one
+    # control point: defer to the median-scale 1-GCP fit, which tries each world candidate.
+    if len(_distinct_pixel_gcps(gcps)) == 1:
         ix = f"{gcps[0].feat_a.raw_text} x {gcps[0].feat_b.raw_text}"
+        descr = (
+            ix
+            if len(gcps) == 1
+            else f"{ix} ({len(gcps)} world candidates at one pixel)"
+        )
         if not one_gcp_fits:
             print(
-                f"Only 1 intersection GCP: {ix}; skipping (use --disable-one-gcp-fits to suppress).",
+                f"Only 1 distinct intersection: {descr}; skipping (use --disable-one-gcp-fits to suppress).",
                 file=sys.stderr,
             )
             return ProcessResult(success=False)
         print(
-            f"Only 1 intersection GCP: {ix}; deferring for median-scale processing.",
+            f"Only 1 distinct intersection: {descr}; deferring for median-scale processing.",
             file=sys.stderr,
         )
         return ProcessResult(
@@ -1440,20 +1506,7 @@ def process_image(
         file=sys.stderr,
     )
 
-    residuals: list[float] = []
-    for i in inlier_feat_indices:
-        feat = features[i]
-        blocks = block_index.get(feat.text)
-        if not blocks:
-            continue
-        lon, lat = apply_affine(A, *feat.center)
-        snap = project_to_polyline(lon, lat, blocks)
-        if snap is None:
-            continue
-        nearest_lon, nearest_lat, _ = snap
-        residuals.append(
-            float(np.linalg.norm(np.array([lon - nearest_lon, lat - nearest_lat])))
-        )
+    residuals = _inlier_residuals(features, block_index, A, inlier_feat_indices)
 
     scale, center = _finalize_georef(
         A,
@@ -1607,15 +1660,18 @@ def process_deferred_image(
     cos_phi: float,
     neighbor_rotations: list[tuple[tuple[float, float], float]],
 ) -> ProcessResult:
-    """Georeference an image that was deferred due to having only 1 intersection GCP.
+    """Georeference an image that was deferred for having a single distinct intersection.
 
     Uses the provided scale (deg/px) and estimates rotation from the two streets at the
-    single GCP. The undirected rotation is then validated against adjacent pages (already
+    GCP. The undirected rotation is then validated against adjacent pages (already
     successfully georeferenced): if ≥2 neighbours within 1.5× page dimensions agree with
     one of the two directed candidates (±180°), that candidate is used. When both are
-    equally supported, the 180° ambiguity is resolved by the north-up heuristic. Confirmed
-    fits (≥2 neighbours) are written to output_path (.georef.json); unconfirmed fits are
-    written to a .georef-1gcp.json sidecar instead and returned with success=False.
+    equally supported, the 180° ambiguity is resolved by the north-up heuristic.
+
+    When the intersection has several world candidates (a jogging street's two crossings),
+    each is fitted and the one with the most inlier labels — then the lowest total residual —
+    is kept. Confirmed fits (≥2 neighbours) are written to output_path (.georef.json);
+    unconfirmed fits are written to a .georef-1gcp.json sidecar and returned success=False.
     """
     image_path: str = deferred["image_path"]
     output_path: str = deferred["output_path"]
@@ -1626,51 +1682,65 @@ def process_deferred_image(
     img_w: int = deferred["img_w"]
     img_h: int = deferred["img_h"]
     parameters: dict | None = deferred["parameters"]
-    gcp = gcps[0]
-
-    undirected = _rotation_from_gcp_features(gcp, block_index)
-    if undirected is None:
-        print("Could not estimate rotation from GCP street angles.", file=sys.stderr)
-        return ProcessResult(success=False)
 
     page_dim_lat = scale_deg_per_px * img_h
     page_dim_lon = scale_deg_per_px * img_w / cos_phi
-    decision = _rotation_from_neighbors(
-        candidate=undirected,
-        approx_center=gcp.geo,
-        page_dim_deg=(page_dim_lon, page_dim_lat),
-        neighbor_rotations=neighbor_rotations,
-    )
-    rotation = decision.rotation
-
     pos_threshold = 0.001
-    A = build_affine_from_scale_rotation_gcp(scale_deg_per_px, rotation, gcp, cos_phi)
-    inlier_feat_indices, _ = label_inliers(
-        features, block_index, A, pos_threshold, extrapolate=True
-    )
 
-    if not inlier_feat_indices:
-        print("No inliers found for deferred image.", file=sys.stderr)
+    # Fit each world candidate for the single image point and keep the best by inlier count,
+    # then by total residual. With one candidate (the usual 1-GCP case) the loop runs once.
+    best: (
+        tuple[
+            tuple[int, float],
+            np.ndarray,
+            list[int],
+            list[float],
+            RotationDecision,
+            IntersectionGCP,
+        ]
+        | None
+    ) = None
+    for gcp in gcps:
+        undirected = _rotation_from_gcp_features(gcp, block_index)
+        if undirected is None:
+            continue
+        decision = _rotation_from_neighbors(
+            candidate=undirected,
+            approx_center=gcp.geo,
+            page_dim_deg=(page_dim_lon, page_dim_lat),
+            neighbor_rotations=neighbor_rotations,
+        )
+        A = build_affine_from_scale_rotation_gcp(
+            scale_deg_per_px, decision.rotation, gcp, cos_phi
+        )
+        inliers, _ = label_inliers(
+            features, block_index, A, pos_threshold, extrapolate=True
+        )
+        if not inliers:
+            continue
+        residuals = _inlier_residuals(features, block_index, A, inliers)
+        # Maximise inlier count, then minimise total residual (better-aligned jog side).
+        key = (len(inliers), -sum(residuals))
+        if best is None or key > best[0]:
+            best = (key, A, inliers, residuals, decision, gcp)
+
+    if best is None:
+        print(
+            "No usable deferred fit (no rotation estimate or no inliers).",
+            file=sys.stderr,
+        )
         return ProcessResult(success=False)
+
+    _, A, inlier_feat_indices, residuals, decision, gcp = best
+    if len(gcps) > 1:
+        print(
+            f"Deferred: picked 1 of {len(gcps)} world candidates at the shared pixel.",
+            file=sys.stderr,
+        )
     print(
         f"Deferred: {len(inlier_feat_indices)} / {len(features)} inlier labels",
         file=sys.stderr,
     )
-
-    residuals: list[float] = []
-    for i in inlier_feat_indices:
-        feat = features[i]
-        blocks = block_index.get(feat.text)
-        if not blocks:
-            continue
-        lon, lat = apply_affine(A, *feat.center)
-        snap = project_to_polyline(lon, lat, blocks)
-        if snap is None:
-            continue
-        nearest_lon, nearest_lat, _ = snap
-        residuals.append(
-            float(np.linalg.norm(np.array([lon - nearest_lon, lat - nearest_lat])))
-        )
 
     actual_output_path = (
         output_path

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -9,16 +9,56 @@ from mapsnap.georef_from_labels import (
     _FT_PER_DEG_LAT,
     _angle_diff_abs,
     _cluster_geo_coords,
+    _distinct_pixel_gcps,
     _rotation_from_neighbors,
     assemble_multiword_streets,
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
+    IntersectionGCP,
+    LabelFeature,
     label_features,
     promote_avenue_letters,
     project_to_polyline,
 )
 from mapsnap.streets import Block
+
+
+def _make_gcp(pixel: tuple[float, float], geo: tuple[float, float]) -> IntersectionGCP:
+    """Minimal IntersectionGCP for grouping tests (only pixel/geo matter)."""
+    feat = LabelFeature("A", "A", (0.0, 0.0), 0.0, 1.0, 1.0)
+    return IntersectionGCP("A", "B", pixel, geo, 0.0, feat, feat)
+
+
+def test_distinct_pixel_gcps_groups_coincident_pixels():
+    # Two GCPs at the same pixel (a jog: same image crossing, two world points) -> one group.
+    gcps = [
+        _make_gcp((100.0, 200.0), (-83.0, 42.0)),
+        _make_gcp((101.0, 201.0), (-83.0005, 42.0)),  # within 5px tolerance
+    ]
+    groups = _distinct_pixel_gcps(gcps)
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+
+
+def test_distinct_pixel_gcps_separates_distinct_pixels():
+    # Two GCPs at far-apart pixels are independent control points -> two groups.
+    gcps = [
+        _make_gcp((100.0, 200.0), (-83.0, 42.0)),
+        _make_gcp((900.0, 800.0), (-82.9, 42.1)),
+    ]
+    assert len(_distinct_pixel_gcps(gcps)) == 2
+
+
+def test_distinct_pixel_gcps_mixed():
+    # A jog pair at one pixel plus one distinct pixel -> two groups (RANSAC still has a pair).
+    gcps = [
+        _make_gcp((100.0, 200.0), (-83.0, 42.0)),
+        _make_gcp((102.0, 200.0), (-83.0005, 42.0)),
+        _make_gcp((900.0, 800.0), (-82.9, 42.1)),
+    ]
+    groups = _distinct_pixel_gcps(gcps)
+    assert sorted(len(g) for g in groups) == [1, 2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
GCPs that share one image pixel are the same intersection with alternative world locations — a jogging street crossing its cross-street twice, or a divided road's two carriageways. They can't pair with each other to fix an affine, so a page whose GCPs all collapse onto one pixel has just **one** control point.

Rather than fail such a page, defer it to the median-scale 1-GCP fit, which now tries **each** world candidate at the shared pixel and keeps the one with the most inlier labels (then lowest total residual). Adds `_distinct_pixel_gcps` and `_inlier_residuals`.

Verified: full test suite green.

## Experiment — 6 volumes vs `main` (f62de9b9)

Each row: `mapsnap fit` on this branch vs main; mean RMSE (ft) against OIM truth, georeferenced-page count, and notable per-page changes (≥20 ft or coverage).

| Volume | mean RMSE ft (Δ) | georef pages | notable |
|---|---|---|---|
| brooklyn_ny_1939_vol_1 | 20.8 → 20.8 (+0.0) | 54 → 54 | no change |
| champaign_ill_1915 | 13.0 → 13.0 (+0.0) | 18 → 18 | no change |
| chicago_il_1950_vol_1 | 114.1 → 114.1 (+0.0) | 98 → 98 | no change |
| detroit_mich_1929_vol_11 | 32.8 → 33.1 (+0.3) | 83 → 84 | placed p32 |
| new_orleans_la_1896_vol_2 | 53.1 → 53.1 (+0.0) | 80 → 80 | no change |
| new_orleans_la_1951_vol_5 | 17.0 → 17.3 (+0.3) | 102 → 103 | placed p432 |

**Takeaway:** places 2 previously-failing pages (Detroit p32, New Orleans-1951 p432) at a negligible +0.3 ft mean cost on those volumes; every other volume unchanged. (Chicago's 114 ft is a property of the `main` baseline — identical on both sides.)
