### PR TITLE
Mapsnap keymap

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -31,6 +31,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.keymap.pipeline",
         "Prepare key map(s): OCR+georef, page-number detection, and region segmentation",
     ),
+    "keymap-detect": (
+        "mapsnap.keymap.identify",
+        "Identify which page(s) of a volume are key maps (from 25%-scale images)",
+    ),
     "iiif": (
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -27,6 +27,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.georef_from_labels",
         "Georeference a map from detected street labels",
     ),
+    "keymap": (
+        "mapsnap.keymap.pipeline",
+        "Prepare key map(s): OCR+georef, page-number detection, and region segmentation",
+    ),
     "iiif": (
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -15,7 +15,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from mapsnap.ctc_vocab_decode import HINT_STRINGS, generate_vocab_strings
-from mapsnap.keymap.locate import KeymapLocator, page_number
+from mapsnap.keymap.locate import KeymapLocator, page_number, resolve_keymaps
 from mapsnap.streets import build_block_index, polygon_side_lengths
 from mapsnap.utils import default_centerlines, image_stem
 
@@ -697,6 +697,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--ignore-keymap",
+        action="store_true",
+        help=(
+            "Do not use key maps. By default, when --keymap is not given, key-map detections "
+            "files (<stem>.keymap.json with a sibling .georef.json) next to the images or under "
+            "raw/ are discovered and used automatically; this flag turns that off."
+        ),
+    )
+    parser.add_argument(
         "--beam-width",
         type=int,
         default=20,
@@ -793,12 +802,15 @@ def main() -> None:
     # With a georeferenced key map, restrict each placed page's vocabulary to nearby streets,
     # falling back to the streets within the whole key map's rectangle (a volume-wide box every
     # page sits inside) for pages the neighborhood misses or the key map does not place.
+    keymap_files = resolve_keymaps(args.keymap, args.ignore_keymap, args.images)
     locator = None
     rectangle_vocab = vocab_strings
-    if args.keymap is not None:
-        locator = KeymapLocator.from_keymaps(
-            [Path(k) for k in args.keymap], args.keymap_radius
+    if keymap_files:
+        print(
+            "Using key map(s): " + ", ".join(str(path) for path in keymap_files),
+            file=sys.stderr,
         )
+        locator = KeymapLocator.from_keymaps(keymap_files, args.keymap_radius)
         rectangle = locator.rectangle_features(geojson["features"])
         if rectangle:
             rectangle_index = build_block_index(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -31,7 +31,12 @@ from PIL import Image
 from tqdm import tqdm
 
 from mapsnap.compare_iiif_georef import truth_polygons_by_page
-from mapsnap.keymap.locate import KeymapLocator, page_number, region_scale_m_per_px
+from mapsnap.keymap.locate import (
+    KeymapLocator,
+    page_number,
+    region_scale_m_per_px,
+    resolve_keymaps,
+)
 from mapsnap.streets import (
     DIRECTION_WORDS,
     HINT_STRINGS,
@@ -2793,6 +2798,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--ignore-keymap",
+        action="store_true",
+        help=(
+            "Do not use key maps. By default, when --keymap is not given, key-map detections "
+            "files (<stem>.keymap.json with a sibling .georef.json) next to the images or under "
+            "raw/ are discovered and used automatically; this flag turns that off."
+        ),
+    )
+    parser.add_argument(
         "--num-workers",
         type=int,
         default=1,
@@ -2867,12 +2881,15 @@ def main() -> None:
     # With a georeferenced key map, each placed page is matched first against its own
     # neighborhood and, if that starves the fit, against the whole key-map rectangle (a
     # volume-wide box every page sits in — far smaller than the full centerlines).
+    keymap_files = resolve_keymaps(args.keymap, args.ignore_keymap, args.images)
     locator = None
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None
-    if args.keymap is not None:
-        locator = KeymapLocator.from_keymaps(
-            [Path(k) for k in args.keymap], args.keymap_radius
+    if keymap_files:
+        print(
+            "Using key map(s): " + ", ".join(str(path) for path in keymap_files),
+            file=sys.stderr,
         )
+        locator = KeymapLocator.from_keymaps(keymap_files, args.keymap_radius)
         rectangle = locator.rectangle_features(geojson["features"])
         if rectangle:
             rectangle_bi = build_block_index(

--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -1,0 +1,247 @@
+"""Identify which page(s) of a volume are key maps, from the 25%-scale page images.
+
+A key map is, by definition, an index of the whole volume: one colored block per page with its
+page number printed inside. So its printed numbers, read back, reconstruct the volume's own page
+set — and that is what tells a key map apart from a regular map page. Detection *count* does not:
+a dense downtown page can carry more number-like glyphs (lot and dimension numbers) than the key
+map. But *coverage* of the volume's page set separates them cleanly (measured across four volumes:
+key maps recover 88-96% of their pages; regular pages <=4%).
+
+Two stages:
+
+  * candidates (cheap, filenames only) — the key map is always page 0 or page 1, including
+    lettered/split variants (p0, p0b, p0L/p0R, p1a-d). candidate_keys nominates the page-0 and
+    page-1 families, no model needed.
+  * confirmation (content) — read each candidate's numbers with the CNN localizer + CRNN
+    recognizer, snap to the valid page set, and keep candidates whose distinct valid reads cover a
+    large fraction of the volume (see is_keymap). Handles split key maps (each half still covers a
+    large share) and rejects number-dense regular pages.
+
+Everything runs on the always-present ``<volume>/p*.jpg``: 25% scale is the CNN's native working
+resolution (keymap_patches.working_scale uses it as-is), so no full-resolution download is needed
+to decide which pages to fetch and process as key maps.
+
+    uv run mapsnap keymap-detect data/chicago_il_1950_vol_1
+"""
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from mapsnap.keymap.crnn_model import build_crnn, central_group, ctc_greedy_decode
+from mapsnap.keymap.detect_numbers_cnn import (
+    DEFAULT_NMS_DIST,
+    DEFAULT_STRIDE,
+    DEFAULT_THRESHOLD,
+    detect_candidate_centers,
+)
+from mapsnap.keymap.detect_numbers_crnn import read_candidates, snap_to_pages
+from mapsnap.keymap.fit_keymap import page_number, volume_page_numbers
+from mapsnap.keymap.number_model import build_model, select_device
+from mapsnap.utils import image_stem
+
+DEFAULT_CNN_WEIGHTS = Path("models/number_detector.pt")
+DEFAULT_CRNN_WEIGHTS = Path("models/number_crnn.pt")
+
+# A candidate is confirmed a key map when its distinct valid page reads cover at least
+# MIN_COVERAGE of the volume's pages and number at least MIN_DISTINCT. The observed gap is huge
+# (key maps >=0.88, regular pages <=0.04), so 0.3 leaves room for a split key map (~0.45 each half)
+# while never admitting a regular page; MIN_DISTINCT guards tiny volumes where the ratio is coarse.
+MIN_COVERAGE = 0.3
+MIN_DISTINCT = 6
+
+# The key map is always page 0 or page 1 (its lettered/split siblings share that number); the
+# real map pages may begin far higher (e.g. p125), so we nominate by absolute number, not rank.
+CANDIDATE_PAGE_NUMBERS = (0, 1)
+
+
+def volume_valid_pages(volume: Path) -> list[str]:
+    """The volume's real page numbers as strings (positive, from its ``p*.jpg`` images)."""
+    return [
+        str(number) for number in sorted(volume_page_numbers(volume)) if number >= 1
+    ]
+
+
+def candidate_keys(volume: Path) -> list[str]:
+    """Page keys to test as key maps: every page numbered 0 or 1 (CANDIDATE_PAGE_NUMBERS).
+
+    The key map is always page 0 or page 1, and shares its number with any lettered/split siblings
+    (p0/p0b/p0L/p0R, p1a-d); nominating both families covers a page-0 cover sitting in front of a
+    page-1 key map while staying a handful of pages. Numbering by absolute value (not rank) avoids
+    dragging in the first real map page when it starts high, e.g. p125. Split panels (stems with
+    ``__``) are never key maps and are skipped.
+    """
+    by_number: dict[int, list[str]] = defaultdict(list)
+    for image in sorted(volume.glob("p*.jpg")):
+        stem = image_stem(str(image))
+        if "__" in stem:
+            continue
+        number = page_number(stem)
+        if number is not None and number in CANDIDATE_PAGE_NUMBERS:
+            by_number[number].append(stem)
+    keys: list[str] = []
+    for number in sorted(by_number):
+        keys.extend(by_number[number])
+    return keys
+
+
+def is_keymap(
+    distinct_valid: int,
+    volume_pages: int,
+    *,
+    min_coverage: float = MIN_COVERAGE,
+    min_distinct: int = MIN_DISTINCT,
+) -> bool:
+    """True when ``distinct_valid`` page reads cover enough of a ``volume_pages``-page volume.
+
+    A key map's numbers reconstruct the volume's page set (high coverage); a regular page yields
+    only a few coincidental valid reads. Requires both a coverage fraction and an absolute floor so
+    a tiny volume cannot pass on one lucky read.
+    """
+    if volume_pages <= 0:
+        return False
+    coverage = distinct_valid / volume_pages
+    return distinct_valid >= min_distinct and coverage >= min_coverage
+
+
+@torch.no_grad()
+def read_valid_pages(
+    image_path: str,
+    valid_pages: list[str],
+    cnn: torch.nn.Module,
+    crnn: torch.nn.Module,
+    device,
+) -> set[str]:
+    """Distinct read numbers on ``image_path`` that snap to a valid volume page.
+
+    Runs the same CNN-localize then CRNN-read as the key-map detector, but in memory (no sidecar
+    written) and keeping only the central number of each crop snapped to ``valid_pages``.
+    """
+    image = np.asarray(Image.open(image_path).convert("RGB"))
+    centers, factor = detect_candidate_centers(
+        image,
+        cnn,
+        device,
+        stride=DEFAULT_STRIDE,
+        threshold=DEFAULT_THRESHOLD,
+        nms_dist=DEFAULT_NMS_DIST,
+    )
+    reads, _ = read_candidates(image, centers, factor, crnn, device)
+    valid = set(valid_pages)
+    found: set[str] = set()
+    for _, path in reads:
+        group = central_group(path)
+        if group is None:
+            continue
+        text = snap_to_pages(
+            ctc_greedy_decode(path[group[0] : group[1] + 1]), valid_pages
+        )
+        if text in valid:
+            found.add(text)
+    return found
+
+
+def load_models(
+    cnn_weights: Path, crnn_weights: Path
+) -> tuple[torch.nn.Module, torch.nn.Module, object]:
+    """Load the CNN localizer and CRNN recognizer onto the selected device."""
+    device = select_device()
+    cnn = build_model(pretrained=False)
+    cnn.load_state_dict(torch.load(cnn_weights, map_location=device))
+    cnn.to(device)
+    crnn = build_crnn()
+    crnn.load_state_dict(torch.load(crnn_weights, map_location=device))
+    crnn.to(device)
+    return cnn, crnn, device
+
+
+def identify_keymaps(
+    volume: Path,
+    *,
+    scan_all: bool = False,
+    min_coverage: float = MIN_COVERAGE,
+    min_distinct: int = MIN_DISTINCT,
+    cnn_weights: Path = DEFAULT_CNN_WEIGHTS,
+    crnn_weights: Path = DEFAULT_CRNN_WEIGHTS,
+) -> list[str]:
+    """Page keys of ``volume`` that are key maps (candidate generation + coverage confirmation).
+
+    By default only the low-numbered candidate pages are tested (candidate_keys); ``scan_all``
+    tests every non-split page image, a slower fallback for a volume whose key map is not in the
+    front matter. Returns the confirmed keys sorted by page number.
+    """
+    valid_pages = volume_valid_pages(volume)
+    if scan_all:
+        keys = [
+            image_stem(str(image))
+            for image in sorted(volume.glob("p*.jpg"))
+            if "__" not in image_stem(str(image))
+        ]
+    else:
+        keys = candidate_keys(volume)
+
+    cnn, crnn, device = load_models(cnn_weights, crnn_weights)
+    confirmed: list[str] = []
+    for key in keys:
+        image = volume / f"{key}.jpg"
+        if not image.exists():
+            continue
+        found = read_valid_pages(str(image), valid_pages, cnn, crnn, device)
+        coverage = len(found) / len(valid_pages) if valid_pages else 0.0
+        keymap = is_keymap(
+            len(found),
+            len(valid_pages),
+            min_coverage=min_coverage,
+            min_distinct=min_distinct,
+        )
+        print(
+            f"  {key:8s} distinct-valid={len(found):4d}/{len(valid_pages)} "
+            f"coverage={coverage:5.2f} {'KEY MAP' if keymap else ''}",
+            file=sys.stderr,
+        )
+        if keymap:
+            confirmed.append(key)
+    return sorted(confirmed, key=lambda key: (page_number(key) or 0, key))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Identify which page(s) of a volume are key maps (from 25%-scale images)."
+    )
+    parser.add_argument(
+        "volume", type=Path, help="Volume directory holding p*.jpg page images."
+    )
+    parser.add_argument(
+        "--scan-all",
+        action="store_true",
+        help="Test every page, not just the low-numbered candidates (slower fallback).",
+    )
+    parser.add_argument(
+        "--min-coverage", type=float, default=MIN_COVERAGE, metavar="FRAC"
+    )
+    parser.add_argument("--min-distinct", type=int, default=MIN_DISTINCT, metavar="N")
+    parser.add_argument("--cnn-weights", type=Path, default=DEFAULT_CNN_WEIGHTS)
+    parser.add_argument("--crnn-weights", type=Path, default=DEFAULT_CRNN_WEIGHTS)
+    args = parser.parse_args()
+
+    keys = identify_keymaps(
+        args.volume,
+        scan_all=args.scan_all,
+        min_coverage=args.min_coverage,
+        min_distinct=args.min_distinct,
+        cnn_weights=args.cnn_weights,
+        crnn_weights=args.crnn_weights,
+    )
+    if not keys:
+        print(f"No key map identified in {args.volume}.", file=sys.stderr)
+        sys.exit(1)
+    print(" ".join(keys))
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/keymap/identify_test.py
+++ b/mapsnap/keymap/identify_test.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from mapsnap.keymap.identify import candidate_keys, is_keymap, volume_valid_pages
+
+
+def make_volume(tmp_path: Path, names: list[str]) -> Path:
+    volume = tmp_path / "vol"
+    volume.mkdir()
+    for name in names:
+        (volume / name).write_bytes(b"")
+    return volume
+
+
+def test_candidate_keys_page_zero_family(tmp_path: Path):
+    # p0 is the key map; taking the two smallest numbers also nominates the page-1 page.
+    volume = make_volume(
+        tmp_path, ["p0.jpg", "p1N.jpg", "p5.jpg", "p112N.jpg", "covr.jpg"]
+    )
+    assert candidate_keys(volume) == ["p0", "p1N"]
+
+
+def test_candidate_keys_lettered_page_one_family(tmp_path: Path):
+    # No page 0 (washington-style): the page-1 family p1a-d are the candidates.
+    volume = make_volume(
+        tmp_path, ["p1a.jpg", "p1b.jpg", "p1c.jpg", "p1d.jpg", "p125.jpg"]
+    )
+    assert candidate_keys(volume) == ["p1a", "p1b", "p1c", "p1d"]
+
+
+def test_candidate_keys_skips_split_panels(tmp_path: Path):
+    volume = make_volume(tmp_path, ["p0.jpg", "p1N.jpg", "p1N__2.jpg", "p1N__3.jpg"])
+    assert candidate_keys(volume) == ["p0", "p1N"]
+
+
+def test_volume_valid_pages_positive_only(tmp_path: Path):
+    # p0's "page 0" and non-numeric covr are excluded; split panels collapse to their number.
+    volume = make_volume(
+        tmp_path, ["p0.jpg", "p1.jpg", "p2.jpg", "p2__2.jpg", "covr.jpg"]
+    )
+    assert volume_valid_pages(volume) == ["1", "2"]
+
+
+def test_is_keymap_high_coverage():
+    assert is_keymap(98, 112)  # chicago key map: 0.88
+    assert is_keymap(23, 24)  # champaign key map: 0.96
+
+
+def test_is_keymap_rejects_regular_page():
+    assert not is_keymap(1, 112)  # a coincidental valid read
+    assert not is_keymap(0, 101)  # detroit p66: many candidates, zero valid coverage
+
+
+def test_is_keymap_accepts_split_halfmap():
+    # A split key map covers roughly half the volume — still far above any regular page.
+    assert is_keymap(50, 112)
+
+
+def test_is_keymap_absolute_floor_guards_tiny_volume():
+    # 5 valid reads out of 12 is 0.42 coverage but below the absolute distinct floor.
+    assert not is_keymap(5, 12, min_coverage=0.3, min_distinct=6)
+
+
+def test_is_keymap_empty_volume():
+    assert not is_keymap(0, 0)

--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -22,7 +22,7 @@ Point = tuple[float, float]
 M_PER_DEG_LAT = 110540.0
 M_PER_DEG_LON_EQUATOR = 111320.0
 
-__all__ = ["KeymapLocator", "page_number"]
+__all__ = ["KeymapLocator", "page_number", "discover_keymaps", "resolve_keymaps"]
 
 
 def keymap_georef_path(keymap_json: Path) -> Path:
@@ -30,6 +30,44 @@ def keymap_georef_path(keymap_json: Path) -> Path:
     return keymap_json.with_name(
         keymap_json.name.replace(".keymap.json", ".georef.json")
     )
+
+
+def discover_keymaps(image_paths: list[str]) -> list[Path]:
+    """Usable ``<stem>.keymap.json`` files near the input images, for default key-map use.
+
+    Searches each image's own directory and its ``raw/`` subdirectory (where ``mapsnap keymap``
+    writes them) and keeps only detections files that have the sibling ``<stem>.georef.json`` a
+    locator needs — a bare ``.keymap.json`` from a key map whose georeferencing failed is skipped.
+    Returns them de-duplicated in directory-then-name order; empty when none are found.
+    """
+    directories: list[Path] = []
+    for image_path in image_paths:
+        parent = Path(image_path).parent
+        for directory in (parent, parent / "raw"):
+            if directory.is_dir() and directory not in directories:
+                directories.append(directory)
+    found: list[Path] = []
+    for directory in directories:
+        for keymap_json in sorted(directory.glob("*.keymap.json")):
+            if keymap_georef_path(keymap_json).exists() and keymap_json not in found:
+                found.append(keymap_json)
+    return found
+
+
+def resolve_keymaps(
+    explicit: list[str] | None, ignore: bool, image_paths: list[str]
+) -> list[Path]:
+    """The key-map files ``ocr``/``georef`` should use, applying the shared flag precedence.
+
+    ``--ignore-keymap`` (``ignore``) turns the feature off; otherwise an explicit ``--keymap``
+    list wins, and with neither the key maps are auto-discovered next to the images (see
+    :func:`discover_keymaps`). Centralized so both commands resolve key maps identically.
+    """
+    if ignore:
+        return []
+    if explicit:
+        return [Path(path) for path in explicit]
+    return discover_keymaps(image_paths)
 
 
 def keymap_regions_path(keymap_json: Path) -> Path:

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -1,13 +1,16 @@
 import math
+from pathlib import Path
 
 from mapsnap.keymap.locate import (
     KeymapLocator,
     bilinear_pixel_to_world,
+    discover_keymaps,
     estimate_radius,
     geometry_segments,
     geometry_vertices,
     meters_between,
     page_number,
+    resolve_keymaps,
 )
 
 # A key map georeferenced to an axis-aligned box: 1000x500 px over lon 0..1, lat 2..3
@@ -220,3 +223,59 @@ def test_rectangle_features_unions_multiple_keymaps():
     kept = locator.rectangle_features(features)
     assert kept is not None
     assert {f["id"] for f in kept} == {"in_a", "in_b"}  # union of both rectangles
+
+
+def make_keymap(directory: Path, stem: str, *, with_georef: bool = True) -> Path:
+    """Create a <stem>.keymap.json (and optionally its .georef.json sibling) in directory."""
+    directory.mkdir(parents=True, exist_ok=True)
+    keymap = directory / f"{stem}.keymap.json"
+    keymap.write_text("{}")
+    if with_georef:
+        (directory / f"{stem}.georef.json").write_text("{}")
+    return keymap
+
+
+def test_discover_keymaps_finds_under_raw(tmp_path: Path):
+    # ocr/georef run on top-level pages; the key map's sidecars live under raw/.
+    raw = tmp_path / "raw"
+    make_keymap(raw, "p0")
+    found = discover_keymaps([str(tmp_path / "p5.jpg"), str(tmp_path / "p6.jpg")])
+    assert found == [raw / "p0.keymap.json"]
+
+
+def test_discover_keymaps_finds_in_same_directory(tmp_path: Path):
+    make_keymap(tmp_path, "p1b")
+    assert discover_keymaps([str(tmp_path / "p1b.jpg")]) == [
+        tmp_path / "p1b.keymap.json"
+    ]
+
+
+def test_discover_keymaps_skips_keymap_without_georef(tmp_path: Path):
+    # A key map whose georeferencing failed has no .georef.json; a locator can't use it.
+    make_keymap(tmp_path / "raw", "p0", with_georef=False)
+    assert discover_keymaps([str(tmp_path / "p5.jpg")]) == []
+
+
+def test_discover_keymaps_dedups_across_images(tmp_path: Path):
+    make_keymap(tmp_path / "raw", "p0")
+    images = [str(tmp_path / "p5.jpg"), str(tmp_path / "p6.jpg")]
+    assert discover_keymaps(images) == [tmp_path / "raw" / "p0.keymap.json"]
+
+
+def test_resolve_keymaps_ignore_beats_everything(tmp_path: Path):
+    make_keymap(tmp_path / "raw", "p0")
+    assert (
+        resolve_keymaps(["explicit.keymap.json"], True, [str(tmp_path / "p5.jpg")])
+        == []
+    )
+
+
+def test_resolve_keymaps_explicit_wins_over_discovery(tmp_path: Path):
+    make_keymap(tmp_path / "raw", "p0")
+    resolved = resolve_keymaps(["given.keymap.json"], False, [str(tmp_path / "p5.jpg")])
+    assert resolved == [Path("given.keymap.json")]
+
+
+def test_resolve_keymaps_falls_back_to_discovery(tmp_path: Path):
+    keymap = make_keymap(tmp_path / "raw", "p0")
+    assert resolve_keymaps(None, False, [str(tmp_path / "p5.jpg")]) == [keymap]

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -140,10 +140,12 @@ def main() -> None:
     #    downstream --keymap flag has a <stem>.georef.json to read. OCR runs at a key-map-
     #    appropriate detector floor and (by default) tiles the oversized sheet at native
     #    resolution; georef must be told to geocode key maps, which it skips by default once a
-    #    <stem>.keymap.json sibling exists.
+    #    <stem>.keymap.json sibling exists. Both pass --ignore-keymap so that on a re-run they do
+    #    not auto-discover the key map's own .keymap.json and try to locate it against itself.
     ocr_cmd = [
         "mapsnap",
         "ocr",
+        "--ignore-keymap",
         "--centerlines",
         centerlines,
         "--min-short-side",
@@ -156,6 +158,7 @@ def main() -> None:
         [
             "mapsnap",
             "georef",
+            "--ignore-keymap",
             "--centerlines",
             centerlines,
             "--geocode_keymaps",

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -1,0 +1,192 @@
+"""Prepare a full-resolution Sanborn key map for use by the main pipeline.
+
+A key map is the volume's index sheet: one saturated colored block per page, its page number
+printed inside, drawn over an overview of the city's major streets. Downstream, ``mapsnap ocr``
+and ``mapsnap georef`` take ``--keymap`` files to restrict each page's vocabulary/matching to
+its key-map neighborhood; that needs three sidecars next to the (raw) key-map image:
+
+  * ``<stem>.georef.json`` — the key map georeferenced in the world, so a page number's pixel
+    location maps to a world location. Produced by OCR'ing the key map's own street labels and
+    fitting a transform, exactly like a regular page (``mapsnap ocr`` then ``mapsnap georef``).
+    Running it on its own here lets the key map use a page-appropriate ``--min-short-side``: the
+    raw sheet is ~4x the linear resolution of the 25%-scale volume pages, so its text is ~4x
+    larger and a larger detector floor is right. OCR tiles the oversized sheet at native
+    resolution by default, which is what makes the key map's small labels detectable.
+  * ``<stem>.keymap.json`` — the pixel location of every page number, from the CNN localizer +
+    CRNN recognizer (``mapsnap.keymap.detect_numbers_crnn``). ``--pages`` is derived from the
+    volume's page images so decodes snap to valid page numbers and the narrow-detection re-read
+    (which recovers a squished multi-digit number) is enabled.
+  * ``<stem>.regions.panels.json`` — the colored block polygon around each page number
+    (``mapsnap.keymap.page_regions``), so a page's key-map neighborhood is its own block.
+
+    uv run mapsnap keymap data/chicago_il_1950_vol_1/raw/p0b.jpg
+"""
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+from mapsnap.keymap.fit_keymap import volume_page_numbers
+from mapsnap.keymap.records import keymap_path
+from mapsnap.utils import default_centerlines, run_cmd
+
+
+def format_page_spec(numbers: Iterable[int]) -> str:
+    """Collapse page numbers into a compact spec like ``"1-3,5,7-9"`` (a parse_page_spec input)."""
+    ordered = sorted(set(numbers))
+    if not ordered:
+        return ""
+    ranges: list[str] = []
+    start = previous = ordered[0]
+    for number in ordered[1:]:
+        if number == previous + 1:
+            previous = number
+            continue
+        ranges.append(str(start) if start == previous else f"{start}-{previous}")
+        start = previous = number
+    ranges.append(str(start) if start == previous else f"{start}-{previous}")
+    return ",".join(ranges)
+
+
+def keymap_volume_dir(image_path: Path) -> Path:
+    """Volume directory holding a key map's page images.
+
+    Full-resolution key maps live in a ``raw/`` subdirectory (``<volume>/raw/p0b.jpg``); the
+    scaled per-page images used to derive the valid page set live in ``<volume>``. So the volume
+    is the image's parent, or its grandparent when the image sits under ``raw/``.
+    """
+    parent = image_path.parent
+    return parent.parent if parent.name == "raw" else parent
+
+
+def valid_page_spec(keymap_images: list[Path]) -> str:
+    """A ``--pages`` spec of the volume's real page numbers, for the CRNN reader.
+
+    Unions the page numbers found across each key map's volume (from its ``p*.jpg`` page images),
+    drops any non-positive number (a ``p0b`` key map's own "page 0"), and formats the result as a
+    compact range spec. Returns "" when no page numbers are found.
+    """
+    numbers: set[int] = set()
+    for volume in {keymap_volume_dir(image) for image in keymap_images}:
+        numbers |= volume_page_numbers(volume)
+    return format_page_spec(number for number in numbers if number >= 1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare full-resolution key map(s): OCR+georef, page numbers, and regions."
+    )
+    parser.add_argument(
+        "images",
+        nargs="+",
+        metavar="IMAGE",
+        help="Full-resolution key-map image(s), e.g. data/<volume>/raw/p0b.jpg.",
+    )
+    parser.add_argument(
+        "--min-short-side",
+        type=int,
+        default=60,
+        metavar="PX",
+        help=(
+            "Detector floor for the key-map OCR pass (default: %(default)s, ~4x the 25%%-scale "
+            "page default of 15 to match the full-resolution key map)."
+        ),
+    )
+    parser.add_argument(
+        "--pages",
+        metavar="SPEC",
+        help=(
+            "Valid page-number set for the CRNN reader (default: derived from the volume's page "
+            "images, e.g. '1-112')."
+        ),
+    )
+    parser.add_argument(
+        "--centerlines",
+        metavar="GEOJSON",
+        help=(
+            "Centerlines GeoJSON for the OCR/georef passes (default: a centerlines.geojson found "
+            "next to the key map(s) or in the volume directory)."
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip the key-map OCR pass for images that already have a .streets.json output.",
+    )
+    args = parser.parse_args()
+
+    images = [Path(image) for image in args.images]
+
+    centerlines = args.centerlines
+    if centerlines is None:
+        found = default_centerlines(images[0].parent)
+        if found is None:
+            sys.exit(
+                "No --centerlines given and no centerlines.geojson found next to the key map(s)."
+            )
+        centerlines = str(found)
+        print(f"Using centerlines: {centerlines}", file=sys.stderr)
+
+    pages = args.pages or valid_page_spec(images)
+    if not pages:
+        sys.exit(
+            "Could not derive a --pages spec from the volume's page images; pass --pages."
+        )
+
+    image_args = [str(image) for image in images]
+
+    # 1. Georeference each key map from its own street labels, exactly like a regular page, so the
+    #    downstream --keymap flag has a <stem>.georef.json to read. OCR runs at a key-map-
+    #    appropriate detector floor and (by default) tiles the oversized sheet at native
+    #    resolution; georef must be told to geocode key maps, which it skips by default once a
+    #    <stem>.keymap.json sibling exists.
+    ocr_cmd = [
+        "mapsnap",
+        "ocr",
+        "--centerlines",
+        centerlines,
+        "--min-short-side",
+        str(args.min_short_side),
+    ]
+    if args.resume:
+        ocr_cmd.append("--resume")
+    run_cmd([*ocr_cmd, *image_args])
+    run_cmd(
+        [
+            "mapsnap",
+            "georef",
+            "--centerlines",
+            centerlines,
+            "--geocode_keymaps",
+            *image_args,
+        ]
+    )
+
+    # 2. Locate every page number with the CNN localizer + CRNN recognizer. Passing --pages both
+    #    snaps decodes to valid page numbers and enables the narrow-detection re-read.
+    run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "mapsnap.keymap.detect_numbers_crnn",
+            "--pages",
+            pages,
+            *image_args,
+        ]
+    )
+
+    # 3. Segment the colored block around each page number (one key map at a time).
+    for image in images:
+        run_cmd(
+            [
+                sys.executable,
+                "-m",
+                "mapsnap.keymap.page_regions",
+                keymap_path(str(image)),
+            ]
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/keymap/pipeline_test.py
+++ b/mapsnap/keymap/pipeline_test.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from mapsnap.keymap.pipeline import (
+    format_page_spec,
+    keymap_volume_dir,
+    valid_page_spec,
+)
+
+
+def test_format_page_spec_single_run():
+    assert format_page_spec([1, 2, 3, 4, 5]) == "1-5"
+
+
+def test_format_page_spec_with_gaps():
+    assert format_page_spec([1, 2, 3, 5, 7, 8, 9]) == "1-3,5,7-9"
+
+
+def test_format_page_spec_dedups_and_sorts():
+    assert format_page_spec([10, 1, 2, 2, 1]) == "1-2,10"
+
+
+def test_format_page_spec_singletons():
+    assert format_page_spec([1, 3, 5]) == "1,3,5"
+
+
+def test_format_page_spec_empty():
+    assert format_page_spec([]) == ""
+
+
+def test_keymap_volume_dir_under_raw():
+    # A full-resolution key map lives in <volume>/raw/, so the volume is the grandparent.
+    assert keymap_volume_dir(Path("data/chicago/raw/p0b.jpg")) == Path("data/chicago")
+
+
+def test_keymap_volume_dir_flat():
+    # A key map alongside the scaled pages has the volume as its immediate parent.
+    assert keymap_volume_dir(Path("data/chicago/p0b.jpg")) == Path("data/chicago")
+
+
+def test_valid_page_spec_from_volume_images(tmp_path: Path):
+    volume = tmp_path / "vol"
+    (volume / "raw").mkdir(parents=True)
+    for name in ["p1.jpg", "p2.jpg", "p3.jpg", "p10.jpg", "p0b.jpg", "covr.jpg"]:
+        (volume / name).write_bytes(b"")
+    keymap = volume / "raw" / "p0b.jpg"
+    keymap.write_bytes(b"")
+    # covr has no page number; p0b's "page 0" is dropped as non-positive.
+    assert valid_page_spec([keymap]) == "1-3,10"
+
+
+def test_valid_page_spec_unions_multiple_volumes(tmp_path: Path):
+    first = tmp_path / "a"
+    first.mkdir()
+    for name in ["p1.jpg", "p2.jpg", "p0b.jpg"]:
+        (first / name).write_bytes(b"")
+    second = tmp_path / "b"
+    second.mkdir()
+    for name in ["p4.jpg", "p5.jpg", "p0b.jpg"]:
+        (second / name).write_bytes(b"")
+    assert valid_page_spec([first / "p0b.jpg", second / "p0b.jpg"]) == "1-2,4-5"

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -87,7 +87,7 @@ def main() -> None:
         ]
     )
 
-    run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
+    run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 
 
 if __name__ == "__main__":

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -61,6 +61,21 @@ def main() -> None:
         ]
     )
 
+    # Identify the key map(s) from the 25%-scale pages, download just those at full resolution,
+    # and build their sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json
+    # and restrict each page to its key-map neighborhood.
+    from mapsnap.keymap.identify import identify_keymaps
+
+    keymap_keys = identify_keymaps(dir_path)
+    if keymap_keys:
+        print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
+        scaled_keymaps = [str(dir_path / f"{key}.jpg") for key in keymap_keys]
+        run_cmd(["mapsnap", "download-raw", *scaled_keymaps])
+        raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+        run_cmd(["mapsnap", "keymap", *raw_keymaps])
+    else:
+        print("No key map identified; continuing without one.", flush=True)
+
     ocr_images = [str(p) for p in list_pages(dir_path)]
     run_cmd(
         [

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -5,7 +5,7 @@ import glob
 import sys
 from pathlib import Path
 
-from mapsnap.utils import list_pages, run_cmd, write_run_record
+from mapsnap.utils import Step, list_pages, run_cmd, write_run_record
 
 
 def main() -> None:
@@ -19,6 +19,14 @@ def main() -> None:
     parser.add_argument("dir", metavar="DIR", help="Directory containing manifest.json")
     parser.add_argument(
         "relation", metavar="RELATION", help="OSM relation ID for the street network"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Re-run every step even if it already completed. By default a re-run resumes, "
+            "skipping steps whose <dir>/.pipeline/<step>.done stamp is present."
+        ),
     )
     args = parser.parse_args()
 
@@ -35,57 +43,67 @@ def main() -> None:
         dir_path, "loc", {"manifest": str(manifest), "relation": args.relation}
     )
 
-    run_cmd(["mapsnap", "download-loc", "--scale", "pct:25", str(manifest)])
+    step = Step(dir_path, force=args.force)
+
+    with step("download-images"):
+        run_cmd(["mapsnap", "download-loc", "--scale", "pct:25", str(manifest)])
 
     # Detect and write split panels (pN__i.jpg + pN.panels.json) for pages that split.
     page_images = sorted(glob.glob(str(dir_path / "p*.jpg")))
-    run_cmd(["mapsnap", "split", *page_images])
+    with step("split"):
+        run_cmd(["mapsnap", "split", *page_images])
 
-    run_cmd(
-        [
-            "mapsnap",
-            "download-osm",
-            args.relation,
-            "--output",
-            str(dir_path / "streets.osm.json"),
-        ]
-    )
+    with step("download-osm"):
+        run_cmd(
+            [
+                "mapsnap",
+                "download-osm",
+                args.relation,
+                "--output",
+                str(dir_path / "streets.osm.json"),
+            ]
+        )
 
-    run_cmd(
-        [
-            "mapsnap",
-            "osm-to-geojson",
-            str(dir_path / "streets.osm.json"),
-            "--output",
-            str(dir_path / "centerlines.geojson"),
-        ]
-    )
+    with step("osm-to-geojson"):
+        run_cmd(
+            [
+                "mapsnap",
+                "osm-to-geojson",
+                str(dir_path / "streets.osm.json"),
+                "--output",
+                str(dir_path / "centerlines.geojson"),
+            ]
+        )
 
     # Identify the key map(s) from the 25%-scale pages, download just those at full resolution,
     # and build their sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json
     # and restrict each page to its key-map neighborhood.
-    from mapsnap.keymap.identify import identify_keymaps
+    with step("keymap"):
+        from mapsnap.keymap.identify import identify_keymaps
 
-    keymap_keys = identify_keymaps(dir_path)
-    if keymap_keys:
-        print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
-        scaled_keymaps = [str(dir_path / f"{key}.jpg") for key in keymap_keys]
-        run_cmd(["mapsnap", "download-raw", *scaled_keymaps])
-        raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-        run_cmd(["mapsnap", "keymap", *raw_keymaps])
-    else:
-        print("No key map identified; continuing without one.", flush=True)
+        keymap_keys = identify_keymaps(dir_path)
+        if keymap_keys:
+            print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
+            scaled_keymaps = [str(dir_path / f"{key}.jpg") for key in keymap_keys]
+            run_cmd(["mapsnap", "download-raw", *scaled_keymaps])
+            raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+            run_cmd(["mapsnap", "keymap", *raw_keymaps])
+        else:
+            print("No key map identified; continuing without one.", flush=True)
 
+    # --resume so an OCR interrupted partway resumes per page on the re-run that follows.
     ocr_images = [str(p) for p in list_pages(dir_path)]
-    run_cmd(
-        [
-            "mapsnap",
-            "ocr",
-            "--centerlines",
-            str(dir_path / "centerlines.geojson"),
-            *ocr_images,
-        ]
-    )
+    with step("ocr"):
+        run_cmd(
+            [
+                "mapsnap",
+                "ocr",
+                "--resume",
+                "--centerlines",
+                str(dir_path / "centerlines.geojson"),
+                *ocr_images,
+            ]
+        )
 
     run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -5,7 +5,15 @@ import glob
 import urllib.request
 from pathlib import Path
 
-from mapsnap.utils import image_stem, list_pages, run_cmd, write_run_record
+from mapsnap.utils import (
+    image_stem,
+    list_pages,
+    mark_step_done,
+    run_cmd,
+    run_step,
+    step_done,
+    write_run_record,
+)
 
 
 def download_file(url: str, dest: Path) -> None:
@@ -60,6 +68,14 @@ def main() -> None:
             "are kept and the other raw pages are deleted (they duplicate the 25%% pN.jpg)."
         ),
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Re-run every step even if it already completed. By default a re-run resumes, "
+            "skipping steps whose <dir>/.pipeline/<step>.done stamp is present."
+        ),
+    )
     args = parser.parse_args()
 
     print(args.sanborn_slug)
