### PR TITLE
Handle OIM annotations with a null target.source.id

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -295,10 +295,10 @@ def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
     numbering; gen_page_key uses the matched generated split's numbering (they can differ
     when OIM and our splitter number panels differently).
     """
-    source_id: str = truth_item["target"]["source"]["id"]
+    source_id = truth_item["target"]["source"].get("id")
     page_key = source_id_to_page_key(source_id, truth_item["label"])
     gen_index = annotation_split_index(gen_item)
-    base_key = source_id_to_page_key(source_id, "")
+    base_key = page_key.split("__")[0]
     gen_page_key = f"{base_key}__{gen_index}" if gen_index is not None else base_key
 
     truth_gcps = extract_gcps(truth_item)
@@ -380,7 +380,7 @@ def analyze_truth_only(truth_item: dict) -> dict:
 
     Returns a dict with keys: page_key, n_truth, skew_deg, aniso.
     """
-    source_id: str = truth_item["target"]["source"]["id"]
+    source_id = truth_item["target"]["source"].get("id")
     page_key = source_id_to_page_key(source_id, truth_item["label"])
     truth_gcps = extract_gcps(truth_item)
     A_truth = fit_transform(truth_gcps, annotation_transform_type(truth_item))
@@ -508,15 +508,24 @@ def print_tsv(rows: list[dict], missing: list[dict]) -> None:
 
 
 def annotations_by_source(path: Path) -> dict[str, list[dict]]:
-    """Load a IIIF AnnotationPage, grouping items by target.source.id.
+    """Load a IIIF AnnotationPage, grouping items by parent page key.
 
-    Split pages produce several items per source id (they share the parent canvas);
-    full pages produce one. Group order follows file order.
+    Split pages produce several items that share a parent canvas; full pages produce one.
+    The key is the page key (splits collapsed to the parent), derived from the annotation's
+    ``target.source.id`` URL or, when that is null (some OIM volumes carry no linked image
+    service), from the item ``label``. Items with no derivable key are skipped. Group order
+    follows file order.
     """
     data: dict = json.loads(path.read_text())
     groups: dict[str, list[dict]] = defaultdict(list)
     for item in data.get("items", []):
-        groups[item["target"]["source"]["id"]].append(item)
+        source_id = item["target"]["source"].get("id")
+        parent_key = source_id_to_page_key(source_id, item.get("label", "")).split(
+            "__"
+        )[0]
+        if not parent_key:
+            continue
+        groups[parent_key].append(item)
     return dict(groups)
 
 
@@ -644,8 +653,8 @@ def compare_pages(
 
     rows: list[dict] = []
     missing: list[dict] = []
-    for source_id, truth_items in sorted(truth_by_source.items()):
-        gen_items = gen_by_source.get(source_id, [])
+    for page_key, truth_items in sorted(truth_by_source.items()):
+        gen_items = gen_by_source.get(page_key, [])
         truth_splits = [t for t in truth_items if label_split_index(t) is not None]
         if not truth_splits:
             # Full page: pair the single truth and generated annotations directly.
@@ -656,7 +665,7 @@ def compare_pages(
                 rows.append(analyze_pair(truth_items[0], gen_item))
             continue
         # Split page: associate by panel-polygon overlap (numbering may differ).
-        page_key = source_id_to_page_key(source_id, "")
+        # page_key is the parent key from the group; splits share the parent panels.json.
         source = truth_items[0]["target"]["source"]
         source_dims = (float(source["width"]), float(source["height"]))
         truth_polygons = load_split_polygons(oim_dir / f"{page_key}.panels.json")

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -6,6 +6,7 @@ from shapely.geometry import Polygon as ShapelyPolygon
 
 from mapsnap.compare_iiif_georef import (
     annotation_split_index,
+    annotations_by_source,
     load_split_polygons,
     match_split_pairs,
     page_label,
@@ -17,6 +18,32 @@ from mapsnap.compare_iiif_georef import (
     truth_polygons_by_page,
     truth_polygons_world,
 )
+
+
+def test_annotations_by_source_null_ids_key_by_label(tmp_path):
+    # OIM volumes with null source.id must group by the label's page (not collapse to one
+    # None key), with splits of a page sharing the parent entry.
+    doc = {
+        "items": [
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p714",
+                "target": {"source": {"id": None}},
+            },
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [1]",
+                "target": {"source": {"id": None}},
+            },
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [2]",
+                "target": {"source": {"id": None}},
+            },
+        ]
+    }
+    path = tmp_path / "main.iiif.json"
+    path.write_text(json.dumps(doc))
+    groups = annotations_by_source(path)
+    assert sorted(groups) == ["p714", "p721"]
+    assert len(groups["p721"]) == 2  # both splits share the parent entry
 
 
 def test_split_numbering_annotations():

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -38,7 +38,7 @@ from shapely.geometry import mapping as geom_mapping
 
 from mapsnap.clip_masks import compute_all_clip_masks, geo_polygon_to_svg
 from mapsnap.split import panels_json_path, read_panels_json
-from mapsnap.utils import default_centerlines, jpeg_dimensions
+from mapsnap.utils import default_centerlines, jpeg_dimensions, label_to_page_key
 
 # Page images are stored at 25% scale, so the full-resolution canvas is 4× larger.
 FULL_RES_FACTOR = 4
@@ -61,7 +61,7 @@ def georef_path_to_page_key(path: str) -> str | None:
     return f"{page_num}{suffix.lower()}{split}"
 
 
-def _service_url_to_page_key(url: str) -> str | None:
+def _service_url_to_page_key(url: str | None) -> str | None:
     """Extract the page key from a LOC IIIF service URL (OIM or LOC manifest format).
 
     The page key is the trailing segment after the last "-", with leading zeros
