### PR TITLE
Tile CRAFT detection + rank GCP seeds by consensus

### DIFF
--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import multiprocessing
 import sys
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -112,12 +113,152 @@ def has_split_panels(image_path: str) -> bool:
     return any(Path(image_path).parent.glob(f"{stem}__*.jpg"))
 
 
+def _axis_starts(length: int, tile: int, stride: int) -> list[int]:
+    """Tile-start offsets covering [0, length]; the final tile sits flush with the end."""
+    if length <= tile:
+        return [0]
+    starts = list(range(0, length - tile + 1, stride))
+    if starts[-1] != length - tile:
+        starts.append(length - tile)
+    return starts
+
+
+def _iter_tiles(
+    width: int, height: int, tile_size: int, overlap: int
+) -> Iterator[tuple[int, int, int, int]]:
+    """Yield (x0, y0, x1, y1) tiles of at most tile_size px, overlapping by ``overlap``."""
+    stride = max(1, tile_size - overlap)
+    for y0 in _axis_starts(height, tile_size, stride):
+        for x0 in _axis_starts(width, tile_size, stride):
+            yield x0, y0, min(x0 + tile_size, width), min(y0 + tile_size, height)
+
+
+def _iou_xxyy(a: list[float], b: list[float]) -> float:
+    """IoU of two [x_min, x_max, y_min, y_max] boxes."""
+    inter = max(0.0, min(a[1], b[1]) - max(a[0], b[0])) * max(
+        0.0, min(a[3], b[3]) - max(a[2], b[2])
+    )
+    if inter <= 0:
+        return 0.0
+    area_a = max(0.0, a[1] - a[0]) * max(0.0, a[3] - a[2])
+    area_b = max(0.0, b[1] - b[0]) * max(0.0, b[3] - b[2])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _nms_bboxes(bboxes: list[list[float]], iou_threshold: float) -> list[int]:
+    """Greedy NMS over [x_min,x_max,y_min,y_max] boxes; returns kept indices (larger first).
+
+    Used to drop near-duplicate detections produced where adjacent tiles overlap: the
+    larger (more complete) box wins over a copy clipped at a tile seam.
+    """
+    order = sorted(
+        range(len(bboxes)),
+        key=lambda i: (bboxes[i][1] - bboxes[i][0]) * (bboxes[i][3] - bboxes[i][2]),
+        reverse=True,
+    )
+    kept: list[int] = []
+    for i in order:
+        if all(_iou_xxyy(bboxes[i], bboxes[j]) <= iou_threshold for j in kept):
+            kept.append(i)
+    return kept
+
+
+def _detect_frame(
+    reader: easyocr.Reader,
+    array: np.ndarray,
+    min_size: int,
+    link_threshold: float,
+    craft_scale: float,
+    tile_size: int,
+) -> tuple[list, list]:
+    """Run CRAFT on one image frame, tiling frames larger than ``tile_size``.
+
+    EasyOCR caps the CRAFT input's long side at canvas_size (2560px), so a frame larger
+    than that is downscaled before detection — shrinking small labels below the
+    detector's resolution (an 8422px key map is seen at ~0.30×, turning a 40px label
+    into ~12px). When tile_size > 0 and the frame's long side exceeds it, the frame is
+    split into overlapping tiles detected at native resolution and their boxes merged
+    with NMS. Only detection is affected: recognition always crops from the full-
+    resolution image regardless of how boxes were found.
+
+    Returns (horizontal_list, free_list) in ``array`` coordinates. tile_size <= 0
+    disables tiling: the frame is detected in one pass, optionally downscaled by
+    craft_scale.
+    """
+    height, width = array.shape[:2]
+
+    if tile_size <= 0 or max(width, height) <= tile_size:
+        craft_min_size = max(1, int(min_size * craft_scale))
+        if craft_scale != 1.0:
+            detect_array = np.array(
+                Image.fromarray(array).resize(
+                    (
+                        max(1, int(width * craft_scale)),
+                        max(1, int(height * craft_scale)),
+                    ),
+                    Image.Resampling.LANCZOS,
+                )
+            )
+        else:
+            detect_array = array
+        horizontal_agg, free_agg = reader.detect(
+            detect_array, min_size=craft_min_size, link_threshold=link_threshold
+        )
+        inv = 1.0 / craft_scale
+        horizontal = [
+            [int(b[0] * inv), int(b[1] * inv), int(b[2] * inv), int(b[3] * inv)]
+            for b in horizontal_agg[0]
+        ]
+        free = [
+            [[int(c[0] * inv), int(c[1] * inv)] for c in poly] for poly in free_agg[0]
+        ]
+        return horizontal, free
+
+    # Tiled detection at native resolution: every tile is <= tile_size on its long side
+    # so reader.detect does not downscale it.
+    craft_min_size = max(1, min_size)
+    overlap = tile_size // 5
+    horizontal: list = []
+    free: list = []
+    tiles = [*_iter_tiles(width, height, tile_size, overlap)]
+    print(
+        f"Tiling large image ({width}x{height}) into {len(tiles)} tiles.",
+        file=sys.stderr,
+    )
+    for x0, y0, x1, y1 in tiles:
+        tile = array[y0:y1, x0:x1]
+        horizontal_agg, free_agg = reader.detect(
+            tile, min_size=craft_min_size, link_threshold=link_threshold
+        )
+        for b in horizontal_agg[0]:
+            horizontal.append(
+                [int(b[0]) + x0, int(b[1]) + x0, int(b[2]) + y0, int(b[3]) + y0]
+            )
+        for poly in free_agg[0]:
+            free.append([[int(c[0]) + x0, int(c[1]) + y0] for c in poly])
+
+    keep_h = _nms_bboxes(horizontal, 0.4)
+    free_bboxes = [
+        [
+            min(c[0] for c in p),
+            max(c[0] for c in p),
+            min(c[1] for c in p),
+            max(c[1] for c in p),
+        ]
+        for p in free
+    ]
+    keep_f = _nms_bboxes(free_bboxes, 0.4)
+    return [horizontal[i] for i in keep_h], [free[i] for i in keep_f]
+
+
 def _craft_detect_all_angles(
     img: Image.Image,
     reader: easyocr.Reader,
     min_size: int,
     link_threshold: float,
     craft_scale: float,
+    tile_size: int,
 ) -> list[dict]:
     """Run CRAFT detection at 0°, 90°, and 270° and return per-angle box data.
 
@@ -125,36 +266,17 @@ def _craft_detect_all_angles(
       - angle: rotation in degrees (0, 90, or 270)
       - horizontal_list: list of [x_min, x_max, y_min, y_max] in rotated-image coords
       - free_list: list of [[x, y], ...] polygon lists in rotated-image coords
+
+    Frames larger than tile_size are detected in overlapping native-resolution tiles
+    (see _detect_frame) so small labels survive canvas_size downscaling.
     """
