### PR TITLE
Close key-map region polygons

### DIFF
--- a/mapsnap/keymap/page_regions.py
+++ b/mapsnap/keymap/page_regions.py
@@ -411,7 +411,9 @@ def regions_panels_doc(
     panels: list[list[list[float]]] = []
     labels: list[str] = []
     for index, polygon in polygons.items():
-        panels.append([[round(x, 1), round(y, 1)] for x, y in polygon])
+        ring = [[round(x, 1), round(y, 1)] for x, y in polygon]
+        ring.append(ring[0])  # GeoJSON-style rings are explicitly closed
+        panels.append(ring)
         labels.append(texts[index])
     return {
         "image": image_name,

--- a/mapsnap/keymap/page_regions_test.py
+++ b/mapsnap/keymap/page_regions_test.py
@@ -85,10 +85,14 @@ def test_regions_panels_doc():
     doc = regions_panels_doc("p0b.jpg", (100, 200), polygons, ["55", "1", "2"])
     assert doc["image"] == "p0b.jpg"
     assert doc["width"] == 100 and doc["height"] == 200
+    # Rings are explicitly closed (first vertex repeated at the end), matching the
+    # panels.json convention elsewhere (e.g. split.py's Shapely-derived rings).
     assert doc["panels"] == [
-        [[1.0, 2.0], [3.0, 2.0], [3.0, 4.0]],
-        [[5.0, 6.0], [7.0, 6.0], [7.0, 8.0]],
+        [[1.0, 2.0], [3.0, 2.0], [3.0, 4.0], [1.0, 2.0]],
+        [[5.0, 6.0], [7.0, 6.0], [7.0, 8.0], [5.0, 6.0]],
     ]
+    for ring in doc["panels"]:
+        assert ring[0] == ring[-1]
     # labels are parallel to panels and indexed by seed, so polygon 2 -> texts[2] == "2".
     assert doc["labels"] == ["55", "2"]
 


### PR DESCRIPTION
The key-map page-region polygons were written as **open** rings, so the debugger drew each region with one open segment.

`regions_panels_doc` in `page_regions.py` now closes each ring by repeating its first vertex (GeoJSON-style explicit closure); the test asserts the rings are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)