### PR TITLE
Withhold the confidence size discount from collinear-dominated street labels

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -317,6 +317,11 @@ DOUBLE_SCALE_BAND = (1.8, 2.2)
 # treated as buildings. Brown is a dark yellow/orange and shares the band.
 FILL_YELLOW_HUE_BAND = (40.0, 110.0)
 
+# Perpendicular offset (page px) within which two same-bearing labels count as sitting on one
+# line for drop_collinear_dominated. 20 px admits Nashville p9's 4 px 3RD/7TH offset while
+# keeping genuinely parallel streets (a block apart) separate.
+COLLINEAR_PERP_TOLERANCE_PX = 20.0
+
 
 def is_split_page(stem: str) -> bool:
     """Whether an image stem names one panel of a split sheet (p21__1-style suffix)."""
@@ -1990,10 +1995,12 @@ def _init_worker(
     rectangle_index: tuple[dict[str, list[Block]], float] | None = None,
     truth_by_page: dict[int, list[list[list[float]]]] | None = None,
     keep_labels_on_fill: bool = False,
+    collinear_perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
 ) -> None:
     """Populate _worker_state once per worker process (or once in the main process)."""
     _worker_state.update(
         keep_labels_on_fill=keep_labels_on_fill,
+        collinear_perp_tolerance_px=collinear_perp_tolerance_px,
         block_index=block_index,
         cos_phi=cos_phi,
         centerlines_path=centerlines_path,
@@ -2069,6 +2076,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             keymap=keymap,
             truth_polygons=truth_polygons,
             keep_labels_on_fill=_worker_state["keep_labels_on_fill"],
+            collinear_perp_tolerance_px=_worker_state["collinear_perp_tolerance_px"],
         )
 
     with _captured_page_log(log_path, _worker_state["debug"]):
