### PR TITLE
Debugger: truth-data overlay + scale bar / rotation / fixed crosshair / no long animations

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -56,6 +56,7 @@ export function App() {
   const [streets, setStreets] = useState<Street[]>([]);
   const [intersections, setIntersections] = useState<IntersectionPoint[]>([]);
   const [keymap, setKeymap] = useState<KeymapLocation | null>(null);
+  const [truth, setTruth] = useState<[number, number][][] | null>(null);
   const [precomputedCorners, setPrecomputedCorners] = useState<Corners | null>(
     null,
   );
@@ -80,6 +81,7 @@ export function App() {
   const [colorByInlier, setColorByInlier] = useState(true);
   const [showLabels, setShowLabels] = useState(true);
   const [showIntersections, setShowIntersections] = useState(true);
+  const [showTruth, setShowTruth] = useState(false);
   const [filters, setFilters] = useState<DetectionFilters>({
     minConfidence: 0.15,
     minShortSide: 20,
@@ -109,6 +111,7 @@ export function App() {
     setStreets((data.streets ?? []).map((s) => ({ ...s })));
     setIntersections((data.intersections ?? []).map((ix) => ({ ...ix })));
     setKeymap(data.keymap ?? null);
+    setTruth(data.truth ?? null);
     setPrecomputedCorners(data.corners ?? null);
     if (data.width && data.height) {
       setJsonWidth(data.width);
@@ -292,6 +295,7 @@ export function App() {
               intersections={intersections}
               corners={corners}
               keymap={keymap}
+              truth={showTruth ? truth : null}
               imageSrc={imageSrc}
               opacity={opacity / 100}
               showLabels={showLabels}
@@ -328,6 +332,19 @@ export function App() {
               />
               <label htmlFor="show-intersections">
                 Show intersection GCPs on map
+              </label>
+            </div>
+            <div className="opacity-control">
+              <input
+                type="checkbox"
+                id="show-truth"
+                checked={showTruth}
+                disabled={!truth}
+                onChange={(e) => setShowTruth(e.target.checked)}
+              />
+              <label htmlFor="show-truth">
+                Show truth data on map
+                {!truth && ' (none available)'}
               </label>
             </div>
           </>

--- a/app/src/components/MapView.tsx
+++ b/app/src/components/MapView.tsx
@@ -32,6 +32,7 @@ const FALLBACK_COLOR = '#0d9488';
 // Fixed physical size for the key-map center crosshair (not a fraction of the search radius,
 // which varies wildly by volume — e.g. ~270m in Chicago vs ~1585m in Detroit — and would make
 // the crosshair unreadably tiny or huge depending on the volume).
+// This is center-to-tip distance: like a radius, not a diameter.
 const CROSSHAIR_ARM_METERS = 61; // ~200 ft
 
 // A view change closer than this is animated (a smooth fly-to reads as "the view nudged");

--- a/app/src/components/MapView.tsx
+++ b/app/src/components/MapView.tsx
@@ -7,7 +7,7 @@ import type {
   KeymapLocation,
   Street,
 } from '../types';
-import { circlePolygon, crosshairLines, distanceMiles } from '../geometry';
+import { circlePolygon, crosshairLines, distanceKm } from '../geometry';
 
 interface MapViewProps {
   streets: Street[];
@@ -26,6 +26,29 @@ interface MapViewProps {
 // Teal for streets read by the key-map rectangle fallback vocabulary (matching the neighborhood
 // circle and the table badge); otherwise orange/grey by inlier status, or a flat red.
 const FALLBACK_COLOR = '#0d9488';
+
+// Fixed physical size for the key-map center crosshair (not a fraction of the search radius,
+// which varies wildly by volume — e.g. ~270m in Chicago vs ~1585m in Detroit — and would make
+// the crosshair unreadably tiny or huge depending on the volume).
+const CROSSHAIR_ARM_METERS = 61; // ~200 ft
+
+// A view change closer than this is animated (a smooth fly-to reads as "the view nudged");
+// anything farther jumps instantly (an animated pan across a continent is just a multi-second
+// wait). Applies to both the main image-corners fit and the key-map-circle fit below.
+const MAX_ANIMATE_DISTANCE_KM = 10;
+
+// Whether a view change from the map's current center to (lon, lat) is close enough to
+// animate smoothly, vs. jumping instantly (see MAX_ANIMATE_DISTANCE_KM).
+function shouldAnimateTo(
+  map: maplibregl.Map,
+  lon: number,
+  lat: number,
+): boolean {
+  const current = map.getCenter();
+  return (
+    distanceKm(current.lng, current.lat, lon, lat) <= MAX_ANIMATE_DISTANCE_KM
+  );
+}
 
 // Color expression for street labels: key-map fallback reads first, then inlier status.
 function streetColor(
@@ -87,6 +110,15 @@ export function MapView(props: MapViewProps) {
     });
     mapRef.current = map;
     map.on('load', () => setMapReady(true));
+    map.addControl(
+      new maplibregl.ScaleControl({ unit: 'imperial' }),
+      'bottom-left',
+    );
+    map.addControl(
+      new maplibregl.NavigationControl({ visualizePitch: false }),
+      'top-left',
+    );
+
     return () => {
       map.remove();
       mapRef.current = null;
@@ -133,19 +165,16 @@ export function MapView(props: MapViewProps) {
       const maxLat = Math.max(...lats);
       const newCenterLon = (minLon + maxLon) / 2;
       const newCenterLat = (minLat + maxLat) / 2;
-      const currentCenter = map.getCenter();
-      const dist = distanceMiles(
-        currentCenter.lng,
-        currentCenter.lat,
-        newCenterLon,
-        newCenterLat,
-      );
       map.fitBounds(
         [
           [minLon, minLat],
           [maxLon, maxLat],
         ],
-        { padding: 40, maxZoom: 17, animate: dist <= 10 },
+        {
+          padding: 40,
+          maxZoom: 17,
+          animate: shouldAnimateTo(map, newCenterLon, newCenterLat),
+        },
       );
     }
   }, [mapReady, corners, imageSrc, opacity]);
@@ -380,7 +409,7 @@ export function MapView(props: MapViewProps) {
               type: 'Feature',
               geometry: {
                 type: 'MultiLineString',
-                coordinates: crosshairLines(lon, lat, keymap.radius_m * 0.18),
+                coordinates: crosshairLines(lon, lat, CROSSHAIR_ARM_METERS),
               },
               properties: { kind: 'center' },
             }),
@@ -460,12 +489,18 @@ export function MapView(props: MapViewProps) {
       );
       const lons = rings.map((c) => c[0]);
       const lats = rings.map((c) => c[1]);
+      const targetLon = (Math.min(...lons) + Math.max(...lons)) / 2;
+      const targetLat = (Math.min(...lats) + Math.max(...lats)) / 2;
       map.fitBounds(
         [
           [Math.min(...lons), Math.min(...lats)],
           [Math.max(...lons), Math.max(...lats)],
         ],
-        { padding: 60, maxZoom: 16 },
+        {
+          padding: 60,
+          maxZoom: 16,
+          animate: shouldAnimateTo(map, targetLon, targetLat),
+        },
       );
     }
   }, [mapReady, keymap, corners]);

--- a/app/src/components/MapView.tsx
+++ b/app/src/components/MapView.tsx
@@ -15,6 +15,8 @@ interface MapViewProps {
   corners: Corners | null;
   /** The page's key-map neighborhood (center + OCR/fit radius), if placed. */
   keymap: KeymapLocation | null;
+  /** This page's human (OIM truth) footprint(s) to overlay, or null to hide them. */
+  truth: [number, number][][] | null;
   imageSrc: string;
   /** Warped-image opacity in [0, 1]. */
   opacity: number;
@@ -76,6 +78,7 @@ export function MapView(props: MapViewProps) {
     intersections,
     corners,
     keymap,
+    truth,
     imageSrc,
     opacity,
     showLabels,
@@ -504,6 +507,44 @@ export function MapView(props: MapViewProps) {
       );
     }
   }, [mapReady, keymap, corners]);
+
+  // Render this page's human (OIM truth) footprint(s) in green, so the human georeferencing
+  // shows alongside the computed fit. A split page carries all footprints sharing its page
+  // number. Null hides them.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+
+    const geojson: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: (truth ?? []).map((ring) => ({
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [ring] },
+        properties: {},
+      })),
+    };
+
+    const existing = map.getSource('truth') as
+      | maplibregl.GeoJSONSource
+      | undefined;
+    if (existing) {
+      existing.setData(geojson);
+    } else {
+      map.addSource('truth', { type: 'geojson', data: geojson });
+      map.addLayer({
+        id: 'truth-fill',
+        type: 'fill',
+        source: 'truth',
+        paint: { 'fill-color': '#16a34a', 'fill-opacity': 0.08 },
+      });
+      map.addLayer({
+        id: 'truth-line',
+        type: 'line',
+        source: 'truth',
+        paint: { 'line-color': '#16a34a', 'line-width': 1.5 },
+      });
+    }
+  }, [mapReady, truth]);
 
   return <div id="map" ref={containerRef} />;
 }