-    craft_min_size = max(1, int(min_size * craft_scale))
     result = []
     for angle in (0, 90, 270):
         rotated = img.rotate(angle, expand=True) if angle != 0 else img
         rotated_array = np.array(rotated)
-        if craft_scale != 1.0:
-            rot_h, rot_w = rotated_array.shape[:2]
-            small_w = max(1, int(rot_w * craft_scale))
-            small_h = max(1, int(rot_h * craft_scale))
-            detect_array = np.array(
-                Image.fromarray(rotated_array).resize(
-                    (small_w, small_h), Image.Resampling.LANCZOS
-                )
-            )
-        else:
-            detect_array = rotated_array
-        horizontal_list_agg, free_list_agg = reader.detect(
-            detect_array, min_size=craft_min_size, link_threshold=link_threshold
+        horizontal_list, free_list = _detect_frame(
+            reader, rotated_array, min_size, link_threshold, craft_scale, tile_size
         )
-        horizontal_list = horizontal_list_agg[0]
-        free_list = free_list_agg[0]
-        inv = 1.0 / craft_scale
-        horizontal_list = [
-            [int(b[0] * inv), int(b[1] * inv), int(b[2] * inv), int(b[3] * inv)]
-            for b in horizontal_list
-        ]
-        free_list = [
-            [[int(c[0] * inv), int(c[1] * inv)] for c in box] for box in free_list
-        ]
         result.append(
             {
                 "angle": angle,
@@ -183,6 +305,7 @@ def detect_text(
     reader: easyocr.Reader | None = None,
     beam_width: int = 20,
     craft_scale: float = 1.0,
+    tile_size: int = 2560,
     reuse_boxes: bool = False,
 ) -> list[dict]:
     """Run CRAFT-based text detection at 0°, 90°, and 270° and return all results.
@@ -217,6 +340,13 @@ def detect_text(
     original coordinates before recognition, which always runs at full resolution.
     min_size is also scaled proportionally so the same physical text size threshold
     applies. Ignored when reuse_boxes=True.
+
+    tile_size splits images whose long side exceeds it into overlapping tiles that CRAFT
+    detects at native resolution, avoiding EasyOCR's canvas_size (2560px) downscaling
+    that shrinks small labels on oversized sheets (e.g. key maps). Only detection is
+    tiled; recognition is unchanged. Set to 0 to disable (single-pass detection, the
+    prior behavior). Default 2560 matches EasyOCR's canvas_size. Ignored when
+    reuse_boxes=True.
 
     reuse_boxes loads CRAFT bounding boxes from the existing <stem>.boxes.json
     file instead of re-running CRAFT. Useful for iterating on recognition
@@ -254,7 +384,7 @@ def detect_text(
             angle_boxes: list[dict] = json.load(f)["boxes"]
     else:
         angle_boxes = _craft_detect_all_angles(
-            img, reader, min_size, link_threshold, craft_scale
+            img, reader, min_size, link_threshold, craft_scale, tile_size
         )
         boxes_doc = {
             "width": orig_width,
@@ -363,6 +493,7 @@ def _worker_init(
     link_threshold: float,
     beam_width: int,
     craft_scale: float,
+    tile_size: int,
     reuse_boxes: bool,
     gpu: bool,
 ) -> None:
@@ -375,6 +506,7 @@ def _worker_init(
     _worker_state["link_threshold"] = link_threshold
     _worker_state["beam_width"] = beam_width
     _worker_state["craft_scale"] = craft_scale
+    _worker_state["tile_size"] = tile_size
     _worker_state["reuse_boxes"] = reuse_boxes
 
 
@@ -390,6 +522,7 @@ def _process_image(image_path: str) -> str:
         reader=_worker_state["reader"],
         beam_width=_worker_state["beam_width"],
         craft_scale=_worker_state["craft_scale"],
+        tile_size=_worker_state["tile_size"],
         reuse_boxes=_worker_state["reuse_boxes"],
     )
     return image_path
@@ -496,6 +629,18 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--tile-size",
+        type=int,
+        default=2560,
+        metavar="PX",
+        help=(
+            "Detect images larger than this in overlapping native-resolution tiles "
+            "(default: 2560, matching EasyOCR's canvas_size). This avoids downscaling "
+            "small labels on oversized sheets such as key maps. Only CRAFT detection is "
+            "tiled; recognition is unchanged. Set to 0 to disable (single-pass detection)."
+        ),
+    )
+    parser.add_argument(
         "--reuse-boxes",
         action="store_true",
         help=(
@@ -569,6 +714,7 @@ def main() -> None:
             args.link_threshold,
             args.beam_width,
             args.craft_scale,
+            args.tile_size,
             args.reuse_boxes,
             gpu,
         )
@@ -596,6 +742,7 @@ def main() -> None:
                 reader=reader,
                 beam_width=args.beam_width,
                 craft_scale=args.craft_scale,
+                tile_size=args.tile_size,
                 reuse_boxes=args.reuse_boxes,
             )
 

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -4,7 +4,11 @@ import numpy as np
 
 from mapsnap.detect_text import (
     NON_STREET_TEXT,
+    _axis_starts,
     _erase_underlines,
+    _iou_xxyy,
+    _iter_tiles,
+    _nms_bboxes,
     filter_args,
     has_split_panels,
 )
@@ -316,3 +320,79 @@ def test_filter_args_single_image():
 def test_filter_args_no_jpgs():
     argv = ["detect_text.py", "--help"]
     assert filter_args(argv, "x.jpg") == argv
+
+
+# --- tiled detection helpers ---
+
+
+def test_axis_starts_smaller_than_tile():
+    # A frame no larger than the tile needs a single tile at the origin.
+    assert _axis_starts(2000, 2560, 2048) == [0]
+    assert _axis_starts(2560, 2560, 2048) == [0]
+
+
+def test_axis_starts_covers_end_flush():
+    # Last start is snapped to length-tile so the final tile reaches the edge.
+    starts = _axis_starts(8422, 2560, 2048)
+    assert starts[0] == 0
+    assert starts[-1] == 8422 - 2560
+    # every position is within [0, length-tile]
+    assert all(0 <= s <= 8422 - 2560 for s in starts)
+
+
+def test_iter_tiles_covers_whole_image():
+    # Union of tiles must cover every pixel of a large frame.
+    width, height, tile, overlap = 6091, 8422, 2560, 512
+    tiles = list(_iter_tiles(width, height, tile, overlap))
+    assert tiles, "expected at least one tile"
+    covered = np.zeros((height, width), dtype=bool)
+    for x0, y0, x1, y1 in tiles:
+        assert x1 - x0 <= tile and y1 - y0 <= tile
+        covered[y0:y1, x0:x1] = True
+    assert covered.all()
+
+
+def test_iter_tiles_single_tile_when_small():
+    tiles = list(_iter_tiles(2000, 1500, 2560, 512))
+    assert tiles == [(0, 0, 2000, 1500)]
+
+
+def test_iter_tiles_overlap_between_neighbors():
+    # Horizontally adjacent tiles should share the configured overlap.
+    tiles = list(_iter_tiles(6091, 2000, 2560, 512))
+    xs = sorted({(x0, x1) for x0, _, x1, _ in tiles})
+    first_end = xs[0][1]
+    second_start = xs[1][0]
+    assert first_end - second_start == 512  # overlap width = tile - stride
+
+
+def test_iou_identical_boxes():
+    assert _iou_xxyy([0, 10, 0, 10], [0, 10, 0, 10]) == 1.0
+
+
+def test_iou_disjoint_boxes():
+    assert _iou_xxyy([0, 10, 0, 10], [20, 30, 0, 10]) == 0.0
+
+
+def test_iou_half_overlap():
+    # Two 10x10 boxes overlapping in a 5x10 strip: inter=50, union=150.
+    assert _iou_xxyy([0, 10, 0, 10], [5, 15, 0, 10]) == 50 / 150
+
+
+def test_nms_drops_duplicate_keeps_larger():
+    # A duplicate and a clipped copy of one label plus a far-away box:
+    # NMS keeps the larger of the overlapping pair and the disjoint box.
+    boxes = [
+        [0, 100, 0, 20],  # full label
+        [0, 90, 0, 20],  # clipped copy (high IoU with the full one)
+        [500, 600, 0, 20],  # unrelated, disjoint
+    ]
+    kept = _nms_bboxes(boxes, 0.4)
+    assert 0 in kept  # larger box survives
+    assert 1 not in kept  # clipped duplicate suppressed
+    assert 2 in kept  # disjoint box kept
+
+
+def test_nms_keeps_distinct_low_overlap_boxes():
+    boxes = [[0, 100, 0, 20], [95, 195, 0, 20]]  # touch slightly, low IoU
+    assert sorted(_nms_bboxes(boxes, 0.4)) == [0, 1]

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -394,5 +394,8 @@ def test_nms_drops_duplicate_keeps_larger():
 
 
 def test_nms_keeps_distinct_low_overlap_boxes():
-    boxes = [[0.0, 100.0, 0.0, 20.0], [95.0, 195.0, 0.0, 20.0]]  # touch slightly, low IoU
+    boxes = [
+        [0.0, 100.0, 0.0, 20.0],
+        [95.0, 195.0, 0.0, 20.0],
+    ]  # touch slightly, low IoU
     assert sorted(_nms_bboxes(boxes, 0.4)) == [0, 1]

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -383,9 +383,9 @@ def test_nms_drops_duplicate_keeps_larger():
     # A duplicate and a clipped copy of one label plus a far-away box:
     # NMS keeps the larger of the overlapping pair and the disjoint box.
     boxes = [
-        [0, 100, 0, 20],  # full label
-        [0, 90, 0, 20],  # clipped copy (high IoU with the full one)
-        [500, 600, 0, 20],  # unrelated, disjoint
+        [0.0, 100.0, 0.0, 20.0],  # full label
+        [0.0, 90.0, 0.0, 20.0],  # clipped copy (high IoU with the full one)
+        [500.0, 600.0, 0.0, 20.0],  # unrelated, disjoint
     ]
     kept = _nms_bboxes(boxes, 0.4)
     assert 0 in kept  # larger box survives
@@ -394,5 +394,5 @@ def test_nms_drops_duplicate_keeps_larger():
 
 
 def test_nms_keeps_distinct_low_overlap_boxes():
-    boxes = [[0, 100, 0, 20], [95, 195, 0, 20]]  # touch slightly, low IoU
+    boxes = [[0.0, 100.0, 0.0, 20.0], [95.0, 195.0, 0.0, 20.0]]  # touch slightly, low IoU
     assert sorted(_nms_bboxes(boxes, 0.4)) == [0, 1]

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -521,6 +521,80 @@ def find_intersection_gcps(
     return sorted(gcps, key=lambda g: g.pixel_dist)
 
 
+def _nearest_block(lon: float, lat: float, blocks: list[Block]) -> Block | None:
+    """Return the block (connected polyline) with the segment closest to (lon, lat)."""
+    q = np.array([lon, lat])
+    best_dist = float("inf")
+    best_block: Block | None = None
+    for block in blocks:
+        pts = block.coords
+        for k in range(len(pts) - 1):
+            p1, seg = pts[k], pts[k + 1] - pts[k]
+            seg_len_sq = float(np.dot(seg, seg))
+            if seg_len_sq < 1e-20:
+                continue
+            t = float(np.clip(np.dot(q - p1, seg) / seg_len_sq, 0.0, 1.0))
+            dist = float(np.linalg.norm(q - (p1 + t * seg)))
+            if dist < best_dist:
+                best_dist, best_block = dist, block
+    return best_block
+
+
+def _dominant_angle(block: Block) -> float | None:
+    """Length-weighted dominant tangent angle (mod π) of a block via its structure tensor.
+
+    Summing each segment's outer product weights long straight runs far more than short
+    ones, so a brief kink near a junction cannot swing the estimate from the street's true
+    bearing (see commit 9f03711, which introduced this for the key-map anchor path).
+    Returns None if the block has no usable segment.
+    """
+    pts = block.coords
+    tensor = np.zeros((2, 2))
+    for k in range(len(pts) - 1):
+        seg = pts[k + 1] - pts[k]
+        tensor += np.outer(seg, seg)
+    if not np.any(tensor):
+        return None
+    _, eigenvectors = np.linalg.eigh(tensor)
+    direction = eigenvectors[:, -1]
+    return float(np.arctan2(direction[1], direction[0])) % np.pi
+
+
+def is_rotation_outlier(
+    feat: LabelFeature,
+    block_index: dict[str, list[Block]],
+    affine: np.ndarray,
+    dir_threshold: float = np.pi / 6,
+) -> bool:
+    """Whether ``feat``'s mapped label direction disagrees with its street's bearing.
+
+    A position-independent rotation test: the label's mapped direction is compared against the
+    length-weighted dominant bearing of its nearest block (via :func:`_dominant_angle`), so a
+    kinked or truncated end-segment cannot masquerade as a mismatch the way the single nearest
+    segment can. Returns False when the feature has no matching street or no usable bearing.
+
+    Distinguishes a genuinely mis-oriented label (the model's rotation is wrong) from one that
+    merely lands off its centerline: a historical street that ran past where today's OSM line
+    ends leaves its label on the vanished stretch — right bearing, wrong position — and that is
+    not a rotation outlier. Used to gate the self-inconsistent-fit rejection in ransac_hybrid.
+    """
+    blocks = block_index.get(feat.text)
+    if not blocks:
+        return False
+    lon, lat = apply_affine(affine, *feat.center)
+    block = _nearest_block(lon, lat, blocks)
+    if block is None:
+        return False
+    dominant = _dominant_angle(block)
+    if dominant is None:
+        return False
+    d_pixel = np.array([np.cos(feat.dir_pix), np.sin(feat.dir_pix)])
+    d_geo = affine[:, :2] @ d_pixel
+    d_geo_norm = d_geo / (float(np.linalg.norm(d_geo)) + 1e-10)
+    tangent_vec = np.array([np.cos(dominant), np.sin(dominant)])
+    return bool(abs(float(np.dot(d_geo_norm, tangent_vec))) < math.cos(dir_threshold))
+
+
 def ransac_hybrid(
     gcps: list[IntersectionGCP],
     features: list[LabelFeature],
@@ -536,6 +610,11 @@ def ransac_hybrid(
     Generates candidate affines from all C(n, 2) pairs of intersection GCPs, solving for
     the 4-parameter similarity transform (equal metric scale + orthogonality) at each pair.
     Inlier counting uses point-to-polyline + direction for every label.
+
+    A candidate pair is disqualified when one of its own seed streets is a rotation outlier
+    under the model it defines — the fit's orientation contradicts a street it was built from
+    (see is_rotation_outlier and the in-loop comment). If no pair survives, returns
+    (None, [], None) so the caller records no fit for the page.
 
     A global rotation estimate R_est is derived from a histogram cross-correlation of label
     angles vs OSM tangents before the main loop. Each candidate is penalized by rot_penalty
@@ -573,6 +652,24 @@ def ransac_hybrid(
         inliers, err = label_inliers(
             features, block_index, A, pos_threshold, dir_threshold, debug=debug
         )
+
+        # Reject only fits whose own seed streets are *rotation* outliers: each seed GCP is
+        # built from two specific street labels, so if the model maps one of those labels to a
+        # bearing that disagrees with its street, the fit's orientation contradicts its own
+        # evidence (Detroit p28's COREY, mapped ~38° off its dominant bearing). A seed that
+        # matches in direction but lands off its centerline is NOT rejected: that is a
+        # position-only outlier, which is exactly what happens when a historical street ran
+        # past where today's OSM line ends and the label sits on the vanished stretch (Brooklyn
+        # p7's VAN BRUNT, ~3° off but ~115 ft beyond the truncated end). Seeds are the pair's
+        # four source features; is_rotation_outlier identifies each by its own center, so an
+        # ambiguous label's dropped canonical expansion (Detroit p94's KORTE) isn't faulted.
+        seed_feats = (a.feat_a, a.feat_b, b.feat_a, b.feat_b)
+        if any(
+            is_rotation_outlier(f, block_index, A, dir_threshold) for f in seed_feats
+        ):
+            if debug:
+                print(f"  {i1} {i2} REJECTED ({len(inliers)}) seed rotation outlier")
+            continue
 
         # Each inlier contributes (pos_threshold - pos_err) to the score; an inlier at
         # exactly the threshold boundary contributes 0, so a marginal extra inlier cannot

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -595,54 +595,69 @@ def is_rotation_outlier(
     return bool(abs(float(np.dot(d_geo_norm, tangent_vec))) < math.cos(dir_threshold))
 
 
-# Above this many candidate GCPs, ransac_hybrid's exhaustive C(n, 2) pairing is too slow (a
-# key-map index page can yield hundreds of intersections). A fast robust affine RANSAC over the
-# GCP correspondences first discards gross outliers so the label-scored search runs only over
-# the consensus inliers.
-ROBUST_PREFILTER_MIN_GCPS = 100
-# Even after the pre-filter the consensus can be large, and each pair costs a full label scoring
-# (~tens of ms). The consensus is geometrically clean, so only a handful of well-separated pairs
-# are needed to recover the transform; pair just the best (lowest-pixel-distance) GCPs up to this
-# cap. Bounds a many-GCP page to C(cap, 2) label scorings (seconds) instead of minutes.
-MAX_PREFILTER_PAIRING_GCPS = 30
-_M_PER_DEG_LAT: float = 111_320.0
+# The full per-label inlier scoring (~0.4s over hundreds of labels) is far too expensive to run
+# on every GCP pair when a key-map index page yields hundreds of intersections (C(n, 2) in the
+# hundreds of thousands). Instead every pair is cheaply ranked by a vectorized GCP-consensus
+# count and only this many top candidates get the full label scoring.
+STAGE2_MAX_CANDIDATES = 60
 
 
-def _robust_affine_inlier_indices(
-    gcps: list[IntersectionGCP], reproj_threshold_m: float = 30.0
-) -> list[int]:
-    """Indices of GCPs consistent with a robust 6-parameter affine (pixel → local metres).
+def _rank_pairs_by_consensus(
+    gcps: list["IntersectionGCP"],
+    cos_phi: float,
+    pos_threshold: float,
+    top_k: int,
+) -> list[tuple[int, int]]:
+    """Rank all C(n, 2) GCP seed pairs by GCP consensus and return the best ``top_k``.
 
-    Fits a full affine to the pixel↔geo correspondences with cv2.estimateAffine2D's RANSAC
-    (milliseconds even for hundreds of points) and returns its inlier set. Geo is projected to
-    a local equirectangular metre frame so the reprojection threshold is in metres. Used only
-    to prune gross outliers before the slower label-scored similarity search; returns all
-    indices if the robust fit fails to converge.
+    A pair's consensus is how many GCPs its 2-point similarity maps to within ``pos_threshold``
+    degrees of their own geo coordinate. The 2-point similarity has a closed form (the same
+    (α, β, tx, ty) that :func:`solve_similarity_2pts` solves per pair), so every pair's transform
+    is computed with array math and scored against all GCPs in chunks — cheap enough to run
+    exhaustively over hundreds of thousands of pairs, replacing any random sampling. Degenerate
+    pairs (coincident pixels or coincident geo) are excluded. Ties break by pair index so the
+    result is deterministic. Returns pairs as (i, j) with i < j, best consensus first.
     """
-    import cv2  # lazy: heavy import, only needed for many-GCP pages
+    n = len(gcps)
+    px = np.array([g.pixel[0] for g in gcps], dtype=float)
+    py = np.array([g.pixel[1] for g in gcps], dtype=float)
+    glon = np.array([g.geo[0] for g in gcps], dtype=float)
+    glat = np.array([g.geo[1] for g in gcps], dtype=float)
 
-    pixels = np.array([g.pixel for g in gcps], dtype=np.float64)
-    geo = np.array([g.geo for g in gcps], dtype=np.float64)
-    lon0, lat0 = float(geo[:, 0].mean()), float(geo[:, 1].mean())
-    cos0 = math.cos(math.radians(lat0))
-    metres = np.stack(
-        [
-            (geo[:, 0] - lon0) * cos0 * _M_PER_DEG_LAT,
-            (geo[:, 1] - lat0) * _M_PER_DEG_LAT,
-        ],
-        axis=1,
-    )
-    _, mask = cv2.estimateAffine2D(
-        pixels.reshape(-1, 1, 2),
-        metres.reshape(-1, 1, 2),
-        method=cv2.RANSAC,
-        ransacReprojThreshold=reproj_threshold_m,
-        maxIters=5000,
-        confidence=0.999,
-    )
-    if mask is None:
-        return list(range(len(gcps)))
-    return [i for i, keep in enumerate(mask.ravel()) if keep]
+    idx_i, idx_j = np.triu_indices(n, k=1)  # every i < j pair
+    dpx, dpy = px[idx_i] - px[idx_j], py[idx_i] - py[idx_j]
+    dlon, dlat = glon[idx_i] - glon[idx_j], glat[idx_i] - glat[idx_j]
+    det = dpx * dpx + dpy * dpy
+    # Closed form of solve_similarity_2pts: the 2×2 system [[dpx, dpy], [-dpy, dpx]] (α, β) =
+    # (cos_phi·dlon, dlat), then tx, ty back-substituted from GCP i.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        u = cos_phi * dlon
+        alpha = (dpx * u - dpy * dlat) / det
+        beta = (dpy * u + dpx * dlat) / det
+    tx = glon[idx_i] - (alpha * px[idx_i] + beta * py[idx_i]) / cos_phi
+    ty = glat[idx_i] + alpha * py[idx_i] - beta * px[idx_i]
+    valid = (det > 1e-12) & ((dlon * dlon + dlat * dlat) > 1e-18)
+
+    thr_sq = pos_threshold * pos_threshold
+    counts = np.full(len(idx_i), -1, dtype=np.int64)
+    chunk = 4096
+    for start in range(0, len(idx_i), chunk):
+        end = min(start + chunk, len(idx_i))
+        mask = valid[start:end]
+        if not mask.any():
+            continue
+        a = alpha[start:end][mask][:, None]
+        b = beta[start:end][mask][:, None]
+        pred_lon = (a * px[None, :] + b * py[None, :]) / cos_phi + tx[start:end][mask][
+            :, None
+        ]
+        pred_lat = b * px[None, :] - a * py[None, :] + ty[start:end][mask][:, None]
+        d_sq = (pred_lon - glon[None, :]) ** 2 + (pred_lat - glat[None, :]) ** 2
+        counts[np.arange(start, end)[mask]] = (d_sq < thr_sq).sum(axis=1)
+
+    # Sort by consensus descending, breaking ties by pair index ascending (deterministic).
+    order = np.lexsort((np.arange(len(idx_i)), -counts))
+    return [(int(idx_i[k]), int(idx_j[k])) for k in order[:top_k] if counts[k] >= 0]
 
 
 def ransac_hybrid(
@@ -657,9 +672,12 @@ def ransac_hybrid(
 ) -> tuple[np.ndarray | None, list[int], tuple[int, int] | None]:
     """Find the best similarity affine using intersection GCPs as seeds, label-based inlier scoring.
 
-    Generates candidate affines from all C(n, 2) pairs of intersection GCPs, solving for
-    the 4-parameter similarity transform (equal metric scale + orthogonality) at each pair.
-    Inlier counting uses point-to-polyline + direction for every label.
+    Generates candidate affines from pairs of intersection GCPs, solving for the 4-parameter
+    similarity transform (equal metric scale + orthogonality) at each pair. When there are more
+    than STAGE2_MAX_CANDIDATES pairs, every pair is first ranked by a cheap vectorized GCP
+    consensus (see _rank_pairs_by_consensus) and only the top candidates get the expensive
+    per-label inlier scoring; otherwise all pairs are scored. Inlier counting uses
+    point-to-polyline + direction for every label. Fully deterministic — no random sampling.
 
     A candidate pair is disqualified when one of its own seed streets is a rotation outlier
     under the model it defines — the fit's orientation contradicts a street it was built from
@@ -679,22 +697,7 @@ def ransac_hybrid(
     if n < 2:
         return None, [], None
 
-    # For pages with very many candidate GCPs (key-map index pages), the exhaustive C(n, 2)
-    # pairing is prohibitively slow. Prune gross outliers with a fast robust affine first and
-    # search only over the consensus inliers; the final fit is still the label-scored similarity.
-    candidate_indices = list(range(n))
-    if n > ROBUST_PREFILTER_MIN_GCPS:
-        consensus = _robust_affine_inlier_indices(gcps)
-        if len(consensus) >= 2:
-            # gcps are sorted by pixel_dist ascending, so consensus[:cap] keeps the most
-            # reliable intersection estimates.
-            candidate_indices = consensus[:MAX_PREFILTER_PAIRING_GCPS]
-            kept = len(candidate_indices)
-            print(
-                f"Robust-affine pre-filter: {len(consensus)} / {n} GCP inliers; pairing the "
-                f"best {kept} ({kept * (kept - 1) // 2} pairs vs {n * (n - 1) // 2})",
-                file=sys.stderr,
-            )
+    total_pairs = n * (n - 1) // 2
 
     best_A: np.ndarray | None = None
     best_inliers: list[int] = []
@@ -705,17 +708,40 @@ def ransac_hybrid(
     for a in gcps:
         print(f"  {a.label_a} x {a.label_b}")
 
-    for pair_idx in combinations(candidate_indices, 2):
+    # Choose which GCP seed pairs get the expensive per-label scoring (~0.4s each). A key-map
+    # page has C(n, 2) in the hundreds of thousands, so above STAGE2_MAX_CANDIDATES pairs, rank
+    # ALL pairs by a cheap vectorized GCP-consensus count (deterministic and exhaustive — no
+    # random sampling) and keep only the top candidates. At or below the cap, score every pair,
+    # preserving small-page behavior exactly.
+    if total_pairs <= STAGE2_MAX_CANDIDATES:
+        pair_list = list(combinations(range(n), 2))
+    else:
+        pair_list = _rank_pairs_by_consensus(
+            gcps, cos_phi, pos_threshold, STAGE2_MAX_CANDIDATES
+        )
+        print(
+            f"GCP-consensus pre-rank: label-scoring top {len(pair_list)} of {total_pairs} pairs",
+            file=sys.stderr,
+        )
+
+    # Solve each retained pair's similarity (skipping degenerate pairs) for the scoring below.
+    candidates: list[tuple[tuple[int, int], np.ndarray]] = []
+    for pair_idx in pair_list:
         i1, i2 = pair_idx
         a, b = gcps[i1], gcps[i2]
         # Skip pairs that map to the same OSM intersection — singular by construction.
         if abs(a.geo[0] - b.geo[0]) < 1e-6 and abs(a.geo[1] - b.geo[1]) < 1e-6:
             continue
-        pairs = [(gcps[k].pixel, gcps[k].geo) for k in pair_idx]
         try:
-            A = solve_similarity_2pts(pairs, cos_phi)
+            A = solve_similarity_2pts([(a.pixel, a.geo), (b.pixel, b.geo)], cos_phi)
         except np.linalg.LinAlgError:
             continue
+        candidates.append((pair_idx, A))
+
+    # Full per-label inlier scoring on the retained candidates only.
+    for pair_idx, A in candidates:
+        i1, i2 = pair_idx
+        a, b = gcps[i1], gcps[i2]
         inliers, err = label_inliers(
             features, block_index, A, pos_threshold, dir_threshold, debug=debug
         )

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -14,9 +14,13 @@ from mapsnap.georef_from_labels import (
     compute_auto_min_short_side,
     confidence_relaxed_threshold,
     correct_square_feature_dirs,
+    IntersectionGCP,
+    is_rotation_outlier,
     label_features,
+    LabelFeature,
     promote_avenue_letters,
     project_to_polyline,
+    ransac_hybrid,
 )
 from mapsnap.streets import Block
 
@@ -716,3 +720,215 @@ def test_confidence_relaxed_threshold_disabled_when_floor_not_below_base():
         high_confidence_floor=18.0,
     )
     assert result == 18.0
+
+
+# ---------------------------------------------------------------------------
+# _kink_block (shared geometry helper)
+# ---------------------------------------------------------------------------
+
+
+def _kink_block() -> Block:
+    """A long east-west run ending in a short, steep kink segment."""
+    return Block(
+        street_name="MAIN",
+        coords=np.array(
+            [
+                [-89.991, 29.995],  # long horizontal run ...
+                [-89.989, 29.995],  # ... ~190 m of it
+                [-89.9889, 29.9952],  # short ~25 m kink, ~63° off horizontal
+            ]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ransac_hybrid: reject fits whose seed street is a *rotation* outlier (the model's
+# orientation contradicts a street it was built from), while keeping fits whose seed
+# is only a *position* outlier (right bearing, off a since-shortened centerline)
+# ---------------------------------------------------------------------------
+
+# Shared frame for the tests below: an orientation-reversing similarity at 1e-5 deg/px,
+# north-up, where px=500 maps to lon=-90.0 and py=200 to lat=30.0. Two GCPs at
+# (500, 200)->(-90, 30) and (500, 700)->(-90, 29.995) recover it exactly.
+_RH_COS_PHI = math.cos(math.radians(30.0))
+
+
+def _vertical_block(name: str, lon: float) -> Block:
+    """A north-south street segment at the given longitude."""
+    return Block(name, np.array([[lon, 29.99], [lon, 30.01]]))
+
+
+def _horizontal_block(name: str, lat: float) -> Block:
+    """An east-west street segment at the given latitude."""
+    return Block(name, np.array([[-90.02, lat], [-89.98, lat]]))
+
+
+def _rh_feat(text: str, center: tuple[float, float], dir_pix: float) -> LabelFeature:
+    """A label feature for the ransac_hybrid frame (sizes are immaterial here)."""
+    return LabelFeature(text, text, center, dir_pix, 100.0, 20.0)
+
+
+def test_ransac_hybrid_rejects_rotation_outlier_seed():
+    # Both GCPs are seeded by COREY (cf. Detroit p28). COREY's label maps to a bearing ~90°
+    # off its (vertical) street, so it is a rotation outlier: the model's orientation
+    # contradicts a street it was built from. The only candidate pair is disqualified and no
+    # model is returned.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat(
+        "COREY", (500.0, 450.0), 0.0
+    )  # horizontal label on a vertical street
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is None
+    assert inliers == []
+    assert pair is None
+
+
+def test_ransac_hybrid_keeps_position_only_outlier_seed():
+    # Same COREY-seeded frame, but COREY's label keeps its street's (vertical) bearing and is
+    # merely displaced ~4300 ft east of the centerline -- a position-only outlier, as when a
+    # historical street ran past where today's OSM line ends (cf. Brooklyn p7's VAN BRUNT).
+    # The pair is kept even though COREY is not a position inlier.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat(
+        "COREY", (1500.0, 450.0), math.pi / 2
+    )  # right bearing, off the line
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1}  # COREY is a position outlier, but the pair survives
+    assert pair == (0, 1)
+
+
+def test_ransac_hybrid_keeps_fit_when_seed_labels_are_inliers():
+    # Same frame, but COREY's label now sits on its own centerline, so every seed label is an
+    # inlier and the pair is accepted.
+    kerch = _rh_feat("KERCH", (500.0, 200.0), 0.0)
+    jeff = _rh_feat("JEFF", (500.0, 700.0), 0.0)
+    corey = _rh_feat("COREY", (500.0, 450.0), math.pi / 2)  # on COREY's line -> inlier
+    features = [kerch, jeff, corey]
+    block_index = {
+        "KERCH": [_horizontal_block("KERCH", 30.0)],
+        "JEFF": [_horizontal_block("JEFF", 29.995)],
+        "COREY": [_vertical_block("COREY", -90.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "KERCH", "COREY", (500.0, 200.0), (-90.0, 30.0), 0.0, kerch, corey
+        ),
+        IntersectionGCP(
+            "JEFF", "COREY", (500.0, 700.0), (-90.0, 29.995), 0.0, jeff, corey
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1, 2}
+    assert pair == (0, 1)
+
+
+def test_ransac_hybrid_accepts_ambiguous_label_seeding_two_streets():
+    # A single physical "KORTE" label (one center) is ambiguous between KORTE STREET and
+    # KORTE AVENUE and legitimately seeds a GCP under each name (cf. Detroit p94). Only the
+    # real match, KORTE STREET, is an inlier; label_inliers dedups the center to it. Because
+    # the seed check is by center, the pair is accepted -- a name-based check would wrongly
+    # reject it, faulting the dropped KORTE AVENUE expansion as an outlier.
+    drexel = _rh_feat("DREXEL", (500.0, 200.0), 0.0)
+    piper = _rh_feat("PIPER", (500.0, 700.0), 0.0)
+    korte_center = (500.0, 450.0)
+    korte_st = _rh_feat("KORTE STREET", korte_center, math.pi / 2)  # on its line
+    korte_ave = _rh_feat("KORTE AVENUE", korte_center, math.pi / 2)  # wrong street
+    features = [drexel, piper, korte_st, korte_ave]
+    block_index = {
+        "DREXEL": [_horizontal_block("DREXEL", 30.0)],
+        "PIPER": [_horizontal_block("PIPER", 29.995)],
+        "KORTE STREET": [_vertical_block("KORTE STREET", -90.0)],
+        "KORTE AVENUE": [_vertical_block("KORTE AVENUE", -89.0)],
+    }
+    gcps = [
+        IntersectionGCP(
+            "DREXEL",
+            "KORTE AVENUE",
+            (500.0, 200.0),
+            (-90.0, 30.0),
+            0.0,
+            drexel,
+            korte_ave,
+        ),
+        IntersectionGCP(
+            "PIPER",
+            "KORTE STREET",
+            (500.0, 700.0),
+            (-90.0, 29.995),
+            0.0,
+            piper,
+            korte_st,
+        ),
+    ]
+    model, inliers, pair = ransac_hybrid(gcps, features, block_index, _RH_COS_PHI)
+    assert model is not None
+    assert set(inliers) == {0, 1, 2}  # korte_ave (idx 3) deduped out by center
+    assert pair == (0, 1)
+
+
+# is_rotation_outlier ------------------------------------------------------
+
+# Axis-aligned similarity: pixel (x, y) -> (lon, lat) = (-90 + 1e-5·x, 30 - 1e-5·y). A
+# horizontal pixel label (dir_pix=0) maps to an east-west bearing, a vertical one (π/2) to
+# north-south.
+_AXIS_AFFINE = np.array([[1e-5, 0.0, -90.0], [0.0, -1e-5, 30.0]])
+
+
+def test_is_rotation_outlier_true_when_perpendicular():
+    # A horizontal label on a vertical (north-south) street is ~90° off its bearing.
+    feat = _rh_feat("MAIN", (500.0, 500.0), 0.0)
+    block_index = {"MAIN": [_vertical_block("MAIN", -89.995)]}
+    assert is_rotation_outlier(feat, block_index, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_false_when_aligned_even_if_off_position():
+    # A vertical label far (4300 ft) east of a vertical street: wrong position, right bearing.
+    feat = _rh_feat("MAIN", (1500.0, 500.0), math.pi / 2)
+    block_index = {"MAIN": [_vertical_block("MAIN", -89.995)]}
+    assert not is_rotation_outlier(feat, block_index, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_false_when_no_street():
+    feat = _rh_feat("MISSING", (500.0, 500.0), 0.0)
+    assert not is_rotation_outlier(feat, {}, _AXIS_AFFINE)
+
+
+def test_is_rotation_outlier_uses_dominant_bearing_not_kink():
+    # The label runs along the street's long east-west body; the nearest segment is a short
+    # steep kink. The dominant bearing keeps it an inlier, so it is not a rotation outlier.
+    feat = LabelFeature("MAIN", "MAIN", (1110.0, 480.0), 0.0, 100.0, 20.0)
+    block_index = {"MAIN": [_kink_block()]}
+    affine = np.array([[1e-5, 0.0, -90.0], [0.0, -1e-5, 30.0]])
+    assert not is_rotation_outlier(feat, block_index, affine)

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -9,7 +9,7 @@ from mapsnap.georef_from_labels import (
     _FT_PER_DEG_LAT,
     _angle_diff_abs,
     _cluster_geo_coords,
-    _robust_affine_inlier_indices,
+    _rank_pairs_by_consensus,
     _rotation_from_neighbors,
     assemble_multiword_streets,
     compute_auto_min_short_side,
@@ -942,30 +942,45 @@ def test_is_rotation_outlier_uses_dominant_bearing_not_kink():
 
 
 # ---------------------------------------------------------------------------
-# _robust_affine_inlier_indices — many-GCP pre-filter
+# _rank_pairs_by_consensus — cheap vectorized many-GCP pre-rank
 # ---------------------------------------------------------------------------
 
 
-def test_robust_affine_inlier_indices_drops_gross_outliers():
-    # 120 GCPs consistent with a known affine (pixel → lon/lat) plus 8 gross outliers.
-    # The robust affine RANSAC should keep the inliers and reject the outliers.
-    import numpy as np
+def test_rank_pairs_by_consensus_ranks_inlier_pairs_first():
+    # 25 GCPs consistent with a known rotated similarity (exercises the closed form with β≠0)
+    # plus 5 gross outliers. The top-ranked seed pairs must all be inlier×inlier pairs.
+    from mapsnap.georef_from_labels import solve_similarity_2pts
 
-    rng = np.random.default_rng(0)
-    inliers = []
-    for _ in range(120):
-        px, py = rng.uniform(0, 4000), rng.uniform(0, 4000)
-        lon = -90.0 + 1e-4 * px
-        lat = 30.0 - 1e-4 * py
-        inliers.append(_make_gcp((px, py), (lon, lat)))
-    outliers = [
-        _make_gcp((rng.uniform(0, 4000), rng.uniform(0, 4000)), (-95.0, 35.0))
-        for _ in range(8)
+    cos_phi = math.cos(math.radians(30.0))
+    known = solve_similarity_2pts(
+        [((0.0, 0.0), (-90.0, 30.0)), ((1000.0, 0.0), (-89.99, 30.005))], cos_phi
+    )
+
+    def apply(px: float, py: float) -> tuple[float, float]:
+        return (
+            float(known[0, 0] * px + known[0, 1] * py + known[0, 2]),
+            float(known[1, 0] * px + known[1, 1] * py + known[1, 2]),
+        )
+
+    rng = np.random.default_rng(1)
+    gcps = [
+        _make_gcp((px, py), apply(px, py))
+        for px, py in rng.uniform(0, 3000, size=(25, 2))
     ]
-    gcps = inliers + outliers
-    outlier_indices = set(range(120, 128))
+    n_inliers = len(gcps)
+    gcps += [_make_gcp(tuple(rng.uniform(0, 3000, 2)), (-80.0, 40.0)) for _ in range(5)]
 
-    kept = set(_robust_affine_inlier_indices(gcps))
-    # No gross outlier survives, and the large majority of true inliers are kept.
-    assert not (kept & outlier_indices)
-    assert len(kept & set(range(120))) >= 110
+    top = _rank_pairs_by_consensus(gcps, cos_phi, pos_threshold=1e-3, top_k=8)
+    assert len(top) == 8
+    assert all(i < n_inliers and j < n_inliers for i, j in top)
+    assert all(i < j for i, j in top)
+
+
+def test_rank_pairs_by_consensus_is_deterministic():
+    gcps = [
+        _make_gcp((px, py), (-90.0 + 1e-4 * px, 30.0 - 1e-4 * py))
+        for px, py in np.random.default_rng(3).uniform(0, 4000, size=(20, 2))
+    ]
+    a = _rank_pairs_by_consensus(gcps, 1.0, 1e-3, 10)
+    b = _rank_pairs_by_consensus(gcps, 1.0, 1e-3, 10)
+    assert a == b


### PR DESCRIPTION
I'm working towards a workflow where mapsnap georeferences the keymap and extracts page numbers from it to get a good prior on each page's location. Most keymaps georeferenced fine, but Washington, D. C. was a disaster. After some digging, Claude and I discovered that EasyOCR's CRAFT downscales images to have a maximum size of 2560px before running. Running over the full image OOMs, so tiling is the next best option. This took us from very few GCPs to thousands. Most of these are bogus, but there's enough signal to extract a great fit. It's just slow. That's what the changes to the prefilter were all about.

----

Two changes that together let an oversized key-map sheet be georeferenced directly. Validated on Washington DC vol 2 `p1b` (the 6091×8422 index sheet): direct fit **231m → ~23m** vs the manual truth.

## 1. Tile CRAFT detection (`detect_text.py`)
EasyOCR caps the CRAFT input's long side at `canvas_size` (2560px), so any sheet taller than that is downscaled before detection — an 8422px key map is seen at ~0.30×, shrinking a 40px label to ~12px (below CRAFT's resolution). `_detect_frame` now splits a frame whose long side exceeds `--tile-size` (default 2560) into overlapping native-resolution tiles and merges boxes with NMS.

- **Only detection is tiled.** Recognition already crops from the full-resolution image, so `streets.json` is produced by the same code path — just over more boxes.
- On the key map this recovers **~5× more street labels** (12× more numbered streets) in the same region.
- `--tile-size 0` restores the old single-pass behavior. Sheets ≤2560px are unaffected.

## 2. Rank GCP seed pairs by consensus (`georef_from_labels.py`)
`ransac_hybrid` pre-filtered many-GCP pages to the 30 best robust-affine consensus GCPs. On a key map (hundreds of intersections, ~90% outliers) that locks the search onto a biased consensus (~85m off). Replaced with an **exhaustive, deterministic** GCP-consensus pre-rank: every C(n,2) seed pair is scored by how many GCPs its 2-point similarity maps within `pos_threshold` of geo (vectorized closed form of `solve_similarity_2pts`), and only the top `STAGE2_MAX_CANDIDATES=60` get the expensive per-label scoring.

- Removes `_robust_affine_inlier_indices` and its `cv2` dependency.
- No randomness — ties break by pair index.
- Pages with ≤60 possible seed pairs still score every pair (unchanged).

## Testing
- New unit tests: tiling geometry/NMS (`detect_text_test.py`), consensus ranking correctness on a rotated transform + determinism (`georef_from_labels_test.py`).
- Full `detect_text_test.py` + `georef_from_labels_test.py` suites pass; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)