@@ -80,78 +96,117 @@ def main() -> None:
     )
 
     base_url = f"https://oldinsurancemaps.net/iiif/mosaic/{args.sanborn_slug}"
-    download_file(f"{base_url}/main-content/?trim=true", dir_path / "main.iiif.json")
-    download_file(f"{base_url}/key-map/?trim=true", dir_path / "key.iiif.json")
+    if args.force or not step_done(dir_path, "manifests"):
+        download_file(
+            f"{base_url}/main-content/?trim=true", dir_path / "main.iiif.json"
+        )
+        download_file(f"{base_url}/key-map/?trim=true", dir_path / "key.iiif.json")
+        mark_step_done(dir_path, "manifests")
+    else:
+        print("+ [skip manifests: already completed]", flush=True)
 
-    run_cmd(
-        [
-            "mapsnap",
-            "download-oim",
-            str(dir_path / "main.iiif.json"),
-            "--oim-url-prefix",
-            args.oim_prefix,
-        ]
-    )
+    # Download the full-resolution pages. The key map lives only in key.iiif.json (never in
+    # main.iiif.json), so download both into raw/ and let it be treated as just another page —
+    # the key-map detector then finds it by content, without the pipeline knowing its origin.
+    if args.force or not step_done(dir_path, "download-images"):
+        for iiif_name in ("main.iiif.json", "key.iiif.json"):
+            run_cmd(
+                [
+                    "mapsnap",
+                    "download-oim",
+                    str(dir_path / iiif_name),
+                    "--oim-url-prefix",
+                    args.oim_prefix,
+                ]
+            )
+        mark_step_done(dir_path, "download-images")
+    else:
+        print("+ [skip download-images: already completed]", flush=True)
 
     # Downscale the full-resolution raw/ pages to 25% top-level pN.jpg images.
     raw_images = sorted(glob.glob(str(dir_path / "raw" / "*.jpg")))
