### PR TITLE
Stop a bare street-name fragment from claiming every street it prefixes

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -317,6 +317,13 @@ DOUBLE_SCALE_BAND = (1.8, 2.2)
 # treated as buildings. Brown is a dark yellow/orange and shares the band.
 FILL_YELLOW_HUE_BAND = (40.0, 110.0)
 
+# Confidence floor for the *weaker* half of an assembled multi-word street. A part this weak is
+# never trusted alone; it is admitted only when its partner clears min_confidence and the two
+# concatenate into a real street name (assemble_multiword_streets). 0.05 reaches Brooklyn p19's
+# 0.096 "DYKE" — collinear with a 1.000 "VAN", and "VAN DYKE" is a street — while staying above
+# the 0.00-0.03 noise floor that fills these pages.
+WEAK_PARTNER_CONFIDENCE = 0.05
+
 # Perpendicular offset (page px) within which two same-bearing labels count as sitting on one
 # line for drop_collinear_dominated. 20 px admits Nashville p9's 4 px 3RD/7TH offset while
 # keeping genuinely parallel streets (a block apart) separate.
@@ -1701,7 +1708,12 @@ def _assembled_detection(first: dict, second: dict, text: str) -> dict:
     return {
         "polygon": [[round(x), round(y)] for x, y in box],
         "text": text,
-        "confidence": min(first.get("confidence", 0.0), second.get("confidence", 0.0)),
+        # The assembly is a joint hypothesis corroborated by three independent signals: a
+        # confident anchor word, collinear/adjacent geometry, and an exact vocabulary hit. Its
+        # strength is therefore its best part, not its weakest — taking the min would throw away
+        # exactly the evidence that justifies trusting a faint partner (Brooklyn p19's 0.096
+        # "DYKE" beside a 1.000 "VAN": min() would re-sink "VAN DYKE" below the accept gate).
+        "confidence": max(first.get("confidence", 0.0), second.get("confidence", 0.0)),
         "angle": first.get("angle"),
         "dir_pix": round(first.get("dir_pix", 0.0) % math.pi, 4),
         "long_side": round(r1 - r0, 1),
@@ -1716,6 +1728,7 @@ def assemble_multiword_streets(
     perp_tolerance_px: float = 20.0,
     max_word_gap_frac: float = 0.7,
     min_confidence: float = 0.5,
+    weak_partner_confidence: float = WEAK_PARTNER_CONFIDENCE,
 ) -> tuple[list[dict], list[dict]]:
     """Combine adjacent single-word detections into a multi-word street name.
 
@@ -1731,12 +1744,21 @@ def assemble_multiword_streets(
     orders are tried; the order whose concatenation matches a street wins. Returns
     (assembled detections, the source parts that were consumed) so the caller can drop the
     parts — a lone "VAN" is ambiguous on its own.
+
+    One part of a pair may fall below ``min_confidence``, down to ``weak_partner_confidence``,
+    provided its partner clears ``min_confidence``: a read too weak to trust on its own becomes
+    trustworthy when a confident word sits collinear and adjacent to it *and* the concatenation
+    names a real street. Brooklyn p19's "DYKE" scores 0.096 — unusable alone — but sits 1 px off
+    collinear from a 1.000 "VAN", and "VAN DYKE" is a street: assembling the two both recovers
+    Van Dyke Street and consumes the lone "VAN" that would otherwise claim all eight VAN* streets
+    by prefix. Both parts weak is still rejected, so the confident anchor is what buys the
+    context.
     """
     bucket_size = math.pi / 12.0
     parts = [
         d
         for d in detections
-        if d.get("confidence", 0.0) >= min_confidence
+        if d.get("confidence", 0.0) >= min(weak_partner_confidence, min_confidence)
         and not d.get("assembled")
         and (text := d.get("text", "").strip()).isalpha()
         and len(text) >= 3
@@ -1773,6 +1795,9 @@ def assemble_multiword_streets(
             b_long = b.get("long_side", 0.0)
             edge_gap = math.hypot(b_cx - a_cx, b_cy - a_cy) - (a_long + b_long) / 2.0
             if edge_gap > max_word_gap_frac * max(a_long, b_long):
+                continue
+            # At least one part must stand on its own; two weak reads never vouch for each other.
+            if max(a.get("confidence", 0.0), b.get("confidence", 0.0)) < min_confidence:
                 continue
             ordered = None
             for first, second in ((a, b), (b, a)):

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -130,6 +130,43 @@ def test_assemble_adjacent_words_into_street():
     )  # both parts consumed so a lone ambiguous "VAN" doesn't remain
 
 
+def test_assemble_admits_weak_partner_beside_confident_anchor():
+    # Brooklyn p19: a 1.000 "VAN" beside a 0.096 "BRUNT". The faint word is unusable alone but
+    # the confident anchor + collinear geometry + the vocabulary hit vouch for it.
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22, confidence=1.0)
+    brunt = _make_det(
+        "BRUNT", cx=760, cy=1000, long_side=80, short_side=22, confidence=0.096
+    )
+    assembled, consumed = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert len(assembled) == 1
+    assert assembled[0]["text"] == "VAN BRUNT"
+    # The joint hypothesis takes the anchor's strength; min() would re-sink it below the gate.
+    assert assembled[0]["confidence"] == 1.0
+    assert (
+        len(consumed) == 2
+    )  # the lone "VAN" is consumed, so it cannot fan out by prefix
+
+
+def test_assemble_rejects_two_weak_parts():
+    # Neither word stands on its own -> nothing vouches for the pair.
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22, confidence=0.2)
+    brunt = _make_det(
+        "BRUNT", cx=760, cy=1000, long_side=80, short_side=22, confidence=0.096
+    )
+    assembled, consumed = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert assembled == [] and consumed == []
+
+
+def test_assemble_ignores_partner_below_the_noise_floor():
+    # Below weak_partner_confidence the partner is noise, not a faint read.
+    van = _make_det("VAN", cx=700, cy=1000, long_side=50, short_side=22, confidence=1.0)
+    brunt = _make_det(
+        "BRUNT", cx=760, cy=1000, long_side=80, short_side=22, confidence=0.01
+    )
+    assembled, _ = assemble_multiword_streets([van, brunt], _VAN_STREETS)
+    assert assembled == []
+
+
 def test_assemble_resolves_reading_order():
     # Spatial order doesn't matter: only "VAN BRUNT" matches a street, not "BRUNT VAN".
     brunt = _make_det("BRUNT", cx=700, cy=1000, long_side=80, short_side=22)

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -88,6 +88,13 @@ STREET_TYPES: frozenset[str] = (
     frozenset(STREET_ABBREVS.values()) | _UNABBREVIATED_STREET_TYPES
 )
 
