### PR TITLE
Reject fits whose seed street is a rotation outlier

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -521,6 +521,80 @@ def find_intersection_gcps(
     return sorted(gcps, key=lambda g: g.pixel_dist)
 
 
+def _nearest_block(lon: float, lat: float, blocks: list[Block]) -> Block | None:
+    """Return the block (connected polyline) with the segment closest to (lon, lat)."""
+    q = np.array([lon, lat])
+    best_dist = float("inf")
+    best_block: Block | None = None
+    for block in blocks:
+        pts = block.coords
+        for k in range(len(pts) - 1):
+            p1, seg = pts[k], pts[k + 1] - pts[k]
+            seg_len_sq = float(np.dot(seg, seg))
+            if seg_len_sq < 1e-20:
+                continue
+            t = float(np.clip(np.dot(q - p1, seg) / seg_len_sq, 0.0, 1.0))
+            dist = float(np.linalg.norm(q - (p1 + t * seg)))
+            if dist < best_dist:
+                best_dist, best_block = dist, block
+    return best_block
+
+
+def _dominant_angle(block: Block) -> float | None:
+    """Length-weighted dominant tangent angle (mod π) of a block via its structure tensor.
+
+    Summing each segment's outer product weights long straight runs far more than short
+    ones, so a brief kink near a junction cannot swing the estimate from the street's true
+    bearing (see commit 9f03711, which introduced this for the key-map anchor path).
+    Returns None if the block has no usable segment.
+    """
+    pts = block.coords
+    tensor = np.zeros((2, 2))
+    for k in range(len(pts) - 1):
+        seg = pts[k + 1] - pts[k]
+        tensor += np.outer(seg, seg)
+    if not np.any(tensor):
+        return None
+    _, eigenvectors = np.linalg.eigh(tensor)
+    direction = eigenvectors[:, -1]
+    return float(np.arctan2(direction[1], direction[0])) % np.pi
+
+
+def is_rotation_outlier(
+    feat: LabelFeature,
+    block_index: dict[str, list[Block]],
+    affine: np.ndarray,
+    dir_threshold: float = np.pi / 6,
+) -> bool:
+    """Whether ``feat``'s mapped label direction disagrees with its street's bearing.
+
+    A position-independent rotation test: the label's mapped direction is compared against the
+    length-weighted dominant bearing of its nearest block (via :func:`_dominant_angle`), so a
+    kinked or truncated end-segment cannot masquerade as a mismatch the way the single nearest
+    segment can. Returns False when the feature has no matching street or no usable bearing.
+
+    Distinguishes a genuinely mis-oriented label (the model's rotation is wrong) from one that
+    merely lands off its centerline: a historical street that ran past where today's OSM line
+    ends leaves its label on the vanished stretch — right bearing, wrong position — and that is
+    not a rotation outlier. Used to gate the self-inconsistent-fit rejection in ransac_hybrid.
+    """
+    blocks = block_index.get(feat.text)
+    if not blocks:
+        return False
+    lon, lat = apply_affine(affine, *feat.center)
+    block = _nearest_block(lon, lat, blocks)
+    if block is None:
+        return False
+    dominant = _dominant_angle(block)
+    if dominant is None:
+        return False
+    d_pixel = np.array([np.cos(feat.dir_pix), np.sin(feat.dir_pix)])
+    d_geo = affine[:, :2] @ d_pixel
+    d_geo_norm = d_geo / (float(np.linalg.norm(d_geo)) + 1e-10)
+    tangent_vec = np.array([np.cos(dominant), np.sin(dominant)])
+    return bool(abs(float(np.dot(d_geo_norm, tangent_vec))) < math.cos(dir_threshold))
+
+
 def ransac_hybrid(
     gcps: list[IntersectionGCP],
     features: list[LabelFeature],
@@ -536,6 +610,11 @@ def ransac_hybrid(
     Generates candidate affines from all C(n, 2) pairs of intersection GCPs, solving for
     the 4-parameter similarity transform (equal metric scale + orthogonality) at each pair.
     Inlier counting uses point-to-polyline + direction for every label.
+
+    A candidate pair is disqualified when one of its own seed streets is a rotation outlier
+    under the model it defines — the fit's orientation contradicts a street it was built from
+    (see is_rotation_outlier and the in-loop comment). If no pair survives, returns
+    (None, [], None) so the caller records no fit for the page.
 
     A global rotation estimate R_est is derived from a histogram cross-correlation of label
     angles vs OSM tangents before the main loop. Each candidate is penalized by rot_penalty
@@ -573,6 +652,24 @@ def ransac_hybrid(
         inliers, err = label_inliers(
             features, block_index, A, pos_threshold, dir_threshold, debug=debug
         )
+
+        # Reject only fits whose own seed streets are *rotation* outliers: each seed GCP is
+        # built from two specific street labels, so if the model maps one of those labels to a
+        # bearing that disagrees with its street, the fit's orientation contradicts its own
+        # evidence (Detroit p28's COREY, mapped ~38° off its dominant bearing). A seed that
+        # matches in direction but lands off its centerline is NOT rejected: that is a
+        # position-only outlier, which is exactly what happens when a historical street ran
+        # past where today's OSM line ends and the label sits on the vanished stretch (Brooklyn
+        # p7's VAN BRUNT, ~3° off but ~115 ft beyond the truncated end). Seeds are the pair's
+        # four source features; is_rotation_outlier identifies each by its own center, so an
+        # ambiguous label's dropped canonical expansion (Detroit p94's KORTE) isn't faulted.
+        seed_feats = (a.feat_a, a.feat_b, b.feat_a, b.feat_b)
+        if any(
+            is_rotation_outlier(f, block_index, A, dir_threshold) for f in seed_feats
+        ):
+            if debug:
+                print(f"  {i1} {i2} REJECTED ({len(inliers)}) seed rotation outlier")
+            continue
 
         # Each inlier contributes (pos_threshold - pos_err) to the score; an inlier at
         # exactly the threshold boundary contributes 0, so a marginal extra inlier cannot

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -14,9 +14,13 @@ from mapsnap.georef_from_labels import (
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
+    IntersectionGCP,
+    is_rotation_outlier,
     label_features,
+    LabelFeature,
     promote_avenue_letters,
     project_to_polyline,
+    ransac_hybrid,
 )
 from mapsnap.streets import Block
 
@@ -716,3 +720,215 @@ def test_confidence_relaxed_threshold_disabled_when_floor_not_below_base():
         high_confidence_floor=18.0,
     )
     assert result == 18.0
+
+
+# ---------------------------------------------------------------------------
+# _kink_block (shared geometry helper)
+# ---------------------------------------------------------------------------
+
+
+def _kink_block() -> Block:
+    """A long east-west run ending in a short, steep kink segment."""
+    return Block(
+        street_name="MAIN",
+        coords=np.array(
+            [
+                [-89.991, 29.995],  # long horizontal run ...
+                [-89.989, 29.995],  # ... ~190 m of it
+                [-89.9889, 29.9952],  # short ~25 m kink, ~63° off horizontal
+            ]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ransac_hybrid: reject fits whose seed street is a *rotation* outlier (the model's
+# orientation contradicts a street it was built from), while keeping fits whose seed
+# is only a *position* outlier (right bearing, off a since-shortened centerline)
+# ---------------------------------------------------------------------------
+
+# Shared frame for the tests below: an orientation-reversing similarity at 1e-5 deg/px,
+# north-up, where px=500 maps to lon=-90.0 and py=200 to lat=30.0. Two GCPs at
+# (500, 200)->(-90, 30) and (500, 700)->(-90, 29.995) recover it exactly.
+_RH_COS_PHI = math.cos(math.radians(30.0))
+
+
+def _vertical_block(name: str, lon: float) -> Block:
+    """A north-south street segment at the given longitude."""
+    return Block(name, np.array([[lon, 29.99], [lon, 30.01]]))
+
+
+def _horizontal_block(name: str, lat: float) -> Block:
+    """An east-west street segment at the given latitude."""
+    return Block(name, np.array([[-90.02, lat], [-89.98, lat]]))
+
+
+def _rh_feat(text: str, center: tuple[float, float], dir_pix: float) -> LabelFeature:
+    """A label feature for the ransac_hybrid frame (sizes are immaterial here)."""
+    return LabelFeature(text, text, center, dir_pix, 100.0, 20.0)
+
+
+def test_ransac_hybrid_rejects_rotation_outlier_seed():
+    # Both GCPs are seeded by COREY (cf. Detroit p28). COREY's label maps to a bearing ~90°
+    # off its (vertical) street, so it is a rotation outlier: the model's orientation
+    # contradicts a street it was built from. The only candidate pair is disqualified and no
+    # model is returned.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat(
+        "COREY", (500.0, 450.0), 0.0
+    )  # horizontal label on a vertical street
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is None
+    assert inliers == []
+    assert pair is None
+
+
+def test_ransac_hybrid_keeps_position_only_outlier_seed():
+    # Same COREY-seeded frame, but COREY's label keeps its street's (vertical) bearing and is
+    # merely displaced ~4300 ft east of the centerline -- a position-only outlier, as when a
+    # historical street ran past where today's OSM line ends (cf. Brooklyn p7's VAN BRUNT).
+    # The pair is kept even though COREY is not a position inlier.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat(
+        "COREY", (1500.0, 450.0), math.pi / 2
+    )  # right bearing, off the line
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1}  # COREY is a position outlier, but the pair survives
+    assert pair == (0, 1)
+
+
+def test_ransac_hybrid_keeps_fit_when_seed_labels_are_inliers():
+    # Same frame, but COREY's label now sits on its own centerline, so every seed label is an
+    # inlier and the pair is accepted.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat("COREY", (500.0, 450.0), math.pi / 2)  # on COREY's line -> inlier
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1, 2}
+    assert pair == (0, 1)
+
+
+def test_ransac_hybrid_accepts_ambiguous_label_seeding_two_streets():
+    # A single physical "KORTE" label (one center) is ambiguous between KORTE STREET and
+    # KORTE AVENUE and legitimately seeds a GCP under each name (cf. Detroit p94). Only the
+    # real match, KORTE STREET, is an inlier; label_inliers dedups the center to it. Because
+    # the seed check is by center, the pair is accepted -- a name-based check would wrongly
+    # reject it, faulting the dropped KORTE AVENUE expansion as an outlier.
+    drexel = _rh_feat("DREXEL", (500.0, 200.0), 0.0)
+    piper = _rh_feat("PIPER", (500.0, 700.0), 0.0)
+    korte_center = (500.0, 450.0)
+    korte_st = _rh_feat("KORTE STREET", korte_center, math.pi / 2)  # on its line
+    korte_ave = _rh_feat("KORTE AVENUE", korte_center, math.pi / 2)  # wrong street
+    features = [drexel, piper, korte_st, korte_ave]
+    block_index = {
+        "DREXEL": [_horizontal_block("DREXEL", 30.0)],
+        "PIPER": [_horizontal_block("PIPER", 29.995)],
+        "KORTE STREET": [_vertical_block("KORTE STREET", -90.0)],
+        "KORTE AVENUE": [_vertical_block("KORTE AVENUE", -89.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "DREXEL",
+            "KORTE AVENUE",
+            (500.0, 200.0),
+            (-90.0, 30.0),
+            0.0,
+            drexel,
+            korte_ave,
+        ),
+        IntersectionGCP(
+            "PIPER",
+            "KORTE STREET",
+            (500.0, 700.0),
+            (-90.0, 29.995),
+            0.0,
+            piper,
+            korte_st,
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1, 2}  # korte_ave (idx 3) deduped out by center
+    assert pair == (0, 1)
+
+
+# is_rotation_outlier ------------------------------------------------------
+
+# Axis-aligned similarity: pixel (x, y) -> (lon, lat) = (-90 + 1e-5·x, 30 - 1e-5·y). A
+# horizontal pixel label (dir_pix=0) maps to an east-west bearing, a vertical one (π/2) to
+# north-south.
+_AXIS_AFFINE = np.array([[1e-5, 0.0, -90.0], [0.0, -1e-5, 30.0]])
+
+
+def test_is_rotation_outlier_true_when_perpendicular():
+    # A horizontal label on a vertical (north-south) street is ~90° off its bearing.
+    feat = _rh_feat("MAIN", (500.0, 500.0), 0.0)
+    block_index = {"MAIN": [_vertical_block("MAIN", -89.995)]}
+    assert is_rotation_outlier(feat, block_index, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_false_when_aligned_even_if_off_position():
+    # A vertical label far (4300 ft) east of a vertical street: wrong position, right bearing.
+    feat = _rh_feat("MAIN", (1500.0, 500.0), math.pi / 2)
+    block_index = {"MAIN": [_vertical_block("MAIN", -89.995)]}
+    assert not is_rotation_outlier(feat, block_index, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_false_when_no_street():
+    feat = _rh_feat("MISSING", (500.0, 500.0), 0.0)
+    assert not is_rotation_outlier(feat, {}, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_uses_dominant_bearing_not_kink():
+    # The label runs along the street's long east-west body; the nearest segment is a short
+    # steep kink. The dominant bearing keeps it an inlier, so it is not a rotation outlier.
+    feat = LabelFeature("MAIN", "MAIN", (1110.0, 480.0), 0.0, 100.0, 20.0)
+    block_index = {"MAIN": [_kink_block()]}
+    affine = np.array([[1e-5, 0.0, -90.0], [0.0, -1e-5, 30.0]])
+    assert not is_rotation_outlier(feat, block_index, affine)


### PR DESCRIPTION
A GCP pair seeds a candidate fit from two street labels. If the resulting model maps one of those labels to a bearing that disagrees with its street's dominant bearing, the fit's orientation contradicts its own evidence, so the pair is discarded.

The check is on **rotation only**: a seed that keeps the right bearing but lands off a since-shortened centerline (a position-only outlier) is kept — that happens when a historical street ran past where today's OSM line ends and the label sits on the vanished stretch (e.g. Brooklyn p7's VAN BRUNT). A genuinely mis-rotated seed (Detroit p28's COREY, ~38° off) is rejected. If no pair survives, the page gets no fit rather than a confidently-wrong one.

Adds `is_rotation_outlier` plus the `_dominant_angle` / `_nearest_block` geometry helpers it needs, and gates `ransac_hybrid`'s candidate search on it.

Verified: full test suite green.

## Experiment — 6 volumes vs `main` (f62de9b9)

Each row: `mapsnap fit` on this branch vs main; mean RMSE (ft) against OIM truth, georeferenced-page count, and notable per-page changes (≥20 ft or coverage).

| Volume | mean RMSE ft (Δ) | georef pages | notable |
|---|---|---|---|
| brooklyn_ny_1939_vol_1 | 20.8 → 20.8 (+0.0) | 54 → 54 | no change |
| champaign_ill_1915 | 13.0 → 13.0 (+0.0) | 18 → 18 | no change |
| chicago_il_1950_vol_1 | 114.1 → 114.2 (+0.1) | 98 → 98 | no change |
| detroit_mich_1929_vol_11 | 32.8 → 21.9 (-10.9) | 83 → 82 | dropped p28 |
| new_orleans_la_1896_vol_2 | 53.1 → 53.5 (+0.4) | 80 → 81 | placed p164 |
| new_orleans_la_1951_vol_5 | 17.0 → 17.0 (+0.0) | 102 → 102 | no change |

**Takeaway:** the headline win is Detroit **−10.9 ft mean**, from dropping the self-inconsistent p28 (COREY seeds both GCPs yet maps ~38° off its own street). NOLA-1896 places one extra page (p164) at +0.4 ft; all other volumes unchanged.

Here's the bad fit for the motivating Detroit p28:

<img width="566" height="519" alt="image" src="https://github.com/user-attachments/assets/c2d30d11-39e0-427d-84bf-1e67c6137454" />