-    run_cmd(["mapsnap", "scale", *raw_images, "--output-dir", str(dir_path)])
+    run_step(
+        dir_path,
+        "scale",
+        ["mapsnap", "scale", *raw_images, "--output-dir", str(dir_path)],
+        force=args.force,
+    )
 
     # Detect and write split panels (pN__i.jpg + pN.panels.json) for pages that split.
     page_images = sorted(glob.glob(str(dir_path / "p*.jpg")))
-    run_cmd(["mapsnap", "split", *page_images])
+    run_step(dir_path, "split", ["mapsnap", "split", *page_images], force=args.force)
 
-    run_cmd(
+    run_step(
+        dir_path,
+        "download-osm",
         [
             "mapsnap",
             "download-osm",
             args.relation,
             "--output",
             str(dir_path / "streets.osm.json"),
-        ]
+        ],
+        force=args.force,
     )
 
-    run_cmd(
+    run_step(
+        dir_path,
+        "osm-to-geojson",
         [
             "mapsnap",
             "osm-to-geojson",
             str(dir_path / "streets.osm.json"),
             "--output",
             str(dir_path / "centerlines.geojson"),
-        ]
+        ],
+        force=args.force,
     )
 
     # Identify the key map(s) from the 25%-scale pages, keep only those at full resolution (the
     # other raw pages duplicate the 25% pN.jpg — delete them unless --keep_raw), and build their
     # sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json and restrict
     # each page to its key-map neighborhood.