@@ -2225,6 +2233,58 @@ def drop_labels_on_fill(
     return kept, on_fill
 
 
+def drop_collinear_dominated(
+    detections: list[dict],
+    normalized_streets: set[str],
+    perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
+) -> tuple[list[dict], list[dict]]:
+    """Split detections into (kept, dominated) by the collinear-dominance rule.
+
+    A straight run of roadway carries one name, so two collinear labels naming *different*
+    streets cannot both be right. When one is strictly worse — smaller **and** less confident —
+    it is noise riding on the better one's line, and accepting it fabricates an intersection
+    (Nashville p9: a 16px/0.319 "3RD" on the same vertical as a 24px/0.952 "7TH" produced the
+    page's only, and wrong, GCP). Only street-matching detections are compared, since only they
+    can become GCPs. Collinearity is judged on ``dir_pix`` (mod pi, so a 90 vs 270 reading
+    direction is the same line) plus perpendicular offset within ``perp_tolerance_px``.
+    """
+    bucket_size = math.pi / 12.0
+    matchable = [
+        det
+        for det in detections
+        if canonical_street_match(det.get("text", ""), normalized_streets)
+    ]
+    info = []
+    for det in matchable:
+        pts = np.asarray(det["polygon"], dtype=float)
+        cx, cy = float(pts[:, 0].mean()), float(pts[:, 1].mean())
+        dir_pix = float(det.get("dir_pix", 0.0))
+        info.append(
+            (
+                int(round(dir_pix / bucket_size)) % 12,
+                -cx * math.sin(dir_pix) + cy * math.cos(dir_pix),
+                float(det.get("short_side", 0.0)),
+                float(det.get("confidence", 0.0)),
+                normalize_street(det.get("text", "")),
+            )
+        )
+    dominated_ids: set[int] = set()
+    for i, (bucket_a, perp_a, short_a, conf_a, text_a) in enumerate(info):
+        for j, (bucket_b, perp_b, short_b, conf_b, text_b) in enumerate(info):
+            if i == j or bucket_a != bucket_b or text_a == text_b:
+                continue
+            if abs(perp_a - perp_b) > perp_tolerance_px:
+                continue
+            if short_a < short_b and conf_a < conf_b:
+                dominated_ids.add(id(matchable[i]))
+                break
+    if not dominated_ids:
+        return detections, []
+    kept = [det for det in detections if id(det) not in dominated_ids]
+    dominated = [det for det in detections if id(det) in dominated_ids]
+    return kept, dominated
+
+
 def prepare_label_features(
     labels_path: str,
     block_index: dict[str, list[Block]],
@@ -2237,6 +2297,7 @@ def prepare_label_features(
     edge_margin: float = 0.02,
     high_confidence_size_fraction: float = 0.7,
     keep_labels_on_fill: bool = False,
+    collinear_perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
 ) -> list[LabelFeature]:
     """Load, promote, assemble, dedupe, filter, and canonicalize street reads into features.
 
@@ -2313,6 +2374,20 @@ def prepare_label_features(
                 file=sys.stderr,
             )
 
+    # A worse label collinear with a better one naming another street is noise on its line.
+    if collinear_perp_tolerance_px > 0:
+        all_detections, dominated = drop_collinear_dominated(
+            all_detections, normalized_streets, collinear_perp_tolerance_px
+        )
+        if dominated:
+            print(
+                f"Dropped {len(dominated)} collinear-dominated detection(s): "
+                + ", ".join(
+                    f"{d['text']}({d.get('short_side', 0):.0f}px,{d.get('confidence', 0):.2f})"
+                    for d in dominated
+                ),
+                file=sys.stderr,
+            )
     labels_data = []
     for det in all_detections:
         is_promoted = det.get("promoted")
@@ -2403,6 +2478,7 @@ def process_image(
     keymap: dict | None = None,
     truth_polygons: list[list[list[float]]] | None = None,
     keep_labels_on_fill: bool = False,
+    collinear_perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
 ) -> ProcessResult:
     """Fit a georeference model for one image and write GCPs to output_path.
 
@@ -2435,6 +2511,7 @@ def process_image(
         edge_margin=edge_margin,
         high_confidence_size_fraction=high_confidence_size_fraction,
         keep_labels_on_fill=keep_labels_on_fill or is_keymap_page,
+        collinear_perp_tolerance_px=collinear_perp_tolerance_px,
     )
 
     gcps = find_intersection_gcps(features, block_index, (img_w, img_h))
@@ -2977,6 +3054,17 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--collinear-perp-tolerance",
+        type=float,
+        default=COLLINEAR_PERP_TOLERANCE_PX,
+        metavar="PX",
+        help=(
+            "Drop a detection that is collinear (within this perpendicular offset, in page "
+            "pixels) with a strictly larger and more confident detection naming a different "
+            "street (default: %(default)s). Set to 0 to disable."
+        ),
+    )
+    parser.add_argument(
         "--disable-scale-outlier-check",
         action="store_true",
         help=(
@@ -3243,6 +3331,7 @@ def main() -> None:
         rectangle_index,
         truth_by_page,
         args.keep_labels_on_fill,
+        args.collinear_perp_tolerance,
     )
     if args.num_workers > 1:
         with multiprocessing.Pool(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -2233,20 +2233,50 @@ def drop_labels_on_fill(
     return kept, on_fill
 
 
+def needs_size_relaxation(
+    det: dict, min_short_side: float, min_long_side: float
+) -> bool:
+    """Whether a detection clears the size gate only on the strength of its confidence.
+
+    ``confidence_relaxed_threshold`` admits a detection below the volume's base size floor when
+    it is proportionally more confident than ``min_confidence``. One at or above the base floor
+    is admitted on its own evidence and needs no such discount; one below it is present only
+    because the discount was granted. Promoted avenue letters bypass the size gate altogether,
+    so they are never relaxed admissions.
+    """
+    if det.get("promoted"):
+        return False
+    return (
+        det.get("short_side", float("inf")) < min_short_side
+        or det.get("long_side", float("inf")) < min_long_side
+    )
+
+
 def drop_collinear_dominated(
     detections: list[dict],
     normalized_streets: set[str],
+    *,
+    min_short_side: float,
+    min_long_side: float,
     perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
 ) -> tuple[list[dict], list[dict]]:
     """Split detections into (kept, dominated) by the collinear-dominance rule.
 
-    A straight run of roadway carries one name, so two collinear labels naming *different*
-    streets cannot both be right. When one is strictly worse — smaller **and** less confident —
-    it is noise riding on the better one's line, and accepting it fabricates an intersection
-    (Nashville p9: a 16px/0.319 "3RD" on the same vertical as a 24px/0.952 "7TH" produced the
-    page's only, and wrong, GCP). Only street-matching detections are compared, since only they
-    can become GCPs. Collinearity is judged on ``dir_pix`` (mod pi, so a 90 vs 270 reading
-    direction is the same line) plus perpendicular offset within ``perp_tolerance_px``.
+    A straight run of roadway usually carries one name, so a *relaxed* label collinear with a
+    strictly better one naming a different street is likely noise riding on the better one's
+    line, and accepting it fabricates an intersection (Nashville p9: a 16px/0.319 "3RD" on the
+    same vertical as a 24px/0.952 "7TH" produced the page's only, and wrong, GCP). Only
+    street-matching detections are compared, since only they can become GCPs. Collinearity is
+    judged on ``dir_pix`` (mod pi, so a 90 vs 270 reading direction is the same line) plus
+    perpendicular offset within ``perp_tolerance_px``.
+
+    Only a detection that needed ``confidence_relaxed_threshold`` to clear the size gate can be
+    dropped (``needs_size_relaxation``). This rule exists to withhold that discount from a label
+    a collinear neighbour dominates — not to overrule the gate. A label big and confident enough
+    to stand on its own is admitted whatever sits on its line, because collinear labels naming
+    different streets are legitimately common: a street can change name mid-run, a compound label
+    can name two streets at once (Nashville p9's "CAPITOL DR. OR 6TH AV N."), and a page can be
+    an undetected split whose two halves share a page line while being far apart on the ground.
     """
     bucket_size = math.pi / 12.0
     matchable = [
@@ -2270,6 +2300,8 @@ def drop_collinear_dominated(
         )
     dominated_ids: set[int] = set()
     for i, (bucket_a, perp_a, short_a, conf_a, text_a) in enumerate(info):
+        if not needs_size_relaxation(matchable[i], min_short_side, min_long_side):
+            continue
         for j, (bucket_b, perp_b, short_b, conf_b, text_b) in enumerate(info):
             if i == j or bucket_a != bucket_b or text_a == text_b:
                 continue
@@ -2374,10 +2406,14 @@ def prepare_label_features(
                 file=sys.stderr,
             )
 
-    # A worse label collinear with a better one naming another street is noise on its line.
+    # A relaxed label collinear with a better one naming another street is noise on its line.
     if collinear_perp_tolerance_px > 0:
         all_detections, dominated = drop_collinear_dominated(
-            all_detections, normalized_streets, collinear_perp_tolerance_px
+            all_detections,
+            normalized_streets,
+            min_short_side=min_short_side,
+            min_long_side=min_long_side,
+            perp_tolerance_px=collinear_perp_tolerance_px,
         )
         if dominated:
             print(
@@ -3059,9 +3095,11 @@ def main() -> None:
         default=COLLINEAR_PERP_TOLERANCE_PX,
         metavar="PX",
         help=(
-            "Drop a detection that is collinear (within this perpendicular offset, in page "
-            "pixels) with a strictly larger and more confident detection naming a different "
-            "street (default: %(default)s). Set to 0 to disable."
+            "Drop a size-relaxed detection that is collinear (within this perpendicular offset, "
+            "in page pixels) with a strictly larger and more confident detection naming a "
+            "different street (default: %(default)s). Only labels that needed a confidence "
+            "discount to clear --min-short-side are eligible; one that clears it on its own is "
+            "always kept. Set to 0 to disable."
         ),
     )
     parser.add_argument(

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1397,6 +1397,70 @@ def test_consensus_scale_returns_an_actual_page_scale():
     assert consensus_scale(scales) in scales
 
 
+def _vertical_label(text: str, cx: float, cy: float, short: float, conf: float) -> dict:
+    """A vertical (dir_pix=pi/2) detection centered at (cx, cy)."""
+    return {
+        "text": text,
+        "confidence": conf,
+        "short_side": short,
+        "dir_pix": math.pi / 2,
+        "polygon": [
+            [cx - short / 2, cy - 22],
+            [cx + short / 2, cy - 22],
+            [cx + short / 2, cy + 22],
+            [cx - short / 2, cy + 22],
+        ],
+    }
+
+
+_COLLINEAR_STREETS = {"MAIN STREET", "OAK STREET"}
+
+
+def test_drop_collinear_dominated_drops_worse_collinear_label():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # Nashville p9 shape: a small/low-confidence OAK sits on the same vertical line as a
+    # larger/confident MAIN. One straight run of road carries one name -> OAK is noise.
+    good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
+    bad = _vertical_label("OAK", 242, 529, 16.0, 0.32)
+    kept, dropped = drop_collinear_dominated([good, bad], _COLLINEAR_STREETS)
+    assert [d["text"] for d in dropped] == ["OAK"]
+    assert [d["text"] for d in kept] == ["MAIN"]
+
+
+def test_drop_collinear_dominated_keeps_same_street_labelled_twice():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # The same street named twice along its length is normal -> keep both.
+    a = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
+    b = _vertical_label("MAIN", 242, 529, 16.0, 0.32)
+    kept, dropped = drop_collinear_dominated([a, b], _COLLINEAR_STREETS)
+    assert dropped == []
+    assert len(kept) == 2
+
+
+def test_drop_collinear_dominated_keeps_parallel_streets():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # A block apart (perp offset 200px) they are genuinely parallel streets -> keep both.
+    good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
+    other = _vertical_label("OAK", 438, 529, 16.0, 0.32)
+    kept, dropped = drop_collinear_dominated([good, other], _COLLINEAR_STREETS)
+    assert dropped == []
+    assert len(kept) == 2
+
+
+def test_drop_collinear_dominated_keeps_when_not_strictly_worse():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # Smaller but *more* confident is not strictly worse -> keep (needs both to dominate).
+    good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
+    small_but_sure = _vertical_label("OAK", 242, 529, 16.0, 0.99)
+    kept, dropped = drop_collinear_dominated([good, small_but_sure], _COLLINEAR_STREETS)
+    assert dropped == []
+    assert len(kept) == 2
+
+
 def _on(text: str, hue: float, chroma: float = 12.0) -> dict:
     """A detection OCR marked as sitting on a fill of the given hue."""
     return {

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1403,6 +1403,7 @@ def _vertical_label(text: str, cx: float, cy: float, short: float, conf: float) 
         "text": text,
         "confidence": conf,
         "short_side": short,
+        "long_side": 44.0,
         "dir_pix": math.pi / 2,
         "polygon": [
             [cx - short / 2, cy - 22],
@@ -1415,6 +1416,10 @@ def _vertical_label(text: str, cx: float, cy: float, short: float, conf: float) 
 
 _COLLINEAR_STREETS = {"MAIN STREET", "OAK STREET"}
 
+# Nashville's derived gate. A label under 18px short / 36px long only clears it via the
+# confidence discount, so only such a label is eligible to be dropped as collinear.
+_GATE = {"min_short_side": 18.0, "min_long_side": 36.0}
+
 
 def test_drop_collinear_dominated_drops_worse_collinear_label():
     from mapsnap.georef_from_labels import drop_collinear_dominated
@@ -1423,7 +1428,7 @@ def test_drop_collinear_dominated_drops_worse_collinear_label():
     # larger/confident MAIN. One straight run of road carries one name -> OAK is noise.
     good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
     bad = _vertical_label("OAK", 242, 529, 16.0, 0.32)
-    kept, dropped = drop_collinear_dominated([good, bad], _COLLINEAR_STREETS)
+    kept, dropped = drop_collinear_dominated([good, bad], _COLLINEAR_STREETS, **_GATE)
     assert [d["text"] for d in dropped] == ["OAK"]
     assert [d["text"] for d in kept] == ["MAIN"]
 
@@ -1434,7 +1439,7 @@ def test_drop_collinear_dominated_keeps_same_street_labelled_twice():
     # The same street named twice along its length is normal -> keep both.
     a = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
     b = _vertical_label("MAIN", 242, 529, 16.0, 0.32)
-    kept, dropped = drop_collinear_dominated([a, b], _COLLINEAR_STREETS)
+    kept, dropped = drop_collinear_dominated([a, b], _COLLINEAR_STREETS, **_GATE)
     assert dropped == []
     assert len(kept) == 2
 
@@ -1445,7 +1450,7 @@ def test_drop_collinear_dominated_keeps_parallel_streets():
     # A block apart (perp offset 200px) they are genuinely parallel streets -> keep both.
     good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
     other = _vertical_label("OAK", 438, 529, 16.0, 0.32)
-    kept, dropped = drop_collinear_dominated([good, other], _COLLINEAR_STREETS)
+    kept, dropped = drop_collinear_dominated([good, other], _COLLINEAR_STREETS, **_GATE)
     assert dropped == []
     assert len(kept) == 2
 
@@ -1456,7 +1461,9 @@ def test_drop_collinear_dominated_keeps_when_not_strictly_worse():
     # Smaller but *more* confident is not strictly worse -> keep (needs both to dominate).
     good = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
     small_but_sure = _vertical_label("OAK", 242, 529, 16.0, 0.99)
-    kept, dropped = drop_collinear_dominated([good, small_but_sure], _COLLINEAR_STREETS)
+    kept, dropped = drop_collinear_dominated(
+        [good, small_but_sure], _COLLINEAR_STREETS, **_GATE
+    )
     assert dropped == []
     assert len(kept) == 2
 
@@ -1545,4 +1552,51 @@ def test_region_prior_px_per_ft_split_page_uses_mean_ring_area():
     one = {"lat": 0.0005, "lon": 0.0005, "radius_m": 300.0, "regions": [ring_a]}
     assert region_prior_px_per_ft(one, 500, 500) == region_prior_px_per_ft(
         one, 500, 500, split_page=True
+    )
+
+
+def test_drop_collinear_dominated_spares_a_label_that_clears_the_gate_alone():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # Nashville p9's "6TH" (20px, 0.896) is dominated by "7TH" (24px, 0.952) on its line, but
+    # clears the 18px gate on its own evidence, so the collinear rule must not touch it. The
+    # label really reads "CAPITOL DR. OR 6TH AV N." — one compound label naming two streets,
+    # which is exactly the case the collinear premise does not cover.
+    better = _vertical_label("MAIN", 238, 1002, 24.0, 0.952)
+    stands_alone = _vertical_label("OAK", 242, 529, 20.0, 0.896)
+    kept, dropped = drop_collinear_dominated(
+        [better, stands_alone], _COLLINEAR_STREETS, **_GATE
+    )
+    assert dropped == []
+    assert len(kept) == 2
+
+
+def test_drop_collinear_dominated_spares_a_promoted_label():
+    from mapsnap.georef_from_labels import drop_collinear_dominated
+
+    # Promoted avenue letters bypass the size gate entirely, so they are never a relaxed
+    # admission and the collinear rule has no discount to withhold.
+    better = _vertical_label("MAIN", 238, 1002, 24.0, 0.95)
+    promoted = _vertical_label("OAK", 242, 529, 8.0, 0.32)
+    promoted["promoted"] = True
+    kept, dropped = drop_collinear_dominated(
+        [better, promoted], _COLLINEAR_STREETS, **_GATE
+    )
+    assert dropped == []
+    assert len(kept) == 2
+
+
+def test_needs_size_relaxation_tracks_the_base_gate():
+    from mapsnap.georef_from_labels import needs_size_relaxation
+
+    assert needs_size_relaxation({"short_side": 16.0, "long_side": 44.0}, 18.0, 36.0)
+    assert needs_size_relaxation({"short_side": 20.0, "long_side": 30.0}, 18.0, 36.0)
+    assert not needs_size_relaxation(
+        {"short_side": 20.0, "long_side": 44.0}, 18.0, 36.0
+    )
+    assert not needs_size_relaxation(
+        {"short_side": 18.0, "long_side": 36.0}, 18.0, 36.0
+    )
+    assert not needs_size_relaxation(
+        {"short_side": 4.0, "long_side": 4.0, "promoted": True}, 18.0, 36.0
     )


### PR DESCRIPTION
## Idea

`confidence_relaxed_threshold` lets a **high-confidence label in below the volume's size floor** (issue #78). That discount is what admits Nashville p9's bogus `3RD`. This PR withholds the discount from a relaxed label that a **strictly better collinear label** — larger *and* more confident, naming a different street — sits on top of: on one straight run of roadway, the small faint one is usually noise riding on the big one's line, and accepting it fabricates an intersection.

The rule **only ever withholds the discount**. It never overrules the gate: a label that clears `--min-short-side` and `--min-confidence` on its own evidence is admitted no matter what shares its line.

## The case

Nashville **p9** reads `3RD` at **16 px / 0.319**. The volume's auto floor is 18 px, but `confidence_relaxed_threshold(0.319, 0.15, 18, 12.6)` drops the requirement to **15.6 px** — so a 16 px detection squeaks in on confidence alone. It sits **4 px** off the same vertical as a `7TH` at **24 px / 0.952**:

| | conf | short | centre | dir |
|---|---|---|---|---|
| 7TH | 0.952 | 24 px | (238, 1002) | 1.571 |
| 3RD | 0.319 | 16 px | (242, 529) | 1.571 |

That `3RD` produced the page's **only** — and wrong — intersection (`GAY × 3RD`), and the resulting 1-GCP deferred fit landed **1489 ft** out with scale **−44%**. Withholding the discount leaves p9 with **0 GCPs**, so it honestly reports no fit instead of emitting a wildly wrong georeference.

<img width="1304" height="570" alt="image" src="https://github.com/user-attachments/assets/48aa89ab-13d3-4533-a688-eaf6a873caec" />

## Why the scoping matters

The tempting premise — *a straight run of roadway carries one name, so collinear labels naming different streets cannot both be right* — is *false*, and an unscoped rule acts on it:

- **A street changes name mid-run.**
- **A compound label names two streets at once.** p9's own `6TH` is part of `CAPITOL DR. OR 6TH AV N.` — a single printed label offering both names.
- **Two halves of a multi-word name are collinear by construction.** `ST` and `JEAN` share a line because they *are* one label (Detroit p20, p51, p57; New Orleans p489).
- **An undetected split page** puts two halves on one page line while they are hundreds of metres apart on the ground (New Orleans 1896 p125).

Scoping to relaxed admissions sidesteps all of these, because in each case the labels stand on their own size. p9's `6TH` (20 px / 0.896) clears the 18 px floor unaided and is now kept; `3RD` (16 px) still goes. Promoted avenue letters bypass the size gate entirely, so they are never relaxed admissions and are likewise immune.

## Blast radius

Measured across nine volumes (~660 fitted pages) against **this filter disabled**, on top of merged #116. **Six pages move.** Every volume's aggregate is unchanged except Nashville:

| Volume | Fit | mean | median | ≤15 | ≤25 | >500 | max |
|---|---|---|---|---|---|---|---|
| new_orleans_la_1951_vol_5 | 103 | 47.4 | 12.3 | 70 | 88 | 4 | 891.1 | 
| detroit_mich_1929_vol_11 | 83 | 41.0 | 14.8 | 42 | 56 | 0 | 429.3 |
| champaign_ill_1915 | 27 | 12.4 | 9.9 | 23 | 26 | 0 | 61.5 |
| brooklyn_ny_1939_vol_1 | 55 | 80.2 | 9.6 | 40 | 41 | 2 | 1706.2 |
| chicago_il_1950_vol_1 | 100 | 52.0 | 10.1 | 69 → **70** | 83 | 1 | 2989.2 |
| grand_rapids_mi_1953_vol7 | 63 | 62.8 → 63.0 | 18.4 | 21 | 45 → 44 | 2 | 1149.0 |
| hudson_co_nj_1950_vol_9 | 59 | 19.7 → 19.8 | 13.1 → 13.2 | 32 → 31 | 39 | 0 | 92.6 |

**Nashville**, the volume this is for:

| | Fit | mean | median | ≤15 | ≤25 | >500 | max |
|---|---|---|---|---|---|---|---|
| without | 54 | 73.7 | 13.3 | 30 | 36 | 1 | 1489.0 |
| **with** | 53 | **47.0** | 13.2 | 30 | 36 | **0** | **359.3** |

Every page that moves:

```
nashville  p9    1489.0ft -> NO FIT    the intended case: a fabricated GCP becomes an honest no-fit
chicago    p24N    20.8ft -> 14.9ft    better
brooklyn   p3      12.2ft -> 13.6ft    worse by 1.4
hudson     p61     13.1ft -> 18.1ft    worse by 5.0
grand_rap  p810    23.2ft -> 34.5ft    worse by 11.3
nola_1896  p125    11.9ft -> 771.5ft   pre-existing: undetected split page (see below)
```

An earlier, unscoped version of this rule moved **11** pages. Scoping it to relaxed admissions returned five of them to their unfiltered values — including two apparent *wins* (Brooklyn p1 48.0→57.2, p13 48.1→55.6) that were the rule overruling the gate and getting lucky. Declining those bets is the point.

## Known limits

- **New Orleans 1896 p125** (11.9 → 771.5 ft) is not caused by this rule so much as exposed by it. The page is a **split that the splitter fails to detect**, so `NUNS` and `ST. JAMES` — two clean, correctly-read labels of streets that are genuinely parallel and 221 m apart — land 9 px from the same page line. Any fit here is fragile: it only "works" while nothing happens to combine streets from either side of the undetected split. `NUNS` is 20 px against this volume's 24 px floor, so it is a relaxed admission and still eligible. The fix belongs in the splitter.
- **The same-street guard compares `normalize_street` output**, so `GATES AV` (→ `GATES AVENUE`) and bare `GATES` (→ `GATES`) read as different streets and the guard misses them (Hudson p61). It should compare canonical street matches. This affects ~4% of eligible drops and is left for a follow-up.

## Tests

7 unit tests: drops the worse collinear label; keeps a street labelled twice; keeps genuinely parallel streets; keeps a smaller-but-more-confident label; **spares a label that clears the gate alone** (p9's `6TH`); **spares a promoted label**; and `needs_size_relaxation` boundaries. Suite green; ruff + pyright clean.