--- a/app/src/geometry.test.ts
+++ b/app/src/geometry.test.ts
@@ -3,6 +3,7 @@ import {
   circlePolygon,
   computeCorners,
   crosshairLines,
+  distanceKm,
   distanceMiles,
   pointInPolygon,
   polygonArea,
@@ -142,6 +143,17 @@ describe('distanceMiles', () => {
   it('computes a known distance (~1 degree latitude ≈ 69 miles)', () => {
     expect(distanceMiles(0, 40, 0, 41)).toBeGreaterThan(68);
     expect(distanceMiles(0, 40, 0, 41)).toBeLessThan(70);
+  });
+});
+
+describe('distanceKm', () => {
+  it('is zero for identical points', () => {
+    expect(distanceKm(-73.99, 40.7, -73.99, 40.7)).toBeCloseTo(0);
+  });
+
+  it('computes a known distance (~1 degree latitude ≈ 111 km)', () => {
+    expect(distanceKm(0, 40, 0, 41)).toBeGreaterThan(110);
+    expect(distanceKm(0, 40, 0, 41)).toBeLessThan(112);
   });
 });
 

--- a/app/src/geometry.ts
+++ b/app/src/geometry.ts
@@ -70,6 +70,16 @@ export function distanceMiles(
   return R * 2 * Math.asin(Math.sqrt(a));
 }
 
+/** Haversine distance in kilometers between two lon/lat points. */
+export function distanceKm(
+  lon1: number,
+  lat1: number,
+  lon2: number,
+  lat2: number,
+): number {
+  return distanceMiles(lon1, lat1, lon2, lat2) * 1.60934;
+}
+
 /**
  * Fit affine transform lon = a0 + a1*x + a2*y (and lat) from GCPs with lat/lon,
  * then map the 4 image corners to geographic coordinates.

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -68,6 +68,8 @@ export interface GeorefData {
   streets?: Street[];
   intersections?: IntersectionPoint[];
   keymap?: KeymapLocation;
+  /** This page's human (OIM truth) footprint(s): world-space [lon, lat] rings, one per split. */
+  truth?: [number, number][][];
 }
 
 /** New-format streets.json: detection list wrapped with image metadata. */

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -123,6 +123,86 @@ def annotation_transform_type(item: dict) -> str:
     return item.get("body", {}).get("transformation", {}).get("type", "polynomial")
 
 