-    from mapsnap.keymap.identify import identify_keymaps
+    if args.force or not step_done(dir_path, "keymap"):
+        from mapsnap.keymap.identify import identify_keymaps
 
-    keymap_keys = identify_keymaps(dir_path)
-    if keymap_keys:
-        print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
-        if not args.keep_raw:
-            delete_other_raw(dir_path, keymap_keys)
-        raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-        run_cmd(["mapsnap", "keymap", *raw_keymaps])
+        keymap_keys = identify_keymaps(dir_path)
+        if keymap_keys:
+            print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
+            if not args.keep_raw:
+                delete_other_raw(dir_path, keymap_keys)
+            raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+            run_cmd(["mapsnap", "keymap", *raw_keymaps])
+        else:
+            print("No key map identified; continuing without one.", flush=True)
+        mark_step_done(dir_path, "keymap")
     else:
-        print("No key map identified; continuing without one.", flush=True)
+        print("+ [skip keymap: already completed]", flush=True)
 
+    # --resume so an OCR interrupted partway resumes per page on the re-run that follows.
     ocr_images = [str(p) for p in list_pages(dir_path)]
-    run_cmd(
+    run_step(
+        dir_path,
+        "ocr",
         [
             "mapsnap",
             "ocr",
+            "--resume",
             "--centerlines",
             str(dir_path / "centerlines.geojson"),
             *ocr_images,
-        ]
+        ],
+        force=args.force,
     )
 
     # Locate OIM's manual split regions on the canvas (ground truth for compare).