@@ -75,8 +75,11 @@ def _service_url_to_page_key(url: str) -> str | None:
       "...:sb00154s"                        → "p154s"
 
     Non-sheet URLs (covers, indexes: "...-covr", "...-titl", etc.) start with a
-    letter after the "-" and return None.
+    letter after the "-" and return None. A missing/empty URL (e.g. an OIM
+    annotation whose ``source.id`` is null) also returns None.
     """
+    if not url:
+        return None
     url = url.removesuffix("/info.json")
     # Sanborn sb-format: service:...:sb{5-digit page}{suffix char}
     m = re.search(r":sb(\d{5})([a-z0-9])$", url, re.IGNORECASE)
@@ -91,6 +94,20 @@ def _service_url_to_page_key(url: str) -> str | None:
     return f"p{m.group(1)}{m.group(2).lower()}"
 
 
+def _label_parent_page_key(label: str) -> str | None:
+    """Parent page key from an OIM item label, dropping any "[N]" split marker, or None.
+
+    Used when the annotation's ``source.id`` is null (some OIM volumes, e.g. Grand Rapids
+    1953 vol 7) so the service URL cannot supply the key. Reuses ``utils.label_to_page_key``
+    (which returns a split key like "p721__1") and collapses splits to the parent, matching
+    the URL-keyed behavior where all splits of a page share one canvas entry:
+      "Grand Rapids, Mich. | 1953 | Vol. 7 p714"     → "p714"
+      "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [1]" → "p721"
+    """
+    key = label_to_page_key(label)
+    return key.split("__")[0] if key else None
+
+
 def _load_oim_index(data: dict) -> dict[str, dict]:
     """Build parent-page_key → item dict from an OIM IIIF AnnotationPage.
 
@@ -99,11 +116,17 @@ def _load_oim_index(data: dict) -> dict[str, dict]:
     canvas (all splits of a page share the same source id and width/height), so a single
     full-canvas item per page is all make_annotation needs; our own splits are placed
     within it via panels.json.
+
+    The key normally comes from the annotation's image ``source.id`` URL; when that is null
+    (some volumes carry no linked image service) it falls back to the item ``label``.
     """
     index: dict[str, dict] = {}
     for item in data.get("items", []):
-        source_id: str = item.get("target", {}).get("source", {}).get("id", "")
-        page_key = _service_url_to_page_key(source_id)
+        source = (item.get("target") or {}).get("source") or {}
+        source_id = source.get("id") if isinstance(source, dict) else None
+        page_key = _service_url_to_page_key(source_id) or _label_parent_page_key(
+            item.get("label", "")
+        )
         if page_key is None:
             continue
         index[page_key] = item
@@ -272,7 +295,7 @@ def make_annotation(
     as the SvgSelector clipping polygon. Falls back to the full-page rectangle if None.
     """
     source = item["target"]["source"]
