### PR TITLE
Keep diverging intersection pixel locations (NOLA 1896 p153)

### DIFF
--- a/mapsnap/block_index_test.py
+++ b/mapsnap/block_index_test.py
@@ -55,6 +55,10 @@ def _feat(text: str, cx: float, cy: float, dir_pix: float) -> LabelFeature:
 EW = 0.0  # dir_pix for an east-west label (horizontal)
 NS = math.pi / 2  # dir_pix for a north-south label (vertical)
 
+# Image size for the p29n-scale fixtures (labels span ~2400 px). At the 5% diagonal tolerance,
+# crossings within ~177 px merge; the synthetic fixtures keep divergent crossings much farther.
+IMG_SIZE = (2500, 2500)
+
 
 # ---------------------------------------------------------------------------
 # build_block_index — basic construction
@@ -176,14 +180,14 @@ def test_build_index_multilinestring():
 
 
 def test_find_gcps_empty_features():
-    assert find_intersection_gcps([], build_block_index(_load_p29n())) == []
+    assert find_intersection_gcps([], build_block_index(_load_p29n()), IMG_SIZE) == []
 
 
 def test_find_gcps_no_matching_streets():
     # Features whose text doesn't match any block_index key produce no GCPs.
     index = build_block_index(_load_p29n())
     feats = [_feat("NONEXISTENT STREET", 500.0, 500.0, EW)]
-    assert find_intersection_gcps(feats, index) == []
+    assert find_intersection_gcps(feats, index, IMG_SIZE) == []
 
 
 def test_find_gcps_grand_x_peshtigo():
@@ -195,7 +199,7 @@ def test_find_gcps_grand_x_peshtigo():
         _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
         _feat("NORTH PESHTIGO COURT", 1354.0, 2372.0, NS),
     ]
-    gcps = find_intersection_gcps(feats, index)
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(gcps) == 1
     gcp = gcps[0]
     assert {gcp.label_a, gcp.label_b} == {"EAST GRAND AVENUE", "NORTH PESHTIGO COURT"}
@@ -213,7 +217,7 @@ def test_find_gcps_lake_shore_x_ohio():
         _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
         _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
     ]
-    gcps = find_intersection_gcps(feats, index)
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(gcps) == 1
     gcp = gcps[0]
     assert {gcp.label_a, gcp.label_b} == {"NORTH LAKE SHORE DRIVE", "EAST OHIO STREET"}
@@ -229,7 +233,7 @@ def test_find_gcps_parallel_streets_produce_no_gcp():
         _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
         _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
     ]
-    assert find_intersection_gcps(feats, index) == []
+    assert find_intersection_gcps(feats, index, IMG_SIZE) == []
 
 
 def test_curved_junction_straightening_skips_jogs(monkeypatch):
@@ -266,7 +270,7 @@ def test_curved_junction_straightening_skips_jogs(monkeypatch):
         _feat("SINGLE STREET", 700.0, 300.0, NS),
         _feat("JOG STREET", 300.0, 300.0, NS),
     ]
-    module.find_intersection_gcps(feats, index)
+    module.find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(calls) == 1  # only the unique crossing was a straightening candidate
     assert calls[0] == pytest.approx((-90.0, 30.0), abs=1e-6)
 
@@ -280,7 +284,7 @@ def test_find_gcps_sorted_by_pixel_dist():
         _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
         _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
     ]
-    gcps = find_intersection_gcps(feats, index)
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(gcps) == 2
     assert gcps[0].pixel_dist < gcps[1].pixel_dist
     assert {gcps[0].label_a, gcps[0].label_b} == {
@@ -290,43 +294,63 @@ def test_find_gcps_sorted_by_pixel_dist():
 
 
 # ---------------------------------------------------------------------------
-# find_intersection_gcps — one GCP per (label_a, label_b, cluster)
+# find_intersection_gcps — merge coincident crossings, keep divergent ones
 # ---------------------------------------------------------------------------
 
 
-def test_find_gcps_three_lake_instances_one_gcp():
-    # Three detections of "NORTH LAKE SHORE DRIVE" at different pixel positions.
-    # Combined with one EAST OHIO STREET, exactly one GCP must be returned —
-    # the (fa, fb) pair with the smallest pixel_dist.
-    #
-    #   (1883, 1969) × (780, 1591)  pixel_dist ≈ 1166
-    #   (1606,  613) × (780, 1591)  pixel_dist ≈ 1280
-    #   (1186, 1775) × (780, 1591)  pixel_dist ≈  446  ← selected
+def test_find_gcps_collinear_duplicates_collapse_to_one():
+    # Three collinear "NORTH LAKE SHORE DRIVE" labels (same N-S street line, x≈1883) crossing one
+    # EAST OHIO STREET all land at the same crossing (1883, 1591), so they collapse to a single
+    # GCP — the closest-labels (smallest pixel_dist) instance. This is the PR #30 win preserved.
     index = build_block_index(_load_p29n())
     feats = [
-        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
-        _feat("NORTH LAKE SHORE DRIVE", 1606.0, 613.0, NS),
-        _feat("NORTH LAKE SHORE DRIVE", 1186.0, 1775.0, NS),
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),  # pixel_dist ≈ 1166
+        _feat(
+            "NORTH LAKE SHORE DRIVE", 1883.0, 1400.0, NS
+        ),  # pixel_dist ≈ 1119 ← selected
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 700.0, NS),  # pixel_dist ≈ 1418
         _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
     ]