-    run_cmd(["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")])
+    run_step(
+        dir_path,
+        "oim-split-truth",
+        ["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")],
+        force=args.force,
+    )
 
-    run_cmd(["mapsnap", "fit", str(dir_path), "mapsnap"])
+    run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 
 
 if __name__ == "__main__":

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -6,12 +6,10 @@ import urllib.request
 from pathlib import Path
 
 from mapsnap.utils import (
+    Step,
     image_stem,
     list_pages,
-    mark_step_done,
     run_cmd,
-    run_step,
-    step_done,
     write_run_record,
 )
 
@@ -95,20 +93,19 @@ def main() -> None:
         },
     )
 
+    step = Step(dir_path, force=args.force)
+
     base_url = f"https://oldinsurancemaps.net/iiif/mosaic/{args.sanborn_slug}"
-    if args.force or not step_done(dir_path, "manifests"):
+    with step("manifests"):
         download_file(
             f"{base_url}/main-content/?trim=true", dir_path / "main.iiif.json"
         )
         download_file(f"{base_url}/key-map/?trim=true", dir_path / "key.iiif.json")
-        mark_step_done(dir_path, "manifests")
-    else:
-        print("+ [skip manifests: already completed]", flush=True)
 
     # Download the full-resolution pages. The key map lives only in key.iiif.json (never in
     # main.iiif.json), so download both into raw/ and let it be treated as just another page —
     # the key-map detector then finds it by content, without the pipeline knowing its origin.
