### PR TITLE
Straighten GCP geo at sharply curved intersections

### DIFF
--- a/mapsnap/block_index_test.py
+++ b/mapsnap/block_index_test.py
@@ -205,7 +205,9 @@ def test_find_gcps_grand_x_peshtigo():
 
 def test_find_gcps_lake_shore_x_ohio():
     # North Lake Shore Drive (N-S) and East Ohio Street (E-W) share one node:
-    # (-87.6145965, 41.8926846).  Pixel crossing: (1883, 1591).
+    # (-87.6145965, 41.8926846).  Pixel crossing: (1883, 1591).  Lake Shore Drive curves
+    # only mildly here, so the straight-axis correction (~42 ft) stays below its floor and
+    # the raw shared node is kept.
     index = build_block_index(_load_p29n())
     feats = [
         _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
@@ -228,6 +230,45 @@ def test_find_gcps_parallel_streets_produce_no_gcp():
         _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
     ]
     assert find_intersection_gcps(feats, index) == []
+
+
+def test_curved_junction_straightening_skips_jogs(monkeypatch):
+    # A jog — the same street pair crossing twice — must not be straightened: the dominant-axis
+    # window would span both branches and fabricate a bogus shift (cf. Brooklyn p26, COURT
+    # jogging across BRYANT). straight_intersection_geo is called for the unique MAIN x SINGLE
+    # crossing but skipped for the two-node MAIN x JOG pair.
+    import mapsnap.georef_from_labels as module
+
+    calls: list[tuple[float, float]] = []
+    real = module.straight_intersection_geo
+
+    def spy(geo, blocks_a, blocks_b, **kwargs):
+        calls.append(geo)
+        return real(geo, blocks_a, blocks_b, **kwargs)
+
+    monkeypatch.setattr(module, "straight_intersection_geo", spy)
+
+    geojson = _make_geojson(
+        (
+            "MAIN STREET",
+            [[-90.002, 30.0], [-90.001, 30.0], [-90.0, 30.0], [-89.999, 30.0]],
+        ),
+        ("SINGLE STREET", [[-90.0, 30.0], [-90.0, 29.999]]),  # crosses MAIN once
+        # Touches MAIN at two nodes ~630 ft apart -> two clusters (a jog).
+        (
+            "JOG STREET",
+            [[-90.001, 30.0], [-90.001, 29.9995], [-89.999, 29.9995], [-89.999, 30.0]],
+        ),
+    )
+    index = build_block_index(geojson)
+    feats = [
+        _feat("MAIN STREET", 500.0, 500.0, EW),
+        _feat("SINGLE STREET", 700.0, 300.0, NS),
+        _feat("JOG STREET", 300.0, 300.0, NS),
+    ]
+    module.find_intersection_gcps(feats, index)
+    assert len(calls) == 1  # only the unique crossing was a straightening candidate
+    assert calls[0] == pytest.approx((-90.0, 30.0), abs=1e-6)
 
 
 def test_find_gcps_sorted_by_pixel_dist():

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -19,6 +19,7 @@ import multiprocessing
 import os
 import statistics
 import sys
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
@@ -441,6 +442,188 @@ def _cluster_geo_coords(
     return clusters
 
 
+def street_segments_near_vertex(
+    geo: tuple[float, float],
+    blocks: list[Block],
+    radius_ft: float,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Street segments near ``geo`` in a local foot frame, not crossing the street's own forks.
+
+    Normally every centerline segment with an endpoint within ``radius_ft`` of ``geo``. But if
+    the street self-intersects within range — a node where three or more of its own segments
+    meet, e.g. where it forks into two parallel branches — the segments are instead walked
+    outward from the node nearest ``geo`` and the walk stops at each fork. That keeps a
+    forked-off branch from corrupting the street's bearing (Brooklyn p14: two COLUMBIA branches
+    meet at a real COLUMBIA x COLUMBIA node, and only the one leading into the curve should set
+    the direction). Segments are returned as (a, b) endpoint pairs in feet centred on ``geo``.
+    """
+    lon0, lat0 = geo
+    cos0 = math.cos(math.radians(lat0))
+
+    def to_ft(lon: float, lat: float) -> np.ndarray:
+        return np.array(
+            [(lon - lon0) * cos0 * _FT_PER_DEG_LAT, (lat - lat0) * _FT_PER_DEG_LAT]
+        )
+
+    def in_range(node: tuple[float, float]) -> bool:
+        return float(np.hypot(*to_ft(*node))) <= radius_ft
+
+    adjacency: dict[tuple[float, float], list[tuple[float, float]]] = defaultdict(list)
+    for block in blocks:
+        pts = block.coords
+        for k in range(len(pts) - 1):
+            a = (round(float(pts[k][0]), 7), round(float(pts[k][1]), 7))
+            b = (round(float(pts[k + 1][0]), 7), round(float(pts[k + 1][1]), 7))
+            if a != b:
+                adjacency[a].append(b)
+                adjacency[b].append(a)
+
+    def all_in_radius() -> list[tuple[np.ndarray, np.ndarray]]:
+        segments: list[tuple[np.ndarray, np.ndarray]] = []
+        for block in blocks:
+            pts = block.coords
+            for k in range(len(pts) - 1):
+                a = to_ft(float(pts[k][0]), float(pts[k][1]))
+                b = to_ft(float(pts[k + 1][0]), float(pts[k + 1][1]))
+                if float(np.hypot(*a)) <= radius_ft or float(np.hypot(*b)) <= radius_ft:
+                    segments.append((a, b))
+        return segments
+
+    forks = {n for n in adjacency if len(set(adjacency[n])) >= 3 and in_range(n)}
+    candidates = [n for n in adjacency if in_range(n)]
+    if not forks or not candidates:
+        return all_in_radius()
+
+    # Walk outward from the vertex, keeping the segment that reaches a fork but not crossing it.
+    start = min(candidates, key=lambda n: float(np.hypot(*to_ft(*n))))
+    kept: list[tuple[np.ndarray, np.ndarray]] = []
+    visited_edges: set[frozenset[tuple[float, float]]] = set()
+    seen = {start}
+    queue = deque([start])
+    while queue:
+        node = queue.popleft()
+        if node in forks and node != start:
+            continue
+        for neighbor in adjacency[node]:
+            edge = frozenset((node, neighbor))
+            if edge in visited_edges:
+                continue
+            a, b = to_ft(*node), to_ft(*neighbor)
+            if float(np.hypot(*a)) > radius_ft and float(np.hypot(*b)) > radius_ft:
+                continue
+            visited_edges.add(edge)
+            kept.append((a, b))
+            if neighbor not in seen:
+                seen.add(neighbor)
+                queue.append(neighbor)
+    return kept
+
+
+def dominant_axis_near(
+    geo: tuple[float, float],
+    blocks: list[Block],
+    radius_ft: float = 350.0,
+    align_tol: float = math.radians(25.0),
+) -> tuple[tuple[float, float], float] | None:
+    """A street's straight axis near ``geo`` as (anchor lon/lat, bearing radians), or None.
+
+    Considers the street's segments near ``geo`` (:func:`street_segments_near_vertex`, which
+    stops at the street's own forks), computes their length-weighted dominant bearing (structure
+    tensor, so a long straight run outweighs a short curved elbow), then keeps only the segments
+    whose own direction is within ``align_tol`` of that bearing — discarding the curved portion
+    near a junction. The anchor is the centroid of the kept segment endpoints. Returns None if
+    fewer than two aligned segment endpoints survive. Work is in a foot frame centred on ``geo``.
+    """
+    lon0, lat0 = geo
+    cos0 = math.cos(math.radians(lat0))
+
+    segments = street_segments_near_vertex(geo, blocks, radius_ft)
+    if not segments:
+        return None
+
+    tensor = np.zeros((2, 2))
+    for a, b in segments:
+        seg = b - a
+        tensor += np.outer(seg, seg)
+    if not np.any(tensor):
+        return None
+    _, eigenvectors = np.linalg.eigh(tensor)
+    dominant = eigenvectors[:, -1]
+
+    kept: list[np.ndarray] = []
+    for a, b in segments:
+        seg = b - a
+        length = float(np.linalg.norm(seg))
+        if length < 1e-9:
+            continue
+        if abs(float(np.dot(seg / length, dominant))) >= math.cos(align_tol):
+            kept.extend((a, b))
+    if len(kept) < 2:
+        return None
+    centroid = np.mean(kept, axis=0)
+    anchor = (
+        lon0 + float(centroid[0]) / (cos0 * _FT_PER_DEG_LAT),
+        lat0 + float(centroid[1]) / _FT_PER_DEG_LAT,
+    )
+    return anchor, math.atan2(float(dominant[1]), float(dominant[0]))
+
+
+def straight_intersection_geo(
+    geo: tuple[float, float],
+    blocks_a: list[Block],
+    blocks_b: list[Block],
+    radius_ft: float = 350.0,
+    align_tol: float = math.radians(25.0),
+    min_shift_ft: float = 120.0,
+    max_shift_ft: float = 250.0,
+) -> tuple[float, float] | None:
+    """Where two streets' straight axes cross near a shared vertex ``geo``, or None.
+
+    mapsnap places a GCP's pixel at the crossing of two *straight* label lines but pairs it with
+    the raw OSM shared vertex for the geo. When a street curves through that vertex (its tangent
+    there differs from its dominant bearing) the vertex sits off the straight axis the Sanborn
+    map draws, injecting a rotation error (New Orleans 1896 p161: JULIA meets the curving SOUTH
+    CLAIBORNE, tilting the fit ~22°). This returns the intersection of the two streets' straight
+    axes (:func:`dominant_axis_near`) so the geo matches how the pixel was derived.
+
+    Returns None — meaning keep the raw vertex — when either axis is unavailable, the axes are
+    within 10° of parallel (crossing ill-conditioned), or the correction is below ``min_shift_ft``
+    or above ``max_shift_ft``. The ``min_shift_ft`` floor is deliberately large: only a sharp
+    curve (the vertex sitting well off the straight-axis crossing) is corrected. Nudging the many
+    mild curves that fall below it just perturbs otherwise-good fits — across the truth volumes
+    those small corrections were net-neutral churn, while the sharp-curve cases (p161) are wins.
+    """
+    axis_a = dominant_axis_near(geo, blocks_a, radius_ft, align_tol)
+    axis_b = dominant_axis_near(geo, blocks_b, radius_ft, align_tol)
+    if axis_a is None or axis_b is None:
+        return None
+    lon0, lat0 = geo
+    cos0 = math.cos(math.radians(lat0))
+
+    def to_ft(lon: float, lat: float) -> np.ndarray:
+        return np.array(
+            [(lon - lon0) * cos0 * _FT_PER_DEG_LAT, (lat - lat0) * _FT_PER_DEG_LAT]
+        )
+
+    (anchor_a, bearing_a), (anchor_b, bearing_b) = axis_a, axis_b
+    ca, da = to_ft(*anchor_a), np.array([math.cos(bearing_a), math.sin(bearing_a)])
+    cb, db = to_ft(*anchor_b), np.array([math.cos(bearing_b), math.sin(bearing_b)])
+    if abs(float(da[0] * db[1] - da[1] * db[0])) < math.sin(math.radians(10.0)):
+        return None
+    try:
+        ts = np.linalg.solve(np.array([[da[0], -db[0]], [da[1], -db[1]]]), cb - ca)
+    except np.linalg.LinAlgError:
+        return None
+    point = ca + float(ts[0]) * da
+    shift = float(np.hypot(*point))
+    if shift < min_shift_ft or shift > max_shift_ft:
+        return None
+    return (
+        lon0 + float(point[0]) / (cos0 * _FT_PER_DEG_LAT),
+        lat0 + float(point[1]) / _FT_PER_DEG_LAT,
+    )
+
+
 def find_intersection_gcps(
     features: list[LabelFeature],
     block_index: dict[str, list[Block]],
@@ -457,6 +640,11 @@ def find_intersection_gcps(
     jogging streets (e.g. Newport St crosses East Jefferson Ave at two points 115ft apart)
     and divided highways (two carriageway crossings) — both yield two candidate GCPs that
     RANSAC can evaluate independently.
+
+    When a street curves through the shared vertex, the raw vertex is replaced by the crossing
+    of the two streets' straight axes (:func:`straight_intersection_geo`), matching how the
+    pixel side is computed from straight label lines. This applies only where the pair meets
+    once; a jog or divided road (multiple clusters) leaves every vertex unmodified.
 
     Returns GCPs sorted by pixel_dist ascending (closer labels = better pixel estimate).
     """