-    source_id: str = source["id"]
+    source_id: str | None = source["id"]
     source_type: str = source.get("type", "ImageService2")
     source_width: int = source["width"]
     source_height: int = source["height"]
@@ -283,7 +306,12 @@ def make_annotation(
     georef_height = georef["height"]
 
     # Derive a unique canvas ID from the source URL; append split number if present.
-    canvas_id = source_id.removesuffix("/info.json")
+    # When the annotation carries no image service (source.id null, as in some OIM volumes)
+    # fall back to the item's own id so the emitted annotation ids stay unique per page.
+    canvas_base = source_id or item.get("id") or item["target"].get("id")
+    if not canvas_base:
+        raise ValueError(f"item for {page_key} has no source id, item id, or target id")
+    canvas_id = canvas_base.removesuffix("/info.json").rstrip("/")
     split_index: int | None = None
     if "__" in page_key:
         split_index = int(page_key.split("__")[1])

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -321,6 +321,45 @@ def test_load_oim_index_splits_share_one_parent_entry():
     assert list(index.keys()) == ["p6n"]
 
 
+def test_load_oim_index_null_source_id_falls_back_to_label():
+    # Some OIM volumes (e.g. Grand Rapids 1953 vol 7) carry a null source.id; the page key
+    # must then come from the label's trailing "pNNN" token.
+    data = {
+        "items": [
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p714",
+                "target": {"source": {"id": None, "width": 6660, "height": 8070}},
+            }
+        ]
+    }
+    index = _load_oim_index(data)
+    assert list(index.keys()) == ["p714"]
+
+
+def test_load_oim_index_null_source_id_splits_key_by_parent():
+    # Null-source split labels collapse to one parent-keyed entry, matching URL-keyed behavior.
+    data = {
+        "items": [
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [1]",
+                "target": {"source": {"id": None}},
+            },
+            {
+                "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [2]",
+                "target": {"source": {"id": None}},
+            },
+        ]
+    }
+    index = _load_oim_index(data)
+    assert list(index.keys()) == ["p721"]
+
+
+def test_load_oim_index_skips_item_with_no_key():
+    # No source id and an unparseable label -> item is skipped, not a crash.
+    data = {"items": [{"label": "cover", "target": {"source": {"id": None}}}]}
+    assert _load_oim_index(data) == {}
+
+
 def _metadata_value(annotation: dict, label: str) -> str | None:
     for entry in annotation["metadata"]:
         if entry["label"] == label:
@@ -366,6 +405,30 @@ def test_make_annotation_split_uses_panels_json(tmp_path):
         40.0,
         80.0,
     ]
+
+
+def test_make_annotation_null_source_id_uses_item_id(tmp_path):
+    # A null source.id (OIM annotation with no linked image service): the canvas id falls
+    # back to the item's own id (trailing slash trimmed) so annotation ids stay unique.
+    item = {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54270/",
+        "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
+        "target": {
+            "id": "https://oldinsurancemaps.net/iiif/selector/54270/",
+            "source": {
+                "id": None,
+                "type": "ImageService2",
+                "width": 800,
+                "height": 1600,
+            },
+        },
+    }
+    georef = make_georef(width=50, height=100, intersections=[])
+    annotation = make_annotation(
+        item, georef, "p703", tmp_path / "p703.jpg", "http://x", "now"
+    )
+    assert annotation["id"] == "https://oldinsurancemaps.net/iiif/resource/54270/georef"
+    assert annotation["target"]["source"]["id"] is None
 
 
 def test_make_annotation_split_missing_panels_raises(tmp_path):

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -145,7 +145,7 @@ def jpeg_dimensions(path: Path) -> tuple[int, int]:
     raise ValueError(f"No SOF marker found in {path}")
 
 
