### PR TITLE
Build page adjacency graph from numbers on page margins

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import './styles.css';
 import type {
+  AdjacencyData,
   Corners,
   GcpPairResult,
   GeorefData,
@@ -15,11 +16,17 @@ import {
   directionThroughCorners,
   projectThroughCorners,
 } from './geometry';
-import { filterDetections, type DetectionFilters } from './detections';
-import { parseDroppedJson } from './fileLoading';
+import {
+  detectionFromAdjacency,
+  filterDetections,
+  type DetectionFilters,
+  type IndexedDetection,
+} from './detections';
+import { pageStem, parseDroppedJson } from './fileLoading';
 import { ImageColumn, type Mode } from './components/ImageColumn';
 import { MapView } from './components/MapView';
 import { GcpControls, type GcpFitStats } from './components/GcpControls';
+import { AdjacencyTable } from './components/AdjacencyTable';
 import { DetectionsTable } from './components/DetectionsTable';
 import { PanelsTable } from './components/PanelsTable';
 import { loadImage } from './loadImage';
@@ -116,6 +123,12 @@ export function App() {
   const [panelLabels, setPanelLabels] = useState<string[] | undefined>(
     undefined,
   );
+  const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
+    null,
+  );
+  // Stem of the loaded image's filename (e.g. "p49"), which identifies the page
+  // in volume-level files like adjacency.json.
+  const [imageStem, setImageStem] = useState<string | null>(null);
   const [selectedIndices, setSelectedIndices] = useState<Set<number>>(
     new Set(),
   );
@@ -236,6 +249,31 @@ export function App() {
     [detections, filters],
   );
 
+  // Adjacency mode: the loaded image's page entry (identified by filename stem)
+  // and its digit reads converted to the Detection shape the overlay renders.
+  const adjacencyPage =
+    mode === 'adjacency' && adjacencyData && imageStem
+      ? (adjacencyData.pages[imageStem] ?? null)
+      : null;
+  const adjacencyDetections = useMemo<IndexedDetection[]>(() => {
+    if (!adjacencyPage || !adjacencyData || !imageStem) return [];
+    // Page numbers of this page's reciprocated neighbors; claims of these render blue.
+    const mutualNumbers = new Set<number>();
+    for (const [a, b] of adjacencyData.adjacency) {
+      const other = a === imageStem ? b : b === imageStem ? a : null;
+      const number = other ? adjacencyData.pages[other]?.number : null;
+      if (number != null) mutualNumbers.add(number);
+    }
+    return adjacencyPage.detections.map((d, i) => ({
+      det: detectionFromAdjacency(d, mutualNumbers),
+      i,
+    }));
+  }, [adjacencyPage, adjacencyData, imageStem]);
+  // Polygon coordinates live in the scanned image's pixel space; prefer its
+  // recorded dimensions so a different-resolution image still lines up.
+  const overlayWidth = adjacencyPage?.width ?? jsonWidth;
+  const overlayHeight = adjacencyPage?.height ?? jsonHeight;
+
   // Parse georef JSON text and update streets/intersections/corners/dimensions.
   function applyGeorefJson(text: string): void {
     let data: GeorefData;
@@ -293,6 +331,13 @@ export function App() {
       setDetections([]);
       setJsonWidth(result.width);
       setJsonHeight(result.height);
+    } else if (result.kind === 'adjacency') {
+      setMode('adjacency');
+      setSelectedIndices(new Set());
+      setAdjacencyData(result.data);
+      setDetections([]);
+      setPanels([]);
+      setPanelLabels(undefined);
     } else {
       setMode('georef');
       setSelectedIndices(new Set());
@@ -327,6 +372,7 @@ export function App() {
       prevObjectUrlRef.current = url;
       const el = await loadImage(url);
       applyImage(el, url);
+      setImageStem(pageStem(imageFile.name));
       fallbackWidth = el.naturalWidth;
       fallbackHeight = el.naturalHeight;
     }
@@ -355,6 +401,7 @@ export function App() {
         const src = resolveDataUrl(imageFile);
         const el = await loadImage(src);
         applyImage(el, src);
+        setImageStem(pageStem(imageFile));
         fallbackWidth = el.naturalWidth;
         fallbackHeight = el.naturalHeight;
       }
@@ -415,11 +462,13 @@ export function App() {
       <ImageColumn
         mode={mode}
         imageSrc={imageSrc}
-        jsonWidth={jsonWidth}
-        jsonHeight={jsonHeight}
+        jsonWidth={overlayWidth}
+        jsonHeight={overlayHeight}
         streets={streets}
         intersections={intersections}
-        filteredDetections={filteredDetections}
+        filteredDetections={
+          mode === 'adjacency' ? adjacencyDetections : filteredDetections
+        }
         panels={panels}
         panelLabels={panelLabels}
         selectedIndices={selectedIndices}
@@ -523,6 +572,18 @@ export function App() {
             onSelect={(index) => setSelectedIndices(new Set([index]))}
             jsonWidth={jsonWidth}
             jsonHeight={jsonHeight}
+          />
+        )}
+        {mode === 'adjacency' && adjacencyData && (
+          <AdjacencyTable
+            adjacency={adjacencyData}
+            imageStem={imageStem}
+            detections={adjacencyDetections}
+            selectedIndices={selectedIndices}
+            onSelect={(index) => setSelectedIndices(new Set([index]))}
+            image={imageEl}
+            jsonWidth={overlayWidth}
+            jsonHeight={overlayHeight}
           />
         )}
       </div>

--- a/app/src/components/AdjacencyTable.tsx
+++ b/app/src/components/AdjacencyTable.tsx
@@ -1,0 +1,144 @@
+import type { IndexedDetection } from '../detections';
+import type { AdjacencyData, AdjacencyPage } from '../types';
+import { DetectionCanvas } from './DetectionCanvas';
+
+interface AdjacencyTableProps {
+  adjacency: AdjacencyData;
+  /** Page stem from the dropped image's filename, e.g. "p49"; null until an image is dropped. */
+  imageStem: string | null;
+  /** The page's detections converted to Detection shape, parallel to the page's detection list. */
+  detections: IndexedDetection[];
+  selectedIndices: Set<number>;
+  onSelect: (index: number) => void;
+  image: HTMLImageElement | null;
+  jsonWidth: number;
+  jsonHeight: number;
+}
+
+/** The page's mutual neighbors, each with the edge its claim was printed on (or "?"). */
+function neighborSummary(
+  adjacency: AdjacencyData,
+  stem: string,
+  page: AdjacencyPage,
+): { stem: string; edge: string }[] {
+  const neighbors = adjacency.adjacency
+    .filter(([a, b]) => a === stem || b === stem)
+    .map(([a, b]) => (a === stem ? b : a));
+  return neighbors.map((neighborStem) => {
+    const number = adjacency.pages[neighborStem]?.number;
+    const claim = page.detections.find((d) => d.claim && d.number === number);
+    return { stem: neighborStem, edge: claim?.edge ?? '?' };
+  });
+}
+
+/**
+ * Side panel for adjacency mode: the page's mutual neighbors (with the edge
+ * each was printed on) above a table of its page-number detections, claims
+ * first. Clicking a row highlights that detection on the image.
+ */
+export function AdjacencyTable(props: AdjacencyTableProps) {
+  const {
+    adjacency,
+    imageStem,
+    detections,
+    selectedIndices,
+    onSelect,
+    image,
+    jsonWidth,
+    jsonHeight,
+  } = props;
+
+  if (!imageStem) {
+    return (
+      <div id="detections-panel">
+        <p>
+          Drop this page's image to select a page — its filename (e.g.
+          "p49.jpg") identifies the page in adjacency.json.
+        </p>
+      </div>
+    );
+  }
+  const page = adjacency.pages[imageStem];
+  if (!page) {
+    return (
+      <div id="detections-panel">
+        <p>
+          Page "{imageStem}" is not in this adjacency.json (
+          {Object.keys(adjacency.pages).length} pages).
+        </p>
+      </div>
+    );
+  }
+
+  const neighbors = neighborSummary(adjacency, imageStem, page);
+  // Mutual neighbors first (the information this view exists for), then other
+  // claims, then the filtered-out reads; by confidence within each group.
+  const rank = (indexed: IndexedDetection): number =>
+    indexed.det.mutual === true ? 2 : indexed.det.mutual === false ? 1 : 0;
+  const visible = detections
+    .filter(({ i }) => selectedIndices.size === 0 || selectedIndices.has(i))
+    .sort((a, b) => rank(b) - rank(a) || b.det.confidence - a.det.confidence);
+
+  return (
+    <div id="detections-panel">
+      <div className="adjacency-summary">
+        <strong>{imageStem}</strong> — mutual neighbors:{' '}
+        {neighbors.length === 0
+          ? 'none'
+          : neighbors.map(({ stem, edge }, i) => (
+              <span key={stem}>
+                {i > 0 && ', '}
+                {stem} <span className="adjacency-edge">({edge})</span>
+              </span>
+            ))}
+      </div>
+      <table id="detections-table">
+        <thead>
+          <tr>
+            <th>Number</th>
+            <th>Edge</th>
+            <th>Height</th>
+            <th>Conf</th>
+            <th>Mutual</th>
+            <th>Claim</th>
+            <th>Image</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map(({ det, i }) => {
+            const raw = page.detections[i];
+            const classes = [
+              selectedIndices.has(i) ? 'selected' : '',
+              det.mutual === true ? 'mutual' : '',
+              raw?.claim ? '' : 'ignored',
+            ]
+              .filter(Boolean)
+              .join(' ');
+            return (
+              <tr
+                key={i}
+                className={classes || undefined}
+                onClick={() => onSelect(i)}
+              >
+                <td>{raw?.number}</td>
+                <td>{raw?.edge}</td>
+                <td>{raw?.height}</td>
+                <td>{det.confidence.toFixed(3)}</td>
+                <td>{det.mutual === true ? '✓' : ''}</td>
+                <td>{raw?.claim ? '✓' : ''}</td>
+                <td>
+                  <DetectionCanvas
+                    det={det}
+                    image={image}
+                    jsonWidth={jsonWidth}
+                    jsonHeight={jsonHeight}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/components/DetectionsOverlay.tsx
+++ b/app/src/components/DetectionsOverlay.tsx
@@ -45,13 +45,19 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
         const isSelected = selectedIndices.has(i);
         const isIgnored = det.ignore === true;
         const isHint = det.hint === true;
+        // Adjacency claims carry `mutual`: reciprocated neighbors render blue, the
+        // rest of the claims amber; other modes never set the field.
         const color = isSelected
           ? '#ff6600'
-          : isIgnored
-            ? '#999'
-            : isHint
-              ? '#7c3aed'
-              : confidenceColor(det.confidence);
+          : det.mutual === true
+            ? '#2563eb'
+            : det.mutual === false
+              ? '#d97706'
+              : isIgnored
+                ? '#999'
+                : isHint
+                  ? '#7c3aed'
+                  : confidenceColor(det.confidence);
         const points = det.polygon
           .map(([x, y]) => toDisplay(x, y))
           .map(([dx, dy]) => `${dx},${dy}`)

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -7,7 +7,7 @@ import { DetectionsOverlay } from './DetectionsOverlay';
 import { GeorefOverlay } from './GeorefOverlay';
 import { PanelsOverlay } from './PanelsOverlay';
 
-export type Mode = 'georef' | 'streets' | 'panels';
+export type Mode = 'georef' | 'streets' | 'panels' | 'adjacency';
 
 interface ImageColumnProps {
   mode: Mode;
@@ -67,6 +67,8 @@ export function ImageColumn(props: ImageColumnProps) {
   const streetsMode = mode === 'streets';
   const panelsMode = mode === 'panels';
   const georefMode = mode === 'georef';
+  // Adjacency mode renders detections just like streets mode (overlay + click select).
+  const detectionsMode = streetsMode || mode === 'adjacency';
 
   // In streets/panels mode, select the shapes under the click point. The wrapper
   // (currentTarget) tightly wraps the image, so its rect matches the image's.
@@ -120,7 +122,7 @@ export function ImageColumn(props: ImageColumnProps) {
             src={imageSrc}
             style={{ aspectRatio: `${jsonWidth} / ${jsonHeight}` }}
           />
-          {streetsMode && (
+          {detectionsMode && (
             <DetectionsOverlay
               detections={filteredDetections}
               selectedIndices={selectedIndices}

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -159,7 +159,7 @@ describe('detectionFromAdjacency', () => {
     height: 45,
     x_frac: 0.9,
     y_frac: 0.5,
-    edge: 'E',
+    edge: 'R',
     claim: true,
   };
 

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   confidenceColor,
+  detectionFromAdjacency,
   filterDetections,
   previewOrientation,
 } from './detections';
@@ -141,5 +142,62 @@ describe('filterDetections', () => {
       showIgnored: false,
     });
     expect(hidden.map((r) => r.i)).toEqual([0, 1]);
+  });
+});
+
+describe('detectionFromAdjacency', () => {
+  const read50 = {
+    number: 50,
+    text: '50',
+    confidence: 0.98,
+    polygon: [
+      [100, 200],
+      [140, 200],
+      [140, 245],
+      [100, 245],
+    ] as [number, number][],
+    height: 45,
+    x_frac: 0.9,
+    y_frac: 0.5,
+    edge: 'E',
+    claim: true,
+  };
+
+  it('converts a digit read to Detection shape with bbox sides', () => {
+    const det = detectionFromAdjacency(read50, new Set([50]));
+    expect(det.text).toBe('50');
+    expect(det.confidence).toBe(0.98);
+    expect(det.long_side).toBe(45);
+    expect(det.short_side).toBe(40);
+    expect(det.ignore).toBe(false);
+  });
+
+  it('marks a claim of a reciprocated neighbor as mutual', () => {
+    expect(detectionFromAdjacency(read50, new Set([50])).mutual).toBe(true);
+    expect(detectionFromAdjacency(read50, new Set([51])).mutual).toBe(false);
+  });
+
+  it('marks non-claims as ignored, with no mutual flag', () => {
+    const det = detectionFromAdjacency(
+      {
+        number: 2,
+        text: '2',
+        confidence: 0.9,
+        polygon: [
+          [0, 0],
+          [10, 0],
+          [10, 10],
+          [0, 10],
+        ],
+        height: 10,
+        x_frac: 0.5,
+        y_frac: 0.5,
+        edge: 'center',
+        claim: false,
+      },
+      new Set([2]),
+    );
+    expect(det.ignore).toBe(true);
+    expect(det.mutual).toBeUndefined();
   });
 });

--- a/app/src/detections.ts
+++ b/app/src/detections.ts
@@ -1,4 +1,4 @@
-import type { Detection } from './types';
+import type { AdjacencyDetection, Detection } from './types';
 
 /** Filter sliders/toggles that control which detections are shown. */
 export interface DetectionFilters {
@@ -18,6 +18,37 @@ export interface IndexedDetection {
 export function confidenceColor(confidence: number): string {
   const hue = Math.round(confidence * 120); // 0 = red, 120 = green
   return `hsl(${hue}, 90%, 45%)`;
+}
+
+/**
+ * Convert an adjacency.json digit read to the Detection shape the overlay,
+ * table, and preview canvas render. Side lengths come from the polygon's
+ * bounding box; the printed sheet numbers are upright, so angle is 0.
+ *
+ * `mutualNumbers` holds the page numbers of this page's reciprocated
+ * neighbors: a claim of one of those renders blue (`mutual: true`), any other
+ * claim amber (`mutual: false`), and non-claims grey (`ignore`, no `mutual`).
+ */
+export function detectionFromAdjacency(
+  adjacencyDetection: AdjacencyDetection,
+  mutualNumbers: Set<number>,
+): Detection {
+  const xs = adjacencyDetection.polygon.map(([x]) => x);
+  const ys = adjacencyDetection.polygon.map(([, y]) => y);
+  const width = Math.max(...xs) - Math.min(...xs);
+  const height = Math.max(...ys) - Math.min(...ys);
+  return {
+    polygon: adjacencyDetection.polygon,
+    text: String(adjacencyDetection.number),
+    confidence: adjacencyDetection.confidence,
+    angle: 0,
+    long_side: Math.max(width, height),
+    short_side: Math.min(width, height),
+    ignore: !adjacencyDetection.claim,
+    ...(adjacencyDetection.claim
+      ? { mutual: mutualNumbers.has(adjacencyDetection.number) }
+      : {}),
+  };
 }
 
 /** Return detections passing the given filters, paired with their original indices. */

--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseDroppedJson } from './fileLoading';
+import { pageStem, parseDroppedJson } from './fileLoading';
 
 const fallback = { width: 800, height: 600 };
 
@@ -145,5 +145,30 @@ describe('parseDroppedJson', () => {
     });
     const result = parseDroppedJson(text, fallback);
     expect(result).toEqual({ kind: 'georef', text });
+  });
+
+  it('classifies adjacency.json by its pages + adjacency keys', () => {
+    const data = {
+      pages: { p49: { number: 49, detections: [] } },
+      adjacency: [['p49', 'p50']],
+    };
+    const result = parseDroppedJson(JSON.stringify(data), fallback);
+    expect(result.kind).toBe('adjacency');
+    if (result.kind === 'adjacency') {
+      expect(result.data.pages.p49.number).toBe(49);
+      expect(result.data.adjacency).toEqual([['p49', 'p50']]);
+    }
+  });
+});
+
+describe('pageStem', () => {
+  it('strips directories and all extensions', () => {
+    expect(pageStem('p49.jpg')).toBe('p49');
+    expect(pageStem('data/vol/p50n.2048px.jpg')).toBe('p50n');
+    expect(pageStem('/abs/path/p1b.jpg')).toBe('p1b');
+  });
+
+  it('matches split-panel stems', () => {
+    expect(pageStem('p86__2.jpg')).toBe('p86__2');
   });
 });

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -1,4 +1,5 @@
 import type {
+  AdjacencyData,
   Detection,
   PanelPolygon,
   PanelsJsonData,
@@ -23,7 +24,19 @@ export type ParsedJson =
       labels?: string[];
       width: number;
       height: number;
-    };
+    }
+  | { kind: 'adjacency'; data: AdjacencyData };
+
+/**
+ * Page stem from an image file name or URL: the basename with every extension
+ * stripped, so "data/vol/p50n.2048px.jpg" -> "p50n". Mirrors Python's
+ * `image_stem`, letting a dropped page image identify its page in a
+ * volume-level file like adjacency.json.
+ */
+export function pageStem(fileName: string): string {
+  const base = fileName.split(/[\\/]/).pop() ?? fileName;
+  return base.split('.')[0];
+}
 
 /** Fallback image dimensions used when an old-format streets.json omits them. */
 export interface FallbackDimensions {
@@ -53,15 +66,28 @@ function isPanelsFormat(parsed: unknown): parsed is PanelsJsonData {
   );
 }
 
+// Whether a parsed object is a volume adjacency.json (per-page detections + edge list).
+function isAdjacencyFormat(parsed: unknown): parsed is AdjacencyData {
+  return (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'pages' in parsed &&
+    'adjacency' in parsed &&
+    typeof (parsed as AdjacencyData).pages === 'object' &&
+    Array.isArray((parsed as AdjacencyData).adjacency)
+  );
+}
+
 /**
- * Classify dropped JSON text as a streets detection list, panels sidecar, or
- * georef data.
+ * Classify dropped JSON text as a streets detection list, panels sidecar,
+ * volume adjacency data, or georef data.
  *
  * streets.json comes either as a bare array of detections (old format) or as an
  * object with a `streets` array plus image metadata (new format). panels.json is
- * an object with a `panels` array of polygon rings plus image metadata. Anything
- * else is treated as georef data. Returns `{ kind: 'invalid' }` if the text is
- * not JSON.
+ * an object with a `panels` array of polygon rings plus image metadata.
+ * adjacency.json is an object with `pages` and `adjacency` keys. Anything else
+ * is treated as georef data. Returns `{ kind: 'invalid' }` if the text is not
+ * JSON.
  */
 export function parseDroppedJson(
   text: string,
@@ -72,6 +98,10 @@ export function parseDroppedJson(
     parsed = JSON.parse(text);
   } catch {
     return { kind: 'invalid' };
+  }
+
+  if (!Array.isArray(parsed) && isAdjacencyFormat(parsed)) {
+    return { kind: 'adjacency', data: parsed };
   }
 
   if (!Array.isArray(parsed) && isPanelsFormat(parsed)) {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -215,6 +215,23 @@
   vertical-align: middle;
 }
 
+.adjacency-summary {
+  padding: 6px 8px;
+  border-bottom: 2px solid #bbb;
+  font-size: 13px;
+}
+
+.adjacency-edge {
+  color: #2563eb;
+  font-weight: bold;
+}
+
+/* A reciprocated adjacency claim — the mutual-neighbor evidence this view highlights. */
+#detections-table tr.mutual td {
+  color: #2563eb;
+  font-weight: bold;
+}
+
 .gcp-controls {
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -38,6 +38,11 @@ export interface Detection {
   hint?: boolean;
   /** Read by the key-map rectangle fallback vocab rather than the tighter radius vocab. */
   fallback?: boolean;
+  /**
+   * Adjacency-claim reciprocity (adjacency mode only): true renders blue (a mutual
+   * neighbor), false amber (an unreciprocated claim); absent for non-claims.
+   */
+  mutual?: boolean;
 }
 
 /** The key map's expected center and OCR/fit radius for a page (georef.json `keymap`). */
@@ -105,6 +110,37 @@ export interface StreetsJsonData {
   timestamp: string;
   command: string[];
   streets: Detection[];
+}
+
+/** One digit read from page_adjacency.py (a valid page number found on a page). */
+export interface AdjacencyDetection {
+  number: number;
+  text: string;
+  confidence: number;
+  polygon: [number, number][];
+  height: number;
+  x_frac: number;
+  y_frac: number;
+  /** Page edge the detection is near ("N"/"E"/"S"/"W"), a compass corner ("NE"), or "center". */
+  edge: string;
+  /** Passed the adjacency-claim filters (edge band, min height, not the page's own number). */
+  claim: boolean;
+}
+
+/** One page's entry in adjacency.json. */
+export interface AdjacencyPage {
+  number: number | null;
+  /** Dimensions of the scanned image, for rescaling polygons to the loaded image. */
+  width?: number;
+  height?: number;
+  detections: AdjacencyDetection[];
+}
+
+/** adjacency.json: per-page sheet-number detections plus the mutual-edge adjacency graph. */
+export interface AdjacencyData {
+  pages: Record<string, AdjacencyPage>;
+  /** Reciprocated adjacency edges as [stemA, stemB] pairs. */
+  adjacency: [string, string][];
 }
 
 /** A single panel polygon ring (one [x, y] vertex per point, in pixel space). */

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -121,7 +121,11 @@ export interface AdjacencyDetection {
   height: number;
   x_frac: number;
   y_frac: number;
-  /** Page edge the detection is near ("N"/"E"/"S"/"W"), a compass corner ("NE"), or "center". */
+  /**
+   * Image-relative edge the detection is near — "T"op/"B"ottom/"L"eft/"R"ight, a corner
+   * ("TL"/"TR"/"BL"/"BR"), or "center". Not compass directions: the page's world
+   * orientation is unknown at this stage.
+   */
   edge: string;
   /** Passed the adjacency-claim filters (edge band, min height, not the page's own number). */
   claim: boolean;

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -35,6 +35,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.keymap.identify",
         "Identify which page(s) of a volume are key maps (from 25%-scale images)",
     ),
+    "adjacency": (
+        "mapsnap.page_adjacency",
+        "Detect printed adjacent-sheet numbers and build a volume adjacency graph",
+    ),
     "iiif": (
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -115,8 +115,38 @@ def bbox_gap(a: list[list[float]], b: list[list[float]]) -> float:
     return math.hypot(dx, dy)
 
 
+def is_text_veto(
+    letter_text: str, letter_confidence: float, digit_confidence: float
+) -> bool:
+    """Whether a letters-allowlist read reveals the box to be text rather than a number.
+
+    Under the digits-only allowlist the recognizer is *forced* to transcribe street names as
+    numbers ("SMITH" came out as a confident "55" on Brooklyn p56); re-reading the same box
+    with letters available lets such text identify itself. A veto needs both a clear textual
+    reveal — three or more letters, or a letter-dominated read — and the recognizer to
+    *prefer* that reading over the digit one: a genuine "41" also comes back letter-dominated
+    ("AL", look-alike glyphs) but at lower confidence than its digit reading, while SMITH
+    reads as text far more confidently than as "55".
+    """
+    compact = letter_text.replace(" ", "")
+    if not compact or letter_confidence <= digit_confidence:
+        return False
+    letters = sum(1 for c in compact if c.isalpha())
+    return letters >= 3 or letters / len(compact) >= 0.7
+
+
+def box_center(bbox: list[list[float]]) -> tuple[float, float]:
+    """Center of an OCR quad."""
+    return (sum(p[0] for p in bbox) / 4, sum(p[1] for p in bbox) / 4)
+
+
 def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[dict]:
     """All digit reads on one page that parse to a valid volume page number.
+
+    Two recognition passes over the same image: the digits-only pass supplies the
+    transcription (immune to look-alike substitutions like 0 -> O), and a letters-allowed
+    pass over the same boxes vetoes the ones that are actually street names or other text
+    (see is_text_veto).
 
     Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
     confidence, the glyph ``height`` in pixels, position as width/height fractions, the
@@ -128,11 +158,30 @@ def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[
     image = np.asarray(Image.open(image_path).convert("RGB"))
     height, width = image.shape[:2]
     results = reader.readtext(image, allowlist="0123456789")
+    letter_results = reader.readtext(
+        image, allowlist="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    )
+    letter_centers = [box_center(bbox) for bbox, _, _ in letter_results]
     detections = []
     for index, (bbox, text, confidence) in enumerate(results):
         digits = "".join(c for c in text if c.isdigit())
         if not digits or int(digits) not in valid_numbers:
             continue
+        # Veto boxes whose letters-pass read reveals text. Pair by box center; the two
+        # passes share the same detector so boxes normally coincide.
+        cx, cy = box_center(bbox)
+        box_height = max(p[1] for p in bbox) - min(p[1] for p in bbox)
+        nearest_letter = min(
+            (
+                (math.hypot(lx - cx, ly - cy), i)
+                for i, (lx, ly) in enumerate(letter_centers)
+            ),
+            default=(math.inf, -1),
+        )
+        if nearest_letter[0] < box_height:
+            letter_read = letter_results[nearest_letter[1]]
+            if is_text_veto(letter_read[1], float(letter_read[2]), float(confidence)):
+                continue
         x_frac = sum(p[0] for p in bbox) / 4 / width
         y_frac = sum(p[1] for p in bbox) / 4 / height
         glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -6,11 +6,16 @@ sheet continues. Reading these gives page adjacency that is independent of the k
 detected neighbor's edge (top/left/bottom/right of the image) pins the page's orientation.
 
 Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a
-detection only becomes a *claim* when it is a valid page number, near the page edge, and printed
-large; and a claim only becomes an adjacency *edge* when it is reciprocated — page A claims B
-AND page B claims A. Measured on Hudson County: directed claims are ~72% precise, mutual edges
-~98%, covering ~76% of georeferenced-overlap adjacencies and reaching 30/33 pages that street
-matching failed to georeference.
+detection only becomes a *claim* when it is a valid page number, near the page edge, printed
+large, and axis-aligned; and a claim only becomes an adjacency *edge* when it is reciprocated —
+page A claims B AND page B claims A. Reciprocity alone is not proof: junk claims of small
+numbers are common enough to reciprocate by chance (and page numbering correlates with
+adjacency, so such accidents are often "correct"), so single-digit claims — where any tall
+narrow ink can read as a "1" — additionally face a high confidence floor and a height band
+calibrated from the volume's own confirmed multi-digit references (their printed size is very
+consistent: Hudson County median 46 px with p10-p90 of 42-48). Measured on Hudson County the
+result is 167 mutual edges with no known-false edge, reaching 30/33 pages that street matching
+failed to georeference.
 
 This is a whole-volume step: it scans every non-split page image (skipping key-map sheets,
 whose faces are covered in page numbers) and writes a single ``<volume>/adjacency.json`` with
@@ -21,6 +26,7 @@ each page's number detections and the mutual-edge adjacency graph.
 
 import argparse
 import json
+import math
 import sys
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -40,6 +46,18 @@ from mapsnap.utils import image_stem
 EDGE_BAND = 0.25
 MIN_HEIGHT = 28.0
 MIN_CONF = 0.05
+
+# A rotated detection quad is never a sheet reference: every rotated candidate inspected on
+# Hudson County (52 of them) was a misread street name ("WESTSIDE", "Mc ADOO") or pipe
+# annotation ('10" W Pipe'). References are printed upright, so reject quads off-axis by more
+# than this tolerance.
+ROTATION_TOLERANCE_DEG = 5.0
+
+# Single-digit reads are held to a stricter standard than reciprocity alone can provide:
+# a hard confidence floor, and a height band of these fractions around the median height of
+# the volume's multi-digit mutual claims (see single_digit_height_band).
+SINGLE_DIGIT_MIN_CONF = 0.9
+SIZE_BAND_FRACTION = (0.65, 1.4)
 
 
 def volume_page_images(volume: Path) -> list[Path]:
@@ -115,20 +133,69 @@ def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[
     return detections
 
 
+def polygon_rotation_deg(polygon: list[list[float]]) -> float:
+    """Rotation of a detection quad off the image axes, in degrees folded to [0, 45].
+
+    EasyOCR returns an axis-aligned box for upright text and a rotated quad otherwise; this is
+    the angle of the quad's top edge, folded so 0 means axis-aligned in either orientation.
+    """
+    (x0, y0), (x1, y1) = polygon[0], polygon[1]
+    angle = abs(math.degrees(math.atan2(y1 - y0, x1 - x0))) % 90.0
+    return min(angle, 90.0 - angle)
+
+
+def single_digit_height_band(
+    confirmed_heights: list[float],
+) -> tuple[float, float] | None:
+    """Height band for single-digit claims, calibrated from confirmed reference heights.
+
+    ``confirmed_heights`` are the heights of multi-digit claims that ended up in mutual edges —
+    numerals long enough that a junk read is unlikely. Their printed size is very consistent
+    (Hudson County: median 46 px, p10-p90 of 42-48), so a single-digit read far from the median
+    is junk: frame rules and stray strokes read as tall "1"s, house numbers as short ones.
+    Returns None when there are no confirmed heights (e.g. a volume with only one-digit pages).
+    """
+    if not confirmed_heights:
+        return None
+    ordered = sorted(confirmed_heights)
+    median = ordered[len(ordered) // 2]
+    return (SIZE_BAND_FRACTION[0] * median, SIZE_BAND_FRACTION[1] * median)
+
+
 def is_claim(
     detection: dict,
     own_number: int | None,
     *,
     min_height: float = MIN_HEIGHT,
     min_confidence: float = MIN_CONF,
+    single_digit_min_confidence: float = SINGLE_DIGIT_MIN_CONF,
+    height_band: tuple[float, float] | None = None,
 ) -> bool:
-    """Whether a detection qualifies as an adjacency claim (edge-band, large, not the page itself)."""
-    return (
-        detection["number"] != own_number
-        and detection["edge"] != "center"
-        and detection["height"] >= min_height
-        and detection["confidence"] >= min_confidence
-    )
+    """Whether a detection qualifies as an adjacency claim.
+
+    Every claim must be a valid page number other than the page's own, near a page edge, tall
+    enough, confident enough, and axis-aligned (rotated quads are always misread street names
+    or pipe annotations). Single-digit numbers face two stricter tests — the high
+    ``single_digit_min_confidence`` floor and, when known, the ``height_band`` around the
+    volume's printed-reference size — because junk single-digit claims are common enough to
+    reciprocate by coincidence, so reciprocity alone cannot vouch for them.
+    """
+    if (
+        detection["number"] == own_number
+        or detection["edge"] == "center"
+        or detection["height"] < min_height
+        or detection["confidence"] < min_confidence
+        or polygon_rotation_deg(detection["polygon"]) > ROTATION_TOLERANCE_DEG
+    ):
+        return False
+    if detection["number"] < 10:
+        if detection["confidence"] < single_digit_min_confidence:
+            return False
+        if height_band is not None and not (
+            height_band[0] <= detection["height"] <= height_band[1]
+        ):
+            return False
+    return True
 
 
 def mutual_edges(claims_by_page: dict[str, set[int]]) -> list[tuple[str, str]]:
@@ -183,6 +250,16 @@ def main() -> None:
         help="Minimum OCR confidence for a claim (default: %(default)s).",
     )
     parser.add_argument(
+        "--single-digit-min-confidence",
+        type=float,
+        default=SINGLE_DIGIT_MIN_CONF,
+        metavar="C",
+        help=(
+            "Stricter confidence floor for single-digit claims (default: %(default)s); "
+            "junk single-digit reads are common enough to reciprocate by coincidence."
+        ),
+    )
+    parser.add_argument(
         "--no-gpu", action="store_true", help="Disable GPU acceleration for EasyOCR."
     )
     args = parser.parse_args()
@@ -204,29 +281,83 @@ def main() -> None:
     reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
 
     pages: dict[str, dict] = {}
-    claims_by_page: dict[str, set[int]] = {}
     for image in tqdm(images, smoothing=0):
         stem = image_stem(str(image))
-        own_number = page_number(stem)
-        detections = digit_detections(image, reader, valid_numbers)
-        for detection in detections:
-            detection["claim"] = is_claim(
-                detection,
-                own_number,
-                min_height=args.min_height,
-                min_confidence=args.min_confidence,
-            )
-        claims = {d["number"] for d in detections if d["claim"]}
         # Record the scanned image's dimensions so a viewer can rescale detection
         # polygons when it loads the page at a different resolution.
         width, height = Image.open(image).size
         pages[stem] = {
-            "number": own_number,
+            "number": page_number(stem),
             "width": width,
             "height": height,
-            "detections": detections,
+            "detections": digit_detections(image, reader, valid_numbers),
         }
-        claims_by_page[stem] = claims
+
+    def compute_claims(
+        height_band: tuple[float, float] | None,
+    ) -> dict[str, set[int]]:
+        return {
+            stem: {
+                d["number"]
+                for d in page["detections"]
+                if is_claim(
+                    d,
+                    page["number"],
+                    min_height=args.min_height,
+                    min_confidence=args.min_confidence,
+                    single_digit_min_confidence=args.single_digit_min_confidence,
+                    height_band=height_band,
+                )
+            }
+            for stem, page in pages.items()
+        }
+
+    # Two passes: provisional mutual edges (no height band) calibrate the printed-reference
+    # height from their multi-digit claims; single-digit claims are then re-filtered against
+    # that band and the graph rebuilt.
+    provisional_edges = mutual_edges(compute_claims(None))
+    mutual_numbers: dict[str, set[int]] = defaultdict(set)
+    for first, second in provisional_edges:
+        mutual_numbers[first].add(pages[second]["number"])
+        mutual_numbers[second].add(pages[first]["number"])
+    confirmed_heights = [
+        d["height"]
+        for stem, page in pages.items()
+        for d in page["detections"]
+        if d["number"] >= 10
+        and d["number"] in mutual_numbers[stem]
+        and is_claim(
+            d,
+            page["number"],
+            min_height=args.min_height,
+            min_confidence=args.min_confidence,
+            single_digit_min_confidence=args.single_digit_min_confidence,
+        )
+    ]
+    height_band = single_digit_height_band(confirmed_heights)
+    if height_band:
+        print(
+            f"Single-digit height band: [{height_band[0]:.0f}, {height_band[1]:.0f}]px "
+            f"from {len(confirmed_heights)} confirmed multi-digit reference(s).",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "No confirmed multi-digit references; single-digit height band disabled.",
+            file=sys.stderr,
+        )
+
+    claims_by_page = compute_claims(height_band)
+    for stem, page in pages.items():
+        for detection in page["detections"]:
+            detection["claim"] = is_claim(
+                detection,
+                page["number"],
+                min_height=args.min_height,
+                min_confidence=args.min_confidence,
+                single_digit_min_confidence=args.single_digit_min_confidence,
+                height_band=height_band,
+            )
 
     edges = mutual_edges(claims_by_page)
     doc = {
@@ -235,6 +366,8 @@ def main() -> None:
         "edge_band": EDGE_BAND,
         "min_height": args.min_height,
         "min_confidence": args.min_confidence,
+        "single_digit_min_confidence": args.single_digit_min_confidence,
+        "single_digit_height_band": list(height_band) if height_band else None,
         "pages": pages,
         "adjacency": [list(edge) for edge in edges],
     }

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -54,10 +54,14 @@ MIN_CONF = 0.05
 ROTATION_TOLERANCE_DEG = 5.0
 
 # Single-digit reads are held to a stricter standard than reciprocity alone can provide:
-# a hard confidence floor, and a height band of these fractions around the median height of
-# the volume's multi-digit mutual claims (see single_digit_height_band).
+# a hard confidence floor, a height band of these fractions around the median height of the
+# volume's multi-digit mutual claims (see single_digit_height_band), and an isolation floor —
+# a genuine reference is printed in open whitespace, while a junk single digit is typically a
+# fragment of a block/house number whose sibling box it touches (gap ~0), so require clear
+# space of at least this fraction of the same median height around it.
 SINGLE_DIGIT_MIN_CONF = 0.9
 SIZE_BAND_FRACTION = (0.65, 1.4)
+SINGLE_DIGIT_MIN_GAP_FRACTION = 0.3
 
 
 def volume_page_images(volume: Path) -> list[Path]:
@@ -100,24 +104,46 @@ def classify_edge(x_frac: float, y_frac: float, band: float = EDGE_BAND) -> str:
     return edges or "center"
 
 
+def bbox_gap(a: list[list[float]], b: list[list[float]]) -> float:
+    """Gap in pixels between two boxes' axis-aligned bounds (0 when they touch/overlap)."""
+    ax0, ax1 = min(p[0] for p in a), max(p[0] for p in a)
+    ay0, ay1 = min(p[1] for p in a), max(p[1] for p in a)
+    bx0, bx1 = min(p[0] for p in b), max(p[0] for p in b)
+    by0, by1 = min(p[1] for p in b), max(p[1] for p in b)
+    dx = max(0.0, max(ax0, bx0) - min(ax1, bx1))
+    dy = max(0.0, max(ay0, by0) - min(ay1, by1))
+    return math.hypot(dx, dy)
+
+
 def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[dict]:
     """All digit reads on one page that parse to a valid volume page number.
 
     Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
-    confidence, the glyph ``height`` in pixels, position as width/height fractions, and the
-    ``edge`` classification. Filtering into claims is left to the caller so the JSON keeps the
-    full picture.
+    confidence, the glyph ``height`` in pixels, position as width/height fractions, the
+    ``edge`` classification, and ``nearest_box`` — the gap to the nearest other OCR box, since
+    a genuine sheet reference is printed in open whitespace while a junk single digit is
+    usually a fragment of a larger number with sibling text right beside it. Filtering into
+    claims is left to the caller so the JSON keeps the full picture.
     """
     image = np.asarray(Image.open(image_path).convert("RGB"))
     height, width = image.shape[:2]
+    results = reader.readtext(image, allowlist="0123456789")
     detections = []
-    for bbox, text, confidence in reader.readtext(image, allowlist="0123456789"):
+    for index, (bbox, text, confidence) in enumerate(results):
         digits = "".join(c for c in text if c.isdigit())
         if not digits or int(digits) not in valid_numbers:
             continue
         x_frac = sum(p[0] for p in bbox) / 4 / width
         y_frac = sum(p[1] for p in bbox) / 4 / height
         glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))
+        nearest_box = min(
+            (
+                bbox_gap(bbox, other_bbox)
+                for other_index, (other_bbox, _, _) in enumerate(results)
+                if other_index != index
+            ),
+            default=math.inf,
+        )
         detections.append(
             {
                 "number": int(digits),
@@ -128,6 +154,9 @@ def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[
                 "x_frac": round(x_frac, 4),
                 "y_frac": round(y_frac, 4),
                 "edge": classify_edge(x_frac, y_frac),
+                "nearest_box": round(nearest_box, 1)
+                if nearest_box != math.inf
+                else None,
             }
         )
     return detections
@@ -170,15 +199,18 @@ def is_claim(
     min_confidence: float = MIN_CONF,
     single_digit_min_confidence: float = SINGLE_DIGIT_MIN_CONF,
     height_band: tuple[float, float] | None = None,
+    min_gap: float | None = None,
 ) -> bool:
     """Whether a detection qualifies as an adjacency claim.
 
     Every claim must be a valid page number other than the page's own, near a page edge, tall
     enough, confident enough, and axis-aligned (rotated quads are always misread street names
-    or pipe annotations). Single-digit numbers face two stricter tests — the high
-    ``single_digit_min_confidence`` floor and, when known, the ``height_band`` around the
-    volume's printed-reference size — because junk single-digit claims are common enough to
-    reciprocate by coincidence, so reciprocity alone cannot vouch for them.
+    or pipe annotations). Single-digit numbers face three stricter tests — the high
+    ``single_digit_min_confidence`` floor, the ``height_band`` around the volume's
+    printed-reference size, and the ``min_gap`` isolation floor (a digit torn off a larger
+    number touches its sibling box, so it can be a perfect glyph at the right size and still
+    be junk) — because junk single-digit claims are common enough to reciprocate by
+    coincidence, so reciprocity alone cannot vouch for them.
     """
     if (
         detection["number"] == own_number
@@ -194,6 +226,9 @@ def is_claim(
         if height_band is not None and not (
             height_band[0] <= detection["height"] <= height_band[1]
         ):
+            return False
+        nearest_box = detection.get("nearest_box")
+        if min_gap is not None and nearest_box is not None and nearest_box < min_gap:
             return False
     return True
 
@@ -295,6 +330,7 @@ def main() -> None:
 
     def compute_claims(
         height_band: tuple[float, float] | None,
+        min_gap: float | None,
     ) -> dict[str, set[int]]:
         return {
             stem: {
@@ -307,15 +343,16 @@ def main() -> None:
                     min_confidence=args.min_confidence,
                     single_digit_min_confidence=args.single_digit_min_confidence,
                     height_band=height_band,
+                    min_gap=min_gap,
                 )
             }
             for stem, page in pages.items()
         }
 
-    # Two passes: provisional mutual edges (no height band) calibrate the printed-reference
-    # height from their multi-digit claims; single-digit claims are then re-filtered against
-    # that band and the graph rebuilt.
-    provisional_edges = mutual_edges(compute_claims(None))
+    # Two passes: provisional mutual edges (no height band or isolation floor) calibrate the
+    # printed-reference height from their multi-digit claims; single-digit claims are then
+    # re-filtered against the derived band and isolation floor and the graph rebuilt.
+    provisional_edges = mutual_edges(compute_claims(None, None))
     mutual_numbers: dict[str, set[int]] = defaultdict(set)
     for first, second in provisional_edges:
         mutual_numbers[first].add(pages[second]["number"])
@@ -335,19 +372,25 @@ def main() -> None:
         )
     ]
     height_band = single_digit_height_band(confirmed_heights)
-    if height_band:
+    min_gap = None
+    if height_band and confirmed_heights:
+        ordered = sorted(confirmed_heights)
+        median_height = ordered[len(ordered) // 2]
+        min_gap = SINGLE_DIGIT_MIN_GAP_FRACTION * median_height
         print(
-            f"Single-digit height band: [{height_band[0]:.0f}, {height_band[1]:.0f}]px "
-            f"from {len(confirmed_heights)} confirmed multi-digit reference(s).",
+            f"Single-digit height band: [{height_band[0]:.0f}, {height_band[1]:.0f}]px, "
+            f"isolation floor: {min_gap:.0f}px "
+            f"(from {len(confirmed_heights)} confirmed multi-digit references).",
             file=sys.stderr,
         )
     else:
         print(
-            "No confirmed multi-digit references; single-digit height band disabled.",
+            "No confirmed multi-digit references; single-digit height band and "
+            "isolation floor disabled.",
             file=sys.stderr,
         )
 
-    claims_by_page = compute_claims(height_band)
+    claims_by_page = compute_claims(height_band, min_gap)
     for stem, page in pages.items():
         for detection in page["detections"]:
             detection["claim"] = is_claim(
@@ -357,6 +400,7 @@ def main() -> None:
                 min_confidence=args.min_confidence,
                 single_digit_min_confidence=args.single_digit_min_confidence,
                 height_band=height_band,
+                min_gap=min_gap,
             )
 
     edges = mutual_edges(claims_by_page)
@@ -368,6 +412,7 @@ def main() -> None:
         "min_confidence": args.min_confidence,
         "single_digit_min_confidence": args.single_digit_min_confidence,
         "single_digit_height_band": list(height_band) if height_band else None,
+        "single_digit_min_gap": round(min_gap, 1) if min_gap is not None else None,
         "pages": pages,
         "adjacency": [list(edge) for edge in edges],
     }

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -3,7 +3,7 @@
 Sanborn sheets print the neighboring sheet's number on the margin (the key legend calls it a
 "reference to adjoining sheet"): a big numeral across the shared boundary road on the side that
 sheet continues. Reading these gives page adjacency that is independent of the key map — and a
-detected neighbor's edge (N/E/S/W) pins the page's orientation.
+detected neighbor's edge (top/left/bottom/right of the image) pins the page's orientation.
 
 Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a
 detection only becomes a *claim* when it is a valid page number, near the page edge, and printed
@@ -64,19 +64,21 @@ def volume_page_images(volume: Path) -> list[Path]:
 
 
 def classify_edge(x_frac: float, y_frac: float, band: float = EDGE_BAND) -> str:
-    """Which page edge(s) a point (as fractions of width/height) is near: "E", "NW", "center"...
+    """Which page edge(s) a point (as fractions of width/height) is near: "T", "BL", "center"...
 
-    Corners use the conventional compass spelling (vertical first): "NE", "NW", "SE", "SW".
+    Sides are image-relative — "T"op, "B"ottom, "L"eft, "R"ight, with corners "TL", "TR",
+    "BL", "BR" — not compass directions: the page's orientation in the world is unknown at
+    this stage (finding it is what adjacency is *for*).
     """
     edges = ""
     if y_frac < band:
-        edges += "N"
+        edges += "T"
     if y_frac > 1 - band:
-        edges += "S"
+        edges += "B"
     if x_frac < band:
-        edges += "W"
+        edges += "L"
     if x_frac > 1 - band:
-        edges += "E"
+        edges += "R"
     return edges or "center"
 
 

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -41,11 +41,13 @@ from mapsnap.utils import image_stem
 
 # A detection only counts as an adjacency claim when it sits in the outer EDGE_BAND of the
 # page, is at least MIN_HEIGHT px tall (the printed sheet references are large numerals; this
-# excludes house/dimension numbers), and clears a permissive confidence floor (true references
-# read at high confidence, but a partly-degraded one is still rescued by reciprocity).
+# excludes house/dimension numbers), and clears a confidence floor. Measured on Hudson and
+# Brooklyn: 0.3 loses no true edge on either volume while killing junk a permissive floor
+# admits (a forced-transcription street name reads at ~0.1; genuine degraded references read
+# above 0.3); 0.5 would kill a further junk edge but costs Hudson four real ones.
 EDGE_BAND = 0.25
 MIN_HEIGHT = 28.0
-MIN_CONF = 0.05
+MIN_CONF = 0.3
 
 # A rotated detection quad is never a sheet reference: every rotated candidate inspected on
 # Hudson County (52 of them) was a misread street name ("WESTSIDE", "Mc ADOO") or pipe
@@ -155,11 +157,23 @@ def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[
     usually a fragment of a larger number with sibling text right beside it. Filtering into
     claims is left to the caller so the JSON keeps the full picture.
     """
+    from easyocr.utils import reformat_input
+
     image = np.asarray(Image.open(image_path).convert("RGB"))
     height, width = image.shape[:2]
-    results = reader.readtext(image, allowlist="0123456789")
-    letter_results = reader.readtext(
-        image, allowlist="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    # Detect once, recognize twice: CRAFT detection dominates the cost and is
+    # allowlist-independent, so the two passes share its boxes (readtext = detect +
+    # recognize with these same defaults).
+    img, img_grey = reformat_input(image)
+    horizontal_lists, free_lists = reader.detect(img)
+    results = reader.recognize(
+        img_grey, horizontal_lists[0], free_lists[0], allowlist="0123456789"
+    )
+    letter_results = reader.recognize(
+        img_grey,
+        horizontal_lists[0],
+        free_lists[0],
+        allowlist="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     )
     letter_centers = [box_center(bbox) for bbox, _, _ in letter_results]
     detections = []

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -64,16 +64,19 @@ def volume_page_images(volume: Path) -> list[Path]:
 
 
 def classify_edge(x_frac: float, y_frac: float, band: float = EDGE_BAND) -> str:
-    """Which page edge(s) a point (as fractions of width/height) is near, e.g. "E", "WN", "center"."""
+    """Which page edge(s) a point (as fractions of width/height) is near: "E", "NW", "center"...
+
+    Corners use the conventional compass spelling (vertical first): "NE", "NW", "SE", "SW".
+    """
     edges = ""
-    if x_frac < band:
-        edges += "W"
-    if x_frac > 1 - band:
-        edges += "E"
     if y_frac < band:
         edges += "N"
     if y_frac > 1 - band:
         edges += "S"
+    if x_frac < band:
+        edges += "W"
+    if x_frac > 1 - band:
+        edges += "E"
     return edges or "center"
 
 
@@ -212,7 +215,15 @@ def main() -> None:
                 min_confidence=args.min_confidence,
             )
         claims = {d["number"] for d in detections if d["claim"]}
-        pages[stem] = {"number": own_number, "detections": detections}
+        # Record the scanned image's dimensions so a viewer can rescale detection
+        # polygons when it loads the page at a different resolution.
+        width, height = Image.open(image).size
+        pages[stem] = {
+            "number": own_number,
+            "width": width,
+            "height": height,
+            "detections": detections,
+        }
         claims_by_page[stem] = claims
 
     edges = mutual_edges(claims_by_page)

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -1,0 +1,239 @@
+"""Detect printed adjacent-sheet numbers on page margins and build a volume adjacency graph.
+
+Sanborn sheets print the neighboring sheet's number on the margin (the key legend calls it a
+"reference to adjoining sheet"): a big numeral across the shared boundary road on the side that
+sheet continues. Reading these gives page adjacency that is independent of the key map — and a
+detected neighbor's edge (N/E/S/W) pins the page's orientation.
+
+Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a
+detection only becomes a *claim* when it is a valid page number, near the page edge, and printed
+large; and a claim only becomes an adjacency *edge* when it is reciprocated — page A claims B
+AND page B claims A. Measured on Hudson County: directed claims are ~72% precise, mutual edges
+~98%, covering ~76% of georeferenced-overlap adjacencies and reaching 30/33 pages that street
+matching failed to georeference.
+
+This is a whole-volume step: it scans every non-split page image (skipping key-map sheets,
+whose faces are covered in page numbers) and writes a single ``<volume>/adjacency.json`` with
+each page's number detections and the mutual-edge adjacency graph.
+
+    uv run mapsnap adjacency data/hudson_co_nj_1950_vol_9
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+from tqdm import tqdm
+
+from mapsnap.keymap.locate import page_number
+from mapsnap.utils import image_stem
+
+# A detection only counts as an adjacency claim when it sits in the outer EDGE_BAND of the
+# page, is at least MIN_HEIGHT px tall (the printed sheet references are large numerals; this
+# excludes house/dimension numbers), and clears a permissive confidence floor (true references
+# read at high confidence, but a partly-degraded one is still rescued by reciprocity).
+EDGE_BAND = 0.25
+MIN_HEIGHT = 28.0
+MIN_CONF = 0.05
+
+
+def volume_page_images(volume: Path) -> list[Path]:
+    """The whole-page images to scan: top-level ``p*.jpg``, skipping split panels and key maps.
+
+    Split panels (``__`` stems) are cuts of a parent sheet, so the printed margin references
+    live on the parent; the parent is scanned even when panels supersede it for OCR. Key-map
+    sheets are excluded: their faces are covered in page numbers, which would all read as
+    spurious claims.
+    """
+    images = []
+    for image in sorted(volume.glob("p*.jpg")):
+        stem = image_stem(str(image))
+        if "__" in stem:
+            continue
+        if (volume / f"{stem}.keymap.json").exists() or (
+            volume / "raw" / f"{stem}.keymap.json"
+        ).exists():
+            continue
+        images.append(image)
+    return images
+
+
+def classify_edge(x_frac: float, y_frac: float, band: float = EDGE_BAND) -> str:
+    """Which page edge(s) a point (as fractions of width/height) is near, e.g. "E", "WN", "center"."""
+    edges = ""
+    if x_frac < band:
+        edges += "W"
+    if x_frac > 1 - band:
+        edges += "E"
+    if y_frac < band:
+        edges += "N"
+    if y_frac > 1 - band:
+        edges += "S"
+    return edges or "center"
+
+
+def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[dict]:
+    """All digit reads on one page that parse to a valid volume page number.
+
+    Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
+    confidence, the glyph ``height`` in pixels, position as width/height fractions, and the
+    ``edge`` classification. Filtering into claims is left to the caller so the JSON keeps the
+    full picture.
+    """
+    image = np.asarray(Image.open(image_path).convert("RGB"))
+    height, width = image.shape[:2]
+    detections = []
+    for bbox, text, confidence in reader.readtext(image, allowlist="0123456789"):
+        digits = "".join(c for c in text if c.isdigit())
+        if not digits or int(digits) not in valid_numbers:
+            continue
+        x_frac = sum(p[0] for p in bbox) / 4 / width
+        y_frac = sum(p[1] for p in bbox) / 4 / height
+        glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))
+        detections.append(
+            {
+                "number": int(digits),
+                "text": text,
+                "confidence": round(float(confidence), 4),
+                "polygon": [[int(p[0]), int(p[1])] for p in bbox],
+                "height": round(glyph_height, 1),
+                "x_frac": round(x_frac, 4),
+                "y_frac": round(y_frac, 4),
+                "edge": classify_edge(x_frac, y_frac),
+            }
+        )
+    return detections
+
+
+def is_claim(
+    detection: dict,
+    own_number: int | None,
+    *,
+    min_height: float = MIN_HEIGHT,
+    min_confidence: float = MIN_CONF,
+) -> bool:
+    """Whether a detection qualifies as an adjacency claim (edge-band, large, not the page itself)."""
+    return (
+        detection["number"] != own_number
+        and detection["edge"] != "center"
+        and detection["height"] >= min_height
+        and detection["confidence"] >= min_confidence
+    )
+
+
+def mutual_edges(claims_by_page: dict[str, set[int]]) -> list[tuple[str, str]]:
+    """Reciprocated adjacency edges: A claims B's number and B claims A's number.
+
+    ``claims_by_page`` maps page stems to claimed page numbers. A number claimed by A resolves
+    to the page stem(s) carrying that number; the edge exists only if some such stem claims A's
+    number back. Returns sorted (stem, stem) pairs, each once.
+    """
+    stems_by_number: dict[int, list[str]] = defaultdict(list)
+    for stem in claims_by_page:
+        number = page_number(stem)
+        if number is not None:
+            stems_by_number[number].append(stem)
+    edges: set[tuple[str, str]] = set()
+    for stem, claimed in claims_by_page.items():
+        own = page_number(stem)
+        if own is None:
+            continue
+        for number in claimed:
+            for other in stems_by_number.get(number, []):
+                if other != stem and own in claims_by_page.get(other, set()):
+                    first, second = sorted((stem, other))
+                    edges.add((first, second))
+    return sorted(edges)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Detect printed adjacent-sheet numbers and build a volume adjacency graph."
+    )
+    parser.add_argument(
+        "volume", type=Path, help="Volume directory holding p*.jpg pages."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output JSON path (default: <volume>/adjacency.json).",
+    )
+    parser.add_argument(
+        "--min-height",
+        type=float,
+        default=MIN_HEIGHT,
+        metavar="PX",
+        help="Minimum glyph height for a claim (default: %(default)s, tuned for 25%%-scale pages).",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=MIN_CONF,
+        metavar="C",
+        help="Minimum OCR confidence for a claim (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--no-gpu", action="store_true", help="Disable GPU acceleration for EasyOCR."
+    )
+    args = parser.parse_args()
+
+    import easyocr
+
+    images = volume_page_images(args.volume)
+    if not images:
+        sys.exit(f"No page images found in {args.volume}.")
+    valid_numbers = {
+        number
+        for image in images
+        if (number := page_number(image_stem(str(image)))) is not None
+    }
+    print(
+        f"Scanning {len(images)} pages ({len(valid_numbers)} page numbers)...",
+        file=sys.stderr,
+    )
+    reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
+
+    pages: dict[str, dict] = {}
+    claims_by_page: dict[str, set[int]] = {}
+    for image in tqdm(images, smoothing=0):
+        stem = image_stem(str(image))
+        own_number = page_number(stem)
+        detections = digit_detections(image, reader, valid_numbers)
+        for detection in detections:
+            detection["claim"] = is_claim(
+                detection,
+                own_number,
+                min_height=args.min_height,
+                min_confidence=args.min_confidence,
+            )
+        claims = {d["number"] for d in detections if d["claim"]}
+        pages[stem] = {"number": own_number, "detections": detections}
+        claims_by_page[stem] = claims
+
+    edges = mutual_edges(claims_by_page)
+    doc = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "command": sys.argv[:],
+        "edge_band": EDGE_BAND,
+        "min_height": args.min_height,
+        "min_confidence": args.min_confidence,
+        "pages": pages,
+        "adjacency": [list(edge) for edge in edges],
+    }
+    output = args.output or (args.volume / "adjacency.json")
+    output.write_text(json.dumps(doc, indent=2))
+    total_claims = sum(len(c) for c in claims_by_page.values())
+    print(
+        f"Wrote {output}: {len(pages)} pages, {total_claims} directed claims, "
+        f"{len(edges)} mutual edges.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -9,22 +9,22 @@ from mapsnap.page_adjacency import (
 
 
 def make_detection(
-    number: int, edge: str = "E", height: float = 45.0, confidence: float = 0.9
+    number: int, edge: str = "R", height: float = 45.0, confidence: float = 0.9
 ) -> dict:
     return {"number": number, "edge": edge, "height": height, "confidence": confidence}
 
 
 def test_classify_edge_bands():
+    # Image-relative sides (page orientation is unknown at this stage): T/B/L/R.
     assert classify_edge(0.5, 0.5) == "center"
-    assert classify_edge(0.1, 0.5) == "W"
-    assert classify_edge(0.9, 0.5) == "E"
-    assert classify_edge(0.5, 0.1) == "N"
-    assert classify_edge(0.5, 0.9) == "S"
-    # Corners use conventional compass spelling: vertical first.
-    assert classify_edge(0.05, 0.05) == "NW"
-    assert classify_edge(0.95, 0.05) == "NE"
-    assert classify_edge(0.05, 0.95) == "SW"
-    assert classify_edge(0.95, 0.95) == "SE"
+    assert classify_edge(0.1, 0.5) == "L"
+    assert classify_edge(0.9, 0.5) == "R"
+    assert classify_edge(0.5, 0.1) == "T"
+    assert classify_edge(0.5, 0.9) == "B"
+    assert classify_edge(0.05, 0.05) == "TL"
+    assert classify_edge(0.95, 0.05) == "TR"
+    assert classify_edge(0.05, 0.95) == "BL"
+    assert classify_edge(0.95, 0.95) == "BR"
 
 
 def test_is_claim_accepts_large_edge_number():

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -157,3 +157,16 @@ def test_volume_page_images_skips_splits_and_keymaps(tmp_path: Path):
     names = [p.name for p in volume_page_images(tmp_path)]
     # p2 itself stays (the parent sheet carries the margin references); panels are skipped.
     assert names == ["p1.jpg", "p2.jpg"]
+
+
+def test_is_text_veto():
+    from mapsnap.page_adjacency import is_text_veto
+
+    # A veto needs a textual reveal AND the recognizer preferring the letters reading.
+    assert is_text_veto("SMITH", 0.9, 0.1)  # street name reveals itself
+    assert is_text_veto("AV", 0.9, 0.2)  # letter-dominated
+    assert not is_text_veto("70", 0.9, 0.5)  # clean number
+    assert not is_text_veto("7O", 0.9, 0.5)  # one look-alike letter: keep
+    assert not is_text_veto("31NJ", 0.9, 0.5)  # number + short annotation: keep
+    assert not is_text_veto("AL", 0.88, 0.95)  # genuine "41": digits read wins
+    assert not is_text_veto("", 0.9, 0.1)

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -1,17 +1,40 @@
+import math
 from pathlib import Path
 
 from mapsnap.page_adjacency import (
     classify_edge,
     is_claim,
     mutual_edges,
+    polygon_rotation_deg,
+    single_digit_height_band,
     volume_page_images,
 )
 
 
+def axis_polygon(width: float = 40.0, height: float = 45.0) -> list[list[float]]:
+    return [[0, 0], [width, 0], [width, height], [0, height]]
+
+
+def rotated_polygon(degrees: float, width: float = 40.0) -> list[list[float]]:
+    dx = width * math.cos(math.radians(degrees))
+    dy = width * math.sin(math.radians(degrees))
+    return [[0, 0], [dx, dy], [dx - dy, dy + dx], [-dy, dx]]
+
+
 def make_detection(
-    number: int, edge: str = "R", height: float = 45.0, confidence: float = 0.9
+    number: int,
+    edge: str = "R",
+    height: float = 45.0,
+    confidence: float = 0.95,
+    polygon: list[list[float]] | None = None,
 ) -> dict:
-    return {"number": number, "edge": edge, "height": height, "confidence": confidence}
+    return {
+        "number": number,
+        "edge": edge,
+        "height": height,
+        "confidence": confidence,
+        "polygon": polygon if polygon is not None else axis_polygon(),
+    }
 
 
 def test_classify_edge_bands():
@@ -27,6 +50,13 @@ def test_classify_edge_bands():
     assert classify_edge(0.95, 0.95) == "BR"
 
 
+def test_polygon_rotation_deg():
+    assert polygon_rotation_deg(axis_polygon()) == 0.0
+    assert abs(polygon_rotation_deg(rotated_polygon(17.0)) - 17.0) < 0.01
+    # Vertical text boxes are axis-aligned too: fold 90 degrees back to 0.
+    assert abs(polygon_rotation_deg(rotated_polygon(90.0))) < 0.01
+
+
 def test_is_claim_accepts_large_edge_number():
     assert is_claim(make_detection(50), own_number=49)
 
@@ -36,6 +66,44 @@ def test_is_claim_rejects_own_number_center_small_and_lowconf():
     assert not is_claim(make_detection(50, edge="center"), own_number=49)
     assert not is_claim(make_detection(50, height=12.0), own_number=49)
     assert not is_claim(make_detection(50, confidence=0.01), own_number=49)
+
+
+def test_is_claim_rejects_rotated_quads():
+    # Every rotated candidate inspected was a misread street name or pipe annotation.
+    rotated = make_detection(50, polygon=rotated_polygon(17.0))
+    assert not is_claim(rotated, own_number=49)
+
+
+def test_is_claim_single_digit_confidence_floor():
+    # Junk single-digit reads reciprocate by coincidence; require high confidence.
+    assert not is_claim(make_detection(6, confidence=0.5), own_number=49)
+    assert is_claim(make_detection(6, confidence=0.95), own_number=49)
+    # Multi-digit numbers keep the permissive floor.
+    assert is_claim(make_detection(50, confidence=0.5), own_number=49)
+
+
+def test_is_claim_single_digit_height_band():
+    band = (30.0, 65.0)
+    # A 130px "1" is a frame rule, not a reference; a 45px one matches the printed size.
+    assert not is_claim(
+        make_detection(1, height=130.0), own_number=49, height_band=band
+    )
+    assert is_claim(make_detection(1, height=45.0), own_number=49, height_band=band)
+    # The band applies only to single digits; multi-digit heights are already trustworthy.
+    assert is_claim(make_detection(50, height=130.0), own_number=49, height_band=band)
+    # Without a band (no confirmed references), single digits pass on confidence alone.
+    assert is_claim(make_detection(1, height=130.0), own_number=49, height_band=None)
+
+
+def test_single_digit_height_band_from_median():
+    band = single_digit_height_band([42.0, 46.0, 48.0])
+    assert band is not None
+    assert abs(band[0] - 0.65 * 46.0) < 1e-9
+    assert abs(band[1] - 1.4 * 46.0) < 1e-9
+
+
+def test_single_digit_height_band_empty():
+    assert single_digit_height_band([]) is None
 
 
 def test_mutual_edges_requires_reciprocity():

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -20,7 +20,11 @@ def test_classify_edge_bands():
     assert classify_edge(0.9, 0.5) == "E"
     assert classify_edge(0.5, 0.1) == "N"
     assert classify_edge(0.5, 0.9) == "S"
-    assert classify_edge(0.05, 0.05) == "WN"  # corner is both
+    # Corners use conventional compass spelling: vertical first.
+    assert classify_edge(0.05, 0.05) == "NW"
+    assert classify_edge(0.95, 0.05) == "NE"
+    assert classify_edge(0.05, 0.95) == "SW"
+    assert classify_edge(0.95, 0.95) == "SE"
 
 
 def test_is_claim_accepts_large_edge_number():

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from mapsnap.page_adjacency import (
+    classify_edge,
+    is_claim,
+    mutual_edges,
+    volume_page_images,
+)
+
+
+def make_detection(
+    number: int, edge: str = "E", height: float = 45.0, confidence: float = 0.9
+) -> dict:
+    return {"number": number, "edge": edge, "height": height, "confidence": confidence}
+
+
+def test_classify_edge_bands():
+    assert classify_edge(0.5, 0.5) == "center"
+    assert classify_edge(0.1, 0.5) == "W"
+    assert classify_edge(0.9, 0.5) == "E"
+    assert classify_edge(0.5, 0.1) == "N"
+    assert classify_edge(0.5, 0.9) == "S"
+    assert classify_edge(0.05, 0.05) == "WN"  # corner is both
+
+
+def test_is_claim_accepts_large_edge_number():
+    assert is_claim(make_detection(50), own_number=49)
+
+
+def test_is_claim_rejects_own_number_center_small_and_lowconf():
+    assert not is_claim(make_detection(49), own_number=49)  # the sheet's own number
+    assert not is_claim(make_detection(50, edge="center"), own_number=49)
+    assert not is_claim(make_detection(50, height=12.0), own_number=49)
+    assert not is_claim(make_detection(50, confidence=0.01), own_number=49)
+
+
+def test_mutual_edges_requires_reciprocity():
+    claims = {"p49": {50, 51}, "p50": {49}, "p51": set()}
+    # 49<->50 reciprocate; 49->51 is unreciprocated and produces no edge.
+    assert mutual_edges(claims) == [("p49", "p50")]
+
+
+def test_mutual_edges_lettered_stems():
+    # Chicago-style stems: numbers resolve to the lettered page stem.
+    claims = {"p59w": {60}, "p60w": {59}}
+    assert mutual_edges(claims) == [("p59w", "p60w")]
+
+
+def test_mutual_edges_empty_when_one_sided():
+    assert mutual_edges({"p1": {2}, "p2": set()}) == []
+
+
+def test_volume_page_images_skips_splits_and_keymaps(tmp_path: Path):
+    for name in ["p0.jpg", "p1.jpg", "p2.jpg", "p2__1.jpg", "p2__2.jpg"]:
+        (tmp_path / name).write_bytes(b"")
+    # p0 is a key map (detections sidecar under raw/): excluded from the scan.
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "p0.keymap.json").write_text("{}")
+    names = [p.name for p in volume_page_images(tmp_path)]
+    # p2 itself stays (the parent sheet carries the margin references); panels are skipped.
+    assert names == ["p1.jpg", "p2.jpg"]

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -2,6 +2,7 @@ import math
 from pathlib import Path
 
 from mapsnap.page_adjacency import (
+    bbox_gap,
     classify_edge,
     is_claim,
     mutual_edges,
@@ -27,6 +28,7 @@ def make_detection(
     height: float = 45.0,
     confidence: float = 0.95,
     polygon: list[list[float]] | None = None,
+    nearest_box: float | None = 100.0,
 ) -> dict:
     return {
         "number": number,
@@ -34,6 +36,7 @@ def make_detection(
         "height": height,
         "confidence": confidence,
         "polygon": polygon if polygon is not None else axis_polygon(),
+        "nearest_box": nearest_box,
     }
 
 
@@ -93,6 +96,28 @@ def test_is_claim_single_digit_height_band():
     assert is_claim(make_detection(50, height=130.0), own_number=49, height_band=band)
     # Without a band (no confirmed references), single digits pass on confidence alone.
     assert is_claim(make_detection(1, height=130.0), own_number=49, height_band=None)
+
+
+def test_bbox_gap():
+    a = [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]
+    touching = [[10.0, 0.0], [20.0, 0.0], [20.0, 10.0], [10.0, 10.0]]
+    apart = [[40.0, 0.0], [50.0, 0.0], [50.0, 10.0], [40.0, 10.0]]
+    diagonal = [[13.0, 14.0], [23.0, 14.0], [23.0, 24.0], [13.0, 24.0]]
+    assert bbox_gap(a, touching) == 0.0
+    assert bbox_gap(a, apart) == 30.0
+    assert bbox_gap(a, diagonal) == 5.0  # 3-4-5 triangle from the corner
+
+
+def test_is_claim_single_digit_isolation():
+    # A perfect-glyph, right-sized single digit that touches another box is a fragment
+    # of a larger number (p10's "8" torn off a block number), not a sheet reference.
+    fragment = make_detection(8, confidence=1.0, nearest_box=0.0)
+    assert not is_claim(fragment, own_number=10, min_gap=14.0)
+    isolated = make_detection(8, confidence=1.0, nearest_box=21.6)
+    assert is_claim(isolated, own_number=10, min_gap=14.0)
+    # Multi-digit claims are exempt; missing gap data (only box on the page) passes.
+    assert is_claim(make_detection(50, nearest_box=0.0), own_number=10, min_gap=14.0)
+    assert is_claim(make_detection(8, nearest_box=None), own_number=10, min_gap=14.0)
 
 
 def test_single_digit_height_band_from_median():

--- a/mapsnap/score_adjacency.py
+++ b/mapsnap/score_adjacency.py
@@ -1,0 +1,189 @@
+"""Score a volume's adjacency.json against OIM truth footprints.
+
+Two pages count as truth-adjacent when their human-georeferenced footprints (from
+``main.iiif.json``) come within ``--max-gap`` metres of each other; OIM's manual splits clip
+pages to tile cleanly, so genuinely adjacent pages touch or nearly touch rather than overlap.
+
+Reports the mutual-edge precision (fraction of edges whose pages are truth-adjacent), recall
+against all truth-adjacent pairs, and page coverage, and lists the edges that contradict truth
+for inspection. Two caveats when reading the numbers: recall's denominator includes
+corner-to-corner contacts that sheets print no reference for, so it reads low; and a
+truth-consistent edge can still rest on a junk read that reciprocated by coincidence (page
+numbering correlates with adjacency), so precision reads high — inspect surviving edges in the
+debugger's adjacency mode before trusting a new filter.
+
+    uv run python -m mapsnap.score_adjacency data/hudson_co_nj_1950_vol_9
+"""
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from shapely.geometry import Polygon
+from shapely.ops import unary_union
+
+from mapsnap.compare_iiif_georef import truth_polygons_by_page
+from mapsnap.keymap.locate import M_PER_DEG_LAT, M_PER_DEG_LON_EQUATOR
+
+
+def truth_shapes(
+    truth_by_page: dict[int, list[list[list[float]]]],
+) -> dict[int, object]:
+    """One shapely geometry per page number, in a local metre frame.
+
+    Each page's truth footprints (several for a split page) are unioned. Coordinates are
+    projected equirectangularly about the volume's mean latitude so distances are metres.
+    """
+    points = [
+        point
+        for polygons in truth_by_page.values()
+        for polygon in polygons
+        for point in polygon
+    ]
+    if not points:
+        return {}
+    lat0 = sum(point[1] for point in points) / len(points)
+    scale_x = M_PER_DEG_LON_EQUATOR * math.cos(math.radians(lat0))
+    return {
+        number: unary_union(
+            [
+                Polygon([(x * scale_x, y * M_PER_DEG_LAT) for x, y in polygon])
+                for polygon in polygons
+            ]
+        )
+        for number, polygons in truth_by_page.items()
+    }
+
+
+def truth_adjacent_pairs(
+    shapes: dict[int, object], max_gap_m: float
+) -> set[frozenset[int]]:
+    """Unordered page-number pairs whose truth footprints come within ``max_gap_m`` metres."""
+    numbers = sorted(shapes)
+    pairs: set[frozenset[int]] = set()
+    for i, a in enumerate(numbers):
+        for b in numbers[i + 1 :]:
+            if shapes[a].distance(shapes[b]) < max_gap_m:  # type: ignore[attr-defined]
+                pairs.add(frozenset((a, b)))
+    return pairs
+
+
+@dataclass
+class AdjacencyScore:
+    """Mutual-edge accuracy against truth adjacency (see score_adjacency)."""
+
+    edges: int = 0
+    known: int = 0  # edges where both pages have truth footprints
+    correct: int = 0
+    wrong: list[tuple[str, str]] = field(default_factory=list)
+    unknown: list[tuple[str, str]] = field(default_factory=list)
+    truth_pairs: int = 0  # truth-adjacent pairs among scanned pages
+    recovered: int = 0
+    pages: int = 0
+    pages_covered: int = 0
+    single_digit_known: int = 0
+    single_digit_correct: int = 0
+
+
+def score_adjacency(
+    doc: dict, truth_pairs: set[frozenset[int]], truth_numbers: set[int]
+) -> AdjacencyScore:
+    """Score an adjacency.json document's mutual edges against truth-adjacent pairs.
+
+    Edges between pages sharing a number (split variants) are skipped; edges where either
+    page lacks a truth footprint are counted as ``unknown`` rather than wrong.
+    """
+    pages = doc["pages"]
+    score = AdjacencyScore(pages=len(pages))
+    covered: set[str] = set()
+    recovered_pairs: set[frozenset[int]] = set()
+    for stem_a, stem_b in doc["adjacency"]:
+        number_a, number_b = pages[stem_a]["number"], pages[stem_b]["number"]
+        score.edges += 1
+        covered.update((stem_a, stem_b))
+        if number_a == number_b:
+            continue
+        if number_a not in truth_numbers or number_b not in truth_numbers:
+            score.unknown.append((stem_a, stem_b))
+            continue
+        score.known += 1
+        pair = frozenset((number_a, number_b))
+        is_correct = pair in truth_pairs
+        single = min(number_a, number_b) < 10
+        if single:
+            score.single_digit_known += 1
+        if is_correct:
+            score.correct += 1
+            recovered_pairs.add(pair)
+            if single:
+                score.single_digit_correct += 1
+        else:
+            score.wrong.append((stem_a, stem_b))
+    scanned_numbers = {page["number"] for page in pages.values()}
+    relevant = {pair for pair in truth_pairs if all(n in scanned_numbers for n in pair)}
+    score.truth_pairs = len(relevant)
+    score.recovered = len(recovered_pairs & relevant)
+    score.pages_covered = len(covered)
+    return score
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Score adjacency.json mutual edges against OIM truth footprints."
+    )
+    parser.add_argument(
+        "volume",
+        type=Path,
+        help="Volume directory holding adjacency.json and main.iiif.json.",
+    )
+    parser.add_argument(
+        "--max-gap",
+        type=float,
+        default=30.0,
+        metavar="M",
+        help=(
+            "Footprints within this many metres count as truth-adjacent "
+            "(default: %(default)s; OIM clips pages to tile, so neighbors nearly touch)."
+        ),
+    )
+    args = parser.parse_args()
+
+    adjacency_path = args.volume / "adjacency.json"
+    truth_path = args.volume / "main.iiif.json"
+    for path in (adjacency_path, truth_path):
+        if not path.exists():
+            sys.exit(f"Not found: {path}")
+    doc = json.load(open(adjacency_path))
+    shapes = truth_shapes(truth_polygons_by_page(truth_path))
+    if not shapes:
+        sys.exit(f"No usable truth footprints in {truth_path}.")
+    truth_pairs = truth_adjacent_pairs(shapes, args.max_gap)
+    score = score_adjacency(doc, truth_pairs, set(shapes))
+
+    print(f"pages scanned:  {score.pages} ({score.pages_covered} in >=1 mutual edge)")
+    print(f"mutual edges:   {score.edges}")
+    print(
+        f"precision:      {score.correct}/{score.known} truth-consistent"
+        + (f" ({score.correct / score.known:.0%})" if score.known else "")
+    )
+    if score.single_digit_known:
+        print(
+            f"  single-digit: {score.single_digit_correct}/{score.single_digit_known}"
+        )
+    print(
+        f"recall:         {score.recovered}/{score.truth_pairs} truth-adjacent pairs "
+        "(denominator includes corner contacts sheets don't print)"
+    )
+    if score.wrong:
+        print("edges contradicting truth:")
+        for stem_a, stem_b in score.wrong:
+            print(f"  {stem_a} <-> {stem_b}")
+    if score.unknown:
+        print(f"edges without truth coverage: {len(score.unknown)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/score_adjacency_test.py
+++ b/mapsnap/score_adjacency_test.py
@@ -1,0 +1,83 @@
+from mapsnap.score_adjacency import (
+    score_adjacency,
+    truth_adjacent_pairs,
+    truth_shapes,
+)
+
+
+def square(lon: float, lat: float, size_deg: float = 0.003) -> list[list[float]]:
+    return [
+        [lon, lat],
+        [lon + size_deg, lat],
+        [lon + size_deg, lat + size_deg],
+        [lon, lat + size_deg],
+        [lon, lat],
+    ]
+
+
+def test_truth_adjacent_pairs_touching_vs_far():
+    # Pages 1 and 2 share an edge; page 3 is ~1.1 km away.
+    shapes = truth_shapes(
+        {
+            1: [square(0.0, 0.0)],
+            2: [square(0.003, 0.0)],
+            3: [square(0.02, 0.0)],
+        }
+    )
+    pairs = truth_adjacent_pairs(shapes, max_gap_m=30.0)
+    assert pairs == {frozenset((1, 2))}
+
+
+def test_truth_shapes_unions_split_footprints():
+    # A split page's two footprints act as one geometry: page 2 touches only the
+    # second footprint of page 1.
+    shapes = truth_shapes(
+        {
+            1: [square(0.0, 0.0), square(0.006, 0.0)],
+            2: [square(0.009, 0.0)],
+        }
+    )
+    pairs = truth_adjacent_pairs(shapes, max_gap_m=30.0)
+    assert pairs == {frozenset((1, 2))}
+
+
+def make_doc() -> dict:
+    return {
+        "pages": {
+            "p1": {"number": 1},
+            "p2": {"number": 2},
+            "p3": {"number": 3},
+            "p9": {"number": 9},
+        },
+        "adjacency": [["p1", "p2"], ["p1", "p3"], ["p2", "p9"]],
+    }
+
+
+def test_score_adjacency_counts():
+    truth_pairs = {frozenset((1, 2)), frozenset((2, 3))}
+    truth_numbers = {1, 2, 3}
+    score = score_adjacency(make_doc(), truth_pairs, truth_numbers)
+    assert score.edges == 3
+    assert score.known == 2  # p2-p9 lacks truth
+    assert score.correct == 1  # p1-p2
+    assert score.wrong == [("p1", "p3")]
+    assert score.unknown == [("p2", "p9")]
+    assert score.pages == 4
+    assert score.pages_covered == 4
+
+
+def test_score_adjacency_recall_restricted_to_scanned_pages():
+    # Truth pair (2, 3) was not recovered; pair (3, 7) involves an unscanned page
+    # and must not count against recall.
+    truth_pairs = {frozenset((1, 2)), frozenset((2, 3)), frozenset((3, 7))}
+    score = score_adjacency(make_doc(), truth_pairs, {1, 2, 3, 7})
+    assert score.truth_pairs == 2
+    assert score.recovered == 1
+
+
+def test_score_adjacency_single_digit_stats():
+    truth_pairs: set[frozenset[int]] = {frozenset((1, 2))}
+    score = score_adjacency(make_doc(), truth_pairs, {1, 2, 3})
+    # Both scored edges involve single-digit pages here.
+    assert score.single_digit_known == 2
+    assert score.single_digit_correct == 1


### PR DESCRIPTION
Sanborn sheets print the adjoining sheet's number on the margin (the key legend's "reference to adjoining sheet") — a big numeral across the shared boundary road, on the side that sheet continues. This PR reads those references and builds a per-volume **page adjacency graph**: an evidence source that is independent of the key map, works even where street names/geometry have changed since the OSM era, and — because each detection carries which edge of the image it sits on — pins a page's *orientation* from even a single detected neighbor. It's the first building block for pose-graph georeferencing (place the ~1/3 of pages that street matching can't, by anchoring them to neighbors that it can).

See #10

## `mapsnap adjacency <volume>`

Scans every non-split page image (skipping key-map sheets, whose faces are covered in page numbers; split *parents* are scanned since the printed references live on the full sheet's margins) with an EasyOCR digit pass, and writes a single `<volume>/adjacency.json`:

- **per page**: scanned image dimensions plus every digit read that parses to a valid volume page number — polygon, confidence, glyph height, position, image-relative edge (`T`/`B`/`L`/`R`, corners `TL`/`TR`/`BL`/`BR` — deliberately *not* compass terms, since page orientation is unknown at this stage), and nearest-OCR-box gap. Unfiltered reads are kept so filters can be re-tuned without re-OCR.
- **volume-level**: the `adjacency` list of mutual edges.

OCR runs as **one CRAFT detection + two recognition passes** sharing its boxes (detection dominates the cost and is allowlist-independent): a digits-only pass supplies the transcription — immune to look-alike substitutions like 0→O — and a letters-allowed pass over the same boxes vetoes the ones that are actually text (below). ~3.3 s/page on MPS (5 min for a 92-page volume); sharing detection is a 1.56× speedup over two full `readtext` calls, with byte-identical output.

## Claims, reciprocity — and why reciprocity is not enough

Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a read only becomes a **claim** if it's a valid page number ≠ the sheet's own, near a page edge, and printed large; and a claim only becomes an **edge** when reciprocated (A claims B *and* B claims A). Directed claims are ~72% precise; mutual edges ~98%.

But the remaining 2% taught the real lesson: **reciprocity alone can't vouch for weak claims.** Junk claims are common enough to reciprocate by chance, and page numbering correlates with adjacency, so junk edges are often coincidentally "correct" — several edges this PR eliminates would have *passed* truth validation while feeding wrong orientations into a pose graph. Every filter below was validated by cropping actual pixels, not just by scoring against truth (all 52 rotated candidate claims turned out to be misread street names — "WESTSIDE", "Mc ADOO" — or `10" W Pipe` annotations; a conf-1.000 "8" turned out to be a digit torn off block number "1298"; a confident "55" turned out to be the street name "SMITH" force-transcribed under the digit allowlist). The resulting filter stack:

1. **Confidence ≥ 0.3** — measured on Hudson and Brooklyn, this floor loses no true edge on either volume while killing junk a permissive floor admits (forced-transcription street names read at ~0.1; genuine degraded references read above 0.3). 0.5 would kill one further junk edge but costs Hudson four real ones.
2. **Rotation ≤ 5°** — a rotated quad is never a sheet reference.
3. **Text veto (dual recognition pass)** — under a digits-only allowlist the recognizer is *forced* to transcribe street names as numbers; re-reading the same box with letters available lets text identify itself. A veto requires both a clear reveal (≥3 letters or letter-dominated) *and* the recognizer preferring that reading over the digit one — a genuine "41" also comes back letter-dominated ("AL", look-alike glyphs) but at lower confidence than its digit reading, while "SMITH" reads as text far more confidently than as "55".
4. **Single-digit confidence ≥ 0.9** — anything tall and narrow reads as a "1".
5. **Self-calibrated height band** — a two-pass scheme: provisional mutual edges → median height of their multi-digit claims (the printed size is remarkably consistent: Hudson median 46 px, p10–p90 of 42–48) → single-digit claims must fall within [0.65×, 1.4×] of it. Kills the 76–237 px frame-rule "1"s.
6. **Isolation floor (0.3× median)** — a genuine reference floats in whitespace; a digit fragment of a block number *touches* its sibling box (gap ≈ 0) while being a perfect glyph at the right size and confidence. This catches what confidence and size cannot.

Considered and rejected: reciprocal edge complementarity (B on A's right ⇒ A on B's left) — Hudson's diagonal grid makes only 101/158 *genuine* pairs complementary; blacklisting digits 1/8 — the isolation floor dominates it; and a naive letters-in-the-allowlist change — it kills genuine references whose digits flip to look-alike letters (four real edges across the two volumes), which is why the veto needs the confidence gate.

## Results

**Hudson Co. 1950 vol. 9** (`python -m mapsnap.score_adjacency`):

```
pages scanned:  92 (88 in >=1 mutual edge)
mutual edges:   165
precision:      165/165 truth-consistent (100%)
recall:         165/262 truth-adjacent pairs
```

**Brooklyn 1939 vol. 1**: 45 edges, 44/45 truth-consistent, 48/61 pages covered — one junk edge remains (p48–p9, numeric junk that reads as digits in both passes; a candidate for pose-graph loop-closure detection).

433 directed claims → 165 edges on hudson. The 30 pages that reach the graph despite failing street-based georeferencing include the whole waterfront/railyard cluster, connected in chains anchored by fitted pages — exactly the topology pose-graph placement needs. (Recall's denominator includes corner-to-corner contacts that sheets print no reference for, so it reads low.)

## Scoring: `python -m mapsnap.score_adjacency <volume>`

Evaluates an `adjacency.json` against OIM truth: two pages are truth-adjacent when their human-georeferenced footprints come within `--max-gap` (30 m) of each other. Reports precision/recall/coverage and lists contradicting edges. Its docstring carries the honest caveat from above: a truth-consistent edge can still rest on a coincidence-reciprocated junk read, so inspect survivors visually before trusting a new filter.

## Debugger: adjacency mode

Drop a page image + `adjacency.json` onto the debugger (the page is identified by the image's filename stem — e.g. `p49.jpg` → `p49`). The image overlay draws **mutual-neighbor claims in blue**, unreciprocated claims in amber, filtered reads grey-dashed; the side panel summarizes mutual neighbors with the edge each was printed on (`p40 (T), p50 (R), p51 (B), p52 (L), p54 (L)`) above a claims-first detection table with crop previews.

## Known gaps

- **Recall on cluttered margins is a detection problem, not a filter problem**: some genuine references are struck through by the red page-boundary stripe, pipe-line dashes, or the binding fold, and CRAFT misses or fragments them (Kansas City overprints references heavily; hudson p8's west "7" is unreadable). Red-stripe suppression before OCR is a candidate fix.
- Split sheets are scanned as whole parents; scanning panels separately might recover references for pages like p1 (currently uncovered).
- 4/92 hudson pages have no mutual edge (p1, p7, p85, p86 — degraded margins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