-    gcps = find_intersection_gcps(feats, index)
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(gcps) == 1
     gcp = gcps[0]
     assert {gcp.label_a, gcp.label_b} == {"NORTH LAKE SHORE DRIVE", "EAST OHIO STREET"}
-    # Best crossing: N-S line through (1186, 1775) × E-W line through (780, 1591).
-    assert gcp.pixel == pytest.approx((1186.0, 1591.0), abs=1e-6)
-    assert gcp.pixel_dist == pytest.approx(445.7, abs=1.0)
+    assert gcp.pixel == pytest.approx((1883.0, 1591.0), abs=1e-6)
+    assert gcp.pixel_dist == pytest.approx(1119.0, abs=1.0)
+
+
+def test_find_gcps_divergent_crossings_kept_separate():
+    # Two "NORTH LAKE SHORE DRIVE" instances whose crossings with EAST OHIO land far apart —
+    # (1883, 1591) and (1186, 1591), ~697 px > the ~177 px tolerance — as when one label is a
+    # mislabel. Both survive as competing GCPs (same world node, different pixels) so RANSAC can
+    # pick the one consistent with the rest of the page (New Orleans p153's S Liberty × Julia).
+    index = build_block_index(_load_p29n())
+    feats = [
+        _feat("NORTH LAKE SHORE DRIVE", 1883.0, 1969.0, NS),
+        _feat("NORTH LAKE SHORE DRIVE", 1186.0, 1969.0, NS),
+        _feat("EAST OHIO STREET", 780.0, 1591.0, EW),
+    ]
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
+    assert len(gcps) == 2
+    assert all(
+        {g.label_a, g.label_b} == {"NORTH LAKE SHORE DRIVE", "EAST OHIO STREET"}
+        for g in gcps
+    )
+    assert {round(g.pixel[0]) for g in gcps} == {1186, 1883}
+    # Both share the one world node, so they are singular as a seed pair (RANSAC skips that pair).
+    assert gcps[0].geo == pytest.approx(gcps[1].geo, abs=1e-9)
 
 
 def test_find_gcps_two_instances_selects_closer_pair():
-    # Two Peshtigo labels: the one closer to the Grand label wins.
+    # Two collinear Peshtigo labels (x=1354) cross Grand at the same point (1354, 2215); they
+    # collapse to one GCP, keeping the instance closer to the Grand label.
     index = build_block_index(_load_p29n())
     feats = [
         _feat("NORTH PESHTIGO COURT", 1354.0, 2372.0, NS),  # pixel_dist ≈  574
         _feat("NORTH PESHTIGO COURT", 1354.0, 500.0, NS),  # pixel_dist ≈ 1716
         _feat("EAST GRAND AVENUE", 802.0, 2215.0, EW),
     ]