-def source_id_to_page_key(source_id: str, label: str) -> str:
+def source_id_to_page_key(source_id: str | None, label: str) -> str:
     """Extract a short page key like 'p425' from a LOC IIIF image service URL.
 
     Leading zeros in the page number are stripped and a 'p' prefix is added:
@@ -156,6 +156,10 @@ def source_id_to_page_key(source_id: str, label: str) -> str:
     Labels ending with "[N]" produce a split suffix:
       "https://...1950-0156/info.json",  "... [2]"   → "p156__2"
 
+    A null/empty ``source_id`` (some OIM volumes carry no linked image service, e.g.
+    Grand Rapids 1953 vol 7) falls back to the page key parsed from the ``label``;
+    returns "" if the label has no page identifier either.
+
     The sb-format encodes the page number as 5 zero-padded digits followed by
     one character: '0' means no suffix, a letter is used directly as a suffix.
     """
@@ -164,6 +168,9 @@ def source_id_to_page_key(source_id: str, label: str) -> str:
         m = re.search(r"\[(\d+)\]$", label)
         assert m
         split_suffix = f"__{m.group(1)}"
+
+    if not source_id:
+        return label_to_page_key(label) or ""
 
     # Sanborn sb-format: service:...:sb{5-digit page}{suffix char}
     m = re.search(r":sb(\d{5})([a-z0-9])$", source_id, re.IGNORECASE)

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -116,6 +116,23 @@ def test_source_id_split_label():
     )
 
 
+def test_source_id_null_falls_back_to_label():
+    # OIM volumes with no linked image service (null source.id) key off the label.
+    assert (
+        source_id_to_page_key(None, "Grand Rapids, Mich. | 1953 | Vol. 7 p714")
+        == "p714"
+    )
+    assert (
+        source_id_to_page_key(None, "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [1]")
+        == "p721__1"
+    )
+
+
+def test_source_id_null_unparseable_label_is_empty():
+    assert source_id_to_page_key(None, "cover") == ""
+    assert source_id_to_page_key("", "") == ""
+
+
 # source_id_to_page_key — sb format (e.g. Washington DC 1916)
 
 _DC = "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003"


### PR DESCRIPTION
## Problem

`mapsnap iiif` and `mapsnap compare` both crash on `data/grand_rapids_mi_1953_vol7`:

```
AttributeError: 'NoneType' object has no attribute 'removesuffix'    # iiif
TypeError: '<' not supported between instances of 'str' and 'NoneType'   # compare
```

That volume's OIM `main.iiif.json` carries **`"source": {"id": null}`** on 73 of its 83 items — the annotations have no linked image service. Every other volume we process has a real LOC service URL there, so the code assumed a string. `item.get("id", "")`-style defaults don't help: the key is *present with a null value*, not absent.

Nothing is actually lost — each item's `label` still names the page (`"Grand Rapids, Mich. | 1953 | Vol. 7 p714"`); the code just wasn't looking there.

## Fix

- **`utils.source_id_to_page_key`** now takes `str | None` and falls back to the page key parsed from the `label` when the id is null. It already received the label — it just never used it as a fallback.
- **`make_iiif_georef._load_oim_index`** derives the key from the label when `source.id` is null (collapsing `[N]` splits to the parent, matching the URL-keyed behaviour).
- **`make_iiif_georef.make_annotation`** falls back to the item's own `id` for the canvas id, so emitted annotation ids stay unique per page.
- **`compare_iiif_georef.annotations_by_source`** groups by **parent page key** instead of the raw source URL. This also fixes a latent bug: grouping by a null id collapsed all 73 pages into one `None` group, so even without the crash the comparison would have been wrong.

For volumes with real source ids the grouping is the *same partition* (one URL ↔ one page), just keyed by `p714` instead of the URL.

## Verification

- `mapsnap iiif` on Grand Rapids now completes: **45 annotations from 45 georef files**, all ids unique.
- `mapsnap compare` runs: **45/83 pages, median RMSE 18 ft**.
- **Regression check:** Hudson (normal volume, real source ids) is unchanged — 56/95 pages, median 12 ft.
- 4 new unit tests; full suite green; ruff + pyright clean.

## Note

The emitted `source.id` stays `null` for those pages — we can't invent an image service OIM never linked. The GCPs and selector polygons are intact.