-    if args.force or not step_done(dir_path, "download-images"):
+    with step("download-images"):
         for iiif_name in ("main.iiif.json", "key.iiif.json"):
             run_cmd(
                 [
@@ -119,54 +116,44 @@ def main() -> None:
                     args.oim_prefix,
                 ]
             )
-        mark_step_done(dir_path, "download-images")
-    else:
-        print("+ [skip download-images: already completed]", flush=True)
 
     # Downscale the full-resolution raw/ pages to 25% top-level pN.jpg images.
     raw_images = sorted(glob.glob(str(dir_path / "raw" / "*.jpg")))
-    run_step(
-        dir_path,
-        "scale",
-        ["mapsnap", "scale", *raw_images, "--output-dir", str(dir_path)],
-        force=args.force,
-    )
+    with step("scale"):
+        run_cmd(["mapsnap", "scale", *raw_images, "--output-dir", str(dir_path)])
 
     # Detect and write split panels (pN__i.jpg + pN.panels.json) for pages that split.
     page_images = sorted(glob.glob(str(dir_path / "p*.jpg")))
-    run_step(dir_path, "split", ["mapsnap", "split", *page_images], force=args.force)
+    with step("split"):
+        run_cmd(["mapsnap", "split", *page_images])
 
-    run_step(
-        dir_path,
-        "download-osm",
-        [
-            "mapsnap",
-            "download-osm",
-            args.relation,
-            "--output",
-            str(dir_path / "streets.osm.json"),
-        ],
-        force=args.force,
-    )
+    with step("download-osm"):
+        run_cmd(
+            [
+                "mapsnap",
+                "download-osm",
+                args.relation,
+                "--output",
+                str(dir_path / "streets.osm.json"),
+            ]
+        )
 
-    run_step(
-        dir_path,
-        "osm-to-geojson",
-        [
-            "mapsnap",
-            "osm-to-geojson",
-            str(dir_path / "streets.osm.json"),
-            "--output",
-            str(dir_path / "centerlines.geojson"),
-        ],
-        force=args.force,
-    )
+    with step("osm-to-geojson"):
+        run_cmd(
+            [
+                "mapsnap",
+                "osm-to-geojson",
+                str(dir_path / "streets.osm.json"),
+                "--output",
+                str(dir_path / "centerlines.geojson"),
+            ]
+        )
 
     # Identify the key map(s) from the 25%-scale pages, keep only those at full resolution (the
     # other raw pages duplicate the 25% pN.jpg — delete them unless --keep_raw), and build their
     # sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json and restrict
     # each page to its key-map neighborhood.
-    if args.force or not step_done(dir_path, "keymap"):
+    with step("keymap"):
         from mapsnap.keymap.identify import identify_keymaps
 
         keymap_keys = identify_keymaps(dir_path)
@@ -178,33 +165,24 @@ def main() -> None:
             run_cmd(["mapsnap", "keymap", *raw_keymaps])
         else:
             print("No key map identified; continuing without one.", flush=True)
-        mark_step_done(dir_path, "keymap")
-    else:
-        print("+ [skip keymap: already completed]", flush=True)
 
     # --resume so an OCR interrupted partway resumes per page on the re-run that follows.
     ocr_images = [str(p) for p in list_pages(dir_path)]
-    run_step(
-        dir_path,
-        "ocr",
-        [
-            "mapsnap",
-            "ocr",
-            "--resume",
-            "--centerlines",
-            str(dir_path / "centerlines.geojson"),
-            *ocr_images,
-        ],
-        force=args.force,
-    )
+    with step("ocr"):
+        run_cmd(
+            [
+                "mapsnap",
+                "ocr",
+                "--resume",
+                "--centerlines",
+                str(dir_path / "centerlines.geojson"),
+                *ocr_images,
+            ]
+        )
 
     # Locate OIM's manual split regions on the canvas (ground truth for compare).
-    run_step(
-        dir_path,
-        "oim-split-truth",
-        ["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")],
-        force=args.force,
-    )
+    with step("oim-split-truth"):
+        run_cmd(["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")])
 
     run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -5,13 +5,32 @@ import glob
 import urllib.request
 from pathlib import Path
 
-from mapsnap.utils import list_pages, run_cmd, write_run_record
+from mapsnap.utils import image_stem, list_pages, run_cmd, write_run_record
 
 
 def download_file(url: str, dest: Path) -> None:
     """Download url to dest, printing the equivalent curl command."""
     print(f"+ curl -o {dest} {url!r}", flush=True)
     urllib.request.urlretrieve(url, dest)
+
+
+def delete_other_raw(dir_path: Path, keymap_keys: list[str]) -> None:
+    """Delete every full-resolution ``raw/`` page except the identified key map(s).
+
+    OIM downloads every page at full resolution, but only the key maps are needed at full res
+    downstream (to build their sidecars); the rest duplicate the 25% ``pN.jpg`` and waste disk.
+    Removes ``raw/*.jpg`` whose stem is not one of ``keymap_keys``; ``--keep_raw`` skips this.
+    """
+    keep = set(keymap_keys)
+    removed = 0
+    for image in sorted((dir_path / "raw").glob("*.jpg")):
+        if image_stem(str(image)) not in keep:
+            image.unlink()
+            removed += 1
+    print(
+        f"Deleted {removed} non-key-map raw image(s); kept {', '.join(sorted(keep))}.",
+        flush=True,
+    )
 
 
 def main() -> None:
@@ -32,6 +51,14 @@ def main() -> None:
     )
     parser.add_argument(
         "oim_prefix", metavar="OIM_PREFIX", help="OIM URL prefix for image downloads"
+    )
+    parser.add_argument(
+        "--keep_raw",
+        action="store_true",
+        help=(
+            "Keep every full-resolution raw/ image. By default only the identified key map(s) "
+            "are kept and the other raw pages are deleted (they duplicate the 25%% pN.jpg)."
+        ),
     )
     args = parser.parse_args()
 
@@ -93,6 +120,22 @@ def main() -> None:
             str(dir_path / "centerlines.geojson"),
         ]
     )