-    gcps = find_intersection_gcps(feats, index)
+    gcps = find_intersection_gcps(feats, index, IMG_SIZE)
     assert len(gcps) == 1
     assert gcps[0].pixel == pytest.approx((1354.0, 2215.0), abs=1e-6)
     assert gcps[0].pixel_dist < 600.0

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -528,6 +528,44 @@ def label_inliers(
 
 _CLUSTER_THRESHOLD_FT: float = 60.0
 
+# Candidate pixel crossings for one (street_a, street_b) world intersection are merged when they
+# land within this fraction of the image diagonal of each other. Genuine duplicate labels of a
+# straight street are collinear, so their crossings against the cross-street coincide (to within
+# detection noise) and collapse to a single GCP — this is what keeps the RANSAC seed-pair count
+# bounded (PR #30). Crossings that diverge further are kept as competing GCPs: a building legend
+# read as a street (New Orleans p153's "LIBERTY IRON WORKS" mis-read as S Liberty St, whose
+# diagonal box throws its crossing ~1200 px off the real street's) yields two genuinely different
+# image points for one world node, and only by keeping both can RANSAC pick the consistent one.
+DUP_CROSSING_TOL_FRACTION: float = 0.05
+
+
+def _dedupe_crossings_by_pixel(
+    candidates: list["IntersectionGCP"], tol_px: float
+) -> list["IntersectionGCP"]:
+    """Collapse candidate crossings that land at the same image point; keep divergent ones.
+
+    Single-linkage clusters ``candidates`` (all sharing one world intersection) by pixel-crossing
+    proximity, then returns the smallest-``pixel_dist`` (closest-labels, most reliable) member of
+    each cluster. Coincident crossings from genuine duplicate labels become one GCP; crossings
+    more than ``tol_px`` apart survive as separate GCPs for RANSAC to choose between.
+    """
+    clusters: list[list["IntersectionGCP"]] = []
+    for candidate in candidates:
+        for cluster in clusters:
+            if any(
+                math.hypot(
+                    candidate.pixel[0] - member.pixel[0],
+                    candidate.pixel[1] - member.pixel[1],
+                )
+                < tol_px
+                for member in cluster
+            ):
+                cluster.append(candidate)
+                break
+        else:
+            clusters.append([candidate])
+    return [min(cluster, key=lambda g: g.pixel_dist) for cluster in clusters]
+
 
 def _cluster_geo_coords(
     coords: list[tuple[float, float]],
@@ -751,6 +789,7 @@ def straight_intersection_geo(
 def find_intersection_gcps(
     features: list[LabelFeature],
     block_index: dict[str, list[Block]],
+    image_size: tuple[int, int],
 ) -> list[IntersectionGCP]:
     """Find GCPs from pairs of detected labels whose streets share a GeoJSON coordinate.
 
@@ -770,8 +809,16 @@ def find_intersection_gcps(
     pixel side is computed from straight label lines. This applies only where the pair meets
     once; a jog or divided road (multiple clusters) leaves every vertex unmodified.
 
+    When a street is detected several times, each instance produces one candidate pixel crossing
+    against the cross-street. Those that land at the same image point (genuine duplicate labels)
+    collapse to a single GCP — keeping the closest-labels one — so the RANSAC seed-pair count
+    stays bounded; those that diverge (a mislabel throwing its crossing far off) are kept as
+    competing GCPs. ``image_size`` (width, height) sets the merge tolerance via
+    :data:`DUP_CROSSING_TOL_FRACTION` of the diagonal.
+
     Returns GCPs sorted by pixel_dist ascending (closer labels = better pixel estimate).
     """
+    tol_px = DUP_CROSSING_TOL_FRACTION * math.hypot(image_size[0], image_size[1])
     street_coords: dict[str, set[tuple[float, float]]] = {}
     for feat in features:
         blocks = block_index.get(feat.text, [])
@@ -819,10 +866,11 @@ def find_intersection_gcps(
                     )
                     if straightened is not None:
                         geo = straightened
-                # For each (text_a, text_b, cluster), keep only the best (fa, fb) pair
-                # by pixel_dist. All pairs share the same geo centroid, so extra pairs
-                # only add RANSAC iterations without adding independent intersection anchors.
-                best: IntersectionGCP | None = None
+                # Each (fa, fb) instance pair gives one candidate crossing for this world node.
+                # Crossings that coincide (genuine duplicate labels) later collapse to one GCP;
+                # divergent ones (a mislabel like p153's "LIBERTY IRON WORKS") are kept apart so
+                # RANSAC can choose. See _dedupe_crossings_by_pixel / DUP_CROSSING_TOL_FRACTION.
+                candidates: list[IntersectionGCP] = []
                 for fa in feats_by_text[text_a]:
                     for fb in feats_by_text[text_b]:
                         ca, cb = np.array(fa.center), np.array(fb.center)
@@ -832,8 +880,8 @@ def find_intersection_gcps(
                         )
                         if crossing is None:
                             continue
-                        if best is None or pixel_dist < best.pixel_dist:
-                            best = IntersectionGCP(
+                        candidates.append(
+                            IntersectionGCP(
                                 label_a=text_a,
                                 label_b=text_b,
                                 pixel=crossing,
@@ -842,8 +890,8 @@ def find_intersection_gcps(
                                 feat_a=fa,
                                 feat_b=fb,
                             )
-                if best is not None:
-                    gcps.append(best)
+                        )
+                gcps.extend(_dedupe_crossings_by_pixel(candidates, tol_px))
 
     return sorted(gcps, key=lambda g: g.pixel_dist)
 
@@ -2094,7 +2142,7 @@ def process_image(
         file=sys.stderr,
     )
 
-    gcps = find_intersection_gcps(features, block_index)
+    gcps = find_intersection_gcps(features, block_index, (img_w, img_h))
     print(f"Intersection GCPs: {len(gcps)}", file=sys.stderr)
     if len(gcps) == 0:
         print("No intersection GCPs found.", file=sys.stderr)


### PR DESCRIPTION
Fixes a page that fails to georeference because a street's detected intersection is placed at the wrong pixel (New Orleans 1896 p153).

`find_intersection_gcps` had collapsed all candidate pixel crossings for one world intersection to the single closest-labels pair (an optimization from #30). That silently discards the correct crossing when a street has a **mislabeled** instance — on p153, the building legend "LIBERTY IRON WORKS" is mis-read as the street "S Liberty St", whose diagonal box throws its crossing ~1200 px off the real one, and the wrong crossing wins the closest-labels tiebreak.

Now candidate crossings are **deduped by pixel proximity** (`_dedupe_crossings_by_pixel`): coincident crossings from genuine duplicate labels still collapse to a single GCP (preserving #30's bound on RANSAC seed pairs), but crossings that diverge are kept as competing GCPs so RANSAC can pick the one consistent with the rest of the page. p153 now georeferences to ~10 m of truth, with no coverage or accuracy regressions across the volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)