### PR TITLE
Filter ambiguous bare words (CANAL, CHICAGO, …) without a street-type hint

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -35,7 +35,9 @@ from mapsnap.streets import (
     build_block_index,
     canonical_street_matches,
     deduplicate_detections,
+    city_ambiguous_words,
     hint_type_word,
+    is_ambiguous_word,
     is_bare_letter,
     is_number_only,
     normalize_street,
@@ -816,6 +818,47 @@ def reading_vector(polygon: list[list[float]]) -> tuple[float, float]:
     return (polygon[1][0] - polygon[0][0], polygon[1][1] - polygon[0][1])
 
 
+def has_type_hint_support(
+    det: dict,
+    type_hints: list[dict],
+    perp_tolerance_px: float = 20.0,
+    max_along_gap_frac: float = 1.5,
+) -> bool:
+    """Whether a STREET/AVENUE hint sits in the detection's column, just after it.
+
+    Mirrors the column test in promote_avenue_letters: the hint must share the detection's
+    direction bucket and lie within perp_tolerance_px perpendicular of it. It must also fall
+    *along* the reading direction within max_along_gap_frac × the detection's long side, so a
+    "CANAL" with a "ST" right after it counts but an unrelated "STREET" elsewhere does not.
+    Used to support ambiguous bare words like CANAL/BRIDGE (see is_ambiguous_word, issue #51).
+    """
+    bucket_size = math.pi / 12.0
+    det_dir = det.get("dir_pix", 0.0)
+    det_bucket = int(round(det_dir / bucket_size)) % 12
+    cos_d, sin_d = math.cos(det_dir), math.sin(det_dir)
+    dpoly = det["polygon"]
+    det_cx = sum(p[0] for p in dpoly) / 4.0
+    det_cy = sum(p[1] for p in dpoly) / 4.0
+    det_perp = -det_cx * sin_d + det_cy * cos_d
+    long_side = det.get("long_side", 0.0)
+    for hint in type_hints:
+        if hint_type_word(hint.get("text", "")) is None:
+            continue
+        if int(round(hint.get("dir_pix", 0.0) / bucket_size)) % 12 != det_bucket:
+            continue
+        hpoly = hint["polygon"]
+        hcx = sum(p[0] for p in hpoly) / 4.0
+        hcy = sum(p[1] for p in hpoly) / 4.0
+        if abs((-hcx * sin_d + hcy * cos_d) - det_perp) > perp_tolerance_px:
+            continue
+        # Adjacent along the column (gap between centres within ~1.5 word-lengths).
+        if math.hypot(hcx - det_cx, hcy - det_cy) <= max_along_gap_frac * max(
+            long_side, 1.0
+        ):
+            return True
+    return False
+
+
 def promote_avenue_letters(
     hint_detections: list[dict],
     all_detections: list[dict],
@@ -1371,6 +1414,12 @@ def process_image(
             file=sys.stderr,
         )
     normalized_streets = set(block_index.keys())
+    # STREET/AVENUE hints, used both to promote bare letters and to support ambiguous words.
+    street_type_hints = [
+        h for h in hint_detections if hint_type_word(h.get("text", "")) is not None
+    ]
+    # The volume's own city name (e.g. CHICAGO) is filtered like CANAL — see issue #51.
+    city_words = city_ambiguous_words(Path(image_path).parent.name)
     promoted = promote_avenue_letters(
         hint_detections, all_detections, normalized_streets
     )
@@ -1422,6 +1471,12 @@ def process_image(
                 # branch above); an unpromoted "M"/"W" is almost always a rotated misread of
                 # a quadrant/type box, so reject it here.
                 and not is_bare_letter(det["text"])
+                # Ambiguous words (CANAL, BRIDGE, PARK, …) usually label a feature, not a
+                # street, so trust a bare one only when a STREET/AVENUE hint supports it.
+                and not (
+                    is_ambiguous_word(det["text"], city_words)
+                    and not has_type_hint_support(det, street_type_hints)
+                )
                 and (
                     normalize_street(det["text"]) not in DIRECTION_WORDS
                     or det["text"].upper().strip() in normalized_streets

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -755,3 +755,33 @@ def test_robust_affine_inlier_indices_drops_gross_outliers():
     # No gross outlier survives, and the large majority of true inliers are kept.
     assert not (kept & outlier_indices)
     assert len(kept & set(range(120))) >= 110
+
+
+# ---------------------------------------------------------------------------
+# has_type_hint_support — ambiguous-word support (issue #51)
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_word_supported_by_adjacent_type_hint():
+    from mapsnap.georef_from_labels import has_type_hint_support
+
+    # "CANAL" with a "STREET" hint just after it in the same row -> supported.
+    canal = _make_det("CANAL", cx=500, cy=500, long_side=80, dir_pix=0.0)
+    st_hint = _make_det("STREET", cx=600, cy=500, long_side=60, dir_pix=0.0, hint=True)
+    assert has_type_hint_support(canal, [st_hint])
+
+
+def test_ambiguous_word_unsupported_without_hint():
+    from mapsnap.georef_from_labels import has_type_hint_support
+
+    canal = _make_det("CANAL", cx=500, cy=500, long_side=80, dir_pix=0.0)
+    # No hint at all.
+    assert not has_type_hint_support(canal, [])
+    # A hint far away (different row) does not support it.
+    far = _make_det("STREET", cx=600, cy=900, long_side=60, dir_pix=0.0, hint=True)
+    assert not has_type_hint_support(canal, [far])
+    # A hint in a perpendicular column does not support it.
+    perp = _make_det(
+        "STREET", cx=540, cy=560, long_side=60, dir_pix=math.pi / 2, hint=True
+    )
+    assert not has_type_hint_support(canal, [perp])

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -248,6 +248,47 @@ def is_bare_letter(text: str) -> bool:
     return len(text.strip()) == 1 and text.strip().isalpha()
 
 
+# Common words that appear in street names but, on a Sanborn sheet, more often label a
+# physical feature (a bridge, a canal, a park, a river) or page furniture ("Sanborn", the
+# city name). Like a bare single letter, a bare one of these is trusted only when a nearby
+# type-word hint ("STREET"/"AVENUE") supports it: "CANAL STREET" is a street, a plain "CANAL"
+# is probably the waterway. See issue #51.
+AMBIGUOUS_STREET_WORDS: frozenset[str] = frozenset(
+    {"RIVER", "BRIDGE", "CANAL", "WATER", "PARK", "CONGRESS", "SANBORN"}
+)
+
+
+def is_ambiguous_word(text: str, extra: frozenset[str] = frozenset()) -> bool:
+    """Return True if the normalized text is exactly an ambiguous bare word (no type word).
+
+    "CANAL" → True, but "CANAL STREET" → False (normalize keeps the type word, so it is no
+    longer bare). ``extra`` adds volume-specific ambiguous words (the city name); see
+    AMBIGUOUS_STREET_WORDS, city_ambiguous_words, and issue #51.
+    """
+    normalized = normalize_street(text)
+    return normalized in AMBIGUOUS_STREET_WORDS or normalized in extra
+
+
+def city_ambiguous_words(volume_name: str) -> frozenset[str]:
+    """Derive the volume's city name (normalized) from its directory name, for issue-#51.
+
+    Directory names look like ``<city tokens>_<state>_<year>[_vol_<n>]`` (e.g.
+    ``detroit_mich_1929_vol_11`` → "DETROIT", ``new_orleans_la_1896_vol_2`` → "NEW ORLEANS").
+    The city is every token before the state, which is the token immediately before the
+    four-digit year. The city name is itself ambiguous on a Sanborn sheet ("Chicago River",
+    "City of Detroit"), so a bare one is filtered like CANAL unless a type hint supports it.
+    Returns an empty set if the directory name doesn't match the expected pattern.
+    """
+    tokens = volume_name.split("_")
+    year_index = next(
+        (i for i, t in enumerate(tokens) if len(t) == 4 and t.isdigit()), None
+    )
+    if year_index is None or year_index < 2:
+        return frozenset()
+    normalized = normalize_street(" ".join(tokens[: year_index - 1]))
+    return frozenset({normalized}) if normalized else frozenset()
+
+
 def _match_candidates(s: str) -> list[str]:
     """Return the candidate forms to compare against when prefix-matching street key s.
 

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -175,3 +175,41 @@ def test_canonical_street_match_direction_suffixed():
         "NORTH PLACE SOUTHEAST",
         "NORTH ROAD",
     }
+
+
+# ---------------------------------------------------------------------------
+# is_ambiguous_word (issue #51)
+# ---------------------------------------------------------------------------
+
+
+def test_is_ambiguous_word_bare_words():
+    from mapsnap.streets import is_ambiguous_word
+
+    assert is_ambiguous_word("CANAL")
+    assert is_ambiguous_word("Bridge")
+    assert is_ambiguous_word("river")
+    assert is_ambiguous_word("PARK")
+
+
+def test_is_ambiguous_word_with_type_word_is_not_bare():
+    from mapsnap.streets import is_ambiguous_word
+
+    # A type word makes it an unambiguous street name, so it is not flagged.
+    assert not is_ambiguous_word("CANAL STREET")
+    assert not is_ambiguous_word("BRIDGE AVE")
+    # Ordinary streets are never flagged.
+    assert not is_ambiguous_word("HENRY")
+    assert not is_ambiguous_word("MAGAZINE STREET")
+
+
+def test_city_ambiguous_words_from_volume_name():
+    from mapsnap.streets import city_ambiguous_words
+
+    assert city_ambiguous_words("detroit_mich_1929_vol_11") == frozenset({"DETROIT"})
+    assert city_ambiguous_words("champaign_ill_1915") == frozenset({"CHAMPAIGN"})
+    assert city_ambiguous_words("new_orleans_la_1896_vol_2") == frozenset(
+        {"NEW ORLEANS"}
+    )
+    assert city_ambiguous_words("brooklyn_ny_1939_vol_1") == frozenset({"BROOKLYN"})
+    # Unparseable names yield nothing rather than a wrong word.
+    assert city_ambiguous_words("scratch") == frozenset()


### PR DESCRIPTION
Bare geographic/label words that also name a street — `RIVER`, `BRIDGE`, `CANAL`, `WATER`, `PARK`, `CONGRESS`, `SANBORN`, plus the volume's own city name (e.g. `CHICAGO` on a Chicago sheet, from "Chicago River"/"City of Chicago") — are frequent false street matches: they label a feature, not a street. A bare one is now trusted only when a `STREET`/`AVENUE` type-word hint sits next to it in the same column (`CANAL` alone → filtered; `CANAL` + `ST` → kept). Implements issue #51.

`AMBIGUOUS_STREET_WORDS` + `is_ambiguous_word` / `city_ambiguous_words` live in `streets.py`; `has_type_hint_support` and the detection-filter hook are in `georef_from_labels.py`.

Verified: full test suite green.

## Experiment — 6 volumes vs `main` (f62de9b9)

Each row: `mapsnap fit` on this branch vs main; mean RMSE (ft) against OIM truth, georeferenced-page count, and notable per-page changes (≥20 ft or coverage).

| Volume | mean RMSE ft (Δ) | georef pages | notable |
|---|---|---|---|
| brooklyn_ny_1939_vol_1 | 20.8 → 20.1 (-0.7) | 54 → 53 | dropped p9 |
| champaign_ill_1915 | 13.0 → 13.6 (+0.6) | 18 → 18 | no change |
| chicago_il_1950_vol_1 | 114.1 → 14.0 (-100.1) | 98 → 93 | dropped p48N, p53N, p87W, p88W, p94W; p92W 83→13ft; p89W 96→42ft; p6N 7→51ft |
| detroit_mich_1929_vol_11 | 32.8 → 43.5 (+10.7) | 83 → 84 | placed p93 |
| new_orleans_la_1896_vol_2 | 53.1 → 52.0 (-1.1) | 80 → 79 | dropped p105; p183 71→20ft; p103 40→13ft |
| new_orleans_la_1951_vol_5 | 17.0 → 17.0 (+0.0) | 102 → 102 | no change |

**Takeaway.** The headline is **Chicago −100 ft** (114 → 14): `main` was placing two pages catastrophically wrong — p53N seeded off `CANAL`/`WATER` (Lake Michigan labels → Canal St) and p48N off `CHICAGO` (the city name → E. Chicago Ave); the filter discards those false GCPs (5 junk pages dropped, several others improved). NOLA-1896 also nets −1.1 ft.

Two costs, both expected:
- **Brooklyn p9 dropped** — a *legitimate* CONGRESS Street with no adjacent `STREET` hint. On `main` p9 fits at 59.2 ft seeded by `CONGRESS × COLUMBIA`; the filter removes bare `CONGRESS`, so p9 falls to misscale. This is the precision/recall cost of the blacklist: it can't tell a real hint-less Congress St from a spurious one. (The volume mean nominally drops 0.7 ft only because p9 was above-average error — it's a coverage loss, not a win.)
- **Detroit +10.7 ft** — a *side effect*, not a direct filtering error: removing ambiguous detections shifts the volume's median scale, and p93 (a misscale outlier on `main`) slips back under the scale-outlier threshold as a 913 ft garbage placement. Same median-scale coupling seen elsewhere; orthogonal to this change's intent.

Net strongly positive (Chicago dominates), but the Brooklyn p9 CONGRESS false-negative is a known limitation worth a follow-up (e.g. also accept an ambiguous word that is an unambiguous, unique street match in the volume's centerlines).