+def parse_svg_polygon(svg_value: str) -> list[tuple[float, float]]:
+    """Parse the ``points`` of an ``<svg><polygon points="x,y x,y ..."/>`` selector.
+
+    Returns the vertices as (x, y) in the annotation's source-pixel frame — the same
+    frame as the GCP resourceCoords — or an empty list if no points are found.
+    """
+    match = re.search(r'points="([^"]*)"', svg_value)
+    if not match:
+        return []
+    points: list[tuple[float, float]] = []
+    for token in match.group(1).split():
+        x_str, _, y_str = token.partition(",")
+        try:
+            points.append((float(x_str), float(y_str)))
+        except ValueError:
+            continue
+    return points
+
+
+def truth_polygon_world(item: dict) -> list[list[float]] | None:
+    """World-space [lon, lat] ring of a truth annotation's page footprint, or None.
+
+    Fits the annotation's own transform from its GCPs and applies it to the SvgSelector
+    polygon (both live in source-pixel coordinates). Returns None when the annotation
+    lacks a usable selector or enough GCPs to fit.
+    """
+    selector = item.get("target", {}).get("selector", {})
+    if selector.get("type") != "SvgSelector":
+        return None
+    polygon = parse_svg_polygon(selector.get("value", ""))
+    gcps = extract_gcps(item)
+    if len(polygon) < 3 or len(gcps) < 3:
+        return None
+    A = fit_transform(gcps, annotation_transform_type(item))
+    ring = []
+    for px, py in polygon:
+        lon, lat = A @ np.array([px, py, 1.0])
+        ring.append([round(float(lon), 7), round(float(lat), 7)])
+    return ring
+
+
+def truth_polygons_world(iiif_path: Path) -> list[list[list[float]]]:
+    """Every truth annotation's page footprint in world space, from a IIIF file.
+
+    One [lon, lat] ring per annotation (split pages contribute several). Annotations
+    without a usable selector/fit are skipped. Order follows file order.
+    """
+    data: dict = json.loads(iiif_path.read_text())
+    rings = []
+    for item in data.get("items", []):
+        ring = truth_polygon_world(item)
+        if ring is not None:
+            rings.append(ring)
+    return rings
+
+
+def truth_page_number(item: dict) -> int | None:
+    """Page number N from a truth annotation label like '... p156' or '... p73 [1]'."""
+    match = re.search(r"\bp(\d+)", str(item.get("label", "")))
+    return int(match.group(1)) if match else None
+
+
+def truth_polygons_by_page(iiif_path: Path) -> dict[int, list[list[list[float]]]]:
+    """Truth page footprints grouped by page number.
+
+    A page's entry holds every truth annotation sharing its number — so a split page
+    (p73__1, p73__2, …) maps to all of page 73's footprints. Annotations without a
+    usable page number, selector, or fit are skipped.
+    """
+    data: dict = json.loads(iiif_path.read_text())
+    by_page: dict[int, list[list[list[float]]]] = {}
+    for item in data.get("items", []):
+        number = truth_page_number(item)
+        ring = truth_polygon_world(item)
+        if number is None or ring is None:
+            continue
+        by_page.setdefault(number, []).append(ring)
+    return by_page
+
+
 def north_angle(A: np.ndarray) -> float:
     """Return north direction in degrees from a 2×3 affine matrix.
 

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -9,8 +9,13 @@ from mapsnap.compare_iiif_georef import (
     load_split_polygons,
     match_split_pairs,
     page_label,
+    parse_svg_polygon,
     polygon_iou,
     split_numbers_disagree,
+    truth_page_number,
+    truth_polygon_world,
+    truth_polygons_by_page,
+    truth_polygons_world,
 )
 
 
@@ -145,3 +150,95 @@ def test_match_split_pairs_picks_best_overlap_not_file_order():
     assert truth["label"] == "P [1]"
     assert gen["id"] == "http://x/p__1/georef"
     assert {t["label"] for t in unmatched} == {"P [2]", "P [3]"}
+
+
+def test_parse_svg_polygon():
+    value = '<svg><polygon points="10,20 30.5,40 50,60.25" /></svg>'
+    assert parse_svg_polygon(value) == [(10.0, 20.0), (30.5, 40.0), (50.0, 60.25)]
+    assert parse_svg_polygon("<svg></svg>") == []
+
+
+def _identity_georef_item(polygon: list[tuple[float, float]]) -> dict:
+    # An annotation whose GCPs make pixel==world (affine = identity), so the world ring
+    # equals the input polygon; four GCPs so the polynomial fit is well-determined.
+    points = " ".join(f"{x},{y}" for x, y in polygon)
+    return {
+        "target": {
+            "selector": {
+                "type": "SvgSelector",
+                "value": f'<svg><polygon points="{points}" /></svg>',
+            },
+        },
+        "body": {
+            "features": [
+                {
+                    "properties": {"resourceCoords": [px, py]},
+                    "geometry": {"coordinates": [px, py]},
+                }
+                for px, py in [(0, 0), (100, 0), (100, 100), (0, 100)]
+            ],
+        },
+    }
+
+
+def test_truth_polygon_world_applies_annotation_transform():
+    poly = [(10.0, 20.0), (30.0, 20.0), (30.0, 40.0), (10.0, 40.0)]
+    ring = truth_polygon_world(_identity_georef_item(poly))
+    assert ring == [[10.0, 20.0], [30.0, 20.0], [30.0, 40.0], [10.0, 40.0]]
+
+
+def test_truth_polygon_world_none_without_selector_or_gcps():
+    # No SvgSelector.
+    assert truth_polygon_world({"target": {"selector": {"type": "Other"}}}) is None
+    # Fewer than three GCPs.
+    item = _identity_georef_item([(0, 0), (1, 0), (1, 1)])
+    item["body"]["features"] = item["body"]["features"][:2]
+    assert truth_polygon_world(item) is None
+
+
+def test_truth_polygons_world_reads_all_items(tmp_path):
+    poly = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]
+    doc = {
+        "items": [
+            _identity_georef_item(poly),
+            {"target": {"selector": {"type": "Other"}}},  # skipped: no polygon
+            _identity_georef_item(poly),
+        ]
+    }
+    path = tmp_path / "main.iiif.json"
+    path.write_text(json.dumps(doc))
+    rings = truth_polygons_world(path)
+    assert len(rings) == 2  # two usable annotations, one skipped
+    assert rings[0] == [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]]
+
+
+def test_truth_page_number():
+    assert truth_page_number({"label": "New Orleans | 1896 | Vol. 2 p156"}) == 156
+    assert truth_page_number({"label": "New Orleans | 1896 | Vol. 2 p73 [1]"}) == 73
+    assert truth_page_number({"label": "no page here"}) is None
+
+
+def test_truth_polygons_by_page_groups_splits(tmp_path):
+    def labeled(label: str, poly: list[tuple[float, float]]) -> dict:
+        item = _identity_georef_item(poly)
+        item["label"] = label
+        return item
+
+    a = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0)]
+    b = [(20.0, 0.0), (30.0, 0.0), (30.0, 10.0)]
+    c = [(0.0, 20.0), (10.0, 20.0), (10.0, 30.0)]
+    doc = {
+        "items": [
+            labeled("Vol p73 [1]", a),
+            labeled("Vol p73 [2]", b),  # same page 73, second split
+            labeled("Vol p90", c),
+            {"target": {"selector": {"type": "Other"}}, "label": "Vol p99"},  # skipped
+        ]
+    }
+    path = tmp_path / "main.iiif.json"
+    path.write_text(json.dumps(doc))
+    by_page = truth_polygons_by_page(path)
+    assert set(by_page) == {73, 90}  # p99 skipped (no polygon)
+    assert len(by_page[73]) == 2  # both splits of page 73
+    assert by_page[73][0] == [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]]
+    assert len(by_page[90]) == 1

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -30,6 +30,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
+from mapsnap.compare_iiif_georef import truth_polygons_by_page
 from mapsnap.keymap.locate import KeymapLocator, page_number, region_scale_m_per_px
 from mapsnap.streets import (
     DIRECTION_WORDS,
@@ -1196,6 +1197,7 @@ def _finalize_georef(
     extra_fields: dict | None = None,
     parameters: dict | None = None,
     keymap: dict | None = None,
+    truth_polygons: list[list[list[float]]] | None = None,
 ) -> tuple[float, tuple[float, float]]:
     """Print fit stats, write georef JSON, and return (scale_deg_per_px, page_center)."""
 
@@ -1283,6 +1285,8 @@ def _finalize_georef(
     }
     if keymap:
         result["keymap"] = keymap
+    if truth_polygons:
+        result["truth"] = truth_polygons
     if extra_fields:
         result.update(extra_fields)
     with open(output_path, "w") as f:
@@ -1772,6 +1776,7 @@ def _init_worker(
     locator: KeymapLocator | None = None,
     geojson_features: list[dict] | None = None,
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None,
+    truth_by_page: dict[int, list[list[list[float]]]] | None = None,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
@@ -1791,6 +1796,7 @@ def _init_worker(
         locator=locator,
         geojson_features=geojson_features or [],
         rectangle_index=rectangle_index,
+        truth_by_page=truth_by_page or None,
     )
 
 
@@ -1816,11 +1822,13 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
 
     locator: KeymapLocator | None = _worker_state["locator"]
     rectangle_index = _worker_state["rectangle_index"]  # (block_index, cos_phi) | None
-    keymap = (
-        locator.page_keymap(page_number(image_stem(image_path)))
-        if locator is not None
-        else None
+    number = page_number(image_stem(image_path))
+    # This page's truth footprint(s), matched by page number (all splits of the number).
+    truth_by_page = _worker_state["truth_by_page"]
+    truth_polygons = (
+        truth_by_page.get(number) if truth_by_page and number is not None else None
     )
+    keymap = locator.page_keymap(number) if locator is not None else None
 
     def run(
         block_index: dict, cos_phi: float, size_fraction: float = 1.0
@@ -1845,6 +1853,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                 "high_confidence_size_fraction"
             ],
             keymap=keymap,
+            truth_polygons=truth_polygons,
         )
 
     with _captured_page_log(log_path, _worker_state["debug"]):
@@ -1947,10 +1956,11 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     # debugger can still show where the key map expected this page.
     if keymap is not None and not result.success and result.deferred is None:
         nofit_path = output_path.replace(".georef.json", ".georef-nofit.json")
+        nofit: dict = {"keymap": keymap, "streets": [], "intersections": []}
+        if truth_polygons:
+            nofit["truth"] = truth_polygons
         with open(nofit_path, "w") as f:
-            json.dump(
-                {"keymap": keymap, "streets": [], "intersections": []}, f, indent=2
-            )
+            json.dump(nofit, f, indent=2)
     return image_path, result
 
 
@@ -1972,6 +1982,7 @@ def process_image(
     parameters: dict | None = None,
     high_confidence_size_fraction: float = 0.7,
     keymap: dict | None = None,
+    truth_polygons: list[list[list[float]]] | None = None,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -2135,6 +2146,7 @@ def process_image(
                 "img_h": img_h,
                 "parameters": parameters,
                 "keymap": keymap,
+                "truth_polygons": truth_polygons,
             },
         )
 
@@ -2164,6 +2176,7 @@ def process_image(
         initial_pair=seed_pair,
         parameters=parameters,
         keymap=keymap,
+        truth_polygons=truth_polygons,
     )
     rotation = math.atan2(float(A[1, 0]), float(-A[1, 1]))
     return ProcessResult(
@@ -2327,6 +2340,7 @@ def process_deferred_image(
     img_h: int = deferred["img_h"]
     parameters: dict | None = deferred["parameters"]
     keymap: dict | None = deferred.get("keymap")
+    truth_polygons: list[list[list[float]]] | None = deferred.get("truth_polygons")
 
     page_dim_lat = scale_deg_per_px * img_h
     page_dim_lon = scale_deg_per_px * img_w / cos_phi
@@ -2415,6 +2429,7 @@ def process_deferred_image(
         extra_fields=one_gcp_extra,
         parameters=parameters,
         keymap=keymap,
+        truth_polygons=truth_polygons,
     )
     return ProcessResult(
         success=decision.confirmed, scale_deg_per_px=scale, center=center
@@ -2667,6 +2682,21 @@ def main() -> None:
         file=sys.stderr,
     )
 
+    # If OIM truth (main.iiif.json) sits next to the centerlines, copy each page's truth
+    # footprint(s) (world coordinates) into that page's georef file so the debugger can
+    # overlay the human georeferencing. Matched by page number, so a split page gets all of
+    # its number's truth footprints (split index is not matched).
+    truth_by_page: dict[int, list[list[list[float]]]] | None = None
+    truth_iiif = Path(args.centerlines).parent / "main.iiif.json"
+    if truth_iiif.exists():
+        truth_by_page = truth_polygons_by_page(truth_iiif)
+        n_footprints = sum(len(v) for v in truth_by_page.values())
+        print(
+            f"Truth overlay: {n_footprints} footprints across {len(truth_by_page)} "
+            f"pages from {truth_iiif}",
+            file=sys.stderr,
+        )
+
     # With a georeferenced key map, each placed page is matched first against its own
     # neighborhood and, if that starves the fit, against the whole key-map rectangle (a
     # volume-wide box every page sits in — far smaller than the full centerlines).
@@ -2789,6 +2819,7 @@ def main() -> None:
         locator,
         geojson["features"] if locator is not None else None,
         rectangle_index,
+        truth_by_page,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(


### PR DESCRIPTION
Two debugger-map improvements plus a truth-data overlay, grouped because the truth rendering builds on the map changes.

## Map controls & fixes (`MapView.tsx`, `geometry.ts`)
- **Imperial scale bar** (`ScaleControl`) and a **rotation control** (`NavigationControl`).
- **Fixed-size key-map crosshair**: the center crosshair arms are now a fixed physical size (`CROSSHAIR_ARM_METERS = 61`, ~200 ft) instead of a fraction of the search radius, so they don't render unreadably tiny or huge across volumes.
- **No long animated transitions**: a view change farther than `MAX_ANIMATE_DISTANCE_KM = 10` jumps instantly instead of animating a multi-second pan across the map (`shouldAnimateTo` + `distanceKm`).

## Truth-data overlay (`compare_iiif_georef.py`, `georef_from_labels.py`, `App.tsx`, `MapView.tsx`, `types.ts`)
- When a `main.iiif.json` sits next to the centerlines, extract each page's human (OIM) truth footprint(s) and write them into the georef JSON under `truth`, grouped per page (splits grouped together).
- The debugger renders the page's truth polygon(s) in green, behind an off-by-default "show truth data" checkbox (disabled when unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)