+
+    # Identify the key map(s) from the 25%-scale pages, keep only those at full resolution (the
+    # other raw pages duplicate the 25% pN.jpg — delete them unless --keep_raw), and build their
+    # sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json and restrict
+    # each page to its key-map neighborhood.
+    from mapsnap.keymap.identify import identify_keymaps
+
+    keymap_keys = identify_keymaps(dir_path)
+    if keymap_keys:
+        print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
+        if not args.keep_raw:
+            delete_other_raw(dir_path, keymap_keys)
+        raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+        run_cmd(["mapsnap", "keymap", *raw_keymaps])
+    else:
+        print("No key map identified; continuing without one.", flush=True)
 
     ocr_images = [str(p) for p in list_pages(dir_path)]
     run_cmd(

--- a/mapsnap/pipeline_oim_test.py
+++ b/mapsnap/pipeline_oim_test.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from mapsnap.pipeline_oim import delete_other_raw
+
+
+def make_raw(volume: Path, names: list[str]) -> None:
+    (volume / "raw").mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (volume / "raw" / name).write_bytes(b"")
+
+
+def test_delete_other_raw_keeps_only_key_maps(tmp_path: Path):
+    make_raw(tmp_path, ["p0.jpg", "p1.jpg", "p2.jpg", "p50.jpg"])
+    delete_other_raw(tmp_path, ["p0"])
+    remaining = sorted(p.name for p in (tmp_path / "raw").glob("*.jpg"))
+    assert remaining == ["p0.jpg"]
+
+
+def test_delete_other_raw_keeps_multiple_split_key_maps(tmp_path: Path):
+    make_raw(tmp_path, ["p0L.jpg", "p0R.jpg", "p1.jpg", "p2.jpg"])
+    delete_other_raw(tmp_path, ["p0L", "p0R"])
+    remaining = sorted(p.name for p in (tmp_path / "raw").glob("*.jpg"))
+    assert remaining == ["p0L.jpg", "p0R.jpg"]
+
+
+def test_delete_other_raw_leaves_non_jpg_untouched(tmp_path: Path):
+    make_raw(tmp_path, ["p0.jpg", "p1.jpg"])
+    (tmp_path / "raw" / "p0.keymap.json").write_text("{}")
+    delete_other_raw(tmp_path, ["p0"])
+    assert (tmp_path / "raw" / "p0.keymap.json").exists()
+    assert not (tmp_path / "raw" / "p1.jpg").exists()

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import FrameType
 
 
 def run_cmd(cmd: list[str]) -> None:
@@ -34,20 +35,74 @@ def mark_step_done(dir_path: Path, name: str) -> None:
     stamp.write_text("")
 
 
-def run_step(dir_path: Path, name: str, cmd: list[str], *, force: bool = False) -> None:
-    """Run one pipeline subcommand, skipping it on a resumed run once it has completed.
+class _StepSkipped(Exception):
+    """Internal signal raised to skip an already-completed step's ``with``-block body."""
 
-    Records completion as an empty ``<dir>/.pipeline/<name>.done`` stamp only after ``cmd``
-    succeeds — :func:`run_cmd` exits the process on failure, so an interrupted step leaves no
-    stamp and re-runs next time. ``force`` re-runs regardless of the stamp. The step is the unit
-    of skipping; a subcommand that additionally skips finished work internally (``download-oim``,
-    ``ocr --resume``) still does so on the re-run that follows an interruption partway through.
+
+class Step:
+    """Factory for resumable pipeline steps sharing one directory and ``force`` flag.
+
+    Construct once per pipeline run, then wrap each stage in ``with step("name"):``::
+
+        step = Step(dir_path, force=args.force)
+        with step("scale"):
+            run_cmd([...])
+
+    The block runs to completion the first time and records an empty
+    ``<dir>/.pipeline/<name>.done`` stamp; on a later (resumed) run the block is skipped
+    entirely — its body never executes — unless ``force`` is set. The stamp is written only if
+    the body exits without raising, so an interrupted step re-runs next time. Steps whose own
+    subcommand also skips finished work (``download-oim``, ``ocr --resume``) still do so on the
+    re-run that follows an interruption partway through a step.
     """
-    if not force and step_done(dir_path, name):
-        print(f"+ [skip {name}: already completed]", flush=True)
-        return
-    run_cmd(cmd)
-    mark_step_done(dir_path, name)
+
+    def __init__(self, dir_path: Path, *, force: bool = False) -> None:
+        self.dir_path = dir_path
+        self.force = force
+
+    def __call__(self, name: str) -> "_StepContext":
+        return _StepContext(self.dir_path, name, force=self.force)
+
+
+class _StepContext:
+    """One ``with step(name):`` block; created by :class:`Step`.
+
+    Python has no built-in way to skip a ``with`` body, so an already-completed step installs a
+    line trace on the calling frame that raises the instant the body starts and swallows that
+    signal in ``__exit__`` (the standard ``sys.settrace`` idiom; CPython only). The trace is only
+    touched on the skip path, and the prior trace is restored so an outer coverage/debug tracer
+    keeps working.
+    """
+
+    def __init__(self, dir_path: Path, name: str, *, force: bool) -> None:
+        self.dir_path = dir_path
+        self.name = name
+        self.skip = not force and step_done(dir_path, name)
+        self.saved_trace = sys.gettrace()
+        self.frame: FrameType | None = None
+
+    def __enter__(self) -> "_StepContext":
+        if not self.skip:
+            return self
+        print(f"+ [skip {self.name}: already completed]", flush=True)
+        self.saved_trace = sys.gettrace()
+        self.frame = sys._getframe(1)
+        sys.settrace(lambda *_: None)
+        self.frame.f_trace = self._skip_body
+        return self
+
+    def _skip_body(self, frame: FrameType, event: str, arg: object) -> None:
+        raise _StepSkipped
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self.skip:
+            if self.frame is not None:
+                self.frame.f_trace = None
+            sys.settrace(self.saved_trace)
+            return exc_type is not None and issubclass(exc_type, _StepSkipped)
+        if exc_type is None:
+            mark_step_done(self.dir_path, self.name)
+        return False
 
 
 def write_run_record(dir_path: Path, source: str, params: dict[str, str]) -> None:

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -17,6 +17,39 @@ def run_cmd(cmd: list[str]) -> None:
         sys.exit(result.returncode)
 
 
+def step_stamp(dir_path: Path, name: str) -> Path:
+    """Path of the completion marker for pipeline step ``name`` under ``dir_path``."""
+    return dir_path / ".pipeline" / f"{name}.done"
+
+
+def step_done(dir_path: Path, name: str) -> bool:
+    """Whether pipeline step ``name`` has already completed for ``dir_path``."""
+    return step_stamp(dir_path, name).exists()
+
+
+def mark_step_done(dir_path: Path, name: str) -> None:
+    """Record that pipeline step ``name`` completed, so a resumed run skips it."""
+    stamp = step_stamp(dir_path, name)
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text("")
+
+
+def run_step(dir_path: Path, name: str, cmd: list[str], *, force: bool = False) -> None:
+    """Run one pipeline subcommand, skipping it on a resumed run once it has completed.
+
+    Records completion as an empty ``<dir>/.pipeline/<name>.done`` stamp only after ``cmd``
+    succeeds — :func:`run_cmd` exits the process on failure, so an interrupted step leaves no
+    stamp and re-runs next time. ``force`` re-runs regardless of the stamp. The step is the unit
+    of skipping; a subcommand that additionally skips finished work internally (``download-oim``,
+    ``ocr --resume``) still does so on the re-run that follows an interruption partway through.
+    """
+    if not force and step_done(dir_path, name):
+        print(f"+ [skip {name}: already completed]", flush=True)
+        return
+    run_cmd(cmd)
+    mark_step_done(dir_path, name)
+
+
 def write_run_record(dir_path: Path, source: str, params: dict[str, str]) -> None:
     """Record the pipeline invocation in dir_path/mapsnap.json for reproducibility.
 

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -1,10 +1,15 @@
 """Tests for mapsnap.utils."""
 
+from pathlib import Path
+
 from mapsnap.utils import (
     default_centerlines,
     image_stem,
     list_pages,
+    mark_step_done,
+    run_step,
     source_id_to_page_key,
+    step_done,
 )
 
 
@@ -136,3 +141,32 @@ def test_source_id_chicago_non_sheet():
     assert source_id_to_page_key(f"{_CHI}:01790_01N_1950-covr", "") == "covr"
     assert source_id_to_page_key(f"{_CHI}:01790_01N_1950-titl", "") == "titl"
     assert source_id_to_page_key(f"{_CHI}:01790_01N_1950-ind1", "") == "ind1"
+
+
+def test_step_done_and_mark(tmp_path: Path):
+    assert not step_done(tmp_path, "scale")
+    mark_step_done(tmp_path, "scale")
+    assert step_done(tmp_path, "scale")
+    assert not step_done(tmp_path, "split")  # independent of other steps
+
+
+def test_run_step_runs_and_stamps(tmp_path: Path):
+    marker = tmp_path / "ran.txt"
+    run_step(tmp_path, "osm", ["touch", str(marker)], force=False)
+    assert marker.exists()  # command ran
+    assert step_done(tmp_path, "osm")  # and was stamped
+
+
+def test_run_step_skips_when_already_done(tmp_path: Path):
+    mark_step_done(tmp_path, "osm")
+    marker = tmp_path / "ran.txt"
+    # A failing command would sys.exit if run; being skipped means it never runs.
+    run_step(tmp_path, "osm", ["touch", str(marker)], force=False)
+    assert not marker.exists()
+
+
+def test_run_step_force_reruns_completed_step(tmp_path: Path):
+    mark_step_done(tmp_path, "osm")
+    marker = tmp_path / "ran.txt"
+    run_step(tmp_path, "osm", ["touch", str(marker)], force=True)
+    assert marker.exists()

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -2,12 +2,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from mapsnap.utils import (
+    Step,
     default_centerlines,
     image_stem,
     list_pages,
     mark_step_done,
-    run_step,
     source_id_to_page_key,
     step_done,
 )
@@ -150,23 +152,38 @@ def test_step_done_and_mark(tmp_path: Path):
     assert not step_done(tmp_path, "split")  # independent of other steps
 
 
-def test_run_step_runs_and_stamps(tmp_path: Path):
-    marker = tmp_path / "ran.txt"
-    run_step(tmp_path, "osm", ["touch", str(marker)], force=False)
-    assert marker.exists()  # command ran
+def test_step_runs_body_and_stamps(tmp_path: Path):
+    step = Step(tmp_path)
+    ran = []
+    with step("osm"):
+        ran.append(1)
+    assert ran == [1]  # body ran
     assert step_done(tmp_path, "osm")  # and was stamped
 
 
-def test_run_step_skips_when_already_done(tmp_path: Path):
+def test_step_skips_completed_body(tmp_path: Path):
     mark_step_done(tmp_path, "osm")
-    marker = tmp_path / "ran.txt"
-    # A failing command would sys.exit if run; being skipped means it never runs.
-    run_step(tmp_path, "osm", ["touch", str(marker)], force=False)
-    assert not marker.exists()
+    step = Step(tmp_path)
+    ran = []
+    with step("osm"):
+        ran.append(1)  # must not execute
+    assert ran == []  # whole body was skipped
+    line_after_block = True  # code after the block still runs normally
+    assert line_after_block
 
 
-def test_run_step_force_reruns_completed_step(tmp_path: Path):
+def test_step_force_reruns_completed(tmp_path: Path):
     mark_step_done(tmp_path, "osm")
-    marker = tmp_path / "ran.txt"
-    run_step(tmp_path, "osm", ["touch", str(marker)], force=True)
-    assert marker.exists()
+    step = Step(tmp_path, force=True)
+    ran = []
+    with step("osm"):
+        ran.append(1)
+    assert ran == [1]
+
+
+def test_step_leaves_no_stamp_when_body_raises(tmp_path: Path):
+    step = Step(tmp_path)
+    with pytest.raises(ValueError):
+        with step("osm"):
+            raise ValueError("boom")
+    assert not step_done(tmp_path, "osm")  # interrupted step re-runs next time


### PR DESCRIPTION
Makes key-map processing fully automatic and both volume pipelines resumable. Previously a volume's key map had to be manually identified, downloaded at full resolution, and processed by hand, and `ocr`/`georef` had to be told about it with `--keymap`. This PR adds a command to build a key map's sidecars, a detector that finds which page(s) are key maps, wires both into the LOC and OIM pipelines with no manual step, fixes two bugs a real `run-oim` uncovered, and makes both pipelines skip already-completed work on a re-run.

## `mapsnap keymap <raw/pN.jpg>`

Runs the three sidecar steps on a full-resolution key map:

1. **OCR + georef** the key map from its own street labels (`--geocode_keymaps`, so georef doesn't skip it), at a key-map-appropriate `--min-short-side` (default 60 ≈ 4× the 25%-scale page default of 15, since the raw sheet is ~4× the linear resolution). Native-resolution tiling is already on by default, which is what makes the sheet's small labels detectable. → `<stem>.streets.json`, `<stem>.georef.json`
2. **CNN + CRNN page numbers** with `--pages` **auto-derived** from the volume's page images (e.g. `1-32,34-85`, correctly excluding missing pages). Passing `--pages` is what enables the narrow-detection re-read — there is no separate `--reread` flag. → `<stem>.keymap.json`
3. **Region segmentation** (`page_regions`). → `<stem>.regions.panels.json`

## `mapsnap keymap-detect <volume>` — which page is the key map?

The convention is messy (`p0`, split `p0L`/`p0R`, `p1b` among cover/title/index siblings, `p1` in small volumes), and no manifest metadata reliably flags it — LOC labels every page "Page N", and OIM excludes the key map from `main.iiif.json`. So this uses a content signal.

**Key finding: identify by page-set _coverage_, not detection _count_.** A key map is an index of the whole volume, so its numbers reconstruct the volume's own page set. Raw CNN candidate count does **not** separate key maps from regular pages — a dense downtown page can have *more* number-like glyphs (measured: detroit's regular p66 had 209 candidates vs the key map's 116). But coverage does, with a huge margin:

| volume | key map coverage | best regular page |
|---|---|---|
| chicago | 0.88 | 0.01 |
| washington | 0.93 (→ `p1b`) | 0.02 |
| champaign | 0.96 | 0.04 |
| detroit | 0.95 | 0.00 (p66, despite 209 candidates) |

Two stages: **Tier B** nominates the page-0/page-1 families from filenames (cheap); **Tier C** confirms by reading each candidate's numbers (CNN+CRNN, snapped to the valid page set) and keeping those with coverage ≥ 0.3. Runs on the always-present **25%-scale `p*.jpg`** — that's the CNN's native working resolution (`keymap_patches.working_scale` uses it as-is), so no full-res download is needed to decide what to fetch. Deliberately does **not** use OIM's `key.iiif.json` for identification (truth data must not be a pipeline input).

## Pipeline wiring + `ocr`/`georef` auto-discovery

Both pipelines call `identify_keymaps` after building centerlines, then `mapsnap keymap`:

- **LOC** downloads the identified key map(s) at full resolution via `mapsnap download-raw`.
- **OIM** already has `raw/`, so it **deletes the non-key-map raw images** (they duplicate the 25% `pN.jpg`) unless `--keep_raw` — a new default-on behavior for disk savings.

**`ocr` and `georef` now use key maps by default** (behavior change). When `--keymap` is not given, `resolve_keymaps`/`discover_keymaps` (in `keymap/locate.py`) find `<stem>.keymap.json` files — with a sibling `.georef.json`, so a failed georef is skipped — in the images' directory or under `raw/`. Precedence: `--ignore-keymap` (new) turns it off, an explicit `--keymap` still wins, otherwise auto-discover. `mapsnap keymap`'s own internal `ocr`/`georef` pass `--ignore-keymap` so a re-run doesn't locate the key map against itself.

## Pipeline fixes (from a real `run-oim`)

- **OIM never downloaded the key map.** It lives only in `key.iiif.json`, never in `main.iiif.json`, so `download-oim` (run only on `main`) never fetched it → identify found nothing. Since `download-oim` reads *any* AnnotationPage's `items` by label, `pipeline_oim` now runs it on **both** files; the key map lands in `raw/`, is scaled, and is found by content — the pipeline never learns it came from `key.iiif.json`.
- **Malformed `mapsnap georef` crash.** `fit` made `--tag` a *flag*, but both pipelines called `mapsnap fit <dir> mapsnap`; the bare positional `"mapsnap"` fell through `parse_known_args` into the georef passthrough args (`… --centerlines … mapsnap` → *"unrecognized arguments: mapsnap"*). Fixed to `mapsnap fit <dir> --tag mapsnap` in both pipelines.

## Resumable pipelines

Both `run-loc` and `run-oim` now resume: a re-run skips steps that already completed, so an interrupted or crashed pipeline picks up where it stopped instead of redoing downloads, scaling, OSM, OCR, etc.

A new `Step` context manager (`utils.py`) is constructed once with the directory and a `force` flag, then each stage is `with step("name"):` wrapping the existing `run_cmd` calls — no per-step `if/else`. Completion is recorded as an empty `<dir>/.pipeline/<name>.done` stamp written only on clean exit (`run_cmd` exits the process on failure, so an interrupted step leaves no stamp and re-runs). `--force` re-runs everything; OCR additionally gets `--resume` so a partway-interrupted OCR resumes per page within its re-run.

Skipping an already-completed step's `with`-body — which Python doesn't support directly — installs a line trace on the calling frame that raises the instant the body starts and swallows it in `__exit__` (the standard `sys.settrace` idiom, CPython-only), restoring the prior trace so an outer coverage/debug tracer keeps working. Verified on 3.13; the repo runs no coverage to collide with it.

## Testing

Unit tests for the new pure logic — coverage thresholds, candidate generation, page-spec derivation, discovery precedence / `.georef.json` filtering, the destructive `delete_other_raw`, and the `Step` skip/run/force/raise paths (including a chained skip-then-run resume). Validated end-to-end: `mapsnap keymap` reproduces chicago's hand-built sidecars (identical georef corners, 103 detections, 102 regions); `keymap-detect` returns the correct page on chicago/detroit/champaign and disambiguates washington's `p1a/b/c/d` → `p1b`; a real `georef` run auto-discovers the key map with no flags; and a `download-oim --dry-run` on `key.iiif.json` confirms it resolves to `raw/p0.jpg`. Full suite green (501 tests).

## Notes for the reviewer

- The scaled top-level key map (`p0.jpg`) is in `list_pages`, so the main run also processes it as a regular page. This is pre-existing behavior, but note it now actually triggers on OIM volumes since the key map is finally downloaded into the volume.
- The `Step` skip uses `sys.settrace`; it only touches tracing on the resume/skip path and restores it, but it is CPython-specific — flagged in case that matters.
- Argparse help strings need `%%` not `%` (a literal `25%` in `--keep_raw` help crashed `--help`; fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
