### PR TITLE
Scale outliers: consensus reference, 0.5x/2x bands, and drop the region rescue

### DIFF
--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -104,7 +104,7 @@ def normalize_flags_for_hash(flag_tokens: list[str]) -> list[str]:
     """Drop output-irrelevant flags (e.g. ``--num-workers N``) from a passthrough token list.
 
     The remaining tokens are returned in their original order; they're folded into the config
-    hash so that, e.g., ``--scale-outlier-threshold 0`` archives separately from the default.
+    hash so that, e.g., ``--disable-scale-outlier-check`` archives separately from the default.
     """
     result: list[str] = []
     i = 0

--- a/mapsnap/experiments_test.py
+++ b/mapsnap/experiments_test.py
@@ -55,10 +55,9 @@ def test_combined_sha256_changes_with_content(tmp_path):
 
 
 def test_normalize_flags_drops_num_workers():
-    flags = ["--scale-outlier-threshold", "0", "--num-workers", "2", "--debug"]
+    flags = ["--disable-scale-outlier-check", "--num-workers", "2", "--debug"]
     assert normalize_flags_for_hash(flags) == [
-        "--scale-outlier-threshold",
-        "0",
+        "--disable-scale-outlier-check",
         "--debug",
     ]
 
@@ -73,7 +72,7 @@ def test_config_hash_ignores_num_workers():
 def test_config_hash_changes_with_flags():
     inputs = {"streets": {"combined_sha": "sha256:x"}}
     a = compute_config_hash([], inputs)
-    b = compute_config_hash(["--scale-outlier-threshold", "0"], inputs)
+    b = compute_config_hash(["--disable-scale-outlier-check"], inputs)
     assert a != b
     assert len(a) == 8
 

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -254,14 +254,17 @@ MISSCALE_REGION_AGREEMENT = 1.3
 # plausibility gate.
 KEYMAP_RETRY_SIZE_FRACTION = 0.6
 
-# Scale-outlier bands: a fit whose scale-vs-reference ratio lands near an exact 0.5x or 2x
-# multiple is kept as a genuine differently-scaled sheet, not dropped as a misfit. Many
-# volumes (Nashville, Grand Rapids, Champaign) mix 50 ft/in and 100 ft/in pages, which land
-# almost exactly at half or double the reference; a clean multiple is the signature of a good
-# fit on a differently-scaled page rather than the scatter a bad fit produces.
+# Scale-outlier bands: the three ratios-to-the-reference a fit may land on and still be kept.
+# SAME_SCALE_BAND is the tolerance around the reference itself; a fit near an exact 0.5x or 2x
+# multiple is kept as a genuine differently-scaled sheet rather than dropped as a misfit, because
+# many volumes (Nashville, Grand Rapids, Champaign) mix 50 ft/in and 100 ft/in pages, and a clean
+# multiple is the signature of a good fit on a differently-scaled page rather than the scatter a
+# bad fit produces. All three are fixed: they describe how Sanborn sheet scales actually relate
+# (1x / 2x / 4x rungs, plus fitting noise), not a preference to tune per volume. Use
+# --disable-scale-outlier-check to switch the whole check off.
+SAME_SCALE_BAND = (0.75, 1.25)
 HALF_SCALE_BAND = (0.4, 0.6)
 DOUBLE_SCALE_BAND = (1.8, 2.2)
-DEFAULT_SCALE_OUTLIER_THRESHOLD = 0.25
 
 
 def is_split_page(stem: str) -> bool:
@@ -337,26 +340,23 @@ def region_corroborates_scale(fitted_ratio: float, region_ratio: float) -> bool:
     return 1.0 / MISSCALE_REGION_AGREEMENT <= agreement <= MISSCALE_REGION_AGREEMENT
 
 
