### PR TITLE
Fit key maps with a full 6-DOF affine

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -30,7 +30,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
-from mapsnap.compare_iiif_georef import truth_polygons_by_page
+from mapsnap.compare_iiif_georef import truth_distortion, truth_polygons_by_page
 from mapsnap.keymap.locate import (
     KeymapLocator,
     page_number,
@@ -2386,16 +2386,21 @@ def process_image(
 
     # A key-map index page (one with a sibling <stem>.keymap.json) is refit with a full 6-DOF
     # affine on its own inlier GCPs, so the georef.json corners capture the scale anisotropy and
-    # skew a 4-parameter similarity cannot — read straight off by the key-map locator and the
-    # region-shape placer (no separate refit there).
+    # skew a 4-parameter similarity cannot — read straight off by the key-map locator, with no
+    # separate refit downstream.
     keymap_json = os.path.join(
         os.path.dirname(image_path), f"{image_stem(image_path)}.keymap.json"
     )
     if os.path.exists(keymap_json):
         affine = fit_keymap_affine(A, gcps, cos_phi)
         if affine is not None:
+            # Report what the extra two degrees of freedom actually bought. A similarity is
+            # anisotropy 1.0 / skew 0° by construction, so these are exactly the distortion it
+            # could not have represented.
+            skew_deg, aniso = truth_distortion(affine)
             print(
-                "Key map: refitting corners with a 6-DOF affine on its GCPs.",
+                "Key map: refitting corners with a 6-DOF affine on its GCPs "
+                f"(anisotropy {aniso:.4f}, skew {skew_deg:+.3f}°).",
                 file=sys.stderr,
             )
             A = affine

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -190,6 +190,56 @@ def solve_similarity_2pts(
     return np.array([[alpha / cos_phi, beta / cos_phi, tx], [beta, -alpha, ty]])
 
 
+def fit_keymap_affine(
+    similarity: np.ndarray,
+    gcps: list["IntersectionGCP"],
+    cos_phi: float,
+    min_gcps: int = 8,
+    pos_threshold: float = 0.001,
+    trim: float = 2.5,
+    rounds: int = 3,
+) -> np.ndarray | None:
+    """Robust 6-DOF affine (pixel → lon/lat) fit to a key map's own inlier intersection GCPs.
+
+    A key map's own georeference is fit from many street-intersection GCPs; a full **affine**
+    captures the scale anisotropy and skew a 4-parameter similarity cannot — which most affects
+    pages near the sheet edge — while staying independent of the page georeferencing. Fits only on
+    the GCPs the ``similarity`` fit accepts (residual within ``pos_threshold``), in a
+    cos(lat)-corrected frame so longitude and latitude errors weigh equally, dropping points beyond
+    ``trim`` × the median residual each round. Returns a 2×3 affine in the same form as
+    :func:`solve_similarity_2pts` (``[lon, lat]^T = A @ [px, py, 1]^T``), or None with fewer than
+    ``min_gcps`` inliers.
+    """
+    inliers = [
+        g
+        for g in gcps
+        if float(
+            np.linalg.norm(
+                np.array(apply_affine(similarity, *g.pixel)) - np.array(g.geo)
+            )
+        )
+        <= pos_threshold
+    ]
+    if len(inliers) < min_gcps:
+        return None
+    pixels = np.array([[g.pixel[0], g.pixel[1], 1.0] for g in inliers])
+    world = np.array(
+        [[g.geo[0] * cos_phi, g.geo[1]] for g in inliers]
+    )  # cos-corrected lon
+    keep = np.ones(len(inliers), dtype=bool)
+    solution = np.zeros((3, 2))
+    for _ in range(rounds):
+        solution = np.linalg.lstsq(pixels[keep], world[keep], rcond=None)[0]
+        residual = np.linalg.norm(world - pixels @ solution, axis=1)
+        updated = residual < trim * float(np.median(residual[keep]))
+        if bool((updated == keep).all()):
+            break
+        keep = updated
+    affine = solution.T.copy()  # 2×3: row 0 = (lon·cos_phi) coeffs, row 1 = lat coeffs
+    affine[0] /= cos_phi  # undo the longitude correction so the affine maps to raw lon
+    return affine
+
+
 _FT_PER_DEG_LAT: float = math.pi * 20_925_524.0 / 180.0  # feet per degree latitude
 
 
@@ -2333,6 +2383,23 @@ def process_image(
     )
 
     residuals = _inlier_residuals(features, block_index, A, inlier_feat_indices)
+
+    # A key-map index page (one with a sibling <stem>.keymap.json) is refit with a full 6-DOF
+    # affine on its own inlier GCPs, so the georef.json corners capture the scale anisotropy and
+    # skew a 4-parameter similarity cannot — read straight off by the key-map locator and the
+    # region-shape placer (no separate refit there).
+    keymap_json = os.path.join(
+        os.path.dirname(image_path), f"{image_stem(image_path)}.keymap.json"
+    )
+    if os.path.exists(keymap_json):
+        affine = fit_keymap_affine(A, gcps, cos_phi)
+        if affine is not None:
+            print(
+                "Key map: refitting corners with a 6-DOF affine on its GCPs.",
+                file=sys.stderr,
+            )
+            A = affine
+            residuals = _inlier_residuals(features, block_index, A, inlier_feat_indices)
 
     scale, center = _finalize_georef(
         A,

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1252,6 +1252,38 @@ def test_rank_pairs_by_consensus_is_deterministic():
     assert a == b
 
 
+def test_fit_keymap_affine_recovers_a_skewed_affine():
+    # A 6-DOF affine with skew (off-diagonal terms) that a 4-parameter similarity cannot
+    # represent; fitting the key map's own GCPs must recover it exactly.
+    from mapsnap.georef_from_labels import apply_affine, fit_keymap_affine
+
+    truth = np.array([[1e-5, 2e-6, -74.0], [-1e-6, -1e-5, 40.7]])
+    cos_phi = math.cos(math.radians(40.7))
+    rng = np.random.default_rng(0)
+    gcps = [
+        _make_gcp((float(px), float(py)), apply_affine(truth, px, py))
+        for px, py in rng.uniform(0, 2000, size=(12, 2))
+    ]
+    # Passing the truth affine as the "similarity" accepts every GCP as an inlier.
+    affine = fit_keymap_affine(truth, gcps, cos_phi)
+    assert affine is not None
+    for px, py in [(0.0, 0.0), (2000.0, 1500.0), (500.0, 900.0)]:
+        got = apply_affine(affine, px, py)
+        want = apply_affine(truth, px, py)
+        assert math.isclose(got[0], want[0], abs_tol=1e-9)
+        assert math.isclose(got[1], want[1], abs_tol=1e-9)
+
+
+def test_fit_keymap_affine_none_without_enough_inliers():
+    from mapsnap.georef_from_labels import apply_affine, fit_keymap_affine
+
+    truth = np.array([[1e-5, 0.0, -74.0], [0.0, -1e-5, 40.7]])
+    gcps = [
+        _make_gcp((float(i), float(i)), apply_affine(truth, i, i)) for i in range(3)
+    ]
+    assert fit_keymap_affine(truth, gcps, 1.0) is None
+
+
 def test_label_features_carries_fallback_flag():
     poly = [[0, 0], [40, 0], [40, 10], [0, 10]]
     feats = label_features(

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -5,6 +5,10 @@ printed inside, drawn over an overview of the city's major streets. Downstream, 
 and ``mapsnap georef`` take ``--keymap`` files to restrict each page's vocabulary/matching to
 its key-map neighborhood; that needs three sidecars next to the (raw) key-map image:
 
+  * ``<stem>.keymap.json`` — the pixel location of every page number, from the CNN localizer +
+    CRNN recognizer (``mapsnap.keymap.detect_numbers_crnn``). ``--pages`` is derived from the
+    volume's page images so decodes snap to valid page numbers and the narrow-detection re-read
+    (which recovers a squished multi-digit number) is enabled.
   * ``<stem>.georef.json`` — the key map georeferenced in the world, so a page number's pixel
     location maps to a world location. Produced by OCR'ing the key map's own street labels and
     fitting a transform, exactly like a regular page (``mapsnap ocr`` then ``mapsnap georef``).
@@ -12,12 +16,13 @@ its key-map neighborhood; that needs three sidecars next to the (raw) key-map im
     raw sheet is ~4x the linear resolution of the 25%-scale volume pages, so its text is ~4x
     larger and a larger detector floor is right. OCR tiles the oversized sheet at native
     resolution by default, which is what makes the key map's small labels detectable.
-  * ``<stem>.keymap.json`` — the pixel location of every page number, from the CNN localizer +
-    CRNN recognizer (``mapsnap.keymap.detect_numbers_crnn``). ``--pages`` is derived from the
-    volume's page images so decodes snap to valid page numbers and the narrow-detection re-read
-    (which recovers a squished multi-digit number) is enabled.
   * ``<stem>.regions.panels.json`` — the colored block polygon around each page number
     (``mapsnap.keymap.page_regions``), so a page's key-map neighborhood is its own block.
+
+They are built in that order for a reason: ``<stem>.keymap.json`` is what identifies a page as a
+key map, and the georef step reads it to decide whether to refit the corners with a full 6-DOF
+affine. Detecting the page numbers after georeferencing would leave a first run with the plain
+4-parameter similarity.
 
     uv run mapsnap keymap data/chicago_il_1950_vol_1/raw/p0b.jpg
 """
@@ -136,12 +141,31 @@ def main() -> None:
 
     image_args = [str(image) for image in images]
 
-    # 1. Georeference each key map from its own street labels, exactly like a regular page, so the
+    # 1. Locate every page number with the CNN localizer + CRNN recognizer. Passing --pages both
+    #    snaps decodes to valid page numbers and enables the narrow-detection re-read.
+    #
+    #    This runs first, before the georef, even though it needs nothing the georef produces:
+    #    <stem>.keymap.json is what marks a page as a key map, and georef refits a key map's
+    #    corners with a full 6-DOF affine. Detecting the numbers afterwards would leave the file
+    #    absent at georef time, so a first run would silently get the 4-parameter similarity and
+    #    only a *second* run would pick up the affine.
+    run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "mapsnap.keymap.detect_numbers_crnn",
+            "--pages",
+            pages,
+            *image_args,
+        ]
+    )
+
+    # 2. Georeference each key map from its own street labels, exactly like a regular page, so the
     #    downstream --keymap flag has a <stem>.georef.json to read. OCR runs at a key-map-
     #    appropriate detector floor and (by default) tiles the oversized sheet at native
-    #    resolution; georef must be told to geocode key maps, which it skips by default once a
-    #    <stem>.keymap.json sibling exists. Both pass --ignore-keymap so that on a re-run they do
-    #    not auto-discover the key map's own .keymap.json and try to locate it against itself.
+    #    resolution; georef must be told to geocode key maps, which it skips by default for a page
+    #    with a <stem>.keymap.json sibling. Both pass --ignore-keymap so they do not auto-discover
+    #    the key map's own .keymap.json and try to locate it against itself.
     ocr_cmd = [
         "mapsnap",
         "ocr",
@@ -162,19 +186,6 @@ def main() -> None:
             "--centerlines",
             centerlines,
             "--geocode_keymaps",
-            *image_args,
-        ]
-    )
-
-    # 2. Locate every page number with the CNN localizer + CRNN recognizer. Passing --pages both
-    #    snaps decodes to valid page numbers and enables the narrow-detection re-read.
-    run_cmd(
-        [
-            sys.executable,
-            "-m",
-            "mapsnap.keymap.detect_numbers_crnn",
-            "--pages",
-            pages,
             *image_args,
         ]
     )


### PR DESCRIPTION
## Why

A key map's own georeference is fit from *many* street-intersection GCPs, so it can support more than the 4-parameter similarity we use for ordinary pages. A full affine additionally captures the **scale anisotropy and skew** a similarity cannot — which most affects pages near the sheet edge.

## What

`process_image` refits a key map's corners with the new `fit_keymap_affine` whenever a `<stem>.keymap.json` sibling exists (our key-map identity test). So `mapsnap georef --geocode_keymaps` produces it with **no new flag**.

The fit is a robust least-squares affine over the GCPs the page's own similarity fit already accepts (`apply_affine` residual within `pos_threshold`), computed in a **cos(lat)-corrected frame** so longitude and latitude errors weigh equally, with a 2.5×-median trim. It needs at least `min_gcps` inliers and otherwise returns `None`, leaving the similarity untouched.

## Why no downstream change is needed

The affine simply overwrites `A` before `_finalize_georef`, so the four written corners already carry it — **bilinear interpolation of a parallelogram's corners reproduces an affine exactly**, so every existing corner-based consumer keeps working unmodified.

## Ordering fix: the refit was silently dead on a first run

`<stem>.keymap.json` is both the key-map identity test *and* the trigger for this refit — but `mapsnap keymap` built it in **step 2, after** the georef in step 1. So on a **fresh** run the file was absent when georef ran, the key map got the plain similarity, and only a **second** run (using the file left behind by the first) picked up the affine. Both `pipeline_loc` and `pipeline_oim` delegate to that pipeline, so both were affected.

Page-number detection needs nothing the georef produces — it reads only the image and `--pages` — so it now runs **first**. OCR and georef already pass `--ignore-keymap`, so the now-present `.keymap.json` doesn't make them try to locate the key map against itself. The new order is:

1. `detect_numbers_crnn` → `<stem>.keymap.json`
2. OCR + georef → `<stem>.georef.json` (**now with the affine on a first run**)
3. `page_regions` → `<stem>.regions.panels.json`

## Distortion logging

The refit now reports what the extra two degrees of freedom bought, reusing `compare_iiif_georef.truth_distortion`:

```
Key map: refitting corners with a 6-DOF affine on its GCPs (anisotropy 1.0110, skew -1.230°).
```

A similarity is anisotropy 1.0 / skew 0° **by construction**, so these numbers are exactly the distortion it could not have represented. Measured on the two New Orleans key maps, the similarity fit reads 1.0000 / ~0.00° as expected — a useful sanity check on the metric:

| volume | similarity | affine |
|---|---|---|
| New Orleans 1896 vol 2 | 1.0000 / −0.003° | **1.0110 / −1.231°** |
| New Orleans 1951 vol 5 | 1.0000 / +0.001° | **1.0174 / −0.312°** |

## Effect

Corner shift vs the similarity, by volume:

| volume | shift | notes |
|---|---|---|
| **New Orleans 1896 vol 2** | **41–356 ft** | 504 inlier GCPs; largest single-corner shift measured (BR 356 ft) |
| Chicago | 149–313 ft | |
| **New Orleans 1951 vol 5** | **48–204 ft** | 511 inlier GCPs |
| Hudson | 10–157 ft | |
| Detroit | 29–41 ft | |
| Brooklyn | 1–10 ft | its key maps are near-isotropic |

Per-corner detail for the two New Orleans volumes (TL / TR / BR / BL):

- **1896 vol 2** (6397×7795): 216 / 128 / **356** / 41 ft
- **1951 vol 5** (5648×8149): 126 / **204** / 48 / 139 ft

Both were measured by running `mapsnap georef --geocode_keymaps` on `raw/p0.jpg` on `main` (similarity) and on this branch (affine), then taking the haversine distance at each corner. The lopsided per-corner shifts are exactly what a similarity cannot represent: a uniform rotation+scale would move all four corners together, whereas here the correction is 8× larger at one corner than another. 1896's larger skew (−1.231° vs −0.312°) matches its larger corner shift (356 ft vs 204 ft).

## Tests

2 new unit tests (recovers a skewed affine exactly; returns `None` below `min_gcps`). Full suite green; ruff + pyright clean.