### PR TITLE
Reject street labels printed on coloured building fills

### DIFF
--- a/app/src/components/DetectionsOverlay.tsx
+++ b/app/src/components/DetectionsOverlay.tsx
@@ -1,4 +1,8 @@
-import { confidenceColor, type IndexedDetection } from '../detections';
+import {
+  confidenceColor,
+  isOnBuildingFill,
+  type IndexedDetection,
+} from '../detections';
 
 interface DetectionsOverlayProps {
   detections: IndexedDetection[];
@@ -45,6 +49,9 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
         const isSelected = selectedIndices.has(i);
         const isIgnored = det.ignore === true;
         const isHint = det.hint === true;
+        // A label on a red/blue building fill is dropped before georeferencing, so draw it
+        // like the other discarded reads rather than by its confidence.
+        const isOnFill = isOnBuildingFill(det);
         // Adjacency claims carry `mutual`: reciprocated neighbors render blue, the
         // rest of the claims amber; other modes never set the field.
         const color = isSelected
@@ -57,12 +64,20 @@ export function DetectionsOverlay(props: DetectionsOverlayProps) {
                 ? '#999'
                 : isHint
                   ? '#7c3aed'
-                  : confidenceColor(det.confidence);
+                  : isOnFill
+                    ? '#be123c'
+                    : confidenceColor(det.confidence);
         const points = det.polygon
           .map(([x, y]) => toDisplay(x, y))
           .map(([dx, dy]) => `${dx},${dy}`)
           .join(' ');
-        const dashArray = isIgnored ? '4 3' : isHint ? '3 2' : undefined;
+        const dashArray = isIgnored
+          ? '4 3'
+          : isHint
+            ? '3 2'
+            : isOnFill
+              ? '5 3'
+              : undefined;
 
         const [lx, ly] = toDisplay(det.polygon[0][0], det.polygon[0][1]);
 

--- a/app/src/components/DetectionsTable.tsx
+++ b/app/src/components/DetectionsTable.tsx
@@ -1,4 +1,5 @@
 import type { IndexedDetection } from '../detections';
+import { isOnBuildingFill } from '../detections';
 import { DetectionCanvas } from './DetectionCanvas';
 
 interface DetectionsTableProps {
@@ -47,11 +48,13 @@ export function DetectionsTable(props: DetectionsTableProps) {
         </thead>
         <tbody>
           {visible.map(({ det, i }, rowIdx) => {
+            const onFill = isOnBuildingFill(det);
             const classes = [
               selectedIndices.has(i) ? 'selected' : '',
               det.ignore ? 'ignored' : '',
               det.hint ? 'hint' : '',
               det.fallback ? 'fallback' : '',
+              onFill ? 'on-fill' : '',
             ]
               .filter(Boolean)
               .join(' ');
@@ -74,6 +77,28 @@ export function DetectionsTable(props: DetectionsTableProps) {
                       title="Read by the key-map rectangle fallback vocabulary, not the tighter page-neighborhood radius vocabulary"
                     >
                       fallback
+                    </span>
+                  )}
+                  {det.background && (
+                    <span
+                      className={
+                        onFill ? 'fill-badge dropped' : 'fill-badge spared'
+                      }
+                      title={
+                        `Background ${det.background.color} — hue ${det.background.hue}°, ` +
+                        `chroma ${det.background.chroma}. ` +
+                        (onFill
+                          ? 'Outside the yellow/brown band, so georeferencing treats this as a ' +
+                            'label on a coloured building and drops it.'
+                          : 'Yellow/brown is ambiguous (aged paper, a taped-on patch, or a ' +
+                            'frame building), so georeferencing keeps this.')
+                      }
+                    >
+                      <span
+                        className="fill-swatch"
+                        style={{ background: det.background.color }}
+                      />
+                      {onFill ? 'on fill' : 'on yellow'}
                     </span>
                   )}
                 </td>

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   confidenceColor,
   detectionFromAdjacency,
+  FILL_YELLOW_HUE_BAND,
   filterDetections,
+  isOnBuildingFill,
   previewOrientation,
 } from './detections';
 import type { Detection } from './types';
@@ -199,5 +201,44 @@ describe('detectionFromAdjacency', () => {
     );
     expect(det.ignore).toBe(true);
     expect(det.mutual).toBeUndefined();
+  });
+});
+
+describe('isOnBuildingFill', () => {
+  const withBackground = (hue: number): Detection => ({
+    polygon: [
+      [0, 0],
+      [10, 0],
+      [10, 5],
+      [0, 5],
+    ],
+    text: 'REP',
+    confidence: 1,
+    angle: 0,
+    long_side: 10,
+    short_side: 5,
+    background: { color: '#c04040', hue, chroma: 12 },
+  });
+
+  it('is false when OCR recorded no background (the label is on paper)', () => {
+    const { background: _background, ...onPaper } = withBackground(0);
+    expect(isOnBuildingFill(onPaper)).toBe(false);
+  });
+
+  it('is true for the red brick and blue stone of the Sanborn colour code', () => {
+    expect(isOnBuildingFill(withBackground(5))).toBe(true);
+    expect(isOnBuildingFill(withBackground(250))).toBe(true);
+  });
+
+  it('is false inside the yellow/brown band, which paper and tape share', () => {
+    expect(isOnBuildingFill(withBackground(93))).toBe(false);
+    expect(isOnBuildingFill(withBackground(102.7))).toBe(false);
+  });
+
+  it('treats the band edges as spared', () => {
+    const [low, high] = FILL_YELLOW_HUE_BAND;
+    expect(isOnBuildingFill(withBackground(low))).toBe(false);
+    expect(isOnBuildingFill(withBackground(high))).toBe(false);
+    expect(isOnBuildingFill(withBackground(low - 0.1))).toBe(true);
   });
 });

--- a/app/src/detections.ts
+++ b/app/src/detections.ts
@@ -21,6 +21,28 @@ export function confidenceColor(confidence: number): string {
 }
 
 /**
+ * Hue range georeferencing refuses to read as a building fill.
+ *
+ * Mirrors `FILL_YELLOW_HUE_BAND` in mapsnap/georef_from_labels.py — keep the two in step.
+ * Aged paper, the tape patches pasted over renamed streets, and brown ink all land in this
+ * band, so a label on a yellow/brown background is ambiguous and is kept.
+ */
+export const FILL_YELLOW_HUE_BAND: [number, number] = [40, 110];
+
+/**
+ * True if georeferencing will discard this detection as a building label.
+ *
+ * A detection carries a `background` when it sits on something more saturated than the page's
+ * paper, but only one outside the yellow/brown band — the red brick and blue stone of the
+ * Sanborn colour code — is treated as a building.
+ */
+export function isOnBuildingFill(det: Detection): boolean {
+  if (!det.background) return false;
+  const [low, high] = FILL_YELLOW_HUE_BAND;
+  return det.background.hue < low || det.background.hue > high;
+}
+
+/**
  * Convert an adjacency.json digit read to the Detection shape the overlay,
  * table, and preview canvas render. Side lengths come from the polygon's
  * bounding box; the printed sheet numbers are upright, so angle is 0.

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -278,3 +278,37 @@
 .gcp-stats-warning {
   color: #b00;
 }
+
+/* Background colour recorded by OCR for a label that is not on paper. */
+.fill-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
+/* Red: georeferencing drops these as building labels. Grey: kept, hue too ambiguous to judge. */
+.fill-badge.dropped {
+  background: #be123c;
+}
+
+.fill-badge.spared {
+  background: #6b7280;
+}
+
+.fill-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 2px;
+}
+
+tr.on-fill td {
+  opacity: 0.75;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -27,6 +27,16 @@ export interface IntersectionPoint {
 }
 
 /** A single OCR text detection from detect_text.py. */
+/** A measured CIELAB colour, as recorded by `detect_text.region_color`. */
+export interface LabColor {
+  /** sRGB hex ('#rrggbb'), for display. */
+  color: string;
+  /** Degrees: 0 = red, 90 = yellow, 180 = green, 270 = blue. */
+  hue: number;
+  /** Distance from neutral grey; 0 is unsaturated. */
+  chroma: number;
+}
+
 export interface Detection {
   polygon: [number, number][];
   text: string;
@@ -38,6 +48,12 @@ export interface Detection {
   hint?: boolean;
   /** Read by the key-map rectangle fallback vocab rather than the tighter radius vocab. */
   fallback?: boolean;
+  /**
+   * The background under this detection, set only when it is more saturated than the page's
+   * paper — i.e. the label is printed on a coloured building fill rather than on the paper
+   * where street names belong. Absent for the ordinary on-paper case.
+   */
+  background?: LabColor;
   /**
    * Adjacency-claim reciprocity (adjacency mode only): true renders blue (a mutual
    * neighbor), false amber (an unreciprocated claim); absent for non-claims.

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import math
 import multiprocessing
 import sys
 from collections.abc import Iterator
@@ -9,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import cv2
 import easyocr
 import numpy as np
 from PIL import Image
@@ -54,6 +56,114 @@ NON_STREET_TEXT: frozenset[str] = frozenset(
     # vertical text: '6' → 'S', '"' dropped; W → W / M
     | {"SM PIPE", "S W PIPE", "S W. PIPE"}
 )
+
+# How much a detection's box must exceed the page's own paper chroma (CIELAB) before its
+# background colour is recorded rather than treated as paper. 4.0 separates Nashville's building
+# labels (p51 "REP" at 9-14 chroma over 2.2 paper) from its street labels (1.0-3.6).
+BACKGROUND_CHROMA_MARGIN = 4.0
+
+
+def page_lab(rgb: np.ndarray) -> np.ndarray:
+    """CIELAB image from an RGB array, with a/b re-centered on 0.
+
+    cv2 stores 8-bit Lab with a/b offset by 128; this subtracts that so hue and chroma are
+    ordinary polar coordinates of (a, b). skimage's rgb2lab is not an option here: it segfaults
+    once scipy's MINPACK has run in-process, which it has by the time georeferencing calls back.
+    """
+    lab = cv2.cvtColor(rgb, cv2.COLOR_RGB2Lab).astype(np.float64)
+    lab[:, :, 1] -= 128.0
+    lab[:, :, 2] -= 128.0
+    return lab
+
+
+def lab_to_hex(lightness: float, a: float, b: float) -> str:
+    """sRGB hex string ('#rrggbb') for a single CIELAB colour with a/b centered on 0."""
+    values = np.clip([lightness, a + 128.0, b + 128.0], 0, 255)
+    pixel = np.array([[values]], dtype=np.uint8)
+    red, green, blue = cv2.cvtColor(pixel, cv2.COLOR_Lab2RGB)[0, 0]
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def region_color(lab: np.ndarray, polygon: list) -> dict:
+    """The median colour under a polygon's bounding box, as {color, hue, chroma}.
+
+    A detection's box holds the glyphs (near-neutral ink) plus whatever they sit on, so the
+    median reports the *background*: paper for a street label, the fill colour for a label
+    printed on a building. ``a`` and ``b`` are medianed separately and combined afterwards,
+    because hue is circular and a median over it is not meaningful.
+    """
+    pts = np.asarray(polygon, dtype=float)
+    x0, x1 = max(0, int(pts[:, 0].min())), int(pts[:, 0].max())
+    y0, y1 = max(0, int(pts[:, 1].min())), int(pts[:, 1].max())
+    region = lab[y0 : y1 + 1, x0 : x1 + 1]
+    if not region.size:
+        return {"color": "#000000", "hue": 0.0, "chroma": 0.0}
+    lightness = float(np.median(region[:, :, 0]))
+    a = float(np.median(region[:, :, 1]))
+    b = float(np.median(region[:, :, 2]))
+    return {
+        "color": lab_to_hex(lightness, a, b),
+        "hue": round(math.degrees(math.atan2(b, a)) % 360.0, 1),
+        "chroma": round(math.hypot(a, b), 1),
+    }
+
+
+def annotate_backgrounds(
+    detections: list[dict],
+    rgb: np.ndarray,
+    margin: float = BACKGROUND_CHROMA_MARGIN,
+) -> dict:
+    """Record each detection's background colour when it differs from the page's paper.
+
+    Sanborn sheets print street names on the paper background, so text sitting inside a coloured
+    block is a *building* label. Sets ``background`` ({color, hue, chroma}) on every detection
+    whose box is more saturated than the paper by more than ``margin``, and leaves it unset
+    otherwise — the property's presence alone means "this label is not on paper". Deciding which
+    of those colours disqualify a label is left to the reader of the file (see
+    ``georef_from_labels.drop_labels_on_fill``), so re-OCR is not needed to change that policy.
+
+    The chroma reference is the page's own because paper varies enormously between volumes:
+    near-white in Nashville (chroma 1-5), heavily yellowed in Chicago and New Orleans (13-20).
+
+    Returns the paper colour itself, for the caller to record alongside the detections.
+    """
+    lab = page_lab(rgb)
+    lab_a, lab_b = lab[:, :, 1], lab[:, :, 2]
+    # Chroma is medianed per pixel (the typical saturation), while the paper's displayed colour
+    # comes from the median a/b — the right reduction for each, so they differ slightly.
+    paper_chroma = float(np.median(np.hypot(lab_a, lab_b)))
+    paper_a, paper_b = float(np.median(lab_a)), float(np.median(lab_b))
+    for det in detections:
+        background = region_color(lab, det["polygon"])
+        if background["chroma"] > paper_chroma + margin:
+            det["background"] = background
+    return {
+        "color": lab_to_hex(float(np.median(lab[:, :, 0])), paper_a, paper_b),
+        "hue": round(math.degrees(math.atan2(paper_b, paper_a)) % 360.0, 1),
+        "chroma": round(paper_chroma, 1),
+    }
+
+
+def backfill_backgrounds(image_path: str) -> int:
+    """Add ``background`` to an existing <stem>.streets.json in place, without re-running OCR.
+
+    Background colour is a pure function of the image and the detection boxes, so a file OCR'd
+    before the property existed can be brought up to date far more cheaply than by re-reading the
+    page. Returns the number of detections found to be on a coloured fill.
+    """
+    path = _streets_path(image_path)
+    with open(path) as f:
+        streets_doc = json.load(f)
+    detections = streets_doc["streets"]
+    for det in detections:
+        det.pop("background", None)
+    with Image.open(image_path) as img:
+        streets_doc["paper"] = annotate_backgrounds(
+            detections, np.array(img.convert("RGB"))
+        )
+    with open(path, "w") as f:
+        json.dump(streets_doc, f, indent=2)
+    return sum(1 for det in detections if "background" in det)
 
 
 def _erase_underlines(
@@ -483,6 +593,12 @@ def detect_text(
       - short_side: length of the shorter pair of polygon sides (pixels)
       - ignore: True if the text matches a NON_STREET_TEXT pattern (absent otherwise)
       - fallback: True if the read came from fallback_vocab, not vocab_strings (absent otherwise)
+      - background: {color, hue, chroma} of the box's background when it is more saturated than
+        the page's paper, i.e. the label is printed on a coloured building fill (absent when the
+        label sits on paper, which is where street names belong)
+
+    The written <stem>.streets.json also records the page's own ``paper`` colour in the same
+    {color, hue, chroma} form, which is the reference the ``background`` property is relative to.
     """
     if reader is None:
         reader = easyocr.Reader(["en"], gpu=True, verbose=False)
@@ -537,11 +653,14 @@ def detect_text(
         elif det["text"].upper() in HINT_STRINGS:
             det["hint"] = True
 
+    paper = annotate_backgrounds(all_detections, np.array(img))
+
     streets_doc = {
         "width": orig_width,
         "height": orig_height,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "command": filter_args(sys.argv[:], image_path),
+        "paper": paper,
         "streets": all_detections,
     }
     with open(_streets_path(image_path), "w") as f:
@@ -718,6 +837,15 @@ def main() -> None:
         help="Skip images that already have a .streets.json output file.",
     )
     parser.add_argument(
+        "--backfill-background",
+        action="store_true",
+        help=(
+            "Do not run OCR. Instead, add the 'background' colour property to the detections in "
+            "each image's existing <stem>.streets.json, which is all that pages OCR'd before that "
+            "property existed need. Images with no .streets.json are skipped."
+        ),
+    )
+    parser.add_argument(
         "--num-workers",
         type=int,
         default=1,
@@ -780,6 +908,22 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    if args.backfill_background:
+        pending = [p for p in args.images if Path(_streets_path(p)).exists()]
+        print(
+            f"Backfilling background colour for {len(pending)}/{len(args.images)} image(s) with "
+            "existing detections.",
+            file=sys.stderr,
+        )
+        on_fill = 0
+        for image_path in tqdm(pending, smoothing=0):
+            on_fill += backfill_backgrounds(image_path)
+        print(
+            f"Marked {on_fill} detection(s) as sitting on a coloured fill.",
+            file=sys.stderr,
+        )
+        return
 
     if args.centerlines is None:
         centerlines = default_centerlines(Path(args.images[0]).parent)

--- a/mapsnap/detect_text_test.py
+++ b/mapsnap/detect_text_test.py
@@ -10,6 +10,10 @@ from mapsnap.detect_text import (
     _iter_tiles,
     _merge_vocab_passes,
     _nms_bboxes,
+    annotate_backgrounds,
+    lab_to_hex,
+    page_lab,
+    region_color,
     filter_args,
     has_split_panels,
     page_vocabs,
@@ -472,3 +476,66 @@ def test_merge_vocab_passes_flags_only_fallback_wins():
     assert (
         "fallback" not in by_text["OAK"]
     )  # agreed on text, so not a fallback-only read
+
+
+def _rgb_page(shape=(100, 100)) -> np.ndarray:
+    """A faintly yellowed paper page, the usual Sanborn background."""
+    page = np.full((*shape, 3), 250, dtype=np.uint8)
+    page[:, :, 2] = 235  # slightly less blue => yellowish
+    return page
+
+
+def _box(x0: int, y0: int, x1: int, y1: int) -> list[list[int]]:
+    return [[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+
+
+def test_region_color_reports_the_box_background_not_the_ink():
+    # Dark glyphs on a red block: the median under the box must report the red, since the ink
+    # covers well under half the pixels.
+    page = _rgb_page((50, 50))
+    page[10:30, 10:30] = (200, 40, 40)
+    page[18:22, 12:28] = (20, 20, 20)  # a line of "text"
+    lab = page_lab(page)
+    background = region_color(lab, _box(10, 10, 29, 29))
+    assert 340 <= background["hue"] or background["hue"] <= 40  # red
+    assert background["chroma"] > 40
+
+
+def test_annotate_backgrounds_marks_only_labels_off_the_paper():
+    page = _rgb_page()
+    page[50:70, 50:70] = (200, 40, 40)  # a red brick building
+    on_paper = {"text": "MAIN", "polygon": _box(10, 10, 30, 20)}
+    on_fill = {"text": "REP", "polygon": _box(55, 55, 65, 65)}
+    paper = annotate_backgrounds([on_paper, on_fill], page)
+
+    assert "background" not in on_paper  # street names sit on paper: nothing to record
+    assert on_fill["background"]["chroma"] > paper["chroma"] + 4.0
+    assert on_fill["background"]["color"].startswith("#")
+    assert 340 <= on_fill["background"]["hue"] or on_fill["background"]["hue"] <= 40
+
+
+def test_annotate_backgrounds_uses_the_pages_own_paper_as_the_reference():
+    # A heavily yellowed page (Chicago, New Orleans): an ordinary label on that paper must not
+    # be marked, even though the paper itself is far from neutral in absolute terms.
+    page = np.full((100, 100, 3), 210, dtype=np.uint8)
+    page[:, :, 2] = 150  # strongly yellow paper
+    det = {"text": "HALSTED", "polygon": _box(10, 10, 30, 20)}
+    paper = annotate_backgrounds([det], page)
+    assert paper["chroma"] > 10  # the paper really is saturated...
+    assert (
+        "background" not in det
+    )  # ...but the label matches it, so nothing is recorded
+
+
+def test_lab_to_hex_renders_a_swatch_of_the_lab_colour():
+    # Zero chroma is grey; +a is red; +b is yellow (red and green, little blue).
+    grey = lab_to_hex(128.0, 0.0, 0.0)
+    assert grey[1:3] == grey[3:5] == grey[5:7]
+    red, green, blue = _hex_channels(lab_to_hex(128.0, 60.0, 40.0))
+    assert red > green and red > blue
+    red, green, blue = _hex_channels(lab_to_hex(200.0, 0.0, 60.0))
+    assert red > blue and green > blue
+
+
+def _hex_channels(value: str) -> tuple[int, int, int]:
+    return int(value[1:3], 16), int(value[3:5], 16), int(value[5:7], 16)

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -26,7 +26,6 @@ from itertools import combinations
 from pathlib import Path
 from typing import Any
 
-import cv2
 import numpy as np
 from PIL import Image
 from tqdm import tqdm
@@ -310,11 +309,6 @@ KEYMAP_RETRY_SIZE_FRACTION = 0.6
 SAME_SCALE_BAND = (0.75, 1.25)
 HALF_SCALE_BAND = (0.4, 0.6)
 DOUBLE_SCALE_BAND = (1.8, 2.2)
-
-# CIELAB chroma a detection's box must exceed the page's own paper chroma by before it counts
-# as printed on a coloured building fill (drop_labels_on_fill). 4.0 separates Nashville's
-# building labels (p51 "REP" 9-14 chroma over 2.2 paper) from its street labels (1.0-3.6).
-LABEL_FILL_CHROMA_MARGIN = 4.0
 
 # CIELAB hue range (degrees, 0 = +a = red, 90 = +b = yellow) that drop_labels_on_fill refuses to
 # read as a building fill. Aged paper, the tape patches later pasted over renamed streets, and
@@ -1995,11 +1989,11 @@ def _init_worker(
     geojson_features: list[dict] | None = None,
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None,
     truth_by_page: dict[int, list[list[list[float]]]] | None = None,
-    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
+    keep_labels_on_fill: bool = False,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
-        fill_chroma_margin=fill_chroma_margin,
+        keep_labels_on_fill=keep_labels_on_fill,
         block_index=block_index,
         cos_phi=cos_phi,
         centerlines_path=centerlines_path,
@@ -2074,7 +2068,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             ],
             keymap=keymap,
             truth_polygons=truth_polygons,
-            fill_chroma_margin=_worker_state["fill_chroma_margin"],
+            keep_labels_on_fill=_worker_state["keep_labels_on_fill"],
         )
 
     with _captured_page_log(log_path, _worker_state["debug"]):
@@ -2191,65 +2185,26 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     return image_path, result
 
 
-def page_lab_ab(image_path: str) -> tuple[np.ndarray, np.ndarray] | None:
-    """CIELAB a/b channels of a page image, centered at 0, or None if it cannot be read.
-
-    Uses cv2's Lab (a/b stored centered at 128); skimage's rgb2lab segfaults after scipy MINPACK
-    runs in-process, so cv2 is the only safe converter here.
-    """
-    bgr = cv2.imread(image_path)
-    if bgr is None:
-        return None
-    lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float64)
-    return lab[:, :, 1] - 128.0, lab[:, :, 2] - 128.0
-
-
-def detection_fill_color(
-    lab_a: np.ndarray, lab_b: np.ndarray, polygon: list
-) -> tuple[float, float]:
-    """(chroma, hue in degrees) of the median colour under a detection's bounding box.
-
-    The box holds the glyphs (near-neutral ink) plus whatever they sit on, so the median reports
-    the *background*: paper for a street label, the fill colour for a label printed on a building.
-    ``a`` and ``b`` are medianed separately and combined afterwards, because hue is a circular
-    quantity whose median is not meaningful.
-    """
-    pts = np.asarray(polygon, dtype=float)
-    x0, x1 = max(0, int(pts[:, 0].min())), int(pts[:, 0].max())
-    y0, y1 = max(0, int(pts[:, 1].min())), int(pts[:, 1].max())
-    region_a = lab_a[y0 : y1 + 1, x0 : x1 + 1]
-    region_b = lab_b[y0 : y1 + 1, x0 : x1 + 1]
-    if not region_a.size:
-        return 0.0, 0.0
-    a = float(np.median(region_a))
-    b = float(np.median(region_b))
-    return math.hypot(a, b), math.degrees(math.atan2(b, a)) % 360.0
-
-
 def drop_labels_on_fill(
     detections: list[dict],
-    lab_a: np.ndarray,
-    lab_b: np.ndarray,
-    margin: float = LABEL_FILL_CHROMA_MARGIN,
     yellow_band: tuple[float, float] = FILL_YELLOW_HUE_BAND,
 ) -> tuple[list[dict], list[dict]]:
-    """Split detections into (kept, on-fill) by whether each sits on a coloured building fill.
+    """Split detections into (kept, on-fill) by the ``background`` colour OCR recorded for each.
 
     Sanborn sheets print street names on the paper background; text inside a coloured block is a
     *building* label, which can still prefix-match a street name and fabricate GCPs (Nashville's
-    "REP" -> "REP JOHN LEWIS WAY", "SEARS", "SERVICE" -> "SERVICE ROAD"). A detection is on-fill
-    when its box's median chroma exceeds the page's own paper chroma by ``margin`` *and* its hue
-    lies outside ``yellow_band``. The chroma reference is per page because paper varies a lot
-    (Nashville p9 1.0, p51 2.2, p2 5.1 chroma).
+    "REP" -> "REP JOHN LEWIS WAY", "SEARS", "SERVICE" -> "SERVICE ROAD"). ``detect_text`` records a
+    ``background`` on exactly the detections that sit on something more saturated than the page's
+    own paper; this decides which of those colours actually disqualify a label.
 
-    The hue test is what makes the chroma test usable across volumes. Chroma alone asks only "is
-    this more saturated than the paper", which on a yellowed scan is answered "yes" by an ordinary
-    street label: Chicago's and New Orleans' paper is itself chroma 13-20 at hue ~90-95, and a
-    street name taped on later (aged to brown-on-yellow) sits only 4-6 chroma above it — enough to
-    trip a bare chroma test, which cost Chicago its HALSTED and KINZIE labels and New Orleans its
-    TCHOUPITOULAS. Those all sit at hue 90-95: the same hue as the paper they are printed on.
-    Sparing the yellow/brown band keeps them, while still dropping the red and blue fills that
-    carry the real building labels (all 18 of Nashville's "REP" reads are hue 0-6 or 240-257).
+    Only hue outside ``yellow_band`` does. Being on *some* colour is not enough, because on a
+    yellowed scan an ordinary street label is more saturated than the paper: Chicago's and New
+    Orleans' paper is itself chroma 13-20 at hue ~90-95, and a street name taped on later (aged to
+    brown-on-yellow) sits only 4-6 chroma above it. Dropping those cost Chicago its HALSTED and
+    KINZIE labels and New Orleans its TCHOUPITOULAS — all at hue 90-95, the same hue as the paper
+    they are printed on. Sparing the yellow/brown band keeps them while still dropping the red and
+    blue fills that carry the real building labels (all 18 of Nashville's "REP" reads are hue 0-6
+    or 240-257).
 
     The cost is deliberate: Sanborn's colour code also paints *frame* buildings yellow, so a label
     on one is spared too (Brooklyn p57's "CARROLL TRUCKING CORP." is yellow, not red). Hue cannot
@@ -2258,13 +2213,12 @@ def drop_labels_on_fill(
     Key-map pages must skip this entirely — their street names sit on the coloured region blocks
     by design.
     """
-    paper = float(np.median(np.hypot(lab_a, lab_b)))
     low, high = yellow_band
     kept: list[dict] = []
     on_fill: list[dict] = []
     for det in detections:
-        chroma, hue = detection_fill_color(lab_a, lab_b, det["polygon"])
-        if chroma > paper + margin and not (low <= hue <= high):
+        background = det.get("background")
+        if background is not None and not (low <= background["hue"] <= high):
             on_fill.append(det)
         else:
             kept.append(det)
@@ -2282,8 +2236,7 @@ def prepare_label_features(
     min_aspect_ratio: float = 2.0,
     edge_margin: float = 0.02,
     high_confidence_size_fraction: float = 0.7,
-    image_path: str | None = None,
-    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
+    keep_labels_on_fill: bool = False,
 ) -> list[LabelFeature]:
     """Load, promote, assemble, dedupe, filter, and canonicalize street reads into features.
 
@@ -2294,6 +2247,10 @@ def prepare_label_features(
     (one feature per distinct candidate street). Split out of :func:`process_image` so that which
     reads are accepted is separable from how they are fitted, and so any future consumer can
     accept exactly the same reads.
+
+    keep_labels_on_fill retains labels printed on a coloured building fill, which are normally
+    dropped (``drop_labels_on_fill``). Key-map pages need it: their street names sit on the
+    coloured region blocks by design.
     """
     img_w, img_h = image_size
     all_detections = load_detections(labels_path)
@@ -2340,25 +2297,21 @@ def prepare_label_features(
 
     # Street names are printed on paper; text on a coloured building fill is a building label
     # that can still prefix-match a street name and fabricate GCPs.
-    if image_path is not None and fill_chroma_margin > 0:
-        lab = page_lab_ab(image_path)
-        if lab is not None:
-            all_detections, on_fill = drop_labels_on_fill(
-                all_detections, lab[0], lab[1], fill_chroma_margin
+    if not keep_labels_on_fill:
+        all_detections, on_fill = drop_labels_on_fill(all_detections)
+        if on_fill:
+            named = sorted(
+                {
+                    d["text"]
+                    for d in on_fill
+                    if canonical_street_match(d.get("text", ""), normalized_streets)
+                }
             )
-            if on_fill:
-                named = sorted(
-                    {
-                        d["text"]
-                        for d in on_fill
-                        if canonical_street_match(d.get("text", ""), normalized_streets)
-                    }
-                )
-                print(
-                    f"Dropped {len(on_fill)} detection(s) on coloured fill"
-                    + (f"; street-matching: {', '.join(named)}" if named else ""),
-                    file=sys.stderr,
-                )
+            print(
+                f"Dropped {len(on_fill)} detection(s) on coloured fill"
+                + (f"; street-matching: {', '.join(named)}" if named else ""),
+                file=sys.stderr,
+            )
 
     labels_data = []
     for det in all_detections:
@@ -2449,7 +2402,7 @@ def process_image(
     high_confidence_size_fraction: float = 0.7,
     keymap: dict | None = None,
     truth_polygons: list[list[list[float]]] | None = None,
-    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
+    keep_labels_on_fill: bool = False,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -2481,8 +2434,7 @@ def process_image(
         min_aspect_ratio=min_aspect_ratio,
         edge_margin=edge_margin,
         high_confidence_size_fraction=high_confidence_size_fraction,
-        image_path=image_path,
-        fill_chroma_margin=0.0 if is_keymap_page else fill_chroma_margin,
+        keep_labels_on_fill=keep_labels_on_fill or is_keymap_page,
     )
 
     gcps = find_intersection_gcps(features, block_index, (img_w, img_h))
@@ -3014,15 +2966,14 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--label-fill-chroma-margin",
-        type=float,
-        default=LABEL_FILL_CHROMA_MARGIN,
-        metavar="CHROMA",
+        "--keep-labels-on-fill",
+        action="store_true",
         help=(
-            "Reject detections whose box's median CIELAB chroma exceeds the page's paper "
-            "chroma by more than this, as labels printed on a coloured building fill rather "
-            "than on the street background (default: %(default)s). Set to 0 to disable. "
-            "Key-map pages are always exempt."
+            "Keep detections that OCR recorded as printed on a coloured building fill (a red or "
+            "blue Sanborn block) rather than on the paper. These are building labels, not street "
+            "names, and are dropped by default because they can still prefix-match a street and "
+            "fabricate GCPs. Key-map pages are always exempt, since their street names sit on the "
+            "coloured region blocks by design."
         ),
     )
     parser.add_argument(
@@ -3291,7 +3242,7 @@ def main() -> None:
         geojson["features"] if locator is not None else None,
         rectangle_index,
         truth_by_page,
-        args.label_fill_chroma_margin,
+        args.keep_labels_on_fill,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -316,6 +316,13 @@ DOUBLE_SCALE_BAND = (1.8, 2.2)
 # building labels (p51 "REP" 9-14 chroma over 2.2 paper) from its street labels (1.0-3.6).
 LABEL_FILL_CHROMA_MARGIN = 4.0
 
+# CIELAB hue range (degrees, 0 = +a = red, 90 = +b = yellow) that drop_labels_on_fill refuses to
+# read as a building fill. Aged paper, the tape patches later pasted over renamed streets, and
+# brown ink all land here, so a label on a yellow/brown background is ambiguous and is kept. Only
+# fills outside the band — the red/pink brick and blue stone of the Sanborn colour code — are
+# treated as buildings. Brown is a dark yellow/orange and shares the band.
+FILL_YELLOW_HUE_BAND = (40.0, 110.0)
+
 
 def is_split_page(stem: str) -> bool:
     """Whether an image stem names one panel of a split sheet (p21__1-style suffix)."""
@@ -2184,52 +2191,80 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     return image_path, result
 
 
-def page_chroma_map(image_path: str) -> np.ndarray | None:
-    """CIELAB chroma per pixel of a page image, or None if it cannot be read.
+def page_lab_ab(image_path: str) -> tuple[np.ndarray, np.ndarray] | None:
+    """CIELAB a/b channels of a page image, centered at 0, or None if it cannot be read.
 
-    Uses cv2's Lab (a/b centered at 128); skimage's rgb2lab segfaults after scipy MINPACK
+    Uses cv2's Lab (a/b stored centered at 128); skimage's rgb2lab segfaults after scipy MINPACK
     runs in-process, so cv2 is the only safe converter here.
     """
     bgr = cv2.imread(image_path)
     if bgr is None:
         return None
     lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float64)
-    return np.hypot(lab[:, :, 1] - 128.0, lab[:, :, 2] - 128.0)
+    return lab[:, :, 1] - 128.0, lab[:, :, 2] - 128.0
 
 
-def detection_fill_chroma(chroma: np.ndarray, polygon: list) -> float:
-    """Median CIELAB chroma under a detection's bounding box.
+def detection_fill_color(
+    lab_a: np.ndarray, lab_b: np.ndarray, polygon: list
+) -> tuple[float, float]:
+    """(chroma, hue in degrees) of the median colour under a detection's bounding box.
 
-    The box holds the glyphs (near-neutral ink, low chroma) plus whatever they sit on, so the
-    median reports the *background*: paper for a street label, the fill colour for a label
-    printed inside a building.
+    The box holds the glyphs (near-neutral ink) plus whatever they sit on, so the median reports
+    the *background*: paper for a street label, the fill colour for a label printed on a building.
+    ``a`` and ``b`` are medianed separately and combined afterwards, because hue is a circular
+    quantity whose median is not meaningful.
     """
     pts = np.asarray(polygon, dtype=float)
     x0, x1 = max(0, int(pts[:, 0].min())), int(pts[:, 0].max())
     y0, y1 = max(0, int(pts[:, 1].min())), int(pts[:, 1].max())
-    region = chroma[y0 : y1 + 1, x0 : x1 + 1]
-    return float(np.median(region)) if region.size else 0.0
+    region_a = lab_a[y0 : y1 + 1, x0 : x1 + 1]
+    region_b = lab_b[y0 : y1 + 1, x0 : x1 + 1]
+    if not region_a.size:
+        return 0.0, 0.0
+    a = float(np.median(region_a))
+    b = float(np.median(region_b))
+    return math.hypot(a, b), math.degrees(math.atan2(b, a)) % 360.0
 
 
 def drop_labels_on_fill(
     detections: list[dict],
-    chroma: np.ndarray,
+    lab_a: np.ndarray,
+    lab_b: np.ndarray,
     margin: float = LABEL_FILL_CHROMA_MARGIN,
+    yellow_band: tuple[float, float] = FILL_YELLOW_HUE_BAND,
 ) -> tuple[list[dict], list[dict]]:
     """Split detections into (kept, on-fill) by whether each sits on a coloured building fill.
 
     Sanborn sheets print street names on the paper background; text inside a coloured block is a
     *building* label, which can still prefix-match a street name and fabricate GCPs (Nashville's
     "REP" -> "REP JOHN LEWIS WAY", "SEARS", "SERVICE" -> "SERVICE ROAD"). A detection is on-fill
-    when its box's median chroma exceeds the page's own paper chroma by ``margin``. The reference
-    is per page because paper varies (Nashville p9 1.0, p51 2.2, p2 5.1 chroma). Key-map pages
-    must skip this — their street names sit on the coloured region blocks by design.
+    when its box's median chroma exceeds the page's own paper chroma by ``margin`` *and* its hue
+    lies outside ``yellow_band``. The chroma reference is per page because paper varies a lot
+    (Nashville p9 1.0, p51 2.2, p2 5.1 chroma).
+
+    The hue test is what makes the chroma test usable across volumes. Chroma alone asks only "is
+    this more saturated than the paper", which on a yellowed scan is answered "yes" by an ordinary
+    street label: Chicago's and New Orleans' paper is itself chroma 13-20 at hue ~90-95, and a
+    street name taped on later (aged to brown-on-yellow) sits only 4-6 chroma above it — enough to
+    trip a bare chroma test, which cost Chicago its HALSTED and KINZIE labels and New Orleans its
+    TCHOUPITOULAS. Those all sit at hue 90-95: the same hue as the paper they are printed on.
+    Sparing the yellow/brown band keeps them, while still dropping the red and blue fills that
+    carry the real building labels (all 18 of Nashville's "REP" reads are hue 0-6 or 240-257).
+
+    The cost is deliberate: Sanborn's colour code also paints *frame* buildings yellow, so a label
+    on one is spared too (Brooklyn p57's "CARROLL TRUCKING CORP." is yellow, not red). Hue cannot
+    separate a yellow frame building from yellowed paper, and sparing both is the safer error.
+
+    Key-map pages must skip this entirely — their street names sit on the coloured region blocks
+    by design.
     """
-    paper = float(np.median(chroma))
+    paper = float(np.median(np.hypot(lab_a, lab_b)))
+    low, high = yellow_band
     kept: list[dict] = []
     on_fill: list[dict] = []
     for det in detections:
-        if detection_fill_chroma(chroma, det["polygon"]) > paper + margin:
+        chroma, hue = detection_fill_color(lab_a, lab_b, det["polygon"])
+        if chroma > paper + margin and not (low <= hue <= high):
             on_fill.append(det)
         else:
             kept.append(det)
@@ -2306,10 +2341,10 @@ def prepare_label_features(
     # Street names are printed on paper; text on a coloured building fill is a building label
     # that can still prefix-match a street name and fabricate GCPs.
     if image_path is not None and fill_chroma_margin > 0:
-        chroma = page_chroma_map(image_path)
-        if chroma is not None:
+        lab = page_lab_ab(image_path)
+        if lab is not None:
             all_detections, on_fill = drop_labels_on_fill(
-                all_detections, chroma, fill_chroma_margin
+                all_detections, lab[0], lab[1], fill_chroma_margin
             )
             if on_fill:
                 named = sorted(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -26,6 +26,7 @@ from itertools import combinations
 from pathlib import Path
 from typing import Any
 
+import cv2
 import numpy as np
 from PIL import Image
 from tqdm import tqdm
@@ -42,6 +43,7 @@ from mapsnap.streets import (
     HINT_STRINGS,
     Block,
     build_block_index,
+    canonical_street_match,
     canonical_street_matches,
     deduplicate_detections,
     hint_type_word,
@@ -308,6 +310,11 @@ KEYMAP_RETRY_SIZE_FRACTION = 0.6
 SAME_SCALE_BAND = (0.75, 1.25)
 HALF_SCALE_BAND = (0.4, 0.6)
 DOUBLE_SCALE_BAND = (1.8, 2.2)
+
+# CIELAB chroma a detection's box must exceed the page's own paper chroma by before it counts
+# as printed on a coloured building fill (drop_labels_on_fill). 4.0 separates Nashville's
+# building labels (p51 "REP" 9-14 chroma over 2.2 paper) from its street labels (1.0-3.6).
+LABEL_FILL_CHROMA_MARGIN = 4.0
 
 
 def is_split_page(stem: str) -> bool:
@@ -1981,9 +1988,11 @@ def _init_worker(
     geojson_features: list[dict] | None = None,
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None,
     truth_by_page: dict[int, list[list[list[float]]]] | None = None,
+    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
+        fill_chroma_margin=fill_chroma_margin,
         block_index=block_index,
         cos_phi=cos_phi,
         centerlines_path=centerlines_path,
@@ -2058,6 +2067,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             ],
             keymap=keymap,
             truth_polygons=truth_polygons,
+            fill_chroma_margin=_worker_state["fill_chroma_margin"],
         )
 
     with _captured_page_log(log_path, _worker_state["debug"]):
@@ -2174,6 +2184,58 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     return image_path, result
 
 
+def page_chroma_map(image_path: str) -> np.ndarray | None:
+    """CIELAB chroma per pixel of a page image, or None if it cannot be read.
+
+    Uses cv2's Lab (a/b centered at 128); skimage's rgb2lab segfaults after scipy MINPACK
+    runs in-process, so cv2 is the only safe converter here.
+    """
+    bgr = cv2.imread(image_path)
+    if bgr is None:
+        return None
+    lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float64)
+    return np.hypot(lab[:, :, 1] - 128.0, lab[:, :, 2] - 128.0)
+
+
+def detection_fill_chroma(chroma: np.ndarray, polygon: list) -> float:
+    """Median CIELAB chroma under a detection's bounding box.
+
+    The box holds the glyphs (near-neutral ink, low chroma) plus whatever they sit on, so the
+    median reports the *background*: paper for a street label, the fill colour for a label
+    printed inside a building.
+    """
+    pts = np.asarray(polygon, dtype=float)
+    x0, x1 = max(0, int(pts[:, 0].min())), int(pts[:, 0].max())
+    y0, y1 = max(0, int(pts[:, 1].min())), int(pts[:, 1].max())
+    region = chroma[y0 : y1 + 1, x0 : x1 + 1]
+    return float(np.median(region)) if region.size else 0.0
+
+
+def drop_labels_on_fill(
+    detections: list[dict],
+    chroma: np.ndarray,
+    margin: float = LABEL_FILL_CHROMA_MARGIN,
+) -> tuple[list[dict], list[dict]]:
+    """Split detections into (kept, on-fill) by whether each sits on a coloured building fill.
+
+    Sanborn sheets print street names on the paper background; text inside a coloured block is a
+    *building* label, which can still prefix-match a street name and fabricate GCPs (Nashville's
+    "REP" -> "REP JOHN LEWIS WAY", "SEARS", "SERVICE" -> "SERVICE ROAD"). A detection is on-fill
+    when its box's median chroma exceeds the page's own paper chroma by ``margin``. The reference
+    is per page because paper varies (Nashville p9 1.0, p51 2.2, p2 5.1 chroma). Key-map pages
+    must skip this — their street names sit on the coloured region blocks by design.
+    """
+    paper = float(np.median(chroma))
+    kept: list[dict] = []
+    on_fill: list[dict] = []
+    for det in detections:
+        if detection_fill_chroma(chroma, det["polygon"]) > paper + margin:
+            on_fill.append(det)
+        else:
+            kept.append(det)
+    return kept, on_fill
+
+
 def prepare_label_features(
     labels_path: str,
     block_index: dict[str, list[Block]],
@@ -2185,6 +2247,8 @@ def prepare_label_features(
     min_aspect_ratio: float = 2.0,
     edge_margin: float = 0.02,
     high_confidence_size_fraction: float = 0.7,
+    image_path: str | None = None,
+    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
 ) -> list[LabelFeature]:
     """Load, promote, assemble, dedupe, filter, and canonicalize street reads into features.
 
@@ -2238,6 +2302,29 @@ def prepare_label_features(
         all_detections, normalized_streets=normalized_streets
     )
     print(f"Deduped detections: {len(all_detections)}")
+
+    # Street names are printed on paper; text on a coloured building fill is a building label
+    # that can still prefix-match a street name and fabricate GCPs.
+    if image_path is not None and fill_chroma_margin > 0:
+        chroma = page_chroma_map(image_path)
+        if chroma is not None:
+            all_detections, on_fill = drop_labels_on_fill(
+                all_detections, chroma, fill_chroma_margin
+            )
+            if on_fill:
+                named = sorted(
+                    {
+                        d["text"]
+                        for d in on_fill
+                        if canonical_street_match(d.get("text", ""), normalized_streets)
+                    }
+                )
+                print(
+                    f"Dropped {len(on_fill)} detection(s) on coloured fill"
+                    + (f"; street-matching: {', '.join(named)}" if named else ""),
+                    file=sys.stderr,
+                )
+
     labels_data = []
     for det in all_detections:
         is_promoted = det.get("promoted")
@@ -2327,6 +2414,7 @@ def process_image(
     high_confidence_size_fraction: float = 0.7,
     keymap: dict | None = None,
     truth_polygons: list[list[list[float]]] | None = None,
+    fill_chroma_margin: float = LABEL_FILL_CHROMA_MARGIN,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -2340,6 +2428,14 @@ def process_image(
     with Image.open(image_path) as pil_img:
         img_w, img_h = pil_img.size
 
+    # A key map prints its street names *on* the coloured region blocks, so the on-fill filter
+    # would reject exactly the labels that georeference it; exempt those pages.
+    is_keymap_page = os.path.exists(
+        os.path.join(
+            os.path.dirname(image_path), f"{image_stem(image_path)}.keymap.json"
+        )
+    )
+
     features = prepare_label_features(
         labels_path,
         block_index,
@@ -2350,6 +2446,8 @@ def process_image(
         min_aspect_ratio=min_aspect_ratio,
         edge_margin=edge_margin,
         high_confidence_size_fraction=high_confidence_size_fraction,
+        image_path=image_path,
+        fill_chroma_margin=0.0 if is_keymap_page else fill_chroma_margin,
     )
 
     gcps = find_intersection_gcps(features, block_index, (img_w, img_h))
@@ -2881,6 +2979,18 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--label-fill-chroma-margin",
+        type=float,
+        default=LABEL_FILL_CHROMA_MARGIN,
+        metavar="CHROMA",
+        help=(
+            "Reject detections whose box's median CIELAB chroma exceeds the page's paper "
+            "chroma by more than this, as labels printed on a coloured building fill rather "
+            "than on the street background (default: %(default)s). Set to 0 to disable. "
+            "Key-map pages are always exempt."
+        ),
+    )
+    parser.add_argument(
         "--disable-scale-outlier-check",
         action="store_true",
         help=(
@@ -3146,6 +3256,7 @@ def main() -> None:
         geojson["features"] if locator is not None else None,
         rectangle_index,
         truth_by_page,
+        args.label_fill_chroma_margin,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1397,78 +1397,56 @@ def test_consensus_scale_returns_an_actual_page_scale():
     assert consensus_scale(scales) in scales
 
 
-def _paper_ab(shape=(100, 100)) -> tuple[np.ndarray, np.ndarray]:
-    """Faintly yellow paper (chroma 2 at hue 90), the usual Sanborn background."""
-    return np.zeros(shape), np.full(shape, 2.0)
+def _on(text: str, hue: float, chroma: float = 12.0) -> dict:
+    """A detection OCR marked as sitting on a fill of the given hue."""
+    return {
+        "text": text,
+        "background": {"color": "#888888", "hue": hue, "chroma": chroma},
+    }
 
 
-def _paint(lab_a, lab_b, box, chroma: float, hue_deg: float) -> None:
-    """Paint a rectangle a given chroma/hue, in place."""
-    y0, y1, x0, x1 = box
-    lab_a[y0:y1, x0:x1] = chroma * math.cos(math.radians(hue_deg))
-    lab_b[y0:y1, x0:x1] = chroma * math.sin(math.radians(hue_deg))
-
-
-def test_drop_labels_on_fill_drops_a_label_on_a_red_building():
+def test_drop_labels_on_fill_drops_labels_on_red_and_blue_buildings():
     from mapsnap.georef_from_labels import drop_labels_on_fill
 
-    a, b = _paper_ab()
-    _paint(a, b, (50, 70, 50, 70), chroma=12.0, hue_deg=5.0)  # red brick
-    on_paper = {"text": "MAIN", "polygon": [[10, 10], [30, 10], [30, 20], [10, 20]]}
-    on_fill = {"text": "REP", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
-    kept, fill = drop_labels_on_fill([on_paper, on_fill], a, b, 4.0)
+    # The Sanborn colour code: red/pink = brick, blue = stone. Both carry building labels.
+    kept, fill = drop_labels_on_fill(
+        [_on("REP", hue=5.0), _on("SEARS", hue=250.0), {"text": "MAIN"}]
+    )
     assert [d["text"] for d in kept] == ["MAIN"]
-    assert [d["text"] for d in fill] == ["REP"]
-
-
-def test_drop_labels_on_fill_drops_a_label_on_a_blue_building():
-    from mapsnap.georef_from_labels import drop_labels_on_fill
-
-    a, b = _paper_ab()
-    _paint(a, b, (50, 70, 50, 70), chroma=12.0, hue_deg=250.0)  # blue stone
-    on_fill = {"text": "REP", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
-    kept, fill = drop_labels_on_fill([on_fill], a, b, 4.0)
-    assert kept == [] and [d["text"] for d in fill] == ["REP"]
+    assert [d["text"] for d in fill] == ["REP", "SEARS"]
 
 
 def test_drop_labels_on_fill_spares_a_yellow_background():
+    # A street name on a yellowed tape patch is saturated enough that OCR records a background,
+    # but its hue matches the paper. Chicago's HALSTED and New Orleans' TCHOUPITOULAS are exactly
+    # this and must survive; so must a label on a yellow *frame* building (Brooklyn's CARROLL),
+    # which hue cannot tell apart.
     from mapsnap.georef_from_labels import drop_labels_on_fill
 
-    # A street name on a yellowed tape patch: well above the paper's chroma, but the same hue.
-    # Chicago's HALSTED and New Orleans' TCHOUPITOULAS are exactly this and must survive.
-    a, b = _paper_ab()
-    _paint(a, b, (50, 70, 50, 70), chroma=19.0, hue_deg=93.0)
-    taped = {"text": "HALSTED", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
-    kept, fill = drop_labels_on_fill([taped], a, b, 4.0)
-    assert [d["text"] for d in kept] == ["HALSTED"] and fill == []
+    kept, fill = drop_labels_on_fill(
+        [_on("HALSTED", hue=93.0, chroma=19.0), _on("CARROLL", hue=102.7)]
+    )
+    assert [d["text"] for d in kept] == ["HALSTED", "CARROLL"] and fill == []
 
 
-def test_drop_labels_on_fill_spares_faint_colour_within_the_margin():
+def test_drop_labels_on_fill_keeps_detections_with_no_background():
+    # No `background` means OCR found the label no more saturated than the paper — a street name
+    # printed where street names belong.
     from mapsnap.georef_from_labels import drop_labels_on_fill
 
-    a, b = _paper_ab()
-    _paint(
-        a, b, (50, 70, 50, 70), chroma=5.0, hue_deg=5.0
-    )  # red but barely above paper
-    det = {"text": "MAIN", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
-    kept, fill = drop_labels_on_fill([det], a, b, 4.0)
-    assert [d["text"] for d in kept] == ["MAIN"] and fill == []
+    kept, fill = drop_labels_on_fill([{"text": "MAIN"}, {"text": "BROADWAY"}])
+    assert [d["text"] for d in kept] == ["MAIN", "BROADWAY"] and fill == []
 
 
-def test_detection_fill_color_reports_box_background():
-    from mapsnap.georef_from_labels import detection_fill_color
+def test_drop_labels_on_fill_band_edges_are_inclusive():
+    from mapsnap.georef_from_labels import FILL_YELLOW_HUE_BAND, drop_labels_on_fill
 
-    a, b = _paper_ab((50, 50))
-    _paint(a, b, (10, 20, 10, 20), chroma=15.0, hue_deg=0.0)  # pure red patch
-    chroma, hue = detection_fill_color(a, b, [[10, 10], [19, 10], [19, 19], [10, 19]])
-    assert math.isclose(chroma, 15.0, rel_tol=1e-6) and math.isclose(
-        hue, 0.0, abs_tol=1e-6
+    low, high = FILL_YELLOW_HUE_BAND
+    kept, fill = drop_labels_on_fill(
+        [_on("LOW", hue=low), _on("HIGH", hue=high), _on("BELOW", hue=low - 0.1)]
     )
-    # Off the patch we see the paper: chroma 2 at hue 90.
-    chroma, hue = detection_fill_color(a, b, [[30, 30], [40, 30], [40, 40], [30, 40]])
-    assert math.isclose(chroma, 2.0, rel_tol=1e-6) and math.isclose(
-        hue, 90.0, abs_tol=1e-6
-    )
+    assert [d["text"] for d in kept] == ["LOW", "HIGH"]
+    assert [d["text"] for d in fill] == ["BELOW"]
 
 
 def test_is_split_page():

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1397,6 +1397,32 @@ def test_consensus_scale_returns_an_actual_page_scale():
     assert consensus_scale(scales) in scales
 
 
+def test_drop_labels_on_fill_splits_paper_from_building():
+    from mapsnap.georef_from_labels import drop_labels_on_fill
+
+    # Paper at chroma 2 with one coloured building block at chroma 12.
+    chroma = np.full((100, 100), 2.0)
+    chroma[50:70, 50:70] = 12.0
+    on_paper = {"text": "MAIN", "polygon": [[10, 10], [30, 10], [30, 20], [10, 20]]}
+    on_fill = {"text": "REP", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
+    kept, fill = drop_labels_on_fill([on_paper, on_fill], chroma, 4.0)
+    assert [d["text"] for d in kept] == ["MAIN"]
+    assert [d["text"] for d in fill] == ["REP"]
+
+
+def test_detection_fill_chroma_reports_box_background():
+    from mapsnap.georef_from_labels import detection_fill_chroma
+
+    chroma = np.full((50, 50), 3.0)
+    chroma[10:20, 10:20] = 15.0
+    assert math.isclose(
+        detection_fill_chroma(chroma, [[10, 10], [19, 10], [19, 19], [10, 19]]), 15.0
+    )
+    assert math.isclose(
+        detection_fill_chroma(chroma, [[30, 30], [40, 30], [40, 40], [30, 40]]), 3.0
+    )
+
+
 def test_is_split_page():
     from mapsnap.georef_from_labels import is_split_page
 

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1397,29 +1397,77 @@ def test_consensus_scale_returns_an_actual_page_scale():
     assert consensus_scale(scales) in scales
 
 
-def test_drop_labels_on_fill_splits_paper_from_building():
+def _paper_ab(shape=(100, 100)) -> tuple[np.ndarray, np.ndarray]:
+    """Faintly yellow paper (chroma 2 at hue 90), the usual Sanborn background."""
+    return np.zeros(shape), np.full(shape, 2.0)
+
+
+def _paint(lab_a, lab_b, box, chroma: float, hue_deg: float) -> None:
+    """Paint a rectangle a given chroma/hue, in place."""
+    y0, y1, x0, x1 = box
+    lab_a[y0:y1, x0:x1] = chroma * math.cos(math.radians(hue_deg))
+    lab_b[y0:y1, x0:x1] = chroma * math.sin(math.radians(hue_deg))
+
+
+def test_drop_labels_on_fill_drops_a_label_on_a_red_building():
     from mapsnap.georef_from_labels import drop_labels_on_fill
 
-    # Paper at chroma 2 with one coloured building block at chroma 12.
-    chroma = np.full((100, 100), 2.0)
-    chroma[50:70, 50:70] = 12.0
+    a, b = _paper_ab()
+    _paint(a, b, (50, 70, 50, 70), chroma=12.0, hue_deg=5.0)  # red brick
     on_paper = {"text": "MAIN", "polygon": [[10, 10], [30, 10], [30, 20], [10, 20]]}
     on_fill = {"text": "REP", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
-    kept, fill = drop_labels_on_fill([on_paper, on_fill], chroma, 4.0)
+    kept, fill = drop_labels_on_fill([on_paper, on_fill], a, b, 4.0)
     assert [d["text"] for d in kept] == ["MAIN"]
     assert [d["text"] for d in fill] == ["REP"]
 
 
-def test_detection_fill_chroma_reports_box_background():
-    from mapsnap.georef_from_labels import detection_fill_chroma
+def test_drop_labels_on_fill_drops_a_label_on_a_blue_building():
+    from mapsnap.georef_from_labels import drop_labels_on_fill
 
-    chroma = np.full((50, 50), 3.0)
-    chroma[10:20, 10:20] = 15.0
-    assert math.isclose(
-        detection_fill_chroma(chroma, [[10, 10], [19, 10], [19, 19], [10, 19]]), 15.0
+    a, b = _paper_ab()
+    _paint(a, b, (50, 70, 50, 70), chroma=12.0, hue_deg=250.0)  # blue stone
+    on_fill = {"text": "REP", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
+    kept, fill = drop_labels_on_fill([on_fill], a, b, 4.0)
+    assert kept == [] and [d["text"] for d in fill] == ["REP"]
+
+
+def test_drop_labels_on_fill_spares_a_yellow_background():
+    from mapsnap.georef_from_labels import drop_labels_on_fill
+
+    # A street name on a yellowed tape patch: well above the paper's chroma, but the same hue.
+    # Chicago's HALSTED and New Orleans' TCHOUPITOULAS are exactly this and must survive.
+    a, b = _paper_ab()
+    _paint(a, b, (50, 70, 50, 70), chroma=19.0, hue_deg=93.0)
+    taped = {"text": "HALSTED", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
+    kept, fill = drop_labels_on_fill([taped], a, b, 4.0)
+    assert [d["text"] for d in kept] == ["HALSTED"] and fill == []
+
+
+def test_drop_labels_on_fill_spares_faint_colour_within_the_margin():
+    from mapsnap.georef_from_labels import drop_labels_on_fill
+
+    a, b = _paper_ab()
+    _paint(
+        a, b, (50, 70, 50, 70), chroma=5.0, hue_deg=5.0
+    )  # red but barely above paper
+    det = {"text": "MAIN", "polygon": [[55, 55], [65, 55], [65, 65], [55, 65]]}
+    kept, fill = drop_labels_on_fill([det], a, b, 4.0)
+    assert [d["text"] for d in kept] == ["MAIN"] and fill == []
+
+
+def test_detection_fill_color_reports_box_background():
+    from mapsnap.georef_from_labels import detection_fill_color
+
+    a, b = _paper_ab((50, 50))
+    _paint(a, b, (10, 20, 10, 20), chroma=15.0, hue_deg=0.0)  # pure red patch
+    chroma, hue = detection_fill_color(a, b, [[10, 10], [19, 10], [19, 19], [10, 19]])
+    assert math.isclose(chroma, 15.0, rel_tol=1e-6) and math.isclose(
+        hue, 0.0, abs_tol=1e-6
     )
-    assert math.isclose(
-        detection_fill_chroma(chroma, [[30, 30], [40, 30], [40, 40], [30, 40]]), 3.0
+    # Off the patch we see the paper: chroma 2 at hue 90.
+    chroma, hue = detection_fill_color(a, b, [[30, 30], [40, 30], [40, 40], [30, 40]])
+    assert math.isclose(chroma, 2.0, rel_tol=1e-6) and math.isclose(
+        hue, 90.0, abs_tol=1e-6
     )
 
 


### PR DESCRIPTION
## Problem

Sanborn sheets print **street names on the paper background**; text inside a coloured block is a **building label**. But a building label can still prefix-match a street name and fabricate GCPs.

Nashville p51 reads **"REP"** — a building abbreviation, detected 5× at confidence 0.99 — which prefix-matches **"REP JOHN LEWIS WAY SOUTH/NORTH"**, OSM's 2021 renaming of 5th Ave N and a street a **1957** sheet cannot possibly be labelling. Those bogus labels became the page's GCPs (`BROADWAY × REP JOHN LEWIS WAY`) and drove a **4428 ft** fit.

"REP" polluted **27 of Nashville's 71 pages**, alongside SEARS, BAPTIST, SCHOOL, BANK and SERVICE.

<img width="264" height="198" alt="image" src="https://github.com/user-attachments/assets/964ffd31-312a-4b1d-a4b4-5a6f1968864b" />

The actual text is "AUTO REP".

## Two signals, not one

The obvious fix — reject any label more saturated than the paper — **does not survive contact with a second volume**. It asks only "is this more colourful than the paper?", and on a yellowed scan an ordinary street label answers yes: Chicago's and New Orleans' paper is *itself* chroma 13–20, and a street name taped on later (aged to brown-on-yellow) sits only 4–6 chroma above it. Chroma alone cost Chicago its HALSTED and KINZIE and New Orleans its TCHOUPITOULAS.

**Hue separates the two cases.** Those false positives all sit at hue 90–95 — the same hue as the paper they are printed on. All 18 of Nashville's "REP" reads sit at hue 0–6 (red) or 240–257 (blue): the brick and stone of the Sanborn colour code.

So a detection is a building label when its background is **both** more saturated than the page's own paper **and** outside the yellow/brown band (40°–110°). Everything ambiguous — aged paper, tape patches, brown ink — is kept.

**The cost is deliberate.** Sanborn also paints *frame* buildings yellow, so a label on one is spared too: Brooklyn p57's `CARROLL TRUCKING CORP.` is yellow, not red, and its 1706 ft junk fit survives this filter. Hue cannot separate a yellow frame building from yellowed paper, and sparing both is the safer error. That single regression is the price of the Chicago and New Orleans recoveries below.

## Where the filter lives

**`detect_text.py` measures; `georef_from_labels.py` judges.** OCR records the page's `paper` colour and, per detection, the `background` under its box — but only when that background is more saturated than the paper. **Absence of the property is the signal** that a label sits on paper, where street names belong.

```json
"paper": {"color": "#fcfcfa", "hue": 90.0, "chroma": 2.2},
"streets": [
  {"text": "BROADWAY", "confidence": 0.9995},
  {"text": "REP", "confidence": 0.5577,
   "background": {"color": "#cbe2ef", "hue": 240.9, "chroma": 10.3}}
]
```

A raw colour rather than a name (`"background-color": "blue"`), because naming it would bake the classification into the OCR output — and the yellow-vs-red boundary is exactly the judgment this PR exists to calibrate. `hue` carries the decision, `chroma` says how far off paper it is, `color` is a ready-to-render swatch.

The constants split along the same seam: `BACKGROUND_CHROMA_MARGIN` ("is this paper?") lives in `detect_text.py`; `FILL_YELLOW_HUE_BAND` ("does this colour disqualify a label?") lives in `georef_from_labels.py`. **Retuning the band never requires re-OCR.**

**Key-map pages stay exempt**: they print street names *on* the coloured region blocks by design, so the filter would reject exactly the labels that georeference them.

## Debugger

Detections carrying a background show a swatch and a badge for the two cases that matter — red **on fill** for what georeferencing drops, grey **on yellow** for what it spares as ambiguous — with a tooltip giving hue, chroma and the reason. The overlay draws dropped labels crimson and dashed, so they read as discarded rather than merely low-confidence.

<img width="752" height="656" alt="image" src="https://github.com/user-attachments/assets/41e58163-8355-4d87-9cbd-859594b86c36" />

The bottom rows are the filter working: `GOLF`, `TITAN`, `DEL` and `57TH` sit on red and blue buildings and are dropped, while `SHYS` on yellow is spared. `PONTIAC`, on paper, carries no badge at all.

## Results

**Nashville** — the volume this exists for. 4 of its 5 catastrophes die:

| | pages | mean | median | ≤15 ft | ≤25 ft | >500 ft | max |
|---|---|---|---|---|---|---|---|
| before | 56/71 | 216 ft | 14.7 ft | 28 | 34 | 5 | 4428 ft |
| after | 54/71 | **74 ft** | **13.3 ft** | **30** | **36** | **1** | **1489 ft** |

The 2 lost pages are the point: p51's 4428 ft fit and p28's 1415 ft fit become honest no-fits. The surviving >500 ft page (p9, 1489 ft) is the collinear-3RD case #117 handles, not a fill problem.

**The six README volumes are page-for-page identical to running with the filter off.** Not "no regression on aggregate" — byte-identical per page. The hue band makes this filter free everywhere it isn't needed:

| Volume | Num Fit | Median RMSE | ≤15 ft | ≤25 ft | vs filter-off |
|---|---|---|---|---|---|
| new_orleans_la_1951_vol_5 | 103 | 12.3 ft | 70 | 88 | identical |
| new_orleans_la_1896_vol_2 | 82 | 27.2 ft | 26 | 38 | identical |
| detroit_mich_1929_vol_11 | 83 | 14.8 ft | 42 | 56 | identical |
| chicago_il_1950_vol_1 | 100 | 10.1 ft | 69 | 83 | identical |
| champaign_ill_1915 | 27 | 9.9 ft | 23 | 26 | identical |
| brooklyn_ny_1939_vol_1 | 55 | 9.6 ft | 40 | 41 | identical |

That is the hue band's whole job — it concentrates the drops on the volume that needs them:

| Volume | street-matching detections | chroma alone would drop | hue band drops |
|---|---|---|---|
| nashville_tn_1957_vol1a | 830 | 204 (24.6%) | **164 (19.8%)** |
| brooklyn_ny_1939_vol_1 | 503 | 30 (6.0%) | 17 (3.4%) |
| chicago_il_1950_vol_1 | 656 | 29 (4.4%) | **2 (0.3%)** |
| new_orleans_la_1951_vol_5 | 1036 | 71 (6.9%) | **1 (0.1%)** |
| new_orleans_la_1896_vol_2 | 933 | 25 (2.7%) | 12 (1.3%) |
| detroit_mich_1929_vol_11 | 474 | 8 (1.7%) | 4 (0.8%) |
| champaign_ill_1915 | 383 | 10 (2.6%) | 3 (0.8%) |

Against a chroma-only filter, the band recovers Chicago p71W (no-fit → 6.9 ft), p44N (no-fit → 41.4 ft), p55W (839 → 246 ft) and NOLA p428__2 (498 → 47.8 ft), and gives back Brooklyn p57's 1706 ft junk fit.

## Migration

`--label-fill-chroma-margin CHROMA` (where `0` meant off) is **removed** — the margin is no longer georeferencing's to set. It is replaced by `--keep-labels-on-fill`, a boolean defaulting to false.

Existing `.streets.json` files predate the property, but background colour is a pure function of the image and the boxes, so **no re-OCR is needed**:

```
mapsnap ocr --backfill-background data/<volume>/*.jpg
```

Run over all seven volumes above in a couple of minutes; this is what made the equivalence check possible.

## Tests

Python: the filter's tests no longer build image arrays — they assert the hue policy directly (red and blue dropped, yellow spared, no-background kept, band edges inclusive). The measurement tests move to `detect_text_test.py`: background reports the fill and not the ink, only off-paper labels are marked, the reference is the page's own paper, and `lab_to_hex` renders a swatch. App: 4 tests for `isOnBuildingFill`.

571 Python tests + 51 app tests green; ruff, pyright and `tsc` clean.

**The refactor is verified behaviour-preserving**: re-running fits across all seven volumes after moving the code reproduces the pre-refactor numbers exactly, page for page.