-def is_scale_outlier(ratio: float, threshold: float) -> bool:
+def is_scale_outlier(ratio: float) -> bool:
     """Whether a fitted-scale / reference-scale ratio should be dropped as a scale outlier.
 
-    A page is kept (not an outlier) when its ratio is within ``threshold`` of the median
-    (``|ratio - 1| <= threshold``) or lands in the half-scale (~0.5x, :data:`HALF_SCALE_BAND`)
-    or double-scale (~2x, :data:`DOUBLE_SCALE_BAND`) band. The half/double bands admit genuine
-    differently-scaled sheets — a page drawn at 50 vs 100 ft/in relative to the volume median
-    lands almost exactly at 0.5x or 2x — whose clean multiple distinguishes them from the
-    scattered ratios a bad fit produces.
+    A page is kept (not an outlier) when its ratio lands in the band around the reference itself
+    (:data:`SAME_SCALE_BAND`), or in the half-scale (~0.5x, :data:`HALF_SCALE_BAND`) or
+    double-scale (~2x, :data:`DOUBLE_SCALE_BAND`) band. The half/double bands admit genuine
+    differently-scaled sheets — a page drawn at 50 vs 100 ft/in relative to the reference lands
+    almost exactly at 0.5x or 2x — whose clean multiple distinguishes them from the scattered
+    ratios a bad fit produces.
     """
-    if abs(ratio - 1.0) <= threshold:
-        return False
-    if HALF_SCALE_BAND[0] <= ratio <= HALF_SCALE_BAND[1]:
-        return False
-    if DOUBLE_SCALE_BAND[0] <= ratio <= DOUBLE_SCALE_BAND[1]:
-        return False
-    return True
+    return not any(
+        low <= ratio <= high
+        for low, high in (SAME_SCALE_BAND, HALF_SCALE_BAND, DOUBLE_SCALE_BAND)
+    )
 
 
-def consensus_scale(scales: list[float], threshold: float) -> float:
+def consensus_scale(scales: list[float]) -> float:
     """The page scale that keeps the most pages within the scale-outlier bands.
 
     Anchors the scale-outlier check (and the deferred 1-GCP scale prior) on the scale shared —
@@ -375,9 +375,7 @@ def consensus_scale(scales: list[float], threshold: float) -> float:
     """
 
     def kept(reference: float) -> int:
-        return sum(
-            not is_scale_outlier(scale / reference, threshold) for scale in scales
-        )
+        return sum(not is_scale_outlier(scale / reference) for scale in scales)
 
     return max(sorted(scales), key=kept)
 
@@ -2792,15 +2790,13 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--scale-outlier-threshold",
-        type=float,
-        default=DEFAULT_SCALE_OUTLIER_THRESHOLD,
-        metavar="FRAC",
+        "--disable-scale-outlier-check",
+        action="store_true",
         help=(
-            "Delete georef output files whose fitted scale deviates from the reference "
-            "scale by more than this fraction (default: 0.25 = 25%%). Pages fitted at "
-            "~0.5x or ~2x the reference (differently-scaled sheets) are kept regardless. "
-            "Set to 0 to disable. Reference is --scale if given, else the median."
+            "Keep every fit regardless of its scale. By default a georef output file is "
+            "deleted when its fitted scale is not near the reference scale, nor at a clean "
+            "~0.5x or ~2x multiple of it (a differently-scaled sheet). Reference is --scale "
+            "if given, else the volume's consensus scale."
         ),
     )
     parser.add_argument(
@@ -3101,10 +3097,7 @@ def main() -> None:
     if args.scale is not None:
         ref_scale_px_per_ft: float | None = args.scale
     elif scales:
-        anchor_threshold = (
-            args.scale_outlier_threshold or DEFAULT_SCALE_OUTLIER_THRESHOLD
-        )
-        ref_scale_px_per_ft = consensus_scale(scales, anchor_threshold)
+        ref_scale_px_per_ft = consensus_scale(scales)
     else:
         ref_scale_px_per_ft = None
 
@@ -3170,11 +3163,11 @@ def main() -> None:
                         )
 
     # Drop georef files whose fitted scale is a major outlier vs the reference.
-    if ref_scale_px_per_ft is not None and args.scale_outlier_threshold > 0:
+    if ref_scale_px_per_ft is not None and not args.disable_scale_outlier_check:
         n_dropped = 0
         for img_path, px_per_ft in scale_records:
             ratio = px_per_ft / ref_scale_px_per_ft
-            if is_scale_outlier(ratio, args.scale_outlier_threshold):
+            if is_scale_outlier(ratio):
                 # A genuine second-scale sheet (Champaign p19-p23 at half the volume
                 # scale) is indistinguishable from a bad fit by the median check alone;
                 # its key-map region can vouch for it. (A near-exact 0.5x/2x multiple is

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -254,6 +254,15 @@ MISSCALE_REGION_AGREEMENT = 1.3
 # plausibility gate.
 KEYMAP_RETRY_SIZE_FRACTION = 0.6
 