@@ -489,9 +677,24 @@ def find_intersection_gcps(
             if not shared:
                 continue
             geo_clusters = _cluster_geo_coords(sorted(shared))
+            # Only straighten a curved junction when the two streets meet exactly once. With
+            # multiple crossings (a street jogging across the other, or a divided road's two
+            # carriageways) the dominant-axis window spans several branches, so its "straight
+            # axis" is meaningless and would fabricate a large bogus shift (Brooklyn p26: COURT
+            # jogs across BRYANT, mistriggering a 175 ft move that breaks the fit).
+            unique_intersection = len(geo_clusters) == 1
             for cluster in geo_clusters:
                 cluster_pts = np.array(cluster)
                 geo = (float(cluster_pts[:, 0].mean()), float(cluster_pts[:, 1].mean()))
+                # If a street curves through the shared vertex, the vertex sits off the
+                # straight axis the map draws; use the straight-axis crossing instead so the
+                # geo matches the straight-line pixel crossing (no-op for straight junctions).
+                if unique_intersection:
+                    straightened = straight_intersection_geo(
+                        geo, block_index.get(text_a, []), block_index.get(text_b, [])
+                    )
+                    if straightened is not None:
+                        geo = straightened
                 # For each (text_a, text_b, cluster), keep only the best (fa, fb) pair
                 # by pixel_dist. All pairs share the same geo centroid, so extra pairs
                 # only add RANSAC iterations without adding independent intersection anchors.

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -14,9 +14,12 @@ from mapsnap.georef_from_labels import (
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
+    dominant_axis_near,
     label_features,
-    promote_avenue_letters,
     project_to_polyline,
+    promote_avenue_letters,
+    straight_intersection_geo,
+    street_segments_near_vertex,
 )
 from mapsnap.streets import Block
 
@@ -716,3 +719,119 @@ def test_confidence_relaxed_threshold_disabled_when_floor_not_below_base():
         high_confidence_floor=18.0,
     )
     assert result == 18.0