+# How many letters a label must have before it may claim a street whose name continues past it
+# (_covers_whole_name). Below this a fragment is an abbreviation or particle that recurs city-wide
+# and attaches to anything — ST, AV, VAN, REP, NEW, PIER; at or above it the word is distinctive
+# enough that a sheet printing it is naming that street (HARBOR -> Harbor Island Street, CLYDE ->
+# Clyde Park Avenue). 5 is the smallest value that admits CLYDE, and it leaves REP and VAN out.
+MIN_FRAGMENT_LETTERS = 5
+
 # Abbreviations of AVENUE and STREET (the two types used as "hints" in Sanborn maps).
 _LETTERED_TYPE_ABBREVS: frozenset[str] = frozenset(
     k for k, v in STREET_ABBREVS.items() if v in ("AVENUE", "STREET")
@@ -289,18 +296,39 @@ def _match_candidates(s: str) -> list[str]:
     return [s]
 
 
-def _covers_whole_name(normalized: str, candidate: str) -> bool:
+def printed_letters(text: str) -> int:
+    """Letter count of a label as printed on the sheet, before abbreviation expansion.
+
+    _covers_whole_name's length allowance is about the *printed* word: "ST" is two letters on the
+    map even though normalize_street expands it to SAINT, and "AV" is two even though it expands
+    to AVENUE. Counting the expansion would hand the allowance to precisely the abbreviations the
+    rule exists to stop — a bare "ST" would reclaim all 69 of Detroit's SAINT* streets.
+    """
+    return sum(1 for c in text if c.isalnum())
+
+
+def _covers_whole_name(normalized: str, candidate: str, label_letters: int) -> bool:
     """Whether a label that is a prefix of ``candidate`` names the *whole* street.
 
     A label may omit the street type and quadrant ("MAGAZINE" for MAGAZINE STREET,
-    "PRINTERS" for PRINTERS ALLEY), so a prefix match is only sound when everything left
-    over is type and/or direction words. One word of a multi-word *name* is not a match: a
-    lone "VAN" would otherwise claim all eight of Brooklyn's VAN* streets (VAN BRUNT, VAN
-    BUREN, VAN DAM, VAN DYKE, …), and a lone "REP" would claim REP JOHN LEWIS WAY — a street
-    a 1957 Nashville sheet cannot be labelling — fabricating GCPs from a building
-    abbreviation. Such fragments earn a match only by pairing with their sibling word
+    "PRINTERS" for PRINTERS ALLEY), so a prefix match is always sound when everything left
+    over is type and/or direction words.
+
+    When the remainder holds part of the *name* the label is a fragment, and a short fragment
+    is rejected: a lone "VAN" would otherwise claim all eight of Brooklyn's VAN* streets (VAN
+    BRUNT, VAN BUREN, VAN DAM, VAN DYKE, …), and a lone "REP" would claim REP JOHN LEWIS WAY —
+    a street a 1957 Nashville sheet cannot be labelling — fabricating GCPs from a building
+    abbreviation. Such fragments earn a match by pairing with their sibling word instead
     (georef_from_labels.assemble_multiword_streets: "VAN" + "BRUNT" -> "VAN BRUNT"), which is
     what the per-word OCR vocabulary exists for.
+
+    A fragment of ``MIN_FRAGMENT_LETTERS`` or more is accepted, because length is what separates
+    the two kinds of fragment. The short ones are abbreviations and particles that recur across
+    a whole city and attach to anything ("ST", "AV", "VAN", "REP", "NEW", "PIER"); a long one is
+    a distinctive word, and a sheet printing it usually *is* naming that street under an older,
+    shorter name than OSM now carries — Detroit's "HARBOR" for Harbor Island Street, Grand
+    Rapids' "CLYDE" for Clyde Park Avenue, both of which are the page's only real reading and
+    have no sibling word on the sheet to assemble with.
 
     Note this is deliberately *not* an ambiguity test. "REP" is wrong because it is half a
     name, whether the volume holds one REP* street or eight.
@@ -308,7 +336,9 @@ def _covers_whole_name(normalized: str, candidate: str) -> bool:
     if not candidate.startswith(normalized + " "):
         return False
     remainder = candidate[len(normalized) + 1 :].split()
-    return all(word in STREET_TYPES or word in DIRECTION_WORDS for word in remainder)
+    if all(word in STREET_TYPES or word in DIRECTION_WORDS for word in remainder):
+        return True
+    return label_letters >= MIN_FRAGMENT_LETTERS
 
 
 def matches_any_street(text: str, normalized_streets: set[str]) -> bool:
@@ -320,6 +350,7 @@ def matches_any_street(text: str, normalized_streets: set[str]) -> bool:
     naming only part of a multi-word name does not match (see _covers_whole_name).
     """
     normalized = normalize_street(text)
+    label_letters = printed_letters(text)
     for s in normalized_streets:
         for candidate in _match_candidates(s):
             if (
@@ -328,7 +359,7 @@ def matches_any_street(text: str, normalized_streets: set[str]) -> bool:
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or _covers_whole_name(normalized, candidate)
+                or _covers_whole_name(normalized, candidate, label_letters)
             ):
                 return True
     return False
@@ -351,6 +382,7 @@ def canonical_street_match(
     "WEST X" streets when it should match only "AVENUE W".
     """
     normalized = normalize_street(text)
+    label_letters = printed_letters(text)
     raw = text.upper().strip()
     if raw != normalized and raw in normalized_streets:
         return raw
@@ -379,7 +411,7 @@ def canonical_street_match(
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or _covers_whole_name(normalized, candidate)
+                or _covers_whole_name(normalized, candidate, label_letters)
             ):
                 return s
     return None
@@ -408,6 +440,7 @@ def canonical_street_matches(
     "NORTH CAROLINA AVENUE NORTHEAST".
     """
     normalized = normalize_street(text)
+    label_letters = printed_letters(text)
     raw = text.upper().strip()
     if raw != normalized and raw in normalized_streets:
         return [raw]
@@ -432,7 +465,7 @@ def canonical_street_matches(
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or _covers_whole_name(normalized, candidate)
+                or _covers_whole_name(normalized, candidate, label_letters)
             ):
                 matches.append(s)
                 break  # count each key at most once

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -56,8 +56,36 @@ DIRECTION_WORDS: frozenset[str] = frozenset(DIRECTION_ABBREVS.values())
 # (e.g. the label "CHARLES" should still match "SAINT CHARLES AVENUE").
 STRIPPABLE_PREFIXES: frozenset[str] = DIRECTION_WORDS | {"SAINT"}
 
+# Street-type words that appear in centerline names but have no abbreviation worth expanding
+# (they are already short, or their abbreviation collides with something else). They still have
+# to be *recognised* as types so build_block_index can form the bare-name alias that lets a map
+# label naming only the street ("PRINTERS" for PRINTERS ALLEY, "SEWARD" for SEWARD SQUARE) match.
+# Only unambiguous road types belong here: PARK, RIDGE, HILL, VIEW, CREEK, COVE and friends also
+# end street names, but there they are part of the *name* ("PROSPECT PARK", "BROAD BRANCH"), so
+# treating them as types would alias away the very word that identifies the street.
+_UNABBREVIATED_STREET_TYPES: frozenset[str] = frozenset(
+    {
+        "WAY",
+        "TRAIL",
+        "ALLEY",
+        "SQUARE",
+        "PLAZA",
+        "PIKE",
+        "TURNPIKE",
+        "LOOP",
+        "ROW",
+        "WALK",
+        "CROSSING",
+        "TRACE",
+        "CRESCENT",
+        "PASS",
+    }
+)
+
 # Full street-type words (STREET, AVENUE, …); used to identify bare-name aliases in build_block_index.
-STREET_TYPES: frozenset[str] = frozenset(STREET_ABBREVS.values())
+STREET_TYPES: frozenset[str] = (
+    frozenset(STREET_ABBREVS.values()) | _UNABBREVIATED_STREET_TYPES
+)
 
 # Abbreviations of AVENUE and STREET (the two types used as "hints" in Sanborn maps).
 _LETTERED_TYPE_ABBREVS: frozenset[str] = frozenset(
@@ -260,12 +288,35 @@ def _match_candidates(s: str) -> list[str]:
     return [s]
 
 
+def _covers_whole_name(normalized: str, candidate: str) -> bool:
+    """Whether a label that is a prefix of ``candidate`` names the *whole* street.
+
+    A label may omit the street type and quadrant ("MAGAZINE" for MAGAZINE STREET,
+    "PRINTERS" for PRINTERS ALLEY), so a prefix match is only sound when everything left
+    over is type and/or direction words. One word of a multi-word *name* is not a match: a
+    lone "VAN" would otherwise claim all eight of Brooklyn's VAN* streets (VAN BRUNT, VAN
+    BUREN, VAN DAM, VAN DYKE, …), and a lone "REP" would claim REP JOHN LEWIS WAY — a street
+    a 1957 Nashville sheet cannot be labelling — fabricating GCPs from a building
+    abbreviation. Such fragments earn a match only by pairing with their sibling word
+    (georef_from_labels.assemble_multiword_streets: "VAN" + "BRUNT" -> "VAN BRUNT"), which is
+    what the per-word OCR vocabulary exists for.
+
+    Note this is deliberately *not* an ambiguity test. "REP" is wrong because it is half a
+    name, whether the volume holds one REP* street or eight.
+    """
+    if not candidate.startswith(normalized + " "):
+        return False
+    remainder = candidate[len(normalized) + 1 :].split()
+    return all(word in STREET_TYPES or word in DIRECTION_WORDS for word in remainder)
+
+
 def matches_any_street(text: str, normalized_streets: set[str]) -> bool:
     """Return True if text is a prefix-compatible match with any known street name.
 
     Handles labels that omit or include the street-type suffix ("COLUMBIA" matches
     "COLUMBIA PLACE"), omit a direction prefix ("LIBERTY" matches "SOUTH LIBERTY
-    STREET"), or omit a SAINT prefix ("CHARLES" matches "SAINT CHARLES AVENUE").
+    STREET"), or omit a SAINT prefix ("CHARLES" matches "SAINT CHARLES AVENUE"). A label
+    naming only part of a multi-word name does not match (see _covers_whole_name).
     """
     normalized = normalize_street(text)
     for s in normalized_streets:
@@ -276,7 +327,7 @@ def matches_any_street(text: str, normalized_streets: set[str]) -> bool:
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or candidate.startswith(normalized + " ")
+                or _covers_whole_name(normalized, candidate)
             ):
                 return True
     return False
@@ -327,7 +378,7 @@ def canonical_street_match(
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or candidate.startswith(normalized + " ")
+                or _covers_whole_name(normalized, candidate)
             ):
                 return s
     return None
@@ -380,7 +431,7 @@ def canonical_street_matches(
                     len(candidate.split()) >= 2
                     and normalized.startswith(candidate + " ")
                 )
-                or candidate.startswith(normalized + " ")
+                or _covers_whole_name(normalized, candidate)
             ):
                 matches.append(s)
                 break  # count each key at most once

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -62,7 +62,9 @@ STRIPPABLE_PREFIXES: frozenset[str] = DIRECTION_WORDS | {"SAINT"}
 # label naming only the street ("PRINTERS" for PRINTERS ALLEY, "SEWARD" for SEWARD SQUARE) match.
 # Only unambiguous road types belong here: PARK, RIDGE, HILL, VIEW, CREEK, COVE and friends also
 # end street names, but there they are part of the *name* ("PROSPECT PARK", "BROAD BRANCH"), so
-# treating them as types would alias away the very word that identifies the street.
+# treating them as types would alias away the very word that identifies the street. CRESCENT was
+# tried and removed for exactly that reason: Detroit's CRESCENT AVENUE is named *Crescent*, so
+# listing CRESCENT aliased it to a bare "AVENUE" that a 1.000-confidence "AV" label then matched.
 _UNABBREVIATED_STREET_TYPES: frozenset[str] = frozenset(
     {
         "WAY",
@@ -77,7 +79,6 @@ _UNABBREVIATED_STREET_TYPES: frozenset[str] = frozenset(
         "WALK",
         "CROSSING",
         "TRACE",
-        "CRESCENT",
         "PASS",
     }
 )

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -6,6 +6,7 @@ from mapsnap.streets import (
     canonical_street_match,
     canonical_street_matches,
     is_bare_letter,
+    matches_any_street,
     normalize_street,
 )
 
@@ -161,6 +162,46 @@ def test_direction_word_does_not_match_east_grand_avenue():
     matches = canonical_street_matches("E", _DC_STREETS)
     assert "EAST GRAND AVENUE" not in matches
     assert "EAST STREET NORTHEAST" in matches
+
+
+# --- a bare label must name the whole street, not one word of a multi-word name ---
+
+_VAN_STREETS = {
+    "VAN BRUNT STREET",
+    "VAN BUREN STREET",
+    "VAN DYKE STREET",
+    "MAGAZINE STREET",
+    "PRINTERS ALLEY",
+    "REP JOHN LEWIS WAY SOUTH",
+}
+
+
+def test_bare_label_omitting_only_the_type_still_matches():
+    # The prefix rule's purpose: a label may leave off the street type.
+    assert canonical_street_matches("MAGAZINE", _VAN_STREETS) == ["MAGAZINE STREET"]
+
+
+def test_bare_label_omitting_an_unabbreviated_type_still_matches():
+    # ALLEY is a type too (it just has no abbreviation we expand).
+    assert canonical_street_matches("PRINTERS", _VAN_STREETS) == ["PRINTERS ALLEY"]
+
+
+def test_one_word_of_a_multi_word_name_matches_nothing():
+    # A lone "VAN" would otherwise claim VAN BRUNT, VAN BUREN and VAN DYKE alike; it must
+    # earn a match by assembling with its sibling word instead.
+    assert canonical_street_matches("VAN", _VAN_STREETS) == []
+    assert canonical_street_match("VAN", _VAN_STREETS) is None
+    assert not matches_any_street("VAN", _VAN_STREETS)
+
+
+def test_assembled_multi_word_name_matches():
+    assert canonical_street_matches("VAN BRUNT", _VAN_STREETS) == ["VAN BRUNT STREET"]
+
+
+def test_name_fragment_is_rejected_even_when_unambiguous():
+    # Only one REP* street exists here, yet "REP" is still only half a name: a building
+    # abbreviation must not claim the street. This is not an ambiguity test.
+    assert canonical_street_matches("REP", _VAN_STREETS) == []
 
 
 def test_canonical_street_match_direction_suffixed():

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -216,3 +216,45 @@ def test_canonical_street_match_direction_suffixed():
         "NORTH PLACE SOUTHEAST",
         "NORTH ROAD",
     }
+
+
+def test_covers_whole_name_rejects_short_fragments():
+    # A short fragment is an abbreviation or particle: it recurs city-wide and attaches to
+    # anything, so it may not claim a street whose name continues past it.
+    streets = {"VAN BRUNT STREET", "VAN DYKE STREET", "REP JOHN LEWIS WAY", "PIER C"}
+    assert not matches_any_street("VAN", streets)
+    assert not matches_any_street("REP", streets)
+    assert not matches_any_street("PIER", streets)
+
+
+def test_covers_whole_name_admits_a_long_distinctive_fragment():
+    # Detroit's sheet prints "HARBOR" for what OSM now calls Harbor Island Street, and Grand
+    # Rapids' prints "CLYDE" for Clyde Park Avenue. Neither has a sibling word to assemble with.
+    assert matches_any_street("HARBOR", {"HARBOR ISLAND STREET"})
+    assert matches_any_street("CLYDE", {"CLYDE PARK AVENUE SOUTHWEST"})
+
+
+def test_covers_whole_name_measures_the_printed_label_not_the_expansion():
+    # "ST" is two letters on the sheet even though it normalizes to SAINT, and "AV" two even
+    # though it normalizes to AVENUE. Counting the expansion would hand the length allowance to
+    # exactly the abbreviations this rule exists to stop.
+    assert not matches_any_street("ST", {"SAINT CLAIR HEIGHTS DRIVE"})
+    assert not matches_any_street("ST.", {"SAINT CLAIR HEIGHTS DRIVE"})
+    assert not matches_any_street("AV", {"AVENUE EBERLY DRIVE"})
+    # The type-only remainder path is unaffected: ST. CLAIR still names SAINT CLAIR DRIVE.
+    assert matches_any_street("ST. CLAIR", {"SAINT CLAIR DRIVE"})
+
+
+def test_covers_whole_name_still_allows_a_type_only_remainder_at_any_length():
+    # Length only gates the *fragment* path; omitting the type and quadrant is always sound.
+    assert matches_any_street("OAK", {"OAK STREET"})
+    assert matches_any_street("ELM", {"NORTH ELM AVENUE SOUTHWEST"})
+
+
+def test_printed_letters_ignores_punctuation_and_spaces():
+    from mapsnap.streets import printed_letters
+
+    assert printed_letters("ST.") == 2
+    assert printed_letters("CLYDE") == 5
+    assert printed_letters("VAN BRUNT") == 8
+    assert printed_letters("3RD") == 3


### PR DESCRIPTION
## The bug

Street matching accepted a label that was **any prefix** of a key, so a label naming **one word of a multi-word name** claimed every street starting with it.

- Brooklyn v1: a lone **`VAN`** matched **all eight** VAN\* streets — VAN BRUNT, VAN BUREN, VAN DAM, VAN DYKE, VAN SICKLEN, VAN SICLEN AV, VAN SICLEN CT, VAN SINDEREN AV.
- Detroit: a lone **`ST`** (which normalizes to SAINT) claimed **54** streets.
- Nashville: a lone **`REP`**, read off a building abbreviation, claimed **REP JOHN LEWIS WAY SOUTH and NORTH** — fabricating the GCPs behind a 4428 ft fit.

Note the asymmetry: only the **first** word is dangerous. `BRUNT` alone matches nothing, because no street *starts with* "BRUNT ".

This is an **interaction bug**, not one commit's fault. The prefix rule predates #18; #91 added per-word vocabulary so a CRAFT-split "VAN BRUNT" decodes to itself rather than snapping to an unrelated word (`VAN → IVAN`). #91 made `VAN` *decodable*; the old prefix rule then fanned it out to all eight.

## The rule

A label may omit the street type and quadrant ("MAGAZINE" → MAGAZINE STREET), so a prefix match is sound whenever **everything left over is type and/or direction words** (`_covers_whole_name`, applied in all three matchers). When the remainder holds part of the *name*, the label is a fragment.

**Fragments are judged on length.** A short fragment is an abbreviation or particle that recurs across a whole city and attaches to anything — `ST`, `AV`, `VAN`, `REP`, `NEW`, `PIER`. A fragment of **5+ letters** is distinctive, and a sheet printing it usually *is* naming that street under an older, shorter name than OSM now carries. Both cases are the same shape, and only length separates them:

| label | claims | verdict |
|---|---|---|
| `REP` (3) | REP JOHN LEWIS WAY | a building abbreviation on a 1957 sheet — **rejected** |
| `VAN` (3) | 8 VAN\* streets | half a name — **rejected** |
| `HARBOR` (6) | HARBOR ISLAND STREET | Detroit p99's only real reading — **accepted** |
| `CLYDE` (5) | CLYDE PARK AVENUE | Grand Rapids p815's only real reading — **accepted** |

`HARBOR` and `CLYDE` are each a confident, printed label with **no sibling word on the sheet** to assemble with, so rejecting them is unrecoverable. Without the length allowance this PR cost Detroit p99 (20 → 133 ft) and Grand Rapids p815 (17.7 ft → no fit).

**The count is of the label as printed**, not its normalization. `normalize_street` expands `ST` → SAINT (5 letters) and `AV` → AVENUE (6), so counting the expansion would hand the allowance to precisely the abbreviations the rule exists to stop — a bare `ST` would reclaim all 69 of Detroit's SAINT\* streets. Hence `printed_letters()`.

**Deliberately not an ambiguity test.** "REP" is wrong because it is *half a name*, whether the volume holds one REP\* street or eight. An ambiguity gate would also keep matches whose text happens to hit exactly one street — `PIER` on "PIER No 4", `SHIP` on "SHIP YARD" (both confirmed by eye).

## Commits

1. **`admit a faint partner into multi-word street assembly`** — assembly required *both* parts to clear `min_confidence`, so a faint second word left the first stranded, and a lone "VAN" is not inert. Brooklyn p19's `DYKE` scores **0.096** but sits **1 px** off collinear from a **1.000** `VAN`, and "VAN DYKE" *is* a street. One part may now fall to `WEAK_PARTNER_CONFIDENCE` (0.05); its partner must still clear `min_confidence`, so **two weak reads never vouch for each other**. `_assembled_detection` takes `max()` rather than `min()` of the parts: the assembly is corroborated by a confident anchor, collinear geometry and an exact vocabulary hit, so its strength is its **best** part — `min()` would re-sink "VAN DYKE" below the accept gate. p19 goes 12 → **15 GCPs**; across 21 volumes assemblies go **160 → 249**.
2. **`require a bare street label to name the whole street`** — the whole-name rule, plus the `STREET_TYPES` additions it needs (WAY, TRAIL, ALLEY, SQUARE, PLAZA, PIKE, …) so labels that *do* name the whole street still match ("PRINTERS" → PRINTERS ALLEY).
3. **`drop CRESCENT from the unabbreviated street types`** — CRESCENT is the case that list's own comment warns about. Detroit's CRESCENT AVENUE is named *Crescent*, so listing CRESCENT aliased it to a bare `AVENUE` that a 1.000-confidence `AV` label matched. It also widened `W` from 8 candidates to 10 and `S` from 28 to 32. Removing it changes no volume's numbers.
4. **`admit a long, distinctive label to prefix matching`** — the 5-letter allowance and `printed_letters()`.

## Measured

Across the six README volumes, of 4424 street-matching labels (conf ≥ 0.5) the rule **kills 371 outright and narrows 152**. Total candidate streets claimed falls **30575 → 18352 (40% fewer)**. What it kills is exactly the target class:

```
ST x169   AV x84   ST. x40   PIER x26   NEW x13   VAN x11   AV. x9   OLD x3
```

Fit results over eight volumes, against `main`:

| Volume | Fit | mean | median | ≤15 | ≤25 | >500 | max |
|---|---|---|---|---|---|---|---|
| new_orleans_la_1951_vol_5 | 103 | 47.4 | 12.3 | 70 | 88 | 4 | 891.1 |
| new_orleans_la_1896_vol_2 | 82 | 65.5 | 30.3 | 25 | 37 | 1 | 771.5 |
| detroit_mich_1929_vol_11 | 83 | 41.0 | 14.8 | 42 | 56 | 0 | 429.3 |
| grand_rapids_mi_1953_vol7 | 63 | 63.0 | 18.4 | 21 | 44 | 2 | 1149.0 |
| champaign_ill_1915 | 27 | 12.4 | 9.9 | 23 | 26 | 0 | 61.5 |
| brooklyn_ny_1939_vol_1 | 55 | 80.2 → 80.1 | 9.6 | 40 | 41 | 2 | 1706.2 |
| chicago_il_1950_vol_1 | 100 | 52.0 → **48.7** | 10.1 | 70 | 83 | 1 | 2989.2 |
| nashville_tn_1957_vol1a | 53 → **54** | 47.8 | 13.3 | 30 | 36 | 0 | 389.8 |

The first five are **identical to main**. Every page that moves:

```
nashville  p47     NO FIT -> 32.3ft    <- the gain
chicago    p50N   443.5ft -> 118.0ft
brooklyn   p5      69.8ft -> 63.9ft    (the assembly commit)
nashville  p1__2  110.1ft -> 61.3ft    | reference scale 2.5860 -> 2.7716 px/ft
nashville  p65     11.2ft -> 6.7ft     | after p47 joins the fit set (+7%);
nashville  p16    359.3ft -> 389.8ft   | these four are deferred/median-scale
nashville  p25    347.9ft -> 377.9ft   | pages riding the reference, each moving
nashville  p10    292.7ft -> 317.6ft   | +8-10%. Not the rule.
nashville  p56    279.2ft -> 303.4ft   |
```

**The gain is real and it is the REP class.** #116's colour filter catches 27 of Nashville's 30 confident REP reads, but **3 survive** — their backgrounds are yellow, and #116 spares yellow *by design*, because yellow is ambiguous between aged paper, a taped-on patch and a frame building. p47's REP sits at hue 101.7, squarely in the spared band; this PR refuses it and the page recovers from no fit to 32.3 ft.

So the two filters are **complementary rather than redundant**: #116 judges *where a label sits*, this judges *what a label can name*, and each catches REPs the other structurally cannot.

The rest of the case is insurance. `VAN` no longer fans out to eight streets and `ST` no longer to 54; the Brooklyn pages where `VAN` fanned out already fit, because RANSAC tolerated the ambiguity. This removes the mechanism rather than relying on RANSAC to keep absorbing it.

## Tests

8 new tests: 3 for assembly, 5 for matching (short fragments rejected; a long distinctive fragment admitted; the printed-vs-expanded count; the type-only remainder unaffected at any length; `printed_letters` punctuation handling). 591 passed; ruff + pyright clean.