+# Scale-outlier bands: a fit whose scale-vs-reference ratio lands near an exact 0.5x or 2x
+# multiple is kept as a genuine differently-scaled sheet, not dropped as a misfit. Many
+# volumes (Nashville, Grand Rapids, Champaign) mix 50 ft/in and 100 ft/in pages, which land
+# almost exactly at half or double the reference; a clean multiple is the signature of a good
+# fit on a differently-scaled page rather than the scatter a bad fit produces.
+HALF_SCALE_BAND = (0.4, 0.6)
+DOUBLE_SCALE_BAND = (1.8, 2.2)
+DEFAULT_SCALE_OUTLIER_THRESHOLD = 0.25
+
 
 def is_split_page(stem: str) -> bool:
     """Whether an image stem names one panel of a split sheet (p21__1-style suffix)."""
@@ -326,6 +335,51 @@ def region_corroborates_scale(fitted_ratio: float, region_ratio: float) -> bool:
     """
     agreement = fitted_ratio / region_ratio
     return 1.0 / MISSCALE_REGION_AGREEMENT <= agreement <= MISSCALE_REGION_AGREEMENT
+
+
+def is_scale_outlier(ratio: float, threshold: float) -> bool:
+    """Whether a fitted-scale / reference-scale ratio should be dropped as a scale outlier.
+
+    A page is kept (not an outlier) when its ratio is within ``threshold`` of the median
+    (``|ratio - 1| <= threshold``) or lands in the half-scale (~0.5x, :data:`HALF_SCALE_BAND`)
+    or double-scale (~2x, :data:`DOUBLE_SCALE_BAND`) band. The half/double bands admit genuine
+    differently-scaled sheets — a page drawn at 50 vs 100 ft/in relative to the volume median
+    lands almost exactly at 0.5x or 2x — whose clean multiple distinguishes them from the
+    scattered ratios a bad fit produces.
+    """
+    if abs(ratio - 1.0) <= threshold:
+        return False
+    if HALF_SCALE_BAND[0] <= ratio <= HALF_SCALE_BAND[1]:
+        return False
+    if DOUBLE_SCALE_BAND[0] <= ratio <= DOUBLE_SCALE_BAND[1]:
+        return False
+    return True
+
+
+def consensus_scale(scales: list[float], threshold: float) -> float:
+    """The page scale that keeps the most pages within the scale-outlier bands.
+
+    Anchors the scale-outlier check (and the deferred 1-GCP scale prior) on the scale shared —
+    directly or at a clean 0.5x/2x multiple (:func:`is_scale_outlier`) — by the most pages,
+    rather than the positional median. This has two properties the median lacks:
+
+    * On a 1x/2x/4x scale ladder it selects the middle (2x) rung, the only anchor under which
+      every rung lands in a band.
+    * It is robust to a cluster of consistent *bad* fits at an intermediate, non-2x-related
+      scale capturing the median — Nashville's ~2.14 px/ft misfit cluster holds the positional
+      median (keeping 13/59 pages), where the consensus 2.78 keeps 58/59 and still drops the
+      lone wild outlier.
+
+    Always returns an actual page's scale (it never averages two values). ``scales`` must be
+    non-empty; ties are broken toward the smaller scale for determinism.
+    """
+
+    def kept(reference: float) -> int:
+        return sum(
+            not is_scale_outlier(scale / reference, threshold) for scale in scales
+        )
+
+    return max(sorted(scales), key=kept)
 
 
 def image_size(image_path: str) -> tuple[int, int]:
@@ -2740,11 +2794,12 @@ def main() -> None:
     parser.add_argument(
         "--scale-outlier-threshold",
         type=float,
-        default=0.25,
+        default=DEFAULT_SCALE_OUTLIER_THRESHOLD,
         metavar="FRAC",
         help=(
             "Delete georef output files whose fitted scale deviates from the reference "
-            "scale by more than this fraction (default: 0.25 = 25%%). "
+            "scale by more than this fraction (default: 0.25 = 25%%). Pages fitted at "
+            "~0.5x or ~2x the reference (differently-scaled sheets) are kept regardless. "
             "Set to 0 to disable. Reference is --scale if given, else the median."
         ),
     )
@@ -3037,18 +3092,26 @@ def main() -> None:
         elif result.deferred is not None:
             deferred_list.append(result.deferred)
 
-    # Determine reference scale: explicit override takes priority, then median.
+    # Determine reference scale: explicit override takes priority, then the volume's
+    # consensus scale (consensus_scale) — the actual page scale that keeps the most pages
+    # within the outlier bands. The positional median fails when a bimodal or trimodal volume
+    # puts the middle page between the real scale clusters (Nashville: 3 clusters ~1.43/2.14/
+    # 2.9, median lands on the bad-fit ~2.14 middle and drops the two real families); the
+    # consensus anchors on the dominant 0.5x/1x/2x scale family instead.
     if args.scale is not None:
         ref_scale_px_per_ft: float | None = args.scale
     elif scales:
-        ref_scale_px_per_ft = float(np.median(scales))
+        anchor_threshold = (
+            args.scale_outlier_threshold or DEFAULT_SCALE_OUTLIER_THRESHOLD
+        )
+        ref_scale_px_per_ft = consensus_scale(scales, anchor_threshold)
     else:
         ref_scale_px_per_ft = None
 
-    # Print median scale whenever multiple images were processed.
-    if scales and len(args.images) > 1:
+    # Print reference scale whenever multiple images were processed.
+    if scales and len(args.images) > 1 and ref_scale_px_per_ft is not None:
         print(
-            f"\nMedian scale: {float(np.median(scales)):.4f} px/ft ({len(scales)} images)",
+            f"\nReference scale: {ref_scale_px_per_ft:.4f} px/ft ({len(scales)} images)",
             file=sys.stderr,
         )
 
@@ -3111,10 +3174,11 @@ def main() -> None:
         n_dropped = 0
         for img_path, px_per_ft in scale_records:
             ratio = px_per_ft / ref_scale_px_per_ft
-            if abs(ratio - 1.0) > args.scale_outlier_threshold:
+            if is_scale_outlier(ratio, args.scale_outlier_threshold):
                 # A genuine second-scale sheet (Champaign p19-p23 at half the volume
                 # scale) is indistinguishable from a bad fit by the median check alone;
-                # its key-map region can vouch for it.
+                # its key-map region can vouch for it. (A near-exact 0.5x/2x multiple is
+                # already spared by is_scale_outlier; this covers other off-median sheets.)
                 if locator is not None and median_region_prior is not None:
                     entry = locator.page_keymap(page_number(image_stem(img_path)))
                     prior = (

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -239,13 +239,6 @@ BROADENED_SCALE_MAX_RATIO = 6.0
 HALF_SCALE_MAX_RATIO = 0.63
 HALF_SCALE_MIN_RATIO = math.sqrt(0.125)
 
-# A fit dropped as a global scale outlier is spared when its region corroborates the scale:
-# the fitted scale-vs-median ratio must match the region's area-implied ratio within this
-# factor. 1.3 passes the region noise on real second-scale sheets (Champaign p19/p22 agree
-# within 0.94-1.19x of their regions) while staying below the smallest observed bad-fit
-# agreement (Chicago p50n at 0.70x, Detroit p85 at 1.54x).
-MISSCALE_REGION_AGREEMENT = 1.3
-
 # When a key-map-placed page's strict neighborhood fit fails, retry with the size floor
 # scaled by this fraction: the radius-restricted vocabulary makes small confident labels
 # trustworthy (Brooklyn p28's essential cross streets "MILL"/"W. 9TH" are 14px against the
@@ -327,17 +320,6 @@ def region_relative_scale(
     if HALF_SCALE_MIN_RATIO <= ratio < HALF_SCALE_MAX_RATIO:
         return 0.5
     return 1.0
-
-
-def region_corroborates_scale(fitted_ratio: float, region_ratio: float) -> bool:
-    """Whether a fit's scale-vs-median ratio matches its region's area-implied ratio.
-
-    Spares genuine second-scale sheets (Champaign p19-p23, half the volume scale) from
-    the global scale-outlier drop, which cannot tell them from bad fits. Both arguments
-    are ratios to the respective volume medians, so the regions' volume-wide bias cancels.
-    """
-    agreement = fitted_ratio / region_ratio
-    return 1.0 / MISSCALE_REGION_AGREEMENT <= agreement <= MISSCALE_REGION_AGREEMENT
 
 
 def is_scale_outlier(ratio: float) -> bool:
@@ -3168,31 +3150,6 @@ def main() -> None:
         for img_path, px_per_ft in scale_records:
             ratio = px_per_ft / ref_scale_px_per_ft
             if is_scale_outlier(ratio):
-                # A genuine second-scale sheet (Champaign p19-p23 at half the volume
-                # scale) is indistinguishable from a bad fit by the median check alone;
-                # its key-map region can vouch for it. (A near-exact 0.5x/2x multiple is
-                # already spared by is_scale_outlier; this covers other off-median sheets.)
-                if locator is not None and median_region_prior is not None:
-                    entry = locator.page_keymap(page_number(image_stem(img_path)))
-                    prior = (
-                        region_prior_px_per_ft(
-                            entry,
-                            *image_size(img_path),
-                            split_page=is_split_page(image_stem(img_path)),
-                        )
-                        if entry is not None
-                        else None
-                    )
-                    if prior is not None and region_corroborates_scale(
-                        ratio, prior / median_region_prior
-                    ):
-                        print(
-                            f"Keeping scale outlier {img_path}: {ratio:.2f}x the "
-                            f"median matches its key-map region "
-                            f"({prior / median_region_prior:.2f}x the typical region)",
-                            file=sys.stderr,
-                        )
-                        continue
                 _, out_path, _ = derive_paths(img_path)
                 misscale_path = out_path.replace(
                     ".georef.json", ".georef-misscale.json"

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1328,6 +1328,59 @@ def test_region_corroborates_scale():
     assert not region_corroborates_scale(1.37, 0.89)
 
 
+def test_is_scale_outlier():
+    from mapsnap.georef_from_labels import is_scale_outlier
+
+    # Within the median band (default threshold 0.25) -> kept.
+    assert not is_scale_outlier(1.0, 0.25)
+    assert not is_scale_outlier(1.24, 0.25)
+    assert not is_scale_outlier(0.76, 0.25)
+    # Between the median band and the half/double bands -> outlier.
+    assert is_scale_outlier(0.7, 0.25)
+    assert is_scale_outlier(1.4, 0.25)
+    assert is_scale_outlier(3.0, 0.25)
+    # Half-scale band [0.4, 0.6] and double-scale band [1.8, 2.2] -> kept (differently-scaled).
+    assert not is_scale_outlier(0.5, 0.25)
+    assert not is_scale_outlier(0.4, 0.25)
+    assert not is_scale_outlier(0.6, 0.25)
+    assert not is_scale_outlier(2.0, 0.25)
+    assert not is_scale_outlier(1.8, 0.25)
+    assert not is_scale_outlier(2.2, 0.25)
+    # Just outside the half/double bands -> outlier.
+    assert is_scale_outlier(0.65, 0.25)
+    assert is_scale_outlier(0.35, 0.25)
+    assert is_scale_outlier(1.7, 0.25)
+    assert is_scale_outlier(2.3, 0.25)
+
+
+def test_consensus_scale_picks_middle_of_ladder():
+    from mapsnap.georef_from_labels import consensus_scale
+
+    # 1x/2x/4x ladder: only the middle (2.0) rung is within a band of all three rungs.
+    scales = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0]
+    assert consensus_scale(scales, 0.25) == 2.0
+
+
+def test_consensus_scale_ignores_intermediate_bad_cluster():
+    from mapsnap.georef_from_labels import consensus_scale
+
+    # Two real scales 2x apart (2.0, 4.0) plus a bad-fit cluster at 2.8 (not 2x-related).
+    # Anchoring on 2.0 keeps the 2.0 (1x) and 4.0 (2x) families and drops 2.8; anchoring on
+    # 2.8 keeps only itself. The consensus is the dominant family's scale, not the median.
+    scales = [2.0] * 10 + [4.0] * 8 + [2.8] * 3
+    assert (
+        sorted(scales)[len(scales) // 2] == 2.8
+    )  # positional median is the bad cluster
+    assert consensus_scale(scales, 0.25) == 2.0
+
+
+def test_consensus_scale_returns_an_actual_page_scale():
+    from mapsnap.georef_from_labels import consensus_scale
+
+    scales = [1.03, 0.97, 1.0, 1.02, 0.99]
+    assert consensus_scale(scales, 0.25) in scales
+
+
 def test_is_split_page():
     from mapsnap.georef_from_labels import is_split_page
 

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1312,22 +1312,6 @@ def test_region_relative_scale():
     assert region_relative_scale(0.5, 2.23) == 1.0
 
 
-def test_region_corroborates_scale():
-    from mapsnap.georef_from_labels import region_corroborates_scale
-
-    # Champaign's half-scale sheets: fitted 0.515x the median, regions 0.43-0.55x the
-    # typical region -> kept.
-    assert region_corroborates_scale(0.515, 0.55)
-    assert region_corroborates_scale(0.515, 0.43)
-    # A split half whose prior was computed from the wrong panel's block (or, before
-    # the split_page fix, from both blocks summed) disagrees -> still dropped.
-    assert not region_corroborates_scale(0.515, 0.27)
-    # Genuine bad fits: Chicago p50n (0.53x fit, 0.76x region) and Detroit p85 (1.37x
-    # fit, 0.89x region) disagree with their regions -> still dropped.
-    assert not region_corroborates_scale(0.53, 0.76)
-    assert not region_corroborates_scale(1.37, 0.89)
-
-
 def test_is_scale_outlier():
     from mapsnap.georef_from_labels import is_scale_outlier
 

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1331,26 +1331,26 @@ def test_region_corroborates_scale():
 def test_is_scale_outlier():
     from mapsnap.georef_from_labels import is_scale_outlier
 
-    # Within the median band (default threshold 0.25) -> kept.
-    assert not is_scale_outlier(1.0, 0.25)
-    assert not is_scale_outlier(1.24, 0.25)
-    assert not is_scale_outlier(0.76, 0.25)
+    # Within the band around the reference itself -> kept.
+    assert not is_scale_outlier(1.0)
+    assert not is_scale_outlier(1.24)
+    assert not is_scale_outlier(0.76)
     # Between the median band and the half/double bands -> outlier.
-    assert is_scale_outlier(0.7, 0.25)
-    assert is_scale_outlier(1.4, 0.25)
-    assert is_scale_outlier(3.0, 0.25)
+    assert is_scale_outlier(0.7)
+    assert is_scale_outlier(1.4)
+    assert is_scale_outlier(3.0)
     # Half-scale band [0.4, 0.6] and double-scale band [1.8, 2.2] -> kept (differently-scaled).
-    assert not is_scale_outlier(0.5, 0.25)
-    assert not is_scale_outlier(0.4, 0.25)
-    assert not is_scale_outlier(0.6, 0.25)
-    assert not is_scale_outlier(2.0, 0.25)
-    assert not is_scale_outlier(1.8, 0.25)
-    assert not is_scale_outlier(2.2, 0.25)
+    assert not is_scale_outlier(0.5)
+    assert not is_scale_outlier(0.4)
+    assert not is_scale_outlier(0.6)
+    assert not is_scale_outlier(2.0)
+    assert not is_scale_outlier(1.8)
+    assert not is_scale_outlier(2.2)
     # Just outside the half/double bands -> outlier.
-    assert is_scale_outlier(0.65, 0.25)
-    assert is_scale_outlier(0.35, 0.25)
-    assert is_scale_outlier(1.7, 0.25)
-    assert is_scale_outlier(2.3, 0.25)
+    assert is_scale_outlier(0.65)
+    assert is_scale_outlier(0.35)
+    assert is_scale_outlier(1.7)
+    assert is_scale_outlier(2.3)
 
 
 def test_consensus_scale_picks_middle_of_ladder():
@@ -1358,7 +1358,7 @@ def test_consensus_scale_picks_middle_of_ladder():
 
     # 1x/2x/4x ladder: only the middle (2.0) rung is within a band of all three rungs.
     scales = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0]
-    assert consensus_scale(scales, 0.25) == 2.0
+    assert consensus_scale(scales) == 2.0
 
 
 def test_consensus_scale_ignores_intermediate_bad_cluster():
@@ -1371,14 +1371,14 @@ def test_consensus_scale_ignores_intermediate_bad_cluster():
     assert (
         sorted(scales)[len(scales) // 2] == 2.8
     )  # positional median is the bad cluster
-    assert consensus_scale(scales, 0.25) == 2.0
+    assert consensus_scale(scales) == 2.0
 
 
 def test_consensus_scale_returns_an_actual_page_scale():
     from mapsnap.georef_from_labels import consensus_scale
 
     scales = [1.03, 0.97, 1.0, 1.02, 0.99]
-    assert consensus_scale(scales, 0.25) in scales
+    assert consensus_scale(scales) in scales
 
 
 def test_is_split_page():


### PR DESCRIPTION
## Problem

The scale-outlier check took the volume's median fitted scale and dropped any page more than 25% away from it. But many volumes mix **50 ft/in and 100 ft/in sheets** (Nashville, Grand Rapids, Champaign), and a genuine second-scale page lands almost exactly at **half or double** the reference — indistinguishable from a bad fit by a distance-from-median test alone.

The damage was severe. Grand Rapids dropped **20** pages this way. Nashville had to be run with the check **disabled entirely** to get any coverage.

## 1. Half/double bands

A ratio in `[0.4, 0.6]` or `[1.8, 2.2]` is kept as a genuine differently-scaled sheet. A *clean multiple* is the signature of a good fit on a differently-scaled page, not the scatter a bad fit produces.

## 2. Consensus reference, replacing `np.median`

The reference is now *the actual page scale that keeps the most pages within the bands*.

Bands alone aren't enough, because the **median itself can land between the real scales**. Nashville's two real scales are 2× apart (~1.43 and ~2.9 px/ft) and **nearly balanced — 25 pages vs 23** of the 51 direct fits. That leaves the positional median (the 26th of 51) sitting in the sparse middle, on `p41__1` at **2.145 px/ft** — a scale no real sheet in the volume uses. Anchored there, the bands keep just **5/51**; the consensus anchors on the real family at 2.78 and keeps **50/51**.

It doesn't take a big cluster of bad fits to capture the median — only near-balanced real clusters. Just three pages sit between them (`p41__1` 2.145, `p1__1` 2.458, `p41__2` 2.596), and one of them is enough to own the 50th percentile.

The consensus also returns **an actual page's scale** (it never averages two values) and selects the **middle rung of a 1×/2×/4× ladder** — the only anchor within 2× of all three, verified by unit test.

## 3. All three bands are constants; the flag is a boolean

`SAME_SCALE_BAND = (0.75, 1.25)` joins the half/double bands. All three describe how Sanborn sheet scales relate, not a per-volume preference. `--scale-outlier-threshold` is replaced by **`--disable-scale-outlier-check`** — passing `0` to switch the check off was the only thing the old flag was really used for.

## 4. The key-map region rescue is removed

A dropped page could be spared when its key-map region's area corroborated its scale (`region_corroborates_scale`), because a genuine second-scale sheet was otherwise indistinguishable from a bad fit — Champaign p19–p23 were the motivating case. **The 2× band now admits those sheets directly, before a region is ever consulted.**

Measured across **8 volumes / 692 pages**, the rescue fires **zero times** — including on Champaign itself:

| volume | pages | region rescues | scale drops |
|---|---|---|---|
| champaign | 31 | 0 | 0 |
| detroit | 108 | 0 | 0 |
| chicago | 111 | 0 | 1 (p61w, 0.03×) |
| brooklyn v1 | 64 | 0 | 0 |
| hudson | 95 | 0 | 1 (p0, 0.12×) |
| new_orleans 1951 | 112 | 0 | 0 |
| queens | 100 | 0 | 0 |
| nashville | 71 | 0 | 1 (p37, 1.44×) |

The check was genuinely *reachable* on 6 of these (key map **and** median region prior both present — queens has no region prior, Nashville no detected key map), so this isn't a vacuous zero. The only three pages dropped anywhere are wild misfits that no region corroborates.

Removing it takes `MISSCALE_REGION_AGREEMENT` with it. `region_prior_px_per_ft`, `median_region_prior` and `region_relative_scale` **stay** — the deferred 1-GCP path still uses the region to pick a scale multiplier for a page it cannot scale itself. Re-running champaign, detroit, chicago, hudson and brooklyn v1 gives identical outcomes: same reference scale, same drops.

## Results (check **enabled**, defaults)

| volume | before | after | median RMSE |
|---|---|---|---|
| **Grand Rapids** | 45/83 | **63/83** | 18 → 19 ft |
| **Nashville** | needed the check *disabled* | **56/71** | 15 ft |

Grand Rapids gains ~19 half/double-scale sheets with accuracy held (mean RMSE 70 → 63 ft). Nashville now matches its disabled-check workaround **automatically, with the check still active** — it still drops the one genuine wild outlier (p37 at 1.44×), which disabling could not.

## Tests

6 new unit tests (band edges, ladder-middle selection, intermediate-scale rejection, actual-page-scale). Full suite green; ruff + pyright clean.