+
+
+# ---------------------------------------------------------------------------
+# straight-axis intersection correction (curved-junction GCPs)
+# ---------------------------------------------------------------------------
+
+
+def _ll_block(coords: list[tuple[float, float]]) -> Block:
+    """A Block from (lon, lat) tuples."""
+    return Block("S", np.array(coords, dtype=float))
+
+
+# A vertical (north-south) street through the shared vertex V = (-90, 30).
+_V = (-90.0, 30.0)
+_VERTICAL = _ll_block([(-90.0, 29.997), (-90.0, 30.0), (-90.0, 30.003)])
+# A street whose straight east-west axis runs ~110 ft north of V, dropping through a short
+# elbow to reach V at its east end (a miniature of New Orleans p161's curving S. Claiborne).
+_CURVED = [
+    _ll_block(
+        [
+            (-90.0009, 30.0003),
+            (-90.0007, 30.0003),
+            (-90.0005, 30.0003),
+            (-90.0003, 30.0003),
+            (-90.0001, 30.0003),
+        ]
+    ),
+    _ll_block([(-90.0001, 30.0003), (-90.00005, 30.00015), (-90.0, 30.0)]),
+]
+
+
+def test_dominant_axis_near_straight_street_returns_its_bearing():
+    horizontal = _ll_block([(-90.002, 30.0), (-90.0, 30.0), (-89.998, 30.0)])
+    anchor, bearing = dominant_axis_near(_V, [horizontal])
+    assert abs(bearing % math.pi) < math.radians(1)  # east-west
+    axis = dominant_axis_near(_V, [_VERTICAL])
+    assert abs(axis[1] % math.pi - math.pi / 2) < math.radians(1)  # north-south
+
+
+def test_dominant_axis_near_ignores_the_curved_elbow():
+    # The straight east-west run dominates; the short steep elbow is filtered out, so the
+    # bearing stays near horizontal despite the elbow dipping to V.
+    _, bearing = dominant_axis_near(_V, _CURVED)
+    off_horizontal = min(bearing % math.pi, math.pi - bearing % math.pi)
+    assert off_horizontal < math.radians(15)
+
+
+# A street that forks past node F=(-89.9994, 30.0): the main branch into V runs east-west,
+# but two arms beyond F bend northeast (a miniature of Brooklyn p14's two COLUMBIA branches).
+_FORK_MAIN = _ll_block([(-90.0, 30.0), (-89.9997, 30.0), (-89.9994, 30.0)])
+_FORK_ARMS = [
+    _ll_block([(-89.9994, 30.0), (-89.9992, 30.0004), (-89.999, 30.0008)]),
+    _ll_block([(-89.9994, 30.0), (-89.9993, 30.0003), (-89.9992, 30.0006)]),
+]
+
+
+def test_street_segments_near_vertex_stops_at_self_intersection():
+    # Walking from V stops at the fork F, keeping only the main branch (2 segments), not the
+    # forked-off arms — even though the arms have segments within radius.
+    blocks = [_FORK_MAIN, *_FORK_ARMS]
+    assert len(street_segments_near_vertex(_V, blocks, 350.0)) == 2
+
+
+def test_dominant_axis_near_ignores_forked_off_branch():
+    # With the arms excluded the bearing follows the main branch (~0 deg, east-west); including
+    # them would drag it toward the northeast arms (~64 deg).
+    _, bearing = dominant_axis_near(_V, [_FORK_MAIN, *_FORK_ARMS])
+    off_horizontal = min(bearing % math.pi, math.pi - bearing % math.pi)
+    assert off_horizontal < math.radians(5)
+
+
+def test_street_segments_near_vertex_no_fork_keeps_all_in_radius():
+    # Without a self-intersection every within-radius segment is kept (unchanged behavior).
+    straight = _ll_block([(-90.001, 30.0), (-90.0, 30.0), (-89.999, 30.0)])
+    assert len(street_segments_near_vertex(_V, [straight], 350.0)) == 2
+
+
+def test_straight_intersection_geo_none_for_straight_junction():
+    # Two straight streets crossing squarely at V: the straight-axis crossing is V itself, so
+    # the shift is below the deadband and no correction is made.
+    horizontal = _ll_block([(-90.001, 30.0), (-90.0, 30.0), (-89.999, 30.0)])
+    assert straight_intersection_geo(_V, [_VERTICAL], [horizontal]) is None
+
+
+def test_straight_intersection_geo_none_for_near_parallel():
+    almost_parallel = _ll_block([(-90.0002, 29.998), (-90.0002, 30.002)])
+    assert straight_intersection_geo(_V, [_VERTICAL], [almost_parallel]) is None
+
+
+def test_straight_intersection_geo_corrects_curved_junction():
+    # With a low floor the correction moves the vertex north toward the curved street's
+    # straight axis (~lat 30.0003), off the on-curve OSM vertex at lat 30.0.
+    corrected = straight_intersection_geo(_V, [_VERTICAL], _CURVED, min_shift_ft=20.0)
+    assert corrected is not None
+    lon, lat = corrected
+    assert abs(lon - (-90.0)) < 1e-4  # stays on the vertical street
+    assert 30.0001 < lat < 30.0004  # shifted north toward the straight axis
+
+
+def test_straight_intersection_geo_default_ignores_mild_curve():
+    # The synthetic junction's ~84 ft shift is below the default floor, so only sharp curves
+    # are corrected: with defaults it is left at the raw vertex.
+    assert straight_intersection_geo(_V, [_VERTICAL], _CURVED) is None
+
+
+def test_straight_intersection_geo_respects_shift_bounds():
+    # The curved junction is suppressed when its ~84 ft shift falls outside the given bounds.
+    assert (
+        straight_intersection_geo(
+            _V, [_VERTICAL], _CURVED, min_shift_ft=20.0, max_shift_ft=50.0
+        )
+        is None
+    )
+    assert (
+        straight_intersection_geo(_V, [_VERTICAL], _CURVED, min_shift_ft=100.0) is None
+    )

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -795,16 +795,21 @@ _CURVED = [
 
 def test_dominant_axis_near_straight_street_returns_its_bearing():
     horizontal = _ll_block([(-90.002, 30.0), (-90.0, 30.0), (-89.998, 30.0)])
-    anchor, bearing = dominant_axis_near(_V, [horizontal])
+    horizontal_axis = dominant_axis_near(_V, [horizontal])
+    assert horizontal_axis is not None
+    _, bearing = horizontal_axis
     assert abs(bearing % math.pi) < math.radians(1)  # east-west
     axis = dominant_axis_near(_V, [_VERTICAL])
+    assert axis is not None
     assert abs(axis[1] % math.pi - math.pi / 2) < math.radians(1)  # north-south
 
 
 def test_dominant_axis_near_ignores_the_curved_elbow():
     # The straight east-west run dominates; the short steep elbow is filtered out, so the
     # bearing stays near horizontal despite the elbow dipping to V.
-    _, bearing = dominant_axis_near(_V, _CURVED)
+    axis = dominant_axis_near(_V, _CURVED)
+    assert axis is not None
+    _, bearing = axis
     off_horizontal = min(bearing % math.pi, math.pi - bearing % math.pi)
     assert off_horizontal < math.radians(15)
 
@@ -828,7 +833,9 @@ def test_street_segments_near_vertex_stops_at_self_intersection():
 def test_dominant_axis_near_ignores_forked_off_branch():
     # With the arms excluded the bearing follows the main branch (~0 deg, east-west); including
     # them would drag it toward the northeast arms (~64 deg).
-    _, bearing = dominant_axis_near(_V, [_FORK_MAIN, *_FORK_ARMS])
+    axis = dominant_axis_near(_V, [_FORK_MAIN, *_FORK_ARMS])
+    assert axis is not None
+    _, bearing = axis
     off_horizontal = min(bearing % math.pi, math.pi - bearing % math.pi)
     assert off_horizontal < math.radians(5)
 


### PR DESCRIPTION
When a street curves through an intersection's shared OSM vertex, that vertex sits off the straight axis the Sanborn map draws. mapsnap places the GCP's **pixel** at the crossing of two straight label lines, so pairing it with the on-curve vertex injects a rotation error. `find_intersection_gcps` now replaces the vertex with the crossing of the two streets' straight (dominant-bearing) axes (`straight_intersection_geo`).

Guards keep it targeted to genuine sharp curves:
- only shifts ≥120 ft are applied; milder curves are net-neutral churn.
- only where the pair meets exactly once (a jog/divided road would average branches).
- the dominant-axis walk stops at the street's own self-intersections, so a fork into parallel branches can't corrupt the bearing.

Verified: full test suite green.

## Experiment — 6 volumes vs `main` (f62de9b9)

Each row: `mapsnap fit` on this branch vs main; mean RMSE (ft) against OIM truth, georeferenced-page count, and notable per-page changes (≥20 ft or coverage).

| Volume | mean RMSE ft (Δ) | georef pages | notable |
|---|---|---|---|
| brooklyn_ny_1939_vol_1 | 20.8 → 20.8 (+0.0) | 54 → 54 | no change |
| champaign_ill_1915 | 13.0 → 13.0 (+0.0) | 18 → 18 | no change |
| chicago_il_1950_vol_1 | 114.1 → 114.1 (+0.0) | 98 → 98 | no change |
| detroit_mich_1929_vol_11 | 32.8 → 32.7 (-0.1) | 83 → 83 | no change |
| new_orleans_la_1896_vol_2 | 53.1 → 53.2 (+0.1) | 80 → 81 | placed p161 |
| new_orleans_la_1951_vol_5 | 17.0 → 17.0 (+0.0) | 102 → 102 | no change |

**Takeaway:** rescues the motivating case — New Orleans-1896 **p161** (JULIA meeting the curving SOUTH CLAIBORNE), which `main` fails to place, is now georeferenced — at a negligible +0.1 ft mean cost, with every other volume unchanged.

Here's New Orleans 1896 p161, the motivating case. JULIA x S. CLAIBORNE is the intersection that gets "straightened."
<img width="730" height="699" alt="image" src="https://github.com/user-attachments/assets/06adb7a0-6823-4d20-aeff-d60e6b3f34df" />
