### PR TITLE
Rerun and expand test set 

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,29 +189,8 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 
 RMSE was measured across 49 equally-spaced points on each image. You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 
-[nola5]: https://oldinsurancemaps.net/map/sanborn03376_029
-[nola2]: https://oldinsurancemaps.net/map/sanborn03376_006
 [detroit]: https://oldinsurancemaps.net/map/sanborn03985_041
-[chicago]: https://oldinsurancemaps.net/map/sanborn01790_085
-[champaign]: https://oldinsurancemaps.net/map/sanborn01778_006
-[brooklyn1]: https://oldinsurancemaps.net/map/sanborn05791_053
-[dc]: https://oldinsurancemaps.net/map/sanborn01227_003
-[hudson]: https://oldinsurancemaps.net/map/sanborn05511_036
-[kc]: https://oldinsurancemaps.net/map/sanborn04720_021
-[nashville]: https://oldinsurancemaps.net/map/sanborn08356_019
-[grandrapids]: https://oldinsurancemaps.net/map/sanborn04023_023
-
-[nola5-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json
-[nola2-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json
-[detroit-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json
-[chicago-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json
-[champaign-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json
 [brooklyn1-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json
-[dc-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json
-[hudson-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json
-[kc-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fkansas_city_mo_1951_vol_4.iiif.json
-[nashville-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json
-[grandrapids-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fgrand_rapids_mi_1953_vol7.iiif.json
 [test data notes]: https://github.com/danvk/mapsnap/wiki/Test-data-notes
 
 ## How it Works

--- a/README.md
+++ b/README.md
@@ -20,19 +20,172 @@ After a few minutes, depending on the number of images in the Sanborn volume, yo
 
 Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 
-Volume | Fit / Total | Median RMSE | Mean RMSE | Max RMSE | ≤25ft | 25–50ft | 50–100ft | 100–200ft | 200ft+ | Allmaps
------- | ----------- | ----------- | --------- | -------- | ----- | ------- | -------- | --------- | ------ | -------
-[New Orleans 1951 Vol 5][nola5] | 103/109 (94%) | 12ft | 47ft | 878ft | 85% | 7% | 3% | 1% | 4% | [view][nola5-iiif]
-[New Orleans 1896 Vol 2][nola2] | 82/91 (90%) | 30ft | 66ft | 772ft | 45% | 13% | 21% | 17% | 4% | [view][nola2-iiif]
-[Detroit 1929 Vol 11][detroit] | 81/103 (79%) | 15ft | 25ft | 166ft | 70% | 20% | 5% | 5% | 0% | [view][detroit-iiif]
-[Chicago 1950 Vol 1][chicago] | 100/111 (90%) | 10ft | 49ft | 2989ft | 82% | 10% | 5% | 1% | 2% | [view][chicago-iiif]
-[Champaign, Ill. 1915][champaign] | 27/33 (82%) | 10ft | 28ft | 453ft | 89% | 7% | 0% | 0% | 4% | [view][champaign-iiif]
-[Brooklyn 1939 Vol 1][brooklyn1] | 54/62 (87%) | 10ft | 103ft | 2645ft | 76% | 6% | 13% | 0% | 6% | [view][brooklyn1-iiif]
-[Washington DC 1916 Vol 2][dc] | 85/134 (63%) | 28ft | 123ft | 4746ft | 48% | 28% | 12% | 4% | 8% | [view][dc-iiif]
-[Hudson County 1950 Vol 9][hudson] | 60/95 (63%) | 13ft | 34ft | 874ft | 67% | 27% | 5% | 0% | 2% | [view][hudson-iiif]
-[Kansas City 1951 Vol 4][kc] | 107/142 (75%) | 19ft | 39ft | 830ft | 68% | 24% | 2% | 1% | 5% | [view][kc-iiif]
-[Nashville 1957 Vol 1A][nashville] | 55/71 (77%) | 14ft | 52ft | 390ft | 62% | 13% | 15% | 2% | 9% | [view][nashville-iiif]
-[Grand Rapids 1953 Vol 7][grandrapids] | 63/83 (76%) | 18ft | 63ft | 1149ft | 71% | 17% | 3% | 2% | 6% | [view][grandrapids-iiif]
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Volume</th>
+      <th rowspan="2">Fit / Total</th>
+      <th colspan="3">RMSE Stats</th>
+      <th colspan="5">RMSE Distribution</th>
+      <th rowspan="2">Allmaps</th>
+    </tr>
+    <tr>
+      <th>Median</th>
+      <th>Mean</th>
+      <th>Max</th>
+      <th>≤25ft</th>
+      <th>25–50ft</th>
+      <th>50–100ft</th>
+      <th>100–200ft</th>
+      <th>200ft+</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_029">New Orleans 1951 Vol 5</a></td>
+      <td align="right">103/109 (94%)</td>
+      <td align="right">12ft</td>
+      <td align="right">47ft</td>
+      <td align="right">878ft</td>
+      <td align="right">85%</td>
+      <td align="right">7%</td>
+      <td align="right">3%</td>
+      <td align="right">1%</td>
+      <td align="right">4%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_006">New Orleans 1896 Vol 2</a></td>
+      <td align="right">82/91 (90%)</td>
+      <td align="right">30ft</td>
+      <td align="right">66ft</td>
+      <td align="right">772ft</td>
+      <td align="right">45%</td>
+      <td align="right">13%</td>
+      <td align="right">21%</td>
+      <td align="right">17%</td>
+      <td align="right">4%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03985_041">Detroit 1929 Vol 11</a></td>
+      <td align="right">81/103 (79%)</td>
+      <td align="right">15ft</td>
+      <td align="right">25ft</td>
+      <td align="right">166ft</td>
+      <td align="right">70%</td>
+      <td align="right">20%</td>
+      <td align="right">5%</td>
+      <td align="right">5%</td>
+      <td align="right">0%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01790_085">Chicago 1950 Vol 1</a></td>
+      <td align="right">100/111 (90%)</td>
+      <td align="right">10ft</td>
+      <td align="right">49ft</td>
+      <td align="right">2989ft</td>
+      <td align="right">82%</td>
+      <td align="right">10%</td>
+      <td align="right">5%</td>
+      <td align="right">1%</td>
+      <td align="right">2%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01778_006">Champaign, Ill. 1915</a></td>
+      <td align="right">27/33 (82%)</td>
+      <td align="right">10ft</td>
+      <td align="right">28ft</td>
+      <td align="right">453ft</td>
+      <td align="right">89%</td>
+      <td align="right">7%</td>
+      <td align="right">0%</td>
+      <td align="right">0%</td>
+      <td align="right">4%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn05791_053">Brooklyn 1939 Vol 1</a></td>
+      <td align="right">54/62 (87%)</td>
+      <td align="right">10ft</td>
+      <td align="right">103ft</td>
+      <td align="right">2645ft</td>
+      <td align="right">76%</td>
+      <td align="right">6%</td>
+      <td align="right">13%</td>
+      <td align="right">0%</td>
+      <td align="right">6%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01227_003">Washington DC 1916 Vol 2</a></td>
+      <td align="right">85/134 (63%)</td>
+      <td align="right">28ft</td>
+      <td align="right">123ft</td>
+      <td align="right">4746ft</td>
+      <td align="right">48%</td>
+      <td align="right">28%</td>
+      <td align="right">12%</td>
+      <td align="right">4%</td>
+      <td align="right">8%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn05511_036">Hudson County 1950 Vol 9</a></td>
+      <td align="right">60/95 (63%)</td>
+      <td align="right">13ft</td>
+      <td align="right">34ft</td>
+      <td align="right">874ft</td>
+      <td align="right">67%</td>
+      <td align="right">27%</td>
+      <td align="right">5%</td>
+      <td align="right">0%</td>
+      <td align="right">2%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn04720_021">Kansas City 1951 Vol 4</a></td>
+      <td align="right">107/142 (75%)</td>
+      <td align="right">19ft</td>
+      <td align="right">39ft</td>
+      <td align="right">830ft</td>
+      <td align="right">68%</td>
+      <td align="right">24%</td>
+      <td align="right">2%</td>
+      <td align="right">1%</td>
+      <td align="right">5%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fkansas_city_mo_1951_vol_4.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn08356_019">Nashville 1957 Vol 1A</a></td>
+      <td align="right">55/71 (77%)</td>
+      <td align="right">14ft</td>
+      <td align="right">52ft</td>
+      <td align="right">390ft</td>
+      <td align="right">62%</td>
+      <td align="right">13%</td>
+      <td align="right">15%</td>
+      <td align="right">2%</td>
+      <td align="right">9%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn04023_023">Grand Rapids 1953 Vol 7</a></td>
+      <td align="right">63/83 (76%)</td>
+      <td align="right">18ft</td>
+      <td align="right">63ft</td>
+      <td align="right">1149ft</td>
+      <td align="right">71%</td>
+      <td align="right">17%</td>
+      <td align="right">3%</td>
+      <td align="right">2%</td>
+      <td align="right">6%</td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fgrand_rapids_mi_1953_vol7.iiif.json">view</a></td>
+    </tr>
+  </tbody>
+</table>
 
 RMSE was measured across 49 equally-spaced points on each image. You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ After a few minutes, depending on the number of images in the Sanborn volume, yo
 
 Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 
-Volume | Pages | Num Fit | Median RMSE | Within 15ft | Within 25ft | Allmaps
------- | ----- | ------- | ----------- | ----------- | ----------- | -------
-[New Orleans 1951 Vol 5][nola5] | 109 | 103 (94%) | 12ft | 68% | 85% | [view][nola5-iiif]
-[New Orleans 1896 Vol 2][nola2] | 91 | 82 (90%) | 27ft | 32% | 46% | [view][nola2-iiif]
-[Detroit 1929 Vol 11][detroit] | 103 | 83 (81%) | 15ft | 51% | 67% | [view][detroit-iiif]
-[Chicago 1950 Vol 1][chicago] | 111 | 100 (90%) | 10ft | 69% | 83% | [view][chicago-iiif]
-[Champaign, Ill. 1915][champaign] | 33 | 27 (82%) | 10ft | 85% | 96% | [view][champaign-iiif]
-[Brooklyn 1939 Vol 1][brooklyn1] | 62 | 55 (89%) | 10ft | 73% | 75% | [view][brooklyn1-iiif]
+Volume | Fit / Total | Median RMSE | Mean RMSE | Max RMSE | ≤25ft | 25–50ft | 50–100ft | 100–200ft | 200ft+ | Allmaps
+------ | ----------- | ----------- | --------- | -------- | ----- | ------- | -------- | --------- | ------ | -------
+[New Orleans 1951 Vol 5][nola5] | 103/109 (94%) | 12ft | 47ft | 878ft | 85% | 7% | 3% | 1% | 4% | [view][nola5-iiif]
+[New Orleans 1896 Vol 2][nola2] | 82/91 (90%) | 30ft | 66ft | 772ft | 45% | 13% | 21% | 17% | 4% | [view][nola2-iiif]
+[Detroit 1929 Vol 11][detroit] | 81/103 (79%) | 15ft | 25ft | 166ft | 70% | 20% | 5% | 5% | 0% | [view][detroit-iiif]
+[Chicago 1950 Vol 1][chicago] | 100/111 (90%) | 10ft | 49ft | 2989ft | 82% | 10% | 5% | 1% | 2% | [view][chicago-iiif]
+[Champaign, Ill. 1915][champaign] | 27/33 (82%) | 10ft | 28ft | 453ft | 89% | 7% | 0% | 0% | 4% | [view][champaign-iiif]
+[Brooklyn 1939 Vol 1][brooklyn1] | 54/62 (87%) | 10ft | 103ft | 2645ft | 76% | 6% | 13% | 0% | 6% | [view][brooklyn1-iiif]
+[Washington DC 1916 Vol 2][dc] | 85/134 (63%) | 28ft | 123ft | 4746ft | 48% | 28% | 12% | 4% | 8% | [view][dc-iiif]
+[Hudson County 1950 Vol 9][hudson] | 60/95 (63%) | 13ft | 34ft | 874ft | 67% | 27% | 5% | 0% | 2% | [view][hudson-iiif]
+[Kansas City 1951 Vol 4][kc] | 107/142 (75%) | 19ft | 39ft | 830ft | 68% | 24% | 2% | 1% | 5% | [view][kc-iiif]
+[Nashville 1957 Vol 1A][nashville] | 55/71 (77%) | 14ft | 52ft | 390ft | 62% | 13% | 15% | 2% | 9% | [view][nashville-iiif]
+[Grand Rapids 1953 Vol 7][grandrapids] | 63/83 (76%) | 18ft | 63ft | 1149ft | 71% | 17% | 3% | 2% | 6% | [view][grandrapids-iiif]
 
 RMSE was measured across 49 equally-spaced points on each image. You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 
@@ -37,6 +42,11 @@ RMSE was measured across 49 equally-spaced points on each image. You can view th
 [chicago]: https://oldinsurancemaps.net/map/sanborn01790_085
 [champaign]: https://oldinsurancemaps.net/map/sanborn01778_006
 [brooklyn1]: https://oldinsurancemaps.net/map/sanborn05791_053
+[dc]: https://oldinsurancemaps.net/map/sanborn01227_003
+[hudson]: https://oldinsurancemaps.net/map/sanborn05511_036
+[kc]: https://oldinsurancemaps.net/map/sanborn04720_021
+[nashville]: https://oldinsurancemaps.net/map/sanborn08356_019
+[grandrapids]: https://oldinsurancemaps.net/map/sanborn04023_023
 
 [nola5-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json
 [nola2-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json
@@ -44,6 +54,11 @@ RMSE was measured across 49 equally-spaced points on each image. You can view th
 [chicago-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json
 [champaign-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json
 [brooklyn1-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json
+[dc-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json
+[hudson-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json
+[kc-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fkansas_city_mo_1951_vol_4.iiif.json
+[nashville-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json
+[grandrapids-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fgrand_rapids_mi_1953_vol7.iiif.json
 [test data notes]: https://github.com/danvk/mapsnap/wiki/Test-data-notes
 
 ## How it Works

--- a/gallery/champaign_ill_1915.iiif.json
+++ b/gallery/champaign_ill_1915.iiif.json
@@ -21,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"211.5,688.2 5838.9,619.4 5837.6,4653.3 5982.1,6785.4 1068.3,6852.2 446.9,7650.0 -0.0,7650.0 -0.0,5966.0 261.5,5399.2 211.5,688.2\" /></svg>"
+          "value": "<svg><polygon points=\"6101.1,498.3 6057.2,4723.8 6160.3,6565.7 -0.0,6611.8 -0.0,5973.2 254.9,5413.4 229.9,537.9 6101.1,498.3\" /></svg>"
         }
       },
       "body": {
@@ -58,29 +58,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5561.9,
-                2667.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.233769,
-                40.117344
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                236.2,
-                4815.5
+                232.1,
+                4809.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -93,6 +72,27 @@
               "coordinates": [
                 -88.2371024,
                 40.1163368
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                232.1,
+                2664.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2371003,
+                40.117326
               ]
             }
           }
@@ -110,15 +110,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "18"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +137,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6338.3,7507.0 4802.3,7516.9 4240.0,7650.0 269.6,7650.0 167.4,85.8 400.7,80.9 399.5,-0.0 6450.0,-0.0 6450.0,141.4 5840.8,151.3 5843.7,331.8 6251.2,330.7 6338.3,7507.0\" /></svg>"
+          "value": "<svg><polygon points=\"6359.7,7523.8 4298.7,7650.0 258.3,7650.0 121.7,92.3 315.9,-0.0 6450.0,-0.0 6450.0,145.4 5841.6,158.2 5844.9,316.9 6239.3,310.6 6359.7,7523.8\" /></svg>"
         }
       },
       "body": {
@@ -151,8 +151,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6273.6,
-                2632.9
+                6273.9,
+                2624.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,8 +172,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                239.4,
-                5316.3
+                4301.3,
+                5297.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -184,8 +184,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.232106,
-                40.118327
+                -88.232105,
+                40.116357
               ]
             }
           }
@@ -210,8 +210,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6450.0,7254.6 613.1,7167.0 591.6,639.5 5960.9,639.9 5972.1,6327.4 6450.0,6481.4 6450.0,7254.6\" /></svg>"
+          "value": "<svg><polygon points=\"595.5,7167.5 591.8,0.0 5962.1,0.0 5967.4,6345.4 6450.0,6500.1 6450.0,7266.7 595.5,7167.5\" /></svg>"
         }
       },
       "body": {
@@ -244,8 +244,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3281.7,
-                3439.2
+                3277.0,
+                3436.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -265,8 +265,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5971.3,
-                7250.0
+                584.2,
+                3436.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -277,8 +277,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2434886,
-                40.1125772
+                -88.2468178,
+                40.1143682
               ]
             }
           }
@@ -286,13 +286,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Champaign, Ill. | 1915 p13 [2]",
+      "label": "Champaign, Ill. | 1915 p13 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -301,10 +301,26 @@
         {
           "label": "intersections",
           "value": "31"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -313,7 +329,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013/info.json",
@@ -323,11 +339,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"55.3,85.9 1672.6,51.1 1672.1,330.6 3446.6,0.0 4775.5,135.7 6450.0,70.0 6450.0,7274.6 5365.8,7650.0 2524.3,7650.0 55.3,85.9\" /></svg>"
+          "value": "<svg><polygon points=\"2499.7,7650.0 57.8,79.4 1672.9,50.4 1671.5,166.8 1671.5,329.5 2648.6,261.5 3462.1,0.0 4771.1,145.8 6450.0,86.0 6450.0,7270.2 5339.1,7650.0 2499.7,7650.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0013__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -337,8 +353,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1684.9,
-                1411.0
+                1680.5,
+                1408.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -358,8 +374,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2919.5,
-                4160.4
+                2920.9,
+                172.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -370,8 +386,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2426043,
-                40.114523
+                -88.241855,
+                40.116314
               ]
             }
           }
@@ -389,15 +405,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "12"
+          "value": "11"
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,7 +432,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"663.7,7273.1 750.0,7017.9 448.8,7016.4 2667.0,372.3 4370.8,903.3 4370.2,1441.4 5876.6,1398.1 6450.0,980.5 6450.0,7305.7 663.7,7273.1\" /></svg>"
+          "value": "<svg><polygon points=\"6450.0,7299.8 623.5,7259.1 2943.8,423.6 4339.7,894.2 4338.3,1432.4 5844.8,1391.2 6450.0,937.0 6450.0,7299.8\" /></svg>"
         }
       },
       "body": {
@@ -430,8 +446,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2535.3,
-                1751.1
+                3265.0,
+                3456.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.239363,
+                40.114406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2504.8,
+                1740.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -444,27 +481,6 @@
               "coordinates": [
                 -88.2398409,
                 40.1151976
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2973.0,
-                434.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.239585,
-                40.115812
               ]
             }
           }
@@ -482,15 +498,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +525,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6265.6,6814.4 -0.0,6861.4 -0.0,6508.9 1141.7,6523.7 1147.7,6057.0 323.0,5397.2 319.8,265.0 5190.0,266.8 6228.3,411.7 6265.6,6814.4\" /></svg>"
+          "value": "<svg><polygon points=\"6264.9,6767.0 -0.0,6822.8 -0.0,261.5 5189.3,259.1 6228.0,404.1 6264.9,6767.0\" /></svg>"
         }
       },
       "body": {
@@ -523,8 +539,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4494.2,
-                6160.3
+                4493.4,
+                6153.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -544,8 +560,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4494.2,
-                267.7
+                4493.4,
+                260.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -582,8 +598,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -602,7 +618,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5996.8,194.0 6025.7,7619.4 5034.3,7477.9 382.6,7462.3 413.0,188.5 -0.0,186.6 -0.0,-0.0 6450.0,-0.0 6450.0,194.3 5996.8,194.0\" /></svg>"
+          "value": "<svg><polygon points=\"6003.7,168.8 6031.9,7620.7 5036.8,7478.6 367.8,7462.3 399.2,162.6 -0.0,160.7 -0.0,0.0 6450.0,-0.0 6450.0,169.2 6003.7,168.8\" /></svg>"
         }
       },
       "body": {
@@ -616,8 +632,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2384.1,
-                182.7
+                2376.7,
+                2520.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -628,8 +644,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2289594,
-                40.1144501
+                -88.230433,
+                40.1144404
               ]
             }
           },
@@ -637,8 +653,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2384.1,
-                7473.6
+                2376.7,
+                7474.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -668,15 +684,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +711,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"856.8,7580.4 820.1,159.2 1273.0,153.4 1272.8,-0.0 5861.4,-0.0 5900.5,7547.4 856.8,7580.4\" /></svg>"
+          "value": "<svg><polygon points=\"5844.5,7440.3 886.9,7459.8 869.9,165.8 5833.0,115.4 5844.5,7440.3\" /></svg>"
         }
       },
       "body": {
@@ -709,8 +725,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3354.1,
-                5177.7
+                3353.0,
+                2492.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -721,8 +737,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2320757,
-                40.1114893
+                -88.230412,
+                40.1115
               ]
             }
           },
@@ -730,8 +746,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                834.6,
-                5177.7
+                3353.0,
+                7457.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -742,8 +758,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.232088,
-                40.1126956
+                -88.2335732,
+                40.1114748
               ]
             }
           }
@@ -761,15 +777,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "13"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -788,7 +804,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1206.9,7650.0 1206.6,7428.0 878.3,7424.8 705.5,7423.2 705.5,115.0 6450.0,121.1 6450.0,7650.0 1206.9,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"704.2,112.0 5822.5,119.0 5821.2,0.0 6450.0,0.0 6450.0,7650.0 714.8,7650.0 704.2,112.0\" /></svg>"
         }
       },
       "body": {
@@ -802,8 +818,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                705.5,
-                7423.2
+                3409.1,
+                7421.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -814,8 +830,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2319954,
-                40.1068287
+                -88.2303281,
+                40.1068384
               ]
             }
           },
@@ -823,8 +839,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                705.5,
-                113.4
+                704.2,
+                112.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -858,11 +874,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +897,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,176.8 4950.9,185.8 4954.9,2803.7 6198.9,2796.2 6193.3,6540.9 6450.0,6543.8 6450.0,7650.0 -0.0,7650.0 -0.0,829.4 -0.0,176.8\" /></svg>"
+          "value": "<svg><polygon points=\"371.8,175.8 4949.7,180.8 4955.6,2801.4 6200.9,2793.0 6198.7,6673.3 6450.0,6662.7 6450.0,7650.0 -0.0,7650.0 -0.0,828.5 370.5,830.9 371.8,175.8\" /></svg>"
         }
       },
       "body": {
@@ -895,8 +911,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6198.0,
-                5319.4
+                4949.5,
+                1484.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -907,8 +923,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2320085,
-                40.1079555
+                -88.2335732,
+                40.1114748
               ]
             }
           },
@@ -916,8 +932,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4950.9,
-                185.8
+                4949.5,
+                6801.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -928,8 +944,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.233592,
-                40.112676
+                -88.2334956,
+                40.1065769
               ]
             }
           }
@@ -947,15 +963,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "10"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "15"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -974,7 +1006,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"88.5,102.0 3084.6,162.8 3085.4,0.0 3800.1,0.0 4223.7,139.0 4810.8,129.5 4853.3,0.0 5005.3,0.0 4962.4,129.0 6100.4,133.2 6134.9,7621.7 -0.0,7650.0 -0.0,4307.3 86.8,4308.1 88.5,102.0\" /></svg>"
+          "value": "<svg><polygon points=\"96.2,4032.9 108.4,120.3 6450.0,163.2 6450.0,814.0 6081.9,812.3 6094.5,7588.2 6450.0,7587.5 6450.0,7650.0 -0.0,7650.0 -0.0,4030.6 96.2,4032.9\" /></svg>"
         }
       },
       "body": {
@@ -989,7 +1021,7 @@
             "properties": {
               "resourceCoords": [
                 1464.5,
-                2771.5
+                4045.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1000,8 +1032,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.245117,
-                40.110162
+                -88.245106,
+                40.108981
               ]
             }
           },
@@ -1009,8 +1041,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1464.5,
-                1152.7
+                2828.9,
+                2768.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1021,8 +1053,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.245133,
-                40.1116522
+                -88.243467,
+                40.110178
               ]
             }
           }
@@ -1036,7 +1068,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Champaign, Ill. | 1915 p20 [2]",
+      "label": "Champaign, Ill. | 1915 p20 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -1048,23 +1080,23 @@
         },
         {
           "label": "split_canvas_x",
-          "value": "3491.0"
+          "value": "3475.1"
         },
         {
           "label": "split_canvas_y",
-          "value": "3394.0"
+          "value": "3372.1"
         },
         {
           "label": "split_canvas_w",
-          "value": "2959.0"
+          "value": "2974.9"
         },
         {
           "label": "split_canvas_h",
-          "value": "4256.0"
+          "value": "4277.9"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1083,7 +1115,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3491.0,7650.0 3491.0,3495.5 6273.8,3503.4 6307.6,7650.0 3491.0,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"6215.1,7650.0 3475.1,7650.0 3475.1,6152.1 3603.1,6150.7 3579.0,3502.2 6268.8,3503.5 6307.0,7381.7 6211.6,7380.7 6215.1,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1097,8 +1129,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4923.3,
-                4518.6
+                4922.6,
+                4519.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1118,8 +1150,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3598.0,
-                6150.5
+                3603.0,
+                6150.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1145,15 +1177,15 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Champaign, Ill. | 1915 p21 [1]",
+      "label": "Champaign, Ill. | 1915 p21 [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "7"
         },
         {
           "label": "split_canvas_x",
@@ -1161,19 +1193,19 @@
         },
         {
           "label": "split_canvas_y",
-          "value": "2627.0"
+          "value": "0.0"
         },
         {
           "label": "split_canvas_w",
-          "value": "4216.0"
+          "value": "6450.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "5023.0"
+          "value": "7650.0"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1192,7 +1224,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2627.0 4216.0,2627.0 4216.0,7397.5 4050.1,7396.2 4048.9,7515.1 2964.0,7511.0 2962.9,7650.0 123.0,7650.0 122.9,7340.5 -0.0,7339.3 -0.0,2627.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7650.0 -0.0,-0.0 5964.3,0.0 5918.6,84.2 5879.1,7432.1 4063.0,7406.7 4063.3,7281.9 3236.5,7282.8 3236.6,7394.9 3098.1,7395.6 3097.6,7650.0 -0.0,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1206,8 +1238,117 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2178.8,
-                4853.5
+                6065.9,
+                3460.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.254277,
+                40.11628
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6065.9,
+                1312.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.254298,
+                40.118255
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p21 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "22"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2621.9"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "4258.5"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5028.1"
+        }
+      ],
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"143.6,7501.5 140.7,4744.7 -0.0,4744.7 0.0,2621.9 4258.5,2621.9 4258.5,7379.9 4056.0,7379.1 4055.2,7494.5 143.6,7501.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2181.3,
+                4849.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1227,8 +1368,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3120.3,
-                4853.5
+                2181.3,
+                7494.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1239,101 +1380,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2399723,
-                40.1284836
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p21 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7650.0 -0.0,-0.0 5929.4,0.0 5927.5,95.8 5882.6,95.5 5833.9,7414.9 4035.3,7388.1 4035.8,7254.9 3236.2,7252.9 3235.1,7650.0 -0.0,7650.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0021__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6015.4,
-                6475.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2542645,
-                40.1134977
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6031.1,
-                2387.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25429,
-                40.117274
+                -88.241086,
+                40.126012
               ]
             }
           }
@@ -1351,15 +1399,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "15"
+          "value": "13"
         },
         {
           "label": "intersections",
-          "value": "37"
+          "value": "33"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1378,7 +1426,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6329.7,7328.0 -0.0,7292.3 -0.0,-0.0 44.8,-0.0 42.1,209.6 6319.0,209.9 6323.6,1230.7 6047.9,1230.3 6049.0,3391.4 6320.2,3391.4 6329.7,7328.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7300.1 -0.0,-0.0 44.1,0.0 41.8,202.5 6058.8,205.3 6033.4,3393.4 6325.8,3393.5 6333.8,7338.3 -0.0,7300.1\" /></svg>"
         }
       },
       "body": {
@@ -1392,8 +1440,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3596.6,
-                3360.5
+                3605.1,
+                5445.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1404,8 +1452,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2501244,
-                40.1162818
+                -88.2501072,
+                40.1143535
               ]
             }
           },
@@ -1413,8 +1461,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4957.2,
-                211.0
+                2228.7,
+                208.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1425,8 +1473,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.248484,
-                40.119205
+                -88.25179,
+                40.119196
               ]
             }
           }
@@ -1441,115 +1489,6 @@
         "http://iiif.io/api/presentation/3/context.json"
       ],
       "label": "Champaign, Ill. | 1915 p23 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "2305.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "6450.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5345.0"
-        }
-      ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7431.4 -0.0,2305.0 6178.6,2305.0 6249.2,7353.2 -0.0,7431.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2151.0,
-                5281.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.251797,
-                40.121177
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6198.0,
-                3662.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2468495,
-                40.122646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p23 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -1573,11 +1512,120 @@
         },
         {
           "label": "split_canvas_h",
-          "value": "3255.0"
+          "value": "3239.6"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3239.6 -0.0,-0.0 816.1,0.0 815.7,123.1 6197.6,195.4 6189.9,2855.6 6061.4,2855.5 6056.8,3239.6 -0.0,3239.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1412.4,
+                1151.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2559076,
+                40.1116846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6189.9,
+                2855.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25007,
+                40.1101382
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p23 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "27"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "2295.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5355.0"
+        }
+      ],
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1596,7 +1644,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,-0.0 794.7,0.0 794.7,132.3 6099.0,188.5 6078.3,3255.0 -0.0,3255.0 0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7423.8 0.0,2295.0 6180.5,2295.0 6243.3,7355.5 -0.0,7423.8\" /></svg>"
         }
       },
       "body": {
@@ -1610,8 +1658,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2947.9,
-                2855.2
+                2148.7,
+                5278.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1622,8 +1670,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2540082,
-                40.1101189
+                -88.251797,
+                40.121177
               ]
             }
           },
@@ -1631,8 +1679,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6188.6,
-                2855.2
+                6197.9,
+                3666.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1643,8 +1691,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.25007,
-                40.1101382
+                -88.2468495,
+                40.122646
               ]
             }
           }
@@ -1666,11 +1714,11 @@
         },
         {
           "label": "intersections",
-          "value": "30"
+          "value": "24"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1689,7 +1737,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6327.0,193.9 6314.4,7102.0 6198.9,7101.4 5800.3,7097.8 5680.4,7096.9 5666.7,7650.0 -0.0,7614.6 -0.0,0.0 6450.0,-0.0 6450.0,194.3 6327.0,193.9\" /></svg>"
+          "value": "<svg><polygon points=\"1797.8,7650.0 1798.6,7577.1 -0.0,7557.1 -0.0,0.0 6450.0,-0.0 6450.0,272.6 6348.1,271.7 6282.1,7098.7 5627.4,7088.3 5610.8,7650.0 1797.8,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1703,8 +1751,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4459.6,
-                5706.8
+                4457.4,
+                5705.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1724,8 +1772,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5287.9,
-                2947.9
+                1204.4,
+                1568.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1736,8 +1784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.232112,
-                40.11928
+                -88.230464,
+                40.123111
               ]
             }
           }
@@ -1751,19 +1799,35 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Champaign, Ill. | 1915 p2 [1]",
+      "label": "Champaign, Ill. | 1915 p2 [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1480.1"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2105.8"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1782,11 +1846,207 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"679.4,4765.6 -0.0,4756.9 -0.0,-0.0 6072.3,0.0 6068.7,7327.3 683.2,7319.7 679.4,4765.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 1348.3,-0.0 1349.2,1289.7 -0.0,1281.5 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24689261389938,
+                40.12853395956669
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1480.1,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24327233633606,
+                40.12855706140323
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1480.1,
+                2105.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2432293948487,
+                40.12462084168521
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2105.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24684967241201,
+                40.12459773984867
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1348.1,
+                1136.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.243572,
+                40.126426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1348.1,
+                1136.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.243563,
+                40.125991
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p2 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6450.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7650.0"
+        }
+      ],
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4469.7,7430.0 680.0,7462.1 675.0,4731.3 -0.0,4723.9 -0.0,-0.0 6061.2,0.0 6060.1,7650.0 4469.7,7430.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1796,8 +2056,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                677.1,
-                3316.4
+                672.2,
+                3312.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1817,8 +2077,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3351.0,
-                7473.6
+                3345.0,
+                7466.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1838,13 +2098,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Champaign, Ill. | 1915 p3 [2]",
+      "label": "Champaign, Ill. | 1915 p3 [3]",
       "metadata": [
         {
           "label": "streets",
@@ -1855,8 +2115,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1865,7 +2125,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/info.json",
@@ -1875,11 +2135,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"416.8,6873.4 424.8,427.8 5994.7,372.9 6007.1,6897.7 416.8,6873.4\" /></svg>"
+          "value": "<svg><polygon points=\"5983.0,6934.6 406.1,6869.5 440.8,158.8 6267.2,131.9 6253.3,2417.0 6089.4,2417.0 5992.2,2417.7 5983.0,6934.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0003/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1889,8 +2149,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                425.2,
-                4387.2
+                424.1,
+                4385.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1910,7 +2170,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                425.2,
+                2436.8,
                 148.0
               ],
               "creator": {
@@ -1922,8 +2182,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.243563,
-                40.125991
+                -88.242326,
+                40.126002
               ]
             }
           }
@@ -1957,15 +2217,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "3719.0"
+          "value": "3727.2"
         },
         {
           "label": "split_canvas_h",
           "value": "7650.0"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1984,7 +2244,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1337.0,7650.0 -0.0,7650.0 -0.0,238.7 2090.2,229.9 2090.7,0.0 3719.0,0.0 3719.0,7650.0 1520.9,7650.0 1524.4,7083.3 1337.0,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"1336.0,7650.0 -0.0,7650.0 -0.0,2491.9 258.3,2490.7 267.5,231.0 2093.8,224.1 2094.3,0.0 3727.2,0.0 3727.2,7650.0 1507.6,7650.0 1512.7,7117.9 1336.0,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1998,8 +2258,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2090.2,
-                2510.1
+                2093.8,
+                2504.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2019,8 +2279,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2090.2,
-                229.9
+                2093.8,
+                224.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2054,11 +2314,11 @@
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "18"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2077,7 +2337,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5941.8,7378.5 638.4,7443.6 620.0,0.0 5966.3,0.0 5966.6,320.4 5967.0,372.3 5941.8,7378.5\" /></svg>"
+          "value": "<svg><polygon points=\"5964.4,362.0 5974.4,5935.6 6076.1,5938.4 5950.1,6333.3 5947.6,7370.9 642.9,7442.4 616.2,144.0 4382.7,103.7 5964.4,362.0\" /></svg>"
         }
       },
       "body": {
@@ -2091,8 +2351,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3291.1,
-                7423.2
+                3289.0,
+                5361.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2103,8 +2363,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.245199,
-                40.1192201
+                -88.2452035,
+                40.120189
               ]
             }
           },
@@ -2112,8 +2372,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                620.4,
-                148.0
+                616.2,
+                144.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2147,11 +2407,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2170,7 +2430,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6273.2,7187.6 6450.0,7244.6 6450.0,7308.1 -0.0,7311.9 -0.0,1589.5 738.3,1584.9 729.6,191.6 139.8,-0.0 6450.0,-0.0 6273.2,7187.6\" /></svg>"
+          "value": "<svg><polygon points=\"6450.0,-0.0 6290.2,7278.2 -0.0,7326.9 -0.0,1577.5 720.8,1570.6 707.4,178.7 151.0,-0.0 6450.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -2184,29 +2444,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3710.0,
-                3439.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.241225,
-                40.121097
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3710.0,
-                5533.6
+                3713.2,
+                5529.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2219,6 +2458,27 @@
               "coordinates": [
                 -88.24249,
                 40.121099
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3713.2,
+                1116.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.239837,
+                40.121088
               ]
             }
           }
@@ -2236,15 +2496,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "22"
+          "value": "19"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2263,7 +2523,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"539.4,6437.7 -0.0,6437.4 -0.0,2140.4 548.2,2141.6 540.1,111.9 5897.8,55.0 5973.4,7650.0 532.2,7650.0 539.4,6437.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6438.7 -0.0,113.6 5886.6,43.3 5971.6,6993.5 541.7,7017.0 543.8,6437.8 -0.0,6438.7\" /></svg>"
         }
       },
       "body": {
@@ -2277,8 +2537,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                544.8,
-                4232.9
+                3249.0,
+                4233.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2451734,
+                40.117288
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                544.2,
+                4233.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2291,27 +2572,6 @@
               "coordinates": [
                 -88.2468229,
                 40.1172873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3253.3,
-                6383.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2451677,
-                40.1162878
               ]
             }
           }
@@ -2329,15 +2589,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "14"
+          "value": "11"
         },
         {
           "label": "intersections",
-          "value": "31"
+          "value": "29"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2356,7 +2616,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1555.2 -0.0,1160.5 3595.3,0.0 6450.0,0.0 6450.0,1272.1 4620.8,1830.9 5508.5,4736.8 5961.3,4770.9 6002.2,6353.0 6324.9,7409.3 5381.3,7404.5 4629.8,7650.0 3611.1,7650.0 3611.0,7463.7 2004.9,7506.0 -0.0,1555.2\" /></svg>"
+          "value": "<svg><polygon points=\"3597.1,7441.9 1980.4,7476.6 -0.0,1503.2 -0.0,1077.3 3393.4,0.0 6450.0,0.0 6450.0,1190.0 4557.0,1764.4 5449.9,4706.3 5975.8,4743.1 5977.8,6445.5 6257.9,7368.6 6450.0,7500.0 5395.1,7386.2 4574.6,7650.0 3596.4,7650.0 3597.1,7441.9\" /></svg>"
         }
       },
       "body": {
@@ -2370,8 +2630,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4853.2,
-                7574.4
+                3597.1,
+                4705.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2382,8 +2642,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.241855,
-                40.116314
+                -88.242054,
+                40.117775
               ]
             }
           },
@@ -2391,8 +2651,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3599.8,
-                6100.5
+                3597.1,
+                7441.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2403,8 +2663,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2423123,
-                40.117163
+                -88.2425666,
+                40.1165462
               ]
             }
           }
@@ -2422,15 +2682,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:18:25Z",
-      "modified": "2026-06-10T19:18:25Z",
+      "created": "2026-07-17T16:10:56Z",
+      "modified": "2026-07-17T16:10:56Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2449,7 +2709,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6262.2,6287.5 5418.8,7342.7 4879.7,7532.0 3651.8,7570.7 3636.1,7039.0 319.1,6115.5 -0.0,5887.6 -0.0,4772.7 427.1,3233.4 -0.0,3066.9 -0.0,-0.0 6174.3,0.0 6262.2,6287.5\" /></svg>"
+          "value": "<svg><polygon points=\"3549.4,6942.0 371.1,6053.6 -0.0,5777.9 -0.0,4826.2 486.0,3218.5 -0.0,3033.0 -0.0,-0.0 6148.9,0.0 6249.2,5982.4 6217.2,6240.8 6009.9,6525.9 6017.6,7142.5 5689.5,7149.1 5683.9,6954.5 5108.4,7412.9 3645.3,7495.4 3549.4,6942.0\" /></svg>"
         }
       },
       "body": {
@@ -2463,8 +2723,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2242.4,
-                6617.0
+                484.2,
+                3216.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2475,8 +2735,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.239585,
-                40.115812
+                -88.2406645,
+                40.1174173
               ]
             }
           },
@@ -2484,8 +2744,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6194.9,
-                1240.9
+                6193.9,
+                3328.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2496,8 +2756,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2370995,
-                40.118307
+                -88.2371003,
+                40.117326
               ]
             }
           }

--- a/gallery/chicago_il_1950_vol_1.iiif.json
+++ b/gallery/chicago_il_1950_vol_1.iiif.json
@@ -24,8 +24,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5882.0,7323.0 -0.0,7323.0 -0.0,1000.2 5882.0,1010.3 5882.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"5882.0,1008.8 5882.0,7323.0 -0.0,7323.0 -0.0,998.7 5882.0,1008.8\" /></svg>"
         }
       },
       "body": {
@@ -58,8 +58,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1285.3,
-                1005.4
+                1280.4,
+                1003.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -79,8 +79,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2959.7,
-                1005.4
+                2961.0,
+                1003.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -117,8 +117,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +137,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4201.5,6234.1 1791.2,6243.3 1731.4,37.8 4127.1,0.0 4201.5,6234.1\" /></svg>"
+          "value": "<svg><polygon points=\"1785.5,6239.8 1727.2,42.6 4123.1,0.0 4130.9,1244.3 5844.0,1243.0 5844.0,6223.5 1785.5,6239.8\" /></svg>"
         }
       },
       "body": {
@@ -151,8 +151,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4201.5,
-                6234.1
+                4196.0,
+                6231.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,8 +172,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1740.5,
-                1256.0
+                1736.0,
+                1251.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -210,8 +210,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1755.2,6226.4 1716.6,0.0 4077.0,0.0 4132.7,6228.3 1755.2,6226.4\" /></svg>"
+          "value": "<svg><polygon points=\"3408.1,1295.1 1712.6,1287.8 1711.0,0.0 4071.3,0.0 4129.4,6223.2 3383.3,6222.9 3408.1,1295.1\" /></svg>"
         }
       },
       "body": {
@@ -244,8 +244,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1717.6,
-                1290.6
+                1712.6,
+                1287.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -265,8 +265,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4132.7,
-                6228.3
+                4129.4,
+                6223.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -303,8 +303,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,7 +323,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1603.6,1251.1 4117.9,1231.5 4152.3,6222.5 1682.9,6208.1 1603.6,1251.1\" /></svg>"
+          "value": "<svg><polygon points=\"4153.9,6219.8 1684.0,6207.2 1580.4,0.0 4102.0,0.0 4153.9,6219.8\" /></svg>"
         }
       },
       "body": {
@@ -337,8 +337,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4117.9,
-                1233.0
+                4116.0,
+                1227.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -358,8 +358,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1682.9,
-                6208.1
+                1684.0,
+                6207.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -396,8 +396,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,7 +416,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1440.9,4711.8 1440.6,2380.7 3938.4,2352.6 3912.0,0.0 5901.0,0.0 5901.0,7323.0 5147.0,7323.0 5145.6,4709.8 1440.9,4711.8\" /></svg>"
+          "value": "<svg><polygon points=\"1435.4,0.0 5901.0,0.0 5901.0,7323.0 1441.7,7323.0 1435.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -430,8 +430,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1440.7,
-                1256.0
+                1440.2,
+                1251.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -451,101 +451,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1440.7,
-                6283.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6392994,
-                41.8697612
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p106W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5901
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2285.3,7017.3 2287.4,6810.5 -0.0,6789.9 -0.0,1498.1 2286.3,1532.6 2287.4,0.0 5901.0,0.0 5901.0,7323.0 5157.1,7323.0 5155.4,7040.2 2285.3,7017.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0106W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2287.8,
-                6913.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6392291,
-                41.8672683
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2284.9,
-                1532.6
+                1440.2,
+                6279.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -582,8 +489,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -602,7 +509,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,7019.5 2224.5,7051.8 2311.5,1046.9 3420.9,1065.3 3236.0,7323.0 -0.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"3479.2,1059.6 3328.4,7323.0 -0.0,7323.0 -0.0,6997.4 2212.8,7029.4 2299.5,1041.3 3479.2,1059.6\" /></svg>"
         }
       },
       "body": {
@@ -616,8 +523,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2944.7,
-                1057.3
+                2944.5,
+                1051.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -637,8 +544,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2944.7,
-                6381.0
+                2944.5,
+                6379.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -668,15 +575,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +602,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1065.1 5092.6,1002.1 5101.7,1712.1 5718.5,1698.2 5679.2,-0.0 5877.0,-0.0 5877.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1035.1 5085.5,1000.0 5090.8,1717.0 5266.0,1714.1 5877.0,1703.6 5877.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -709,8 +616,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4981.0,
-                6366.6
+                4972.8,
+                3431.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -721,8 +628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6469627,
-                41.8671813
+                -87.6451405,
+                41.8671908
               ]
             }
           },
@@ -730,8 +637,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4981.0,
-                1002.5
+                4972.8,
+                999.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -768,8 +675,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -788,7 +695,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4167.6,995.3 4102.7,7323.0 918.1,7323.0 918.4,6686.5 1651.1,6694.1 1711.6,956.4 4167.6,995.3\" /></svg>"
+          "value": "<svg><polygon points=\"905.8,7323.0 906.6,6684.8 1640.4,6692.8 1704.3,947.9 4163.9,988.3 4095.5,7323.0 905.8,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -802,8 +709,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4149.4,
-                2644.6
+                4144.7,
+                2639.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -823,8 +730,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1711.6,
-                956.4
+                1704.3,
+                947.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -861,8 +768,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +788,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4111.5,725.9 4137.2,6528.9 1679.9,6530.8 1680.0,732.7 4111.5,725.9\" /></svg>"
+          "value": "<svg><polygon points=\"4111.6,735.4 4137.3,6529.2 1684.3,6531.1 1684.4,742.2 4111.6,735.4\" /></svg>"
         }
       },
       "body": {
@@ -895,8 +802,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1679.9,
-                4756.2
+                1684.3,
+                4759.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -916,8 +823,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1679.9,
-                6530.8
+                1684.3,
+                6531.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -954,8 +861,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -974,7 +881,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1699.7,967.9 4270.1,984.7 4244.5,6445.6 4126.9,6446.2 4125.3,7323.0 1691.4,7243.2 1699.7,967.9\" /></svg>"
+          "value": "<svg><polygon points=\"1688.2,7241.6 1696.3,963.9 4125.2,978.0 4124.2,7283.3 1688.2,7241.6\" /></svg>"
         }
       },
       "body": {
@@ -988,8 +895,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1699.7,
-                4433.6
+                1696.3,
+                4431.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1009,8 +916,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1699.7,
-                967.9
+                1696.3,
+                963.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1040,15 +947,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1067,7 +974,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"405.1,6483.3 2892.0,6518.6 2888.6,6732.7 5861.0,6774.5 5861.0,7323.0 402.3,7323.0 405.1,6483.3\" /></svg>"
+          "value": "<svg><polygon points=\"398.3,7323.0 408.1,999.9 2922.2,1048.4 2916.7,2103.5 5861.0,2123.0 5861.0,7323.0 398.3,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -1081,8 +988,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                412.1,
-                4485.4
+                408.1,
+                4483.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1102,8 +1009,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                412.1,
-                1002.5
+                408.1,
+                999.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1137,11 +1044,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "13"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,7 +1067,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4114.6,6548.7 1538.7,6539.4 1538.7,798.0 903.4,796.9 907.3,61.1 5806.0,0.0 5806.0,801.3 4121.2,804.1 4114.6,6548.7\" /></svg>"
+          "value": "<svg><polygon points=\"1535.5,6543.1 1514.7,795.6 876.9,796.9 877.6,42.9 4096.9,0.0 4112.9,6543.0 1535.5,6543.1\" /></svg>"
         }
       },
       "body": {
@@ -1174,8 +1081,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1538.7,
-                6539.4
+                1535.5,
+                2995.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6297433,
+                41.8956607
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1535.5,
+                6543.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1188,27 +1116,6 @@
               "coordinates": [
                 -87.629704,
                 41.8940563
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1538.7,
-                798.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6297803,
-                41.8966555
               ]
             }
           }
@@ -1230,11 +1137,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "15"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1253,7 +1160,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4043.1,732.1 4044.1,6517.4 1798.0,6522.1 1788.5,741.4 4043.1,732.1\" /></svg>"
+          "value": "<svg><polygon points=\"1791.6,6518.4 1810.4,1971.1 3202.2,2426.3 3192.6,6521.3 1791.6,6518.4\" /></svg>"
         }
       },
       "body": {
@@ -1267,8 +1174,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4034.0,
-                2944.2
+                1804.3,
+                2947.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1279,8 +1186,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6268284,
-                41.8957065
+                -87.6281806,
+                41.8956822
               ]
             }
           },
@@ -1288,8 +1195,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1798.0,
-                6522.1
+                4036.7,
+                6523.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1300,8 +1207,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.628138,
-                41.8940776
+                -87.6267831,
+                41.894099
               ]
             }
           }
@@ -1326,8 +1233,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1346,7 +1253,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"842.1,740.8 288.0,741.1 288.0,0.0 5806.0,66.6 5806.0,6470.4 5123.0,6469.3 5125.0,7233.4 4840.1,7232.7 4837.7,6464.1 827.0,6473.2 842.1,740.8\" /></svg>"
+          "value": "<svg><polygon points=\"2908.9,753.1 3962.7,749.5 4205.9,0.0 5806.0,0.0 5806.0,6468.0 5135.7,6467.5 5138.3,7227.6 4848.3,7227.1 4850.3,6462.6 -0.0,6475.3 -0.0,2419.0 1566.6,2927.6 3034.1,2933.0 3018.6,1006.9 2908.9,753.1\" /></svg>"
         }
       },
       "body": {
@@ -1360,8 +1267,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                827.0,
-                2932.7
+                835.7,
+                2931.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1381,8 +1288,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                827.0,
-                6473.2
+                835.7,
+                6475.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1393,7 +1300,7 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6267812,
+                -87.6267831,
                 41.894099
               ]
             }
@@ -1419,8 +1326,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1439,7 +1346,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4718.6,0.0 4720.5,726.6 5809.0,730.4 5809.0,6537.5 1032.5,6541.8 1015.6,0.0 4718.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4714.2,0.0 4730.2,6543.6 1022.7,6546.4 1012.4,0.0 4714.2,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +1360,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.4,
-                2944.2
+                2692.5,
+                2947.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1474,8 +1381,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.4,
-                6542.3
+                2692.5,
+                6547.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1486,7 +1393,7 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6227574,
+                -87.6227571,
                 41.8941636
               ]
             }
@@ -1505,15 +1412,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1532,7 +1439,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1066.6,6542.2 1081.6,772.2 914.2,771.0 175.9,767.6 -0.0,765.5 -0.0,-0.0 5806.0,0.0 5806.0,6517.1 1066.6,6542.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 5806.0,0.0 5806.0,6515.8 -0.0,6539.2 -0.0,770.7 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1546,8 +1453,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2045.8,
-                2952.8
+                2051.3,
+                2955.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1567,8 +1474,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2045.8,
-                6516.4
+                2051.3,
+                6515.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1588,7 +1495,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -1603,10 +1510,26 @@
         {
           "label": "intersections",
           "value": "6"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5798.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7323.0"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1615,7 +1538,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/info.json",
@@ -1625,11 +1548,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1104.6,5481.9 1467.3,0.0 5798.0,0.0 5798.0,7323.0 5182.9,5743.6 1542.4,5894.6 1565.8,5512.2 1104.6,5481.9\" /></svg>"
+          "value": "<svg><polygon points=\"1576.0,0.0 5798.0,0.0 5798.0,5796.4 1123.0,5470.0 1576.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0016N__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1639,8 +1562,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1504.3,
-                6493.3
+                1507.5,
+                6495.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1660,8 +1583,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3230.4,
-                702.9
+                3334.8,
+                703.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1698,8 +1621,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1718,7 +1641,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4315.2,958.0 4726.3,6286.6 4681.5,7323.0 270.3,7219.6 216.0,6699.4 652.6,5646.8 655.8,923.1 4315.2,958.0\" /></svg>"
+          "value": "<svg><polygon points=\"2609.8,946.6 4314.2,962.5 4657.2,7323.0 280.7,7224.7 226.2,6704.6 2609.8,946.6\" /></svg>"
         }
       },
       "body": {
@@ -1732,8 +1655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4111.7,
-                4531.5
+                4114.6,
+                4535.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1753,8 +1676,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5030.9,
-                962.2
+                5034.3,
+                967.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1791,8 +1714,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1811,7 +1734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5559.3,6337.6 483.0,6366.0 417.5,5635.4 -0.0,4885.0 -0.0,973.3 5519.0,955.6 5559.3,6337.6\" /></svg>"
+          "value": "<svg><polygon points=\"5560.6,6348.7 419.5,6371.9 353.9,5526.4 -0.0,4887.2 -0.0,965.6 5529.5,957.4 5560.6,6348.7\" /></svg>"
         }
       },
       "body": {
@@ -1825,8 +1748,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5538.6,
-                2762.7
+                5546.1,
+                2767.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1846,8 +1769,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                815.5,
-                6352.2
+                811.7,
+                6355.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1877,15 +1800,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1904,7 +1827,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4049.2,6324.2 1694.1,6307.7 1685.0,967.4 4053.8,972.7 4049.2,6324.2\" /></svg>"
+          "value": "<svg><polygon points=\"4048.8,6330.2 1692.6,6313.7 1683.4,970.7 4053.4,976.0 4048.8,6330.2\" /></svg>"
         }
       },
       "body": {
@@ -1918,8 +1841,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1694.1,
-                2760.5
+                1692.6,
+                2764.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1939,8 +1862,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1694.1,
-                6307.7
+                1692.6,
+                6313.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1977,8 +1900,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1997,7 +1920,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4221.1,916.9 4261.8,6324.9 1711.7,6322.9 1700.2,916.1 4221.1,916.9\" /></svg>"
+          "value": "<svg><polygon points=\"4268.4,6335.8 1714.9,6333.8 1705.2,1762.3 4233.9,1750.9 4268.4,6335.8\" /></svg>"
         }
       },
       "body": {
@@ -2011,8 +1934,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1700.2,
-                2728.1
+                1703.4,
+                2731.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2032,8 +1955,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1700.2,
-                916.1
+                1703.4,
+                915.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2070,8 +1993,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2090,7 +2013,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3863.7,6276.9 1653.8,6267.4 1653.8,945.1 4187.2,960.4 4176.8,2733.2 3920.3,2733.0 3863.7,6276.9\" /></svg>"
+          "value": "<svg><polygon points=\"1660.6,5268.3 1660.6,948.3 4193.6,963.5 4183.2,2736.0 3926.7,2735.8 3886.1,5278.5 1660.6,5268.3\" /></svg>"
         }
       },
       "body": {
@@ -2104,8 +2027,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1653.8,
-                945.1
+                1660.6,
+                948.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2125,8 +2048,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1653.8,
-                6267.4
+                1660.6,
+                6269.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2163,8 +2086,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2183,7 +2106,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1578.3,5326.3 1609.7,2775.9 1868.1,2774.2 1865.7,989.9 4178.5,991.0 4175.6,7323.0 1580.5,7323.0 1587.3,5326.3 1578.3,5326.3\" /></svg>"
+          "value": "<svg><polygon points=\"1584.0,5333.9 1613.6,2780.9 1872.0,2779.0 1868.4,993.2 4181.3,992.7 4182.9,7323.0 1587.5,7323.0 1593.0,5333.9 1584.0,5333.9\" /></svg>"
         }
       },
       "body": {
@@ -2197,8 +2120,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4178.5,
-                2768.5
+                4182.6,
+                2771.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2218,8 +2141,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4178.5,
-                991.0
+                4182.6,
+                6339.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2230,8 +2153,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.631182,
-                41.8940363
+                -87.631127,
+                41.8916211
               ]
             }
           }
@@ -2256,8 +2179,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2276,7 +2199,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4101.3,959.0 4121.6,6355.6 1640.9,6366.1 1639.5,962.6 4101.3,959.0\" /></svg>"
+          "value": "<svg><polygon points=\"4101.4,965.8 4121.7,6354.7 1644.6,6365.1 1643.3,969.5 4101.4,965.8\" /></svg>"
         }
       },
       "body": {
@@ -2290,8 +2213,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1642.3,
-                2760.5
+                1644.6,
+                2764.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2311,8 +2234,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1642.3,
-                4535.5
+                1644.6,
+                4537.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2349,8 +2272,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2369,7 +2292,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1685.5,889.0 4285.2,971.2 4100.5,7323.0 1495.9,7323.0 1685.5,889.0\" /></svg>"
+          "value": "<svg><polygon points=\"1531.5,6267.1 1529.3,949.7 4098.6,954.3 4101.9,6269.1 1531.5,6267.1\" /></svg>"
         }
       },
       "body": {
@@ -2383,8 +2306,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4233.2,
-                2751.2
+                1531.5,
+                2715.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2395,8 +2318,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6281158,
-                41.8932791
+                -87.6296811,
+                41.8932553
               ]
             }
           },
@@ -2404,8 +2327,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1527.3,
-                6265.7
+                1531.5,
+                6267.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2439,11 +2362,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "16"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2462,7 +2385,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5047.4,6287.2 582.0,6296.6 582.0,904.8 5038.3,900.6 5047.4,6287.2\" /></svg>"
+          "value": "<svg><polygon points=\"5053.9,6273.9 613.4,6298.3 595.1,936.5 5026.6,917.2 5053.9,6273.9\" /></svg>"
         }
       },
       "body": {
@@ -2476,8 +2399,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                582.0,
-                4486.6
+                2845.0,
+                4489.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2488,8 +2411,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6280935,
-                41.8924761
+                -87.626742,
+                41.8924976
               ]
             }
           },
@@ -2497,8 +2420,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                582.0,
-                904.8
+                2845.0,
+                2716.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2509,8 +2432,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.628138,
-                41.8940776
+                -87.6267605,
+                41.8932946
               ]
             }
           }
@@ -2535,8 +2458,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2555,7 +2478,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"677.1,852.7 2544.2,854.1 2542.3,1631.4 2830.5,1633.7 2832.6,860.9 5162.4,879.4 5152.1,4474.0 2803.5,4430.5 2810.3,4264.3 2517.3,4256.1 2518.1,4428.3 665.9,4414.3 677.1,852.7\" /></svg>"
+          "value": "<svg><polygon points=\"672.7,4419.0 683.9,851.9 2553.0,853.3 2546.1,1627.0 2839.6,1629.3 2841.8,860.0 5174.6,878.6 5155.0,4441.5 2812.6,4435.2 2821.1,4225.7 2306.8,4431.4 672.7,4419.0\" /></svg>"
         }
       },
       "body": {
@@ -2569,8 +2492,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                677.1,
-                2641.7
+                683.9,
+                2643.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2590,8 +2513,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                677.1,
-                852.7
+                683.9,
+                851.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2621,15 +2544,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2648,7 +2571,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"851.4,962.4 4928.2,908.9 4983.3,7299.2 915.7,7322.0 851.4,962.4\" /></svg>"
+          "value": "<svg><polygon points=\"4947.9,874.2 5002.3,6301.6 895.0,6368.8 841.3,936.4 4947.9,874.2\" /></svg>"
         }
       },
       "body": {
@@ -2662,8 +2585,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4972.9,
-                6296.2
+                856.3,
+                2744.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2674,8 +2597,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.620235,
-                41.891803
+                -87.6227349,
+                41.8933604
               ]
             }
           },
@@ -2683,8 +2606,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                849.9,
-                962.4
+                4977.7,
+                4533.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2695,8 +2618,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6227574,
-                41.8941636
+                -87.6202626,
+                41.8925884
               ]
             }
           }
@@ -2714,15 +2637,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2741,7 +2664,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"325.4,954.6 4071.3,956.8 4071.6,0.0 4520.9,0.0 4561.8,4571.4 3450.9,4572.8 3439.0,7323.0 329.5,7323.0 325.4,954.6\" /></svg>"
+          "value": "<svg><polygon points=\"4078.0,958.2 4078.4,0.0 4526.7,0.0 4530.9,957.0 5803.0,961.2 5803.0,4597.9 3461.4,4587.8 3449.5,7323.0 331.8,7323.0 327.9,955.9 4078.0,958.2\" /></svg>"
         }
       },
       "body": {
@@ -2755,8 +2678,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                325.6,
-                2739.6
+                327.9,
+                955.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2767,8 +2690,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6202831,
-                41.8934121
+                -87.6203072,
+                41.8942136
               ]
             }
           },
@@ -2776,8 +2699,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                325.6,
-                6323.4
+                327.9,
+                6331.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2807,15 +2730,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2834,7 +2757,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4175.6 409.5,0.0 3947.6,0.0 4480.9,1557.5 4545.5,0.0 5753.0,0.0 5753.0,5062.3 4350.1,4895.2 4375.0,4672.5 -0.0,4175.6\" /></svg>"
+          "value": "<svg><polygon points=\"1562.4,990.5 302.9,978.6 304.5,31.3 4439.4,0.0 5753.0,2609.1 5753.0,7323.0 4654.8,7323.0 4683.1,4623.3 1540.2,4590.3 1562.4,990.5\" /></svg>"
         }
       },
       "body": {
@@ -2848,29 +2771,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3900.6,
-                6381.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6151976,
-                41.8918751
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4295.3,
-                1016.9
+                4240.7,
+                1015.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2883,6 +2785,27 @@
               "coordinates": [
                 -87.6153782,
                 41.894289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5424.9,
+                4591.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6145965,
+                41.8926846
               ]
             }
           }
@@ -2907,8 +2830,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2927,7 +2850,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4136.7,6569.2 1715.4,6571.9 1714.4,6340.5 -0.0,6357.2 -0.0,0.0 3850.7,0.0 4136.7,992.1 4136.7,6569.2\" /></svg>"
+          "value": "<svg><polygon points=\"4140.7,6575.6 3839.8,7323.0 2135.8,7323.0 2128.5,6577.9 1719.0,6578.4 1717.9,6347.3 -0.0,6364.1 0.0,0.0 3852.8,0.0 4140.7,997.9 4140.7,6575.6\" /></svg>"
         }
       },
       "body": {
@@ -2941,8 +2864,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4136.7,
-                2909.6
+                4140.7,
+                2915.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2962,8 +2885,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4136.7,
-                4733.2
+                4140.7,
+                4739.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2997,11 +2920,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3020,7 +2943,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 5803.0,-0.0 5803.0,6347.5 -0.0,6389.1 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"2597.8,6375.6 2577.6,5235.8 -0.0,5281.3 0.0,-0.0 5803.0,-0.0 5803.0,6352.7 2597.8,6375.6\" /></svg>"
         }
       },
       "body": {
@@ -3034,8 +2957,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3333.7,
-                495.5
+                3339.4,
+                519.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3055,8 +2978,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3333.7,
-                6654.7
+                3339.4,
+                6659.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3093,8 +3016,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3113,7 +3036,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2792.0,6502.1 -0.0,6657.1 -0.0,1201.6 5112.9,1015.1 5301.5,6432.2 3521.6,6483.0 3593.8,7256.1 5303.4,7209.1 5315.6,7323.0 2811.5,7323.0 2792.0,6502.1\" /></svg>"
+          "value": "<svg><polygon points=\"2698.7,6432.3 -0.0,6516.2 -0.0,1077.6 5162.4,1024.0 5206.2,6429.4 3481.1,6431.9 3476.5,7201.7 5172.0,7167.2 5171.2,7323.0 2696.6,7323.0 2698.7,6432.3\" /></svg>"
         }
       },
       "body": {
@@ -3127,8 +3050,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5171.1,
-                2800.1
+                1424.2,
+                2803.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6392501,
+                41.8907315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5172.9,
+                2803.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3141,27 +3085,6 @@
               "coordinates": [
                 -87.6370023,
                 41.8907484
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3364.8,
-                6487.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6381188,
-                41.889119
               ]
             }
           }
@@ -3186,8 +3109,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3206,7 +3129,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1662.5,1060.1 4077.2,1038.5 4163.5,4655.4 1714.8,7323.0 -0.0,7323.0 -0.0,6540.7 1662.5,1060.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6544.3 1667.7,1063.9 4081.4,1042.5 4167.3,4659.4 1672.1,7323.0 -0.0,7323.0 -0.0,6544.3\" /></svg>"
         }
       },
       "body": {
@@ -3220,8 +3143,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4163.5,
-                4655.4
+                4167.3,
+                4659.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3241,8 +3164,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1662.5,
-                1060.1
+                1667.7,
+                1063.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3279,8 +3202,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3299,7 +3222,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4210.9,3737.4 1746.9,3890.2 1746.2,1121.5 5825.0,1164.3 5825.0,4635.3 4454.9,4718.6 4200.2,4617.9 4210.9,3737.4\" /></svg>"
+          "value": "<svg><polygon points=\"4209.6,4050.5 1750.0,4021.7 1748.2,1123.0 5825.0,1164.0 5825.0,4732.4 4204.7,4619.4 4209.6,4050.5\" /></svg>"
         }
       },
       "body": {
@@ -3313,8 +3236,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1725.6,
-                2837.6
+                1728.3,
+                2839.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3334,8 +3257,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4200.2,
-                4617.9
+                4204.7,
+                4619.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3372,8 +3295,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3392,7 +3315,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3444.7,4515.2 3415.4,1003.0 4015.4,1002.8 4013.8,4515.6 3444.7,4515.2\" /></svg>"
+          "value": "<svg><polygon points=\"1805.0,1004.2 1800.4,0.0 4033.2,0.0 4021.8,1003.6 1805.0,1004.2\" /></svg>"
         }
       },
       "body": {
@@ -3406,8 +3329,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1800.5,
-                2725.2
+                1804.3,
+                2727.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3427,8 +3350,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1800.5,
-                4511.3
+                1804.3,
+                4515.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3465,8 +3388,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3485,7 +3408,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1416.8,4613.7 1409.4,2026.2 4042.3,2024.4 4042.5,2794.6 5831.0,2802.2 5831.0,4813.1 5748.0,4606.7 1416.8,4613.7\" /></svg>"
+          "value": "<svg><polygon points=\"4043.6,2018.0 4043.9,2795.6 5831.0,2803.3 5831.0,4608.9 831.6,4617.4 840.0,2790.4 -0.0,2793.6 -0.0,1037.2 1407.2,1032.2 1410.0,2018.0 4043.6,2018.0\" /></svg>"
         }
       },
       "body": {
@@ -3499,8 +3422,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4041.9,
-                4609.3
+                4043.3,
+                4611.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3520,8 +3443,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4041.9,
-                1019.8
+                4043.3,
+                1019.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3551,15 +3474,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3578,7 +3501,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1761.9,973.9 4250.5,974.7 4248.7,2770.3 3714.8,4774.5 3533.3,4774.5 3534.3,4568.0 1754.4,2748.3 1761.9,973.9\" /></svg>"
+          "value": "<svg><polygon points=\"1758.6,2749.3 1760.8,978.5 2784.3,975.8 2804.4,2755.4 1758.6,2749.3\" /></svg>"
         }
       },
       "body": {
@@ -3592,8 +3515,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1754.4,
-                2748.3
+                4244.7,
+                4559.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3604,8 +3527,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6311089,
-                41.8908304
+                -87.6295984,
+                41.8900425
               ]
             }
           },
@@ -3613,8 +3536,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1754.4,
-                6366.6
+                4244.7,
+                971.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3625,8 +3548,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6310629,
-                41.8892182
+                -87.6296377,
+                41.8916443
               ]
             }
           }
@@ -3651,8 +3574,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3671,7 +3594,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1468.8,2958.9 4090.8,2915.2 4081.4,3718.1 1459.3,3690.6 1468.8,2958.9\" /></svg>"
+          "value": "<svg><polygon points=\"4092.7,3706.3 927.1,3679.2 905.3,5703.4 772.8,5702.3 684.0,5491.8 743.1,3676.0 -0.0,3663.3 -0.0,1868.0 4107.3,1907.7 4092.7,3706.3\" /></svg>"
         }
       },
       "body": {
@@ -3685,8 +3608,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1428.9,
-                5490.8
+                1431.8,
+                5499.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3706,8 +3629,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4102.4,
-                1930.1
+                4107.3,
+                1907.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3744,8 +3667,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3764,7 +3687,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1947.4,3673.0 1937.4,1859.3 4220.4,1846.6 4222.3,3655.0 1947.4,3673.0\" /></svg>"
+          "value": "<svg><polygon points=\"1944.6,3650.0 1948.3,1839.7 4227.2,1844.3 5683.6,5488.3 5710.4,6862.8 4739.5,7081.0 1944.6,3650.0\" /></svg>"
         }
       },
       "body": {
@@ -3778,8 +3701,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1947.4,
-                3673.0
+                1948.3,
+                1839.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3790,8 +3713,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6280481,
-                41.8908707
+                -87.628071,
+                41.8916668
               ]
             }
           },
@@ -3799,8 +3722,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4220.4,
-                1846.6
+                1948.3,
+                5483.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3811,8 +3734,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6267252,
-                41.8916883
+                -87.6280205,
+                41.8900646
               ]
             }
           }
@@ -3837,8 +3760,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3857,7 +3780,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1804.0,3489.8 1818.4,1703.8 3182.2,1705.3 3214.1,3495.4 1804.0,3489.8\" /></svg>"
+          "value": "<svg><polygon points=\"1806.7,3494.0 1821.1,1706.4 3192.8,1707.9 3293.4,7322.0 3120.8,7322.0 2317.4,7322.0 1806.7,3494.0\" /></svg>"
         }
       },
       "body": {
@@ -3871,8 +3794,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4056.6,
-                3498.2
+                4061.4,
+                3501.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3892,8 +3815,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4056.6,
-                1705.9
+                4061.4,
+                1708.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3923,15 +3846,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3950,7 +3873,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1684.2,1047.4 1403.9,70.8 5879.0,0.0 5879.0,723.4 4258.7,728.1 4127.2,1017.1 4148.2,6535.3 1678.1,6535.3 1684.2,1047.4\" /></svg>"
+          "value": "<svg><polygon points=\"1687.8,1056.1 1405.8,73.9 5879.0,0.0 5879.0,732.1 4260.7,736.8 4129.3,1025.8 4150.2,6543.9 1681.7,6544.0 1687.8,1056.1\" /></svg>"
         }
       },
       "body": {
@@ -3964,8 +3887,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4141.2,
-                4728.6
+                4143.3,
+                4737.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3985,8 +3908,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1680.1,
-                4728.6
+                1683.7,
+                4737.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4016,15 +3939,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4043,7 +3966,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"711.5,1987.5 676.6,207.2 2500.1,0.0 2652.6,0.0 2789.5,0.0 5097.8,106.1 5820.0,2842.1 5820.0,3601.3 2688.5,6217.5 711.5,1987.5\" /></svg>"
+          "value": "<svg><polygon points=\"708.9,118.1 2537.6,117.5 2536.2,0.0 5129.8,105.6 5134.6,1497.3 708.1,1601.6 708.9,118.1\" /></svg>"
         }
       },
       "body": {
@@ -4057,8 +3980,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2725.6,
-                3670.1
+                720.0,
+                5427.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4069,8 +3992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6241601,
-                41.8909467
+                -87.62534,
+                41.8901081
               ]
             }
           },
@@ -4078,8 +4001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5140.0,
-                1901.3
+                5136.0,
+                1899.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4109,15 +4032,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "12"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4136,7 +4059,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2534.1 221.4,592.0 2829.3,780.7 2880.2,0.0 5617.4,0.0 5545.1,973.6 5820.0,1102.5 5528.5,1083.2 5016.7,7323.0 -0.0,7323.0 -0.0,2534.1\" /></svg>"
+          "value": "<svg><polygon points=\"75.6,635.3 2654.3,630.5 2648.8,0.0 5337.4,0.0 5339.3,621.9 5820.0,735.0 5331.9,738.8 5282.7,7323.0 -0.0,7323.0 75.6,635.3\" /></svg>"
         }
       },
       "body": {
@@ -4150,29 +4073,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2829.3,
-                780.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.635528,
-                41.8899603
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                466.8,
-                2587.0
+                464.0,
+                2579.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4185,6 +4087,27 @@
               "coordinates": [
                 -87.6367468,
                 41.889126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5292.0,
+                2579.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6340209,
+                41.8891589
               ]
             }
           }
@@ -4202,15 +4125,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4229,7 +4152,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6327.0 1805.2,6207.3 1902.2,0.0 4663.3,0.0 4456.2,7278.9 -0.0,7323.0 -0.0,6327.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6609.8 1797.5,6624.0 1899.4,0.0 4662.6,0.0 4648.9,3458.8 4456.4,4669.8 4429.2,7209.5 -0.0,7323.0 -0.0,6609.8\" /></svg>"
         }
       },
       "body": {
@@ -4243,8 +4166,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1849.7,
-                1858.1
+                1844.6,
+                1851.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4264,8 +4187,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4278.5,
-                1858.1
+                4277.5,
+                1851.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4299,11 +4222,11 @@
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4322,37 +4245,34 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1625.6,6817.2 1872.2,73.6 5828.0,42.8 5828.0,247.0 4142.7,199.3 4049.4,7053.7 5394.1,7094.7 5386.9,7219.8 2385.9,7122.7 2383.7,7323.0 -0.0,7323.0 -0.0,6764.5 1625.6,6817.2\" /></svg>"
+          "value": "<svg><polygon points=\"2025.8,109.6 5828.0,152.8 5828.0,7323.0 -0.0,7323.0 -0.0,6414.4 2025.8,109.6\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                1684.0,
+                1791.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6336016864351,
-                41.88996998929027
+                -87.6326564,
+                41.8891834
               ]
             }
           },
@@ -4360,71 +4280,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5828.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6300711661468,
-                41.89005508875374
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5828.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.62992755035009,
-                41.88675198170654
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7323.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.63345807063838,
-                41.88666688224307
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4131.2,
-                1800.5
+                4132.0,
+                1791.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4454,15 +4311,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4481,7 +4338,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6866.4 1669.5,0.0 4113.9,0.0 5866.0,7002.9 5866.0,7002.9 5866.0,7323.0 -0.0,7323.0 -0.0,6866.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6866.3 -0.0,6527.5 1644.1,6556.1 1665.2,0.0 4110.8,0.0 4086.3,6265.1 5866.0,6363.3 5866.0,7323.0 2974.5,7323.0 2897.2,6929.7 2893.0,7323.0 1645.0,7323.0 1646.2,7003.2 -0.0,6866.3\" /></svg>"
         }
       },
       "body": {
@@ -4495,29 +4352,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4108.5,
-                1561.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6295795,
-                41.8892418
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1676.8,
-                1561.4
+                1672.6,
+                1559.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4530,6 +4366,27 @@
               "coordinates": [
                 -87.6310629,
                 41.8892182
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4105.4,
+                1559.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6295795,
+                41.8892418
               ]
             }
           }
@@ -4547,15 +4404,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4574,22 +4431,109 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"413.9,7170.9 378.3,6878.7 1569.1,6889.5 1555.7,1538.3 4255.0,1538.3 4137.3,3160.9 4291.6,3114.6 4343.3,3265.0 4347.1,5412.4 5828.0,5414.5 5828.0,7323.0 413.9,7170.9\" /></svg>"
+          "value": "<svg><polygon points=\"5828.0,1452.3 5828.0,7323.0 1449.7,7323.0 1161.4,1689.0 5828.0,1452.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0046N/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4255.0,
-                1538.3
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63014101245237,
+                41.88989622912145
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62717750207356,
+                41.88982162855844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62730341501971,
+                41.88704871866702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63026692539852,
+                41.88712331923003
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4248.0,
+                1539.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4609,8 +4553,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1555.7,
-                1538.3
+                4248.0,
+                1539.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4621,8 +4565,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6295795,
-                41.8892418
+                -87.6280074,
+                41.8892588
               ]
             }
           }
@@ -4647,8 +4591,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4667,7 +4611,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5251.9,3557.6 516.5,3640.4 517.9,2060.9 -0.0,2067.9 -0.0,81.9 5357.4,63.7 5388.8,3234.3 5251.9,3557.6\" /></svg>"
+          "value": "<svg><polygon points=\"4256.6,7323.0 4450.0,3651.3 514.0,3643.7 515.4,2068.9 -0.0,2070.2 -0.0,78.2 5866.0,59.2 5866.0,7323.0 4256.6,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -4681,8 +4625,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3128.9,
-                1863.9
+                3129.1,
+                1863.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4693,7 +4637,7 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6280185,
+                -87.6280205,
                 41.8900646
               ]
             }
@@ -4702,8 +4646,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                518.6,
-                1863.9
+                516.2,
+                1863.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4733,15 +4677,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4760,7 +4704,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5828.0,7323.0 706.9,7323.0 700.4,5266.2 650.7,5122.2 503.0,5166.8 613.6,3612.5 2801.0,3490.4 2827.0,28.2 5010.9,9.1 5023.7,2948.8 5828.0,2770.3 5828.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"999.4,7323.0 354.2,5355.2 -0.0,5469.1 -0.0,0.0 5828.0,0.0 5828.0,4438.5 4800.2,4775.8 4987.7,4988.8 5612.8,6863.4 4178.3,7323.0 999.4,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -4774,8 +4718,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5024.2,
-                1794.7
+                604.0,
+                6127.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4786,8 +4730,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62534,
-                41.8901081
+                -87.6282103,
+                41.8966783
               ]
             }
           },
@@ -4795,8 +4739,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                613.6,
-                3612.5
+                2784.0,
+                5415.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4807,8 +4751,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6280074,
-                41.8892588
+                -87.6268484,
+                41.8967018
               ]
             }
           }
@@ -4833,8 +4777,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4853,7 +4797,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1543.4,4790.9 743.6,4943.6 817.4,2039.4 -0.0,2023.5 -0.0,286.6 2658.0,344.4 2632.0,2054.4 2912.4,2060.5 2940.2,351.4 5242.1,406.8 5226.0,2107.5 5847.0,2123.0 5847.0,7322.0 1468.0,7322.0 1543.4,4790.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,279.2 842.5,294.9 849.6,0.0 5247.3,0.0 5221.7,2141.0 5847.0,2154.3 5847.0,3985.8 5847.0,6167.6 5847.0,7322.0 -0.0,7322.0 -0.0,279.2\" /></svg>"
         }
       },
       "body": {
@@ -4867,8 +4811,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                778.1,
-                3803.6
+                771.9,
+                3801.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4888,8 +4832,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2772.2,
-                2057.4
+                2767.5,
+                2052.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4926,8 +4870,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4946,7 +4890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4032.4,694.5 4110.8,6545.2 1692.6,6555.2 1648.6,1001.6 1779.8,710.3 4032.4,694.5\" /></svg>"
+          "value": "<svg><polygon points=\"4038.0,692.1 4116.7,6565.3 1688.9,6575.4 1644.8,1000.5 1776.5,708.0 4038.0,692.1\" /></svg>"
         }
       },
       "body": {
@@ -4960,8 +4904,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4110.8,
-                2941.3
+                4116.7,
+                2947.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4981,8 +4925,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4110.8,
-                6545.2
+                1660.3,
+                2947.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4993,8 +4937,167 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6385378,
-                41.8939406
+                -87.640025,
+                41.8955262
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p50N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5804
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"905.3,2474.8 888.0,371.9 5705.9,353.1 5804.0,7323.0 1749.9,7323.0 1661.2,2477.0 905.3,2474.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0050N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6231416362396,
+                41.891883374981866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5804.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62018954331725,
+                41.89193764994357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5804.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62009755769601,
+                41.88916400115941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62304965061837,
+                41.8891097261977
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                888.0,
+                371.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6226853,
+                41.8917508
               ]
             }
           }
@@ -5019,8 +5122,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5039,7 +5142,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5811.0,1.4 5811.0,7323.0 -0.0,7323.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5811.0,0.0 5811.0,7323.0 -0.0,7323.0 0.0,-0.0 5811.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -5053,8 +5156,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5514.3,
-                3635.6
+                5515.1,
+                3631.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5074,8 +5177,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5514.3,
-                1846.6
+                5515.1,
+                1839.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5088,6 +5191,99 @@
               "coordinates": [
                 -87.6151976,
                 41.8918751
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0055W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p55W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0055W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0055W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5813
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"305.1,7322.0 225.0,5345.0 -0.0,5350.6 0.0,0.0 5813.0,0.0 5813.0,7322.0 305.1,7322.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0055W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                244.0,
+                6945.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6476914,
+                41.8933844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4416.8,
+                6945.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6458911,
+                41.8933864
               ]
             }
           }
@@ -5109,11 +5305,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5132,7 +5328,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 5813.0,9.2 5813.0,6097.4 1409.6,6060.8 2847.6,7323.0 -0.0,7323.0 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1392.3,7323.0 -0.0,7323.0 -0.0,18.5 1404.2,14.6 1435.0,1434.6 3935.0,1481.6 3947.7,3703.1 4401.0,3703.6 4376.8,6083.2 1404.6,6061.4 1392.3,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -5146,8 +5342,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4380.6,
-                6084.3
+                4376.8,
+                6083.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5167,8 +5363,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1406.4,
-                1166.7
+                1396.2,
+                1163.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5205,8 +5401,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5225,7 +5421,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5468.1,0.0 5466.9,227.0 5865.0,230.3 5865.0,6043.3 1844.6,6057.1 1872.1,0.0 5468.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"452.1,3683.5 -0.0,3680.5 -0.0,1465.2 1450.4,1500.7 1487.2,0.0 5464.8,0.0 5463.6,226.4 5865.0,229.8 5865.0,6037.4 414.3,6056.0 452.1,3683.5\" /></svg>"
         }
       },
       "body": {
@@ -5239,8 +5435,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                452.3,
-                3687.4
+                452.1,
+                3683.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5260,8 +5456,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2834.6,
-                6092.9
+                2832.5,
+                6087.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5291,15 +5487,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5318,7 +5514,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"476.4,1210.0 5813.0,1154.6 5811.8,5963.8 159.5,6053.3 186.6,7323.0 -0.0,7323.0 -0.0,2456.6 1904.3,2435.0 476.4,1210.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2469.4 409.9,2463.4 404.1,1245.6 5615.0,1207.8 5574.1,3552.1 5728.1,3547.5 5664.3,5893.6 110.7,6004.9 125.4,7323.0 -0.0,7323.0 -0.0,2469.4\" /></svg>"
         }
       },
       "body": {
@@ -5332,8 +5528,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3397.9,
-                3629.8
+                416.1,
+                3631.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5344,8 +5540,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6458264,
-                41.8901056
+                -87.6476107,
+                41.8900883
               ]
             }
           },
@@ -5353,8 +5549,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3397.9,
-                1201.3
+                5617.0,
+                1207.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5365,8 +5561,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6458412,
-                41.8912112
+                -87.6443843,
+                41.8912254
               ]
             }
           }
@@ -5384,15 +5580,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5411,7 +5607,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5409.1,6002.2 5446.1,3658.6 5518.6,3657.8 5409.1,6002.2\" /></svg>"
+          "value": "<svg><polygon points=\"0,7323 0,0 5865,0 5865,7323 0,7323\" /></svg>"
         }
       },
       "body": {
@@ -5425,8 +5621,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2952.7,
-                3675.9
+                2940.5,
+                3671.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5446,8 +5642,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                242.0,
-                1253.1
+                268.0,
+                1247.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5481,11 +5677,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5504,7 +5700,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1063.1,673.3 1060.3,0.0 5879.0,0.0 5879.0,659.5 4071.6,658.9 4140.7,6413.2 1752.2,6423.0 1675.0,669.0 1063.1,673.3\" /></svg>"
+          "value": "<svg><polygon points=\"1066.5,679.9 1063.8,0.0 5879.0,0.0 5879.0,666.4 4072.8,665.7 4141.4,6418.6 1755.5,6428.2 1678.8,675.6 1066.5,679.9\" /></svg>"
         }
       },
       "body": {
@@ -5518,8 +5714,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1752.2,
-                2878.7
+                4099.3,
+                2884.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6371439,
+                41.8955545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1755.7,
+                2884.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5532,27 +5749,6 @@
               "coordinates": [
                 -87.6385661,
                 41.8955405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1752.2,
-                6423.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6385378,
-                41.8939406
               ]
             }
           }
@@ -5570,15 +5766,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5597,7 +5793,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1740.2,1261.2 4267.3,1165.2 4313.4,1728.9 5813.0,1734.1 5813.0,6034.3 1755.2,6014.4 1665.7,3639.4 1740.2,1261.2\" /></svg>"
+          "value": "<svg><polygon points=\"1662.6,3634.5 1704.3,1259.8 4240.2,1208.6 4304.9,1724.6 5813.0,1728.0 5813.0,6023.6 1753.6,6006.4 1818.6,3629.9 1662.6,3634.5\" /></svg>"
         }
       },
       "body": {
@@ -5611,8 +5807,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4069.4,
-                6000.7
+                4064.7,
+                5991.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5632,8 +5828,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1709.0,
-                1261.8
+                1704.3,
+                1259.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5667,11 +5863,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5690,7 +5886,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"941.1,1127.1 252.8,1079.4 253.4,0.0 3101.9,0.0 3075.3,1118.4 5828.0,1031.2 5828.0,4885.4 3376.4,4933.3 3416.7,6094.3 1031.7,6101.9 941.1,1127.1\" /></svg>"
+          "value": "<svg><polygon points=\"1029.7,6097.3 942.0,1119.5 261.5,1071.3 263.4,0.0 3159.2,0.0 3161.9,1115.8 3558.7,1140.0 4810.5,982.4 5828.0,1026.5 5828.0,4888.9 3376.5,4935.4 3393.6,5468.1 3405.1,5730.6 3416.0,6091.2 1029.7,6097.3\" /></svg>"
         }
       },
       "body": {
@@ -5704,8 +5900,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3416.7,
-                6095.8
+                3416.0,
+                6091.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5725,8 +5921,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                991.0,
-                1077.4
+                992.0,
+                1071.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5763,8 +5959,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5783,7 +5979,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5711.1,633.6 5651.4,5619.6 306.8,5480.9 310.4,4162.9 -0.0,4157.2 -0.0,602.0 5711.1,633.6\" /></svg>"
+          "value": "<svg><polygon points=\"5653.0,584.2 5665.0,5518.1 375.3,5457.1 362.0,4297.9 -0.0,4294.1 -0.0,634.4 5653.0,584.2\" /></svg>"
         }
       },
       "body": {
@@ -5797,8 +5993,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3301.5,
-                4152.3
+                360.1,
+                4153.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5809,8 +6005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6457272,
-                41.8874361
+                -87.6475357,
+                41.8873891
               ]
             }
           },
@@ -5818,101 +6014,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3301.5,
-                590.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6457947,
-                41.8890393
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p64W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"440.1,5594.7 489.7,592.0 5310.5,725.2 5290.8,5738.1 440.1,5594.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.4,
-                5660.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427857,
-                41.8868117
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                489.7,
-                593.4
+                5653.0,
+                584.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5932,6 +6035,99 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p64W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"484.0,5655.2 385.9,662.1 5199.8,652.7 5328.0,5655.2 484.0,5655.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                484.0,
+                5655.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6442784,
+                41.8868088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5328.0,
+                5655.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.641353,
+                41.8868082
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0065W/georef",
       "type": "Annotation",
       "@context": [
@@ -5942,15 +6138,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5969,7 +6165,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1245.0,1283.7 4155.8,1172.7 4662.6,3503.3 5877.0,3445.8 5877.0,6403.1 5194.8,6435.2 4998.1,6234.0 1527.2,6332.2 1536.9,6522.7 36.7,6603.5 154.0,7322.0 -0.0,7322.0 -0.0,0.0 1167.8,26.5 1245.0,1283.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 1442.0,0.0 1467.2,1149.0 4456.8,1152.3 4882.8,3562.8 5877.0,3554.5 5877.0,6104.0 5274.1,6110.3 5116.9,6376.8 2706.4,6350.3 102.6,6554.6 115.6,7322.0 -0.0,7322.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5983,8 +6179,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4456.7,
-                2365.7
+                1524.3,
+                4841.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5995,8 +6191,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6455034,
-                41.8862367
+                -87.6474629,
+                41.8851008
               ]
             }
           },
@@ -6004,8 +6200,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1526.9,
-                6330.7
+                4456.8,
+                1152.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6016,8 +6212,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6474391,
-                41.8844146
+                -87.6456691,
+                41.8868032
               ]
             }
           }
@@ -6035,15 +6231,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
           "value": "9"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6062,7 +6258,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1788.8,1116.5 2380.0,1129.6 2317.9,3642.4 2180.3,3641.2 1788.8,1116.5\" /></svg>"
+          "value": "<svg><polygon points=\"4055.3,1199.7 4174.2,6485.6 3789.7,6230.1 3202.7,6235.9 3204.2,3641.4 2437.1,3646.3 2192.2,3649.2 1760.0,1195.8 4055.3,1199.7\" /></svg>"
         }
       },
       "body": {
@@ -6076,8 +6272,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4136.9,
-                3667.3
+                4132.0,
+                4951.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6088,8 +6284,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6442408,
-                41.8857101
+                -87.6442158,
+                41.8851166
               ]
             }
           },
@@ -6097,8 +6293,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4136.9,
-                2428.5
+                1760.0,
+                1195.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6109,8 +6305,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.644261,
-                41.8862548
+                -87.6456691,
+                41.8868032
               ]
             }
           }
@@ -6128,15 +6324,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6155,7 +6351,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1839.6,6254.3 1860.2,7322.0 930.2,7322.0 914.2,6496.9 309.1,6503.8 113.3,6288.7 270.7,6019.9 1032.1,6009.1 1123.6,3441.6 -0.0,3454.1 -0.0,1029.4 4136.9,1025.8 4175.4,6230.8 1839.6,6254.3\" /></svg>"
+          "value": "<svg><polygon points=\"4128.7,1020.3 4173.4,6226.9 1836.9,6253.2 1691.0,1022.5 4128.7,1020.3\" /></svg>"
         }
       },
       "body": {
@@ -6169,8 +6365,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1754.5,
-                3434.8
+                1748.3,
+                3432.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6190,8 +6386,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4136.9,
-                1025.8
+                4128.7,
+                1020.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6221,15 +6417,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6248,7 +6444,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4131.3,6237.6 1744.4,6257.7 1676.7,993.9 4042.8,995.5 4131.3,6237.6\" /></svg>"
+          "value": "<svg><polygon points=\"1744.0,6267.2 1676.0,987.9 2193.4,988.2 2409.2,6261.6 1744.0,6267.2\" /></svg>"
         }
       },
       "body": {
@@ -6262,8 +6458,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1676.7,
-                3422.4
+                1676.0,
+                3423.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6283,8 +6479,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1676.7,
-                993.9
+                1676.0,
+                987.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6314,15 +6510,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6341,7 +6537,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4096.6,5884.1 1674.6,5798.2 1797.1,697.2 4123.9,762.4 4096.6,5884.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5741.3 -0.0,621.9 4124.0,761.9 4101.2,5038.5 1694.1,5025.1 1675.6,5795.7 -0.0,5741.3\" /></svg>"
         }
       },
       "body": {
@@ -6355,8 +6551,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4096.6,
-                3106.3
+                4096.7,
+                3104.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6376,8 +6572,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4096.6,
-                5884.1
+                4096.7,
+                5881.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6414,8 +6610,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6434,7 +6630,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4133.7,6603.2 1709.0,6585.5 1708.8,712.5 3553.7,735.2 3561.8,62.2 4185.1,30.4 4133.7,6603.2\" /></svg>"
+          "value": "<svg><polygon points=\"1782.4,6597.8 1709.6,745.0 3547.9,744.9 3547.6,66.9 4204.4,36.2 4197.2,6585.5 1782.4,6597.8\" /></svg>"
         }
       },
       "body": {
@@ -6448,8 +6644,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1709.0,
-                6585.5
+                4187.3,
+                4791.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6460,8 +6656,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63709,
-                41.8939592
+                -87.6356698,
+                41.8947745
               ]
             }
           },
@@ -6469,8 +6665,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4181.8,
-                743.2
+                4187.3,
+                743.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6481,7 +6677,7 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6357092,
+                -87.6357005,
                 41.8965708
               ]
             }
@@ -6500,15 +6696,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6527,7 +6723,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5813.0,7323.0 5417.5,7323.0 5421.7,6347.5 1340.8,6269.6 1291.1,0.0 5813.0,0.0 5813.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"5813.0,7323.0 5421.3,7323.0 5425.5,6348.1 1340.7,6270.2 1291.0,0.0 5813.0,0.0 5813.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -6541,8 +6737,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.4,
-                3485.8
+                1308.2,
+                3483.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6562,8 +6758,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.4,
-                1135.0
+                1308.2,
+                1131.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6593,15 +6789,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6620,7 +6816,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1474.9,824.2 1475.7,626.8 2688.1,654.6 2671.2,3417.6 5867.0,3432.8 5867.0,6441.9 394.2,6408.2 386.2,7322.0 -0.0,7322.0 -0.0,822.5 1474.9,824.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,772.1 2702.7,606.0 2659.9,6418.9 381.6,6408.1 372.1,7322.0 -0.0,7322.0 -0.0,772.1\" /></svg>"
         }
       },
       "body": {
@@ -6634,8 +6830,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1475.4,
-                6408.6
+                1471.7,
+                2088.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6474219,
+                41.8837316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1471.7,
+                6409.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6648,27 +6865,6 @@
               "coordinates": [
                 -87.6473605,
                 41.8817821
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1475.4,
-                625.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6474391,
-                41.8844146
               ]
             }
           }
@@ -6693,8 +6889,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6713,7 +6909,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4148.6,6461.6 3216.8,6459.9 3198.3,3449.8 -0.0,3454.2 -0.0,690.1 2382.9,743.6 2576.3,961.7 3183.0,962.7 3188.1,1789.6 4120.3,1801.8 4148.6,6461.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,685.1 2382.5,738.6 2543.8,471.2 3734.8,470.2 4113.9,726.9 4148.7,6459.1 -0.0,6451.4 -0.0,685.1\" /></svg>"
         }
       },
       "body": {
@@ -6727,8 +6923,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4150.1,
-                4966.5
+                4148.7,
+                4963.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6748,8 +6944,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4150.1,
-                6461.6
+                4148.7,
+                6459.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6786,8 +6982,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6806,7 +7002,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4086.2,6548.3 1751.6,6600.0 1659.8,899.0 3989.1,883.0 4086.2,6548.3\" /></svg>"
+          "value": "<svg><polygon points=\"3990.0,6599.3 1657.7,6539.8 1837.3,842.8 4162.6,937.6 3990.0,6599.3\" /></svg>"
         }
       },
       "body": {
@@ -6820,8 +7016,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4086.2,
-                6546.9
+                4083.3,
+                3661.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6832,8 +7028,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6426722,
-                41.8818475
+                -87.6427118,
+                41.8831922
               ]
             }
           },
@@ -6841,8 +7037,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1659.8,
-                899.0
+                1659.7,
+                6537.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6853,8 +7049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6441836,
-                41.8844246
+                -87.644106,
+                41.8818174
               ]
             }
           }
@@ -6879,8 +7075,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6899,7 +7095,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4200.3,840.6 4222.2,6521.2 1825.7,6516.4 1825.7,799.4 4200.3,840.6\" /></svg>"
+          "value": "<svg><polygon points=\"4214.9,5804.6 1822.3,5823.6 1822.3,799.9 4195.7,841.0 4214.9,5804.6\" /></svg>"
         }
       },
       "body": {
@@ -6913,8 +7109,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1827.2,
-                6516.4
+                1824.3,
+                6515.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6934,8 +7130,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1824.3,
-                800.9
+                1820.3,
+                799.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6972,8 +7168,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6992,7 +7188,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4146.7,6384.1 1720.9,6343.0 1754.5,779.1 4179.7,852.4 4054.8,1038.7 4037.5,3270.2 4176.5,3583.1 4146.7,6384.1\" /></svg>"
+          "value": "<svg><polygon points=\"1720.6,6341.5 1766.5,0.0 4178.3,0.0 4037.0,3265.1 4176.2,3578.2 4147.3,6381.7 1720.6,6341.5\" /></svg>"
         }
       },
       "body": {
@@ -7006,8 +7202,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1729.0,
-                3501.1
+                1727.7,
+                3497.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7027,8 +7223,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4146.7,
-                6385.5
+                4147.3,
+                6381.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7065,8 +7261,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7085,7 +7281,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3917.0,7322.0 3914.3,6466.5 1647.9,6440.2 1647.9,3547.2 1500.9,3225.6 1494.2,920.8 1621.1,726.9 5828.0,785.4 5828.0,7322.0 3917.0,7322.0\" /></svg>"
+          "value": "<svg><polygon points=\"3914.7,7322.0 3911.6,6464.0 1648.0,6437.8 1648.0,3545.0 1501.0,3223.4 1494.3,918.8 1621.3,725.0 5828.0,783.5 5828.0,7322.0 3914.7,7322.0\" /></svg>"
         }
       },
       "body": {
@@ -7099,8 +7295,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1647.9,
-                3547.2
+                1648.0,
+                3545.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7120,8 +7316,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1647.9,
-                6440.2
+                1648.0,
+                6437.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7158,8 +7354,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7178,7 +7374,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4322.8,7322.0 1507.6,7322.0 1492.7,921.2 4314.0,927.9 4323.5,4700.8 4321.4,7176.6 4322.8,7322.0\" /></svg>"
+          "value": "<svg><polygon points=\"4308.7,928.3 4319.5,7271.8 1505.8,7322.0 1488.4,922.7 4308.7,928.3\" /></svg>"
         }
       },
       "body": {
@@ -7192,29 +7388,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4314.0,
-                927.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6440868,
-                41.8805324
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1498.5,
-                6241.4
+                1496.3,
+                6241.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7227,6 +7402,27 @@
               "coordinates": [
                 -87.6473605,
                 41.8817821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4308.7,
+                928.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6440868,
+                41.8805324
               ]
             }
           }
@@ -7251,8 +7447,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7271,7 +7467,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1342.3,7322.0 1352.5,949.0 4154.2,901.9 4163.5,7322.0 1342.3,7322.0\" /></svg>"
+          "value": "<svg><polygon points=\"1350.6,945.6 4152.0,898.2 4162.0,7322.0 1341.1,7322.0 1350.6,945.6\" /></svg>"
         }
       },
       "body": {
@@ -7285,8 +7481,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1345.4,
-                6261.6
+                1344.0,
+                6257.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7306,8 +7502,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4154.2,
-                901.9
+                4152.0,
+                896.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7337,15 +7533,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7364,7 +7560,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4121.1,6487.2 1741.6,6529.9 1662.8,899.8 4015.9,852.6 4121.1,6487.2\" /></svg>"
+          "value": "<svg><polygon points=\"4062.7,6489.8 1689.4,6488.0 1715.6,871.6 4062.7,868.2 4062.7,6489.8\" /></svg>"
         }
       },
       "body": {
@@ -7378,8 +7574,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1671.4,
-                3731.6
+                4064.7,
+                868.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7390,8 +7586,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6440868,
-                41.8805324
+                -87.6426722,
+                41.8818475
               ]
             }
           },
@@ -7399,8 +7595,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4069.0,
-                3731.6
+                4064.7,
+                6489.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7411,8 +7607,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6426265,
-                41.8805412
+                -87.6425803,
+                41.8792909
               ]
             }
           }
@@ -7430,15 +7626,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7457,7 +7653,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1676.1,6494.7 1669.8,0.0 5835.0,0.0 5835.0,696.5 4167.1,709.5 4198.0,6493.6 1676.1,6494.7\" /></svg>"
+          "value": "<svg><polygon points=\"1736.7,0.0 5835.0,0.0 5835.0,715.1 4187.0,719.3 4190.0,7323.0 1670.1,7323.0 1736.7,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7471,8 +7667,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1671.3,
-                4715.9
+                4187.3,
+                4719.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7483,8 +7679,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6356698,
-                41.8947745
+                -87.6341577,
+                41.8947921
               ]
             }
           },
@@ -7492,8 +7688,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1671.3,
-                702.9
+                4187.3,
+                2935.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7504,8 +7700,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6357092,
-                41.8965708
+                -87.6341809,
+                41.8955921
               ]
             }
           }
@@ -7530,8 +7726,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7550,7 +7746,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4174.3,740.5 4124.3,6567.6 1668.0,6526.7 1705.6,710.8 4174.3,740.5\" /></svg>"
+          "value": "<svg><polygon points=\"4126.9,6561.6 1672.0,6525.8 1703.2,0.0 4167.8,0.0 4126.9,6561.6\" /></svg>"
         }
       },
       "body": {
@@ -7564,8 +7760,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4151.3,
-                3705.7
+                4148.0,
+                3701.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7585,8 +7781,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1668.0,
-                6526.7
+                1672.0,
+                6525.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7623,8 +7819,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7657,29 +7853,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1760.8,
-                5120.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6411293,
-                41.8793088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4184.4,
-                5120.5
+                4184.7,
+                5121.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7692,6 +7867,27 @@
               "coordinates": [
                 -87.6396562,
                 41.8793273
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1760.3,
+                5121.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6411293,
+                41.8793088
               ]
             }
           }
@@ -7713,11 +7909,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7736,7 +7932,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1140.8,1155.5 5828.0,1211.1 5828.0,6825.4 1136.2,6773.0 1140.8,1155.5\" /></svg>"
+          "value": "<svg><polygon points=\"1136.0,1150.3 5828.0,1208.7 5828.0,6832.1 1128.2,6777.0 1136.0,1150.3\" /></svg>"
         }
       },
       "body": {
@@ -7750,8 +7946,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1140.8,
-                4014.0
+                3548.0,
+                4009.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7762,8 +7958,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6411695,
-                41.880567
+                -87.6396933,
+                41.8805976
               ]
             }
           },
@@ -7771,8 +7967,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1140.8,
-                1155.5
+                1136.0,
+                1152.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7809,8 +8005,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7829,7 +8025,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4273.6,7120.9 4273.8,7322.0 1462.7,7322.0 1488.0,896.3 4312.9,880.7 4273.6,7120.9\" /></svg>"
+          "value": "<svg><polygon points=\"1455.5,7322.0 1462.1,2637.1 4293.2,2651.3 4277.3,7268.7 1455.5,7322.0\" /></svg>"
         }
       },
       "body": {
@@ -7843,8 +8039,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4276.6,
-                6224.1
+                2868.5,
+                868.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7855,8 +8051,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6472349,
-                41.8779467
+                -87.6440079,
+                41.8786291
               ]
             }
           },
@@ -7864,8 +8060,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2873.2,
-                6224.1
+                2868.5,
+                6221.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7902,8 +8098,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7922,7 +8118,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1592.0,7323.0 1596.8,906.1 4377.1,889.7 4409.0,7323.0 1592.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"4395.3,6264.0 5868.0,6258.2 5868.0,7323.0 1586.1,7323.0 1590.9,898.4 4376.4,881.9 4395.3,6264.0\" /></svg>"
         }
       },
       "body": {
@@ -7936,8 +8132,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2987.3,
-                893.0
+                2984.0,
+                883.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7957,8 +8153,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2987.3,
-                6265.7
+                2984.0,
+                6267.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7995,8 +8191,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8015,7 +8211,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4131.0,850.7 4191.6,6479.1 1808.3,6462.5 1752.2,877.4 4131.0,850.7\" /></svg>"
+          "value": "<svg><polygon points=\"4188.7,6473.8 1807.2,6458.3 1778.1,3694.7 -0.0,3696.9 -0.0,882.5 4125.3,848.3 4188.7,6473.8\" /></svg>"
         }
       },
       "body": {
@@ -8029,8 +8225,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1752.2,
-                876.0
+                1748.3,
+                876.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8050,8 +8246,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4190.2,
-                6477.7
+                4188.7,
+                6473.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8081,15 +8277,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8108,7 +8304,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1758.3,5392.2 1739.8,826.6 4134.8,838.3 4136.3,5413.7 1758.3,5392.2\" /></svg>"
+          "value": "<svg><polygon points=\"4137.4,829.4 4139.8,6499.8 1760.0,6495.1 1736.5,817.8 4137.4,829.4\" /></svg>"
         }
       },
       "body": {
@@ -8122,8 +8318,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1763.0,
-                3664.4
+                1760.0,
+                3663.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8143,8 +8339,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1763.0,
-                2258.5
+                1760.0,
+                6495.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8155,8 +8351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6425476,
-                41.8786453
+                -87.6424927,
+                41.8767364
               ]
             }
           }
@@ -8181,8 +8377,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8201,7 +8397,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1723.3,887.5 4113.6,920.1 4163.7,5258.7 3983.3,7322.0 1670.3,7322.0 1723.3,887.5\" /></svg>"
+          "value": "<svg><polygon points=\"1671.5,6442.9 1720.3,882.2 4299.2,919.3 4240.6,3522.4 4128.7,3689.0 4159.7,5253.6 4001.2,6484.9 1671.5,6442.9\" /></svg>"
         }
       },
       "body": {
@@ -8215,8 +8411,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4132.5,
-                3694.1
+                4128.7,
+                3689.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8236,8 +8432,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1723.3,
-                887.5
+                1720.3,
+                880.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8267,15 +8463,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8294,7 +8490,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5868.0,0.0 5868.0,6530.0 1356.7,6451.0 1524.3,5215.5 1503.7,858.5 3786.9,917.2 3797.8,0.0 5868.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1189.6,6452.4 1431.4,5220.4 1504.0,3639.5 1628.0,3478.8 1860.1,855.9 3962.2,1033.6 4034.9,0.0 5868.0,0.0 5795.2,6806.1 1189.6,6452.4\" /></svg>"
         }
       },
       "body": {
@@ -8308,8 +8504,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1503.7,
-                3644.2
+                1860.0,
+                855.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6395395,
+                41.879328
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1504.0,
+                3639.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8322,27 +8539,6 @@
               "coordinates": [
                 -87.6395924,
                 41.878055
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1503.7,
-                858.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396562,
-                41.8793273
               ]
             }
           }
@@ -8360,15 +8556,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8387,7 +8583,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1107.0,7323.0 1295.0,823.2 5822.0,943.3 5822.0,6300.6 5503.4,6395.1 5822.0,6488.9 5822.0,7323.0 1107.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"718.7,910.2 5822.0,901.7 5822.0,7323.0 703.6,7312.9 718.7,910.2\" /></svg>"
         }
       },
       "body": {
@@ -8401,8 +8597,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1129.3,
-                6283.0
+                2863.0,
+                903.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8413,8 +8609,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.647203,
-                41.8766797
+                -87.6439182,
+                41.8759164
               ]
             }
           },
@@ -8422,8 +8618,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4597.7,
-                910.3
+                4590.4,
+                903.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8460,8 +8656,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8480,7 +8676,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4270.8,6561.1 1668.8,6559.3 1654.5,719.1 4036.1,710.4 4021.7,2962.9 4307.5,2962.3 4270.8,6561.1\" /></svg>"
+          "value": "<svg><polygon points=\"4274.1,6565.3 1671.4,6564.2 1655.5,719.5 4037.8,710.1 4023.9,2964.4 4309.8,2963.7 4274.1,6565.3\" /></svg>"
         }
       },
       "body": {
@@ -8494,8 +8690,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1660.1,
-                2961.5
+                1663.7,
+                2963.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8515,8 +8711,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4141.5,
-                6562.5
+                4147.3,
+                4771.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8527,101 +8723,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6326629,
-                41.8940169
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p90W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5868
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,7213.5 2389.2,7120.9 2357.9,6312.3 2608.5,6313.6 2045.5,6233.4 2350.9,6129.8 2149.7,936.3 5868.0,919.7 5868.0,7323.0 -0.0,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0090W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2932.6,
-                6254.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6471452,
-                41.874331
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2932.6,
-                950.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438857,
-                41.874359
+                -87.6326816,
+                41.8948122
               ]
             }
           }
@@ -8646,8 +8749,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8666,7 +8769,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4123.0,4312.3 4114.0,6324.3 1711.7,6303.2 1731.7,1072.0 4120.7,1107.7 4117.9,3143.9 5029.4,3139.5 4955.4,4313.8 4123.0,4312.3\" /></svg>"
+          "value": "<svg><polygon points=\"4105.7,6321.6 -0.0,6280.1 -0.0,5336.6 1731.6,5338.2 1728.6,1070.9 4115.3,1107.8 4105.7,6321.6\" /></svg>"
         }
       },
       "body": {
@@ -8680,8 +8783,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1711.7,
-                6303.2
+                1707.7,
+                6299.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8701,8 +8804,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4120.7,
-                1106.2
+                4115.3,
+                1107.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8732,15 +8835,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8759,7 +8862,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1714.3,0.0 4096.5,0.0 4140.0,5232.3 1765.7,5241.5 1714.3,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"2326.3,3813.4 4141.4,3815.5 4134.6,5871.6 1728.0,5871.5 1712.6,540.9 4130.0,538.7 4143.5,2612.4 3768.0,2611.3 2933.1,2612.5 2325.2,2614.0 2326.3,3813.4\" /></svg>"
         }
       },
       "body": {
@@ -8773,8 +8876,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4143.1,
-                6332.0
+                4141.4,
+                3815.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8785,8 +8888,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6409931,
-                41.8743938
+                -87.6410117,
+                41.8753051
               ]
             }
           },
@@ -8794,8 +8897,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1728.7,
-                1100.5
+                1728.6,
+                3815.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8806,8 +8909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6424927,
-                41.8767364
+                -87.6424471,
+                41.8752853
               ]
             }
           }
@@ -8825,15 +8928,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "5"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8852,7 +8955,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4219.4 -0.0,2952.1 1571.1,2858.8 1481.3,1563.4 4009.1,1450.8 4161.3,4875.3 1694.9,5053.1 1643.4,4124.9 -0.0,4219.4\" /></svg>"
+          "value": "<svg><polygon points=\"1759.7,6283.1 1768.1,4279.3 -0.0,4275.8 -0.0,3106.8 1771.1,3106.8 1759.7,1085.9 5867.0,1101.5 5867.0,6302.3 1759.7,6283.1\" /></svg>"
         }
       },
       "body": {
@@ -8866,29 +8969,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4178.4,
-                6159.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396278,
-                41.8744068
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1763.6,
-                6288.8
+                1759.7,
+                6283.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8901,6 +8983,27 @@
               "coordinates": [
                 -87.6409931,
                 41.8743938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1759.7,
+                1087.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6410546,
+                41.8767572
               ]
             }
           }
@@ -8918,15 +9021,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8945,7 +9048,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3044.0,6318.9 492.5,6292.3 367.1,5622.7 402.0,1239.3 476.6,1092.0 5012.9,1130.4 5002.7,0.0 5866.0,0.0 5866.0,7323.0 3058.1,7323.0 3044.0,6318.9\" /></svg>"
+          "value": "<svg><polygon points=\"2189.6,6308.2 2235.9,1106.1 5091.1,1130.9 5026.2,0.0 5866.0,0.0 5866.0,7323.0 2834.2,7323.0 2778.7,6314.3 2189.6,6308.2\" /></svg>"
         }
       },
       "body": {
@@ -8959,8 +9062,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                314.0,
-                1088.9
+                316.1,
+                1087.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8980,8 +9083,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                314.0,
-                6288.8
+                316.1,
+                6287.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9018,8 +9121,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9038,7 +9141,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1765.3,4008.4 1741.9,1041.4 4144.5,1043.4 4171.4,5056.8 -0.0,5116.1 -0.0,4002.8 1765.3,4008.4\" /></svg>"
+          "value": "<svg><polygon points=\"4169.0,5058.0 -0.0,5115.5 41.1,1028.4 4148.9,1041.9 4169.0,5058.0\" /></svg>"
         }
       },
       "body": {
@@ -9052,8 +9155,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4178.4,
-                6306.1
+                4175.3,
+                6303.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9073,8 +9176,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1740.5,
-                1042.9
+                1747.7,
+                1035.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9111,8 +9214,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9131,7 +9234,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1800.6,5011.5 1775.0,0.0 4115.2,0.0 4114.0,1083.9 5866.0,1085.8 5866.0,6297.7 4183.4,6306.1 4166.1,5001.3 1800.6,5011.5\" /></svg>"
+          "value": "<svg><polygon points=\"4163.2,5000.8 1795.3,5011.6 1772.6,1083.9 4108.4,1077.2 4163.2,5000.8\" /></svg>"
         }
       },
       "body": {
@@ -9145,8 +9248,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1780.5,
-                1088.9
+                1772.6,
+                1083.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9166,8 +9269,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4183.4,
-                6306.1
+                4181.4,
+                6303.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9197,15 +9300,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9224,7 +9327,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2664.2,6228.6 2742.4,1140.1 1031.6,1112.0 1050.0,0.0 3272.0,0.0 3376.5,1150.5 5867.0,1191.5 5867.0,7323.0 3454.4,7323.0 3466.6,6236.9 2664.2,6228.6\" /></svg>"
+          "value": "<svg><polygon points=\"5867.0,1262.7 5867.0,5162.3 1071.0,4856.9 1280.7,949.8 5867.0,1262.7\" /></svg>"
         }
       },
       "body": {
@@ -9238,8 +9341,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3466.6,
-                6236.9
+                3463.4,
+                6231.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9259,8 +9362,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1031.6,
-                1112.0
+                3463.4,
+                1103.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9271,8 +9374,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6409931,
-                41.8743938
+                -87.6396278,
+                41.8744068
               ]
             }
           }
@@ -9297,8 +9400,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:14:36Z",
-      "modified": "2026-06-10T19:14:36Z",
+      "created": "2026-07-17T17:22:11Z",
+      "modified": "2026-07-17T17:22:11Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9317,7 +9420,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4053.3,6537.8 1723.0,6538.7 1749.7,2982.6 1467.3,2983.9 1475.6,758.1 786.9,760.6 787.0,65.7 5835.0,0.0 5835.0,742.5 4048.5,749.0 4053.3,6537.8\" /></svg>"
+          "value": "<svg><polygon points=\"4055.3,6539.1 1731.3,6538.0 1760.9,2989.9 1479.3,2991.0 1489.5,770.2 787.0,772.1 784.0,58.8 5835.0,0.0 5835.0,758.3 4055.4,763.3 4055.3,6539.1\" /></svg>"
         }
       },
       "body": {
@@ -9331,8 +9434,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1593.5,
-                4767.7
+                4055.3,
+                4771.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9343,8 +9446,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6326816,
-                41.8948122
+                -87.6312006,
+                41.8948312
               ]
             }
           },
@@ -9352,8 +9455,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4048.5,
-                749.0
+                4055.3,
+                6539.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9364,8 +9467,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6312427,
-                41.8966335
+                -87.631182,
+                41.8940363
               ]
             }
           }

--- a/gallery/detroit_mich_1929_vol_11.iiif.json
+++ b/gallery/detroit_mich_1929_vol_11.iiif.json
@@ -24,8 +24,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6224.2,0.0 6205.9,1634.2 6172.6,6362.9 111.8,6390.5 113.5,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6220.3,0.0 6168.7,6359.4 106.6,6386.9 107.8,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -58,8 +58,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4155.3,
-                1659.1
+                4151.4,
+                1655.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -79,8 +79,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                317.9,
-                1659.1
+                312.0,
+                1655.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -117,8 +117,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +137,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5970.7,0.0 5899.8,6367.3 2081.0,6366.4 2074.4,7224.3 108.1,7230.9 199.6,0.0 5970.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5893.5,6351.4 2083.9,6347.8 2076.8,7199.4 115.3,7204.6 211.0,27.6 5968.6,0.0 5893.5,6351.4\" /></svg>"
         }
       },
       "body": {
@@ -151,8 +151,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5965.4,
-                336.9
+                4111.4,
+                336.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.958873,
+                42.379947
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5963.1,
+                336.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -165,27 +186,6 @@
               "coordinates": [
                 -82.957861,
                 42.380321
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                195.2,
-                336.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.961008,
-                42.37916
               ]
             }
           }
@@ -203,15 +203,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,109 +230,22 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"627.8,1941.1 624.1,675.7 920.1,678.0 925.4,0.0 1099.1,0.0 1091.4,672.6 6335.0,712.5 6335.0,7795.0 -0.0,7795.0 -0.0,1934.9 627.8,1941.1\" /></svg>"
+          "value": "<svg><polygon points=\"702.7,7795.0 747.2,673.3 915.9,673.5 916.5,0.0 1088.8,0.0 1085.7,676.0 6335.0,680.0 6335.0,7795.0 702.7,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0100/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93518588042195,
-                42.36199523422316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93173074152871,
-                42.363274958317156
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.92960099890765,
-                42.36013083144301
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93305613780089,
-                42.35885110734901
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1076.8,
-                1945.6
+                1079.8,
+                1943.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -345,6 +258,27 @@
               "coordinates": [
                 -82.934067,
                 42.361428
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4835.2,
+                1943.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.932007,
+                42.362178
               ]
             }
           }
@@ -369,8 +303,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -389,7 +323,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5896.1,7020.5 539.0,7086.0 523.3,694.5 -0.0,701.6 -0.0,-0.0 5871.9,0.0 5896.1,7020.5\" /></svg>"
+          "value": "<svg><polygon points=\"5891.1,7023.1 540.2,7091.9 520.4,708.2 -0.0,715.9 -0.0,-0.0 5862.4,0.0 5891.1,7023.1\" /></svg>"
         }
       },
       "body": {
@@ -403,8 +337,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                522.6,
-                1032.6
+                519.9,
+                1047.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -424,8 +358,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5896.1,
-                7020.5
+                5891.1,
+                7023.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -462,8 +396,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -482,7 +416,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"299.3,7017.4 244.9,62.4 -0.0,-0.0 5960.4,35.6 5990.1,6897.4 299.3,7017.4\" /></svg>"
+          "value": "<svg><polygon points=\"240.9,48.8 5959.8,0.0 5989.9,6898.6 295.4,7018.8 240.9,48.8\" /></svg>"
         }
       },
       "body": {
@@ -496,8 +430,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                251.8,
-                1051.5
+                248.0,
+                1047.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -517,8 +451,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5943.3,
-                1051.5
+                5943.1,
+                1047.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -555,8 +489,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -575,7 +509,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"367.6,6902.2 421.0,0.0 6102.6,50.5 6052.0,6837.7 367.6,6902.2\" /></svg>"
+          "value": "<svg><polygon points=\"6066.0,6847.5 379.9,6928.3 413.5,0.0 6097.2,0.0 6066.0,6847.5\" /></svg>"
         }
       },
       "body": {
@@ -589,8 +523,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2531.0,
-                6872.6
+                2527.6,
+                1063.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -601,8 +535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.949051,
-                42.380548
+                -82.950617,
+                42.382904
               ]
             }
           },
@@ -610,8 +544,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4234.0,
-                1064.1
+                4231.3,
+                6871.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -622,8 +556,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.949681,
-                42.383235
+                -82.948133,
+                42.38089
               ]
             }
           }
@@ -648,8 +582,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -668,7 +602,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"642.2,6764.9 641.6,0.0 6447.0,0.0 6410.4,6752.3 642.2,6764.9\" /></svg>"
+          "value": "<svg><polygon points=\"5611.2,6755.6 637.2,6769.3 636.6,0.0 6447.0,0.0 6447.0,6756.6 5611.2,6755.6\" /></svg>"
         }
       },
       "body": {
@@ -682,8 +616,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3979.0,
-                1032.6
+                3983.4,
+                1023.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -703,8 +637,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                617.0,
-                1032.6
+                611.9,
+                1023.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -741,8 +675,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -761,7 +695,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6174.2,353.9 6133.6,7795.0 -0.0,7795.0 -0.0,374.4 6174.2,353.9\" /></svg>"
+          "value": "<svg><polygon points=\"6173.8,349.3 6135.5,7795.0 -0.0,7795.0 -0.0,372.2 6173.8,349.3\" /></svg>"
         }
       },
       "body": {
@@ -775,8 +709,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2228.7,
-                6268.1
+                2231.7,
+                6263.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -796,8 +730,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4111.2,
-                355.7
+                4111.4,
+                352.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -810,99 +744,6 @@
               "coordinates": [
                 -82.983923,
                 42.367779
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p16",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6007.0,457.4 5971.3,6188.8 6400.4,6155.7 6381.2,7795.0 -0.0,7795.0 -0.0,481.5 6007.0,457.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2083.9,
-                7269.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9808282,
-                42.361736
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3966.4,
-                6718.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.979983,
-                42.3623462
               ]
             }
           }
@@ -927,8 +768,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -947,7 +788,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"454.5,6914.6 415.5,966.5 5471.0,1007.4 5385.6,6865.1 454.5,6914.6\" /></svg>"
+          "value": "<svg><polygon points=\"452.5,6907.1 415.9,959.9 5468.9,1002.7 5381.1,6859.6 452.5,6907.1\" /></svg>"
         }
       },
       "body": {
@@ -961,8 +802,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2505.8,
-                6897.8
+                2503.6,
+                6891.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -982,8 +823,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                415.5,
-                966.5
+                415.9,
+                959.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1020,8 +861,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1040,7 +881,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5671.0,6771.7 -0.0,6913.6 -0.0,1015.1 5756.7,1101.5 5671.0,6771.7\" /></svg>"
+          "value": "<svg><polygon points=\"5667.2,6763.0 -0.0,6904.8 -0.0,1012.7 5752.8,1099.1 5667.2,6763.0\" /></svg>"
         }
       },
       "body": {
@@ -1054,8 +895,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3793.3,
-                6815.9
+                3791.4,
+                6807.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1075,8 +916,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3793.3,
-                1076.7
+                3791.4,
+                1075.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1106,15 +947,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1133,7 +974,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3859.4,1098.7 3861.2,0.0 4660.4,0.0 4686.7,2012.1 5638.2,1999.6 5876.1,6480.5 146.5,6718.4 148.8,1099.4 3859.4,1098.7\" /></svg>"
+          "value": "<svg><polygon points=\"232.0,1091.9 3880.9,1089.7 3882.1,0.0 4651.9,0.0 4682.3,2256.8 6447.0,2233.0 6447.0,6359.3 232.0,6617.2 232.0,1091.9\" /></svg>"
         }
       },
       "body": {
@@ -1147,8 +988,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3859.4,
-                1098.7
+                232.0,
+                6615.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1159,8 +1000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.974881,
-                42.371125
+                -82.9754208,
+                42.3681051
               ]
             }
           },
@@ -1168,8 +1009,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1841.6,
-                1098.7
+                232.0,
+                1091.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1180,8 +1021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.975991,
-                42.370726
+                -82.976922,
+                42.370391
               ]
             }
           }
@@ -1199,15 +1040,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1226,7 +1067,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5212.3,6522.7 248.7,6507.4 211.7,0.0 5270.2,0.0 5212.3,6522.7\" /></svg>"
+          "value": "<svg><polygon points=\"5108.5,6513.5 301.1,6523.8 233.0,0.0 5256.1,0.0 5108.5,6513.5\" /></svg>"
         }
       },
       "body": {
@@ -1240,8 +1081,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4602.3,
-                6507.4
+                4599.3,
+                6503.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1261,8 +1102,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                248.7,
-                6507.4
+                4599.3,
+                627.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1273,8 +1114,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.982806,
-                42.368223
+                -82.982105,
+                42.371489
               ]
             }
           }
@@ -1299,8 +1140,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1319,7 +1160,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5146.4,6401.1 -0.0,6401.5 -0.0,2014.5 5175.9,2139.1 5146.4,6401.1\" /></svg>"
+          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
         }
       },
       "body": {
@@ -1333,8 +1174,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3849.9,
-                6400.3
+                3847.4,
+                6395.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1354,8 +1195,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                330.5,
-                6400.3
+                331.9,
+                6395.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1392,8 +1233,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1412,7 +1253,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5194.5,7741.6 5218.4,7010.5 4666.1,6738.9 4406.4,6160.3 -0.0,6157.6 -0.0,1787.7 184.7,1790.9 215.4,0.0 6447.0,0.0 6447.0,7795.0 5194.5,7741.6\" /></svg>"
+          "value": "<svg><polygon points=\"5006.1,7795.0 5033.0,6972.3 4501.8,6711.0 4252.0,6154.6 -0.0,6152.2 -0.0,2212.8 417.2,2219.9 455.3,0.0 6447.0,0.0 6447.0,7795.0 5006.1,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1441,8 +1282,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97127381899593,
-                42.37289976667562
+                -82.97134924113944,
+                42.37299222800126
               ]
             }
           },
@@ -1462,8 +1303,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96778975238908,
-                42.37424985742501
+                -82.9677269087755,
+                42.374395901819724
               ]
             }
           },
@@ -1483,8 +1324,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96558239954135,
-                42.371135137324416
+                -82.96543181876963,
+                42.37115736844476
               ]
             }
           },
@@ -1504,8 +1345,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96906646614819,
-                42.36978504657503
+                -82.96905415113356,
+                42.3697536946263
               ]
             }
           },
@@ -1513,8 +1354,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                576.1,
-                6148.5
+                567.9,
+                6143.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1551,8 +1392,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1571,7 +1412,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4988.0,7203.6 420.8,7610.7 380.9,406.1 5128.2,333.1 4988.0,7203.6\" /></svg>"
+          "value": "<svg><polygon points=\"5060.8,7189.2 -0.0,7692.8 -0.0,1964.9 390.9,1958.8 383.9,403.9 5139.8,331.4 5060.8,7189.2\" /></svg>"
         }
       },
       "body": {
@@ -1585,8 +1426,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4605.4,
-                7266.1
+                4607.3,
+                7263.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1606,8 +1447,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                380.9,
-                406.1
+                383.9,
+                403.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1644,8 +1485,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1664,7 +1505,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5738.7,6481.9 -0.0,7198.9 -0.0,381.3 5769.2,172.1 5738.7,6481.9\" /></svg>"
+          "value": "<svg><polygon points=\"5688.0,6518.8 -0.0,7173.0 -0.0,352.5 5775.5,195.1 5688.0,6518.8\" /></svg>"
         }
       },
       "body": {
@@ -1678,8 +1519,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1885.6,
-                311.7
+                3935.4,
+                6703.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.974639,
+                42.3650909
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1879.7,
+                300.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1692,27 +1554,6 @@
               "coordinates": [
                 -82.9775274,
                 42.3672704
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5738.7,
-                6482.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.973729,
-                42.3655229
               ]
             }
           }
@@ -1730,15 +1571,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1757,7 +1598,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6188.4,6376.5 207.8,7130.0 165.3,783.4 6161.2,486.3 6188.4,6376.5\" /></svg>"
+          "value": "<svg><polygon points=\"164.0,7055.1 273.5,812.4 6447.0,657.2 6447.0,6425.1 164.0,7055.1\" /></svg>"
         }
       },
       "body": {
@@ -1771,8 +1612,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1866.7,
-                698.9
+                1863.7,
+                6879.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1783,8 +1624,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9745042,
-                42.368471
+                -82.972836,
+                42.3659479
               ]
             }
           },
@@ -1792,8 +1633,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                207.8,
-                7130.7
+                4999.2,
+                691.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1804,8 +1645,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.973729,
-                42.3655229
+                -82.9728344,
+                42.3691355
               ]
             }
           }
@@ -1830,8 +1671,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1850,7 +1691,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5943.2,356.2 5820.6,6211.4 3038.8,6194.8 257.2,6418.9 384.0,467.5 5943.2,356.2\" /></svg>"
+          "value": "<svg><polygon points=\"672.5,6076.1 607.5,0.0 5202.4,0.0 5216.7,409.1 5808.2,384.0 5816.9,6071.2 672.5,6076.1\" /></svg>"
         }
       },
       "body": {
@@ -1864,8 +1705,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5820.6,
-                6211.4
+                3899.4,
+                467.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9702461,
+                42.3701576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5815.1,
+                6207.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1878,27 +1740,6 @@
               "coordinates": [
                 -82.9676821,
                 42.3682039
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                384.0,
-                465.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.972189,
-                42.369392
               ]
             }
           }
@@ -1923,8 +1764,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1943,7 +1784,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"525.7,623.3 4420.0,476.5 4708.1,1053.9 5280.8,1307.2 5286.8,2051.4 6447.0,2053.5 6447.0,6614.2 5429.4,6419.6 570.1,6531.9 525.7,623.3\" /></svg>"
+          "value": "<svg><polygon points=\"6447.0,7795.0 1176.8,7795.0 1167.7,6512.3 569.1,6524.6 523.9,615.9 4418.5,468.6 4706.6,1045.9 5279.4,1299.1 5286.6,2169.9 6447.0,2122.4 6447.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1957,8 +1798,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2392.4,
-                6494.8
+                2391.6,
+                6487.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1978,8 +1819,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                525.7,
-                623.3
+                523.9,
+                615.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1992,99 +1833,6 @@
               "coordinates": [
                 -82.9692214,
                 42.3705636
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0028/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p28",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0028/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0028/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6447,0 6447,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0028/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2128.0,
-                465.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9692214,
-                42.3705636
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2128.0,
-                6960.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9656433,
-                42.3689608
               ]
             }
           }
@@ -2109,8 +1857,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2129,7 +1877,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6755.0 -0.0,-0.0 5982.0,0.0 5855.2,6850.4 -0.0,6755.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6796.7 -0.0,-0.0 5922.5,0.0 5923.1,6783.1 -0.0,6796.7\" /></svg>"
         }
       },
       "body": {
@@ -2143,8 +1891,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1810.1,
-                6784.4
+                5923.1,
+                6783.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2155,8 +1903,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.979141,
-                42.369594
+                -82.976922,
+                42.370391
               ]
             }
           },
@@ -2164,8 +1912,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3916.0,
-                903.5
+                5923.1,
+                895.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2176,8 +1924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9796142,
-                42.3723885
+                -82.97849,
+                42.372792
               ]
             }
           }
@@ -2185,25 +1933,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0030/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p30",
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p31",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2212,21 +1960,114 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0030/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0030/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/info.json",
           "type": "ImageService2",
           "height": 7795,
           "width": 6447
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2687.6,6849.6 2818.3,7795.0 -0.0,7795.0 -0.0,-0.0 5478.5,0.0 5613.7,1531.7 6447.0,1444.4 6447.0,5497.8 5979.2,5562.5 6162.0,7572.1 5249.5,7382.2 2687.6,6849.6\" /></svg>"
+          "value": "<svg><polygon points=\"5077.5,6881.9 -0.0,7053.5 -0.0,-0.0 1314.0,0.0 1313.4,263.8 5091.8,238.0 5077.5,6881.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0030/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3131.5,
+                256.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.961544,
+                42.375929
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5083.2,
+                4799.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.959272,
+                42.374477
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5296.7,0.0 5030.2,7795.0 4466.5,7795.0 -0.0,6214.1 -0.0,-0.0 5296.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -2251,8 +2092,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9640564020039,
-                42.372227564541134
+                -82.96169300108836,
+                42.37247398135021
               ]
             }
           },
@@ -2272,8 +2113,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9603776053783,
-                42.37325715829812
+                -82.95807720591516,
+                42.3738868412227
               ]
             }
           },
@@ -2293,8 +2134,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95869425430541,
-                42.36996835154189
+                -82.95576709616573,
+                42.37065415239988
               ]
             }
           },
@@ -2314,8 +2155,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96237305093102,
-                42.36893875778491
+                -82.95938289133893,
+                42.369241292527384
               ]
             }
           },
@@ -2323,8 +2164,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2222.5,
-                6756.1
+                5023.2,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2335,80 +2176,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9613285,
-                42.3697326
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1324.6,7795.0 1349.4,6280.3 -0.0,6139.0 -0.0,-0.0 1460.5,0.0 1455.6,304.0 5160.6,330.1 5040.7,7795.0 1324.6,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3135.4,
-                4804.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9603535,
-                42.3740746
+                -82.956922,
+                42.3702159
               ]
             }
           },
@@ -2416,8 +2185,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5090.2,
-                4804.2
+                5023.2,
+                8003.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2428,8 +2197,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.959272,
-                42.374477
+                -82.956504,
+                42.3702559
               ]
             }
           }
@@ -2454,8 +2223,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2474,7 +2243,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"106.4,7795.0 -0.0,7795.0 -0.0,6678.2 1180.9,6678.1 1288.1,0.0 5193.4,0.0 5081.8,7269.5 119.9,7163.7 106.4,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"5189.7,0.0 5078.0,7275.2 1174.0,7157.7 1289.0,0.0 5189.7,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2488,8 +2257,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1230.8,
-                3651.9
+                1231.8,
+                3651.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2509,8 +2278,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5146.9,
-                3651.9
+                5143.2,
+                3651.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2547,8 +2316,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2567,7 +2336,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4063.7,7795.0 -0.0,6473.1 -0.0,-0.0 4968.6,0.0 5009.9,7795.0 4063.7,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"5004.5,7795.0 4131.7,7795.0 267.2,6575.0 1098.3,6623.1 989.5,0.0 4894.6,0.0 5004.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -2581,8 +2350,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1108.1,
-                6831.6
+                1103.8,
+                6839.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2602,8 +2371,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5014.7,
-                8103.5
+                5011.2,
+                8071.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2640,8 +2409,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2660,7 +2429,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5241.9,1637.8 5153.2,6184.7 1312.7,6184.7 1384.3,1611.5 5241.9,1637.8\" /></svg>"
+          "value": "<svg><polygon points=\"5239.8,1638.6 5151.2,6179.2 1315.8,6179.2 1387.3,1612.3 5239.8,1638.6\" /></svg>"
         }
       },
       "body": {
@@ -2674,8 +2443,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1312.7,
-                6183.1
+                1315.8,
+                6179.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2695,8 +2464,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5153.2,
-                6183.1
+                5151.2,
+                6179.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2733,8 +2502,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2753,7 +2522,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"418.7,1685.9 5773.1,1634.0 5771.2,6114.0 410.2,6202.2 418.7,1685.9\" /></svg>"
+          "value": "<svg><polygon points=\"415.9,1671.8 5777.4,1628.2 5768.5,6113.8 400.3,6193.7 415.9,1671.8\" /></svg>"
         }
       },
       "body": {
@@ -2767,8 +2536,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3988.5,
-                6142.2
+                3983.4,
+                6139.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2788,8 +2557,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                418.7,
-                1687.4
+                415.9,
+                1671.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2826,8 +2595,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2846,7 +2615,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6012.2,6088.4 285.4,6167.4 302.1,1694.8 6037.2,1632.3 6012.2,6088.4\" /></svg>"
+          "value": "<svg><polygon points=\"6012.4,6086.3 290.4,6165.1 307.0,1694.1 6037.4,1631.7 6012.4,6086.3\" /></svg>"
         }
       },
       "body": {
@@ -2860,8 +2629,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2084.2,
-                6134.2
+                2087.7,
+                6132.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2881,8 +2650,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2084.2,
-                1680.7
+                2087.7,
+                1680.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2919,8 +2688,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2939,7 +2708,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"186.7,1724.7 5841.9,1646.1 5836.7,6082.5 164.9,6150.6 186.7,1724.7\" /></svg>"
+          "value": "<svg><polygon points=\"187.8,1716.8 5843.1,1640.0 5836.4,6078.7 164.5,6144.9 187.8,1716.8\" /></svg>"
         }
       },
       "body": {
@@ -2953,8 +2722,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4023.7,
-                6096.4
+                4023.4,
+                6092.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2974,8 +2743,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5843.4,
-                1646.1
+                5843.1,
+                1640.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3012,8 +2781,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3032,7 +2801,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1136.6,6870.7 1262.5,227.8 5098.0,219.5 4984.8,7796.0 3097.7,7796.0 3113.8,6870.7 1136.6,6870.7\" /></svg>"
+          "value": "<svg><polygon points=\"1139.8,6872.0 1265.1,257.9 5082.2,249.6 4969.5,7796.0 3091.4,7796.0 3107.5,6872.0 1139.8,6872.0\" /></svg>"
         }
       },
       "body": {
@@ -3046,8 +2815,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1136.6,
-                6870.7
+                1139.8,
+                6872.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3067,8 +2836,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3113.8,
-                6870.7
+                3107.5,
+                6872.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3098,15 +2867,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3125,7 +2894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"73.3,6818.8 80.6,0.0 4496.4,0.0 4579.4,5713.8 3780.9,5715.0 3780.7,6812.8 73.3,6818.8\" /></svg>"
+          "value": "<svg><polygon points=\"3775.4,6811.1 63.3,6817.2 70.6,0.0 4475.8,0.0 4558.6,5701.7 3775.7,5702.5 3775.4,6811.1\" /></svg>"
         }
       },
       "body": {
@@ -3139,8 +2908,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3780.7,
-                6812.8
+                3775.4,
+                6811.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3160,8 +2929,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3780.7,
-                928.7
+                3775.4,
+                919.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3198,8 +2967,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3218,7 +2987,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1489.8,6142.8 -0.0,5647.9 1107.3,5705.0 1107.3,821.5 3072.8,790.0 3071.6,1710.1 4947.5,1680.0 4963.6,7295.3 1682.1,6206.7 1631.2,7796.0 1439.9,7796.0 1489.8,6142.8\" /></svg>"
+          "value": "<svg><polygon points=\"1493.5,6130.6 234.5,5712.1 1112.5,5725.4 1112.2,823.4 3071.5,792.0 3070.3,1712.3 4940.3,1682.3 4956.4,7280.1 1685.2,6194.4 1634.0,7796.0 1443.2,7796.0 1493.5,6130.6\" /></svg>"
         }
       },
       "body": {
@@ -3232,8 +3001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3072.8,
-                6669.2
+                3071.5,
+                6656.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3253,8 +3022,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3072.8,
-                790.0
+                3071.5,
+                792.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3284,15 +3053,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3311,7 +3080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"500.6,387.1 4091.4,386.1 5880.3,387.4 6407.0,7523.6 6407.0,7796.0 2491.7,7796.0 381.9,7796.0 500.6,387.1\" /></svg>"
+          "value": "<svg><polygon points=\"495.9,384.0 4079.4,384.0 5864.7,385.7 6407.0,7478.7 6407.0,7796.0 375.2,7796.0 495.9,384.0\" /></svg>"
         }
       },
       "body": {
@@ -3325,8 +3094,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2292.0,
-                387.1
+                4079.4,
+                384.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3337,8 +3106,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.954095,
-                42.376411
+                -82.953123,
+                42.376775
               ]
             }
           },
@@ -3346,8 +3115,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                500.6,
-                387.1
+                495.9,
+                384.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3384,8 +3153,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3404,7 +3173,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"531.2,250.2 4154.3,304.9 4163.8,0.0 5970.0,0.0 5968.2,55.6 6407.0,63.5 6407.0,1230.1 5931.3,1243.2 5746.8,7582.2 4081.0,7476.0 359.9,6085.8 531.2,250.2\" /></svg>"
+          "value": "<svg><polygon points=\"5349.5,7796.0 5361.6,7549.5 3927.4,7415.4 356.5,6117.8 453.2,322.4 4058.1,330.3 4064.2,0.0 5860.6,0.0 5734.3,7539.3 5349.5,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -3418,8 +3187,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3932.4,
-                7434.1
+                3927.4,
+                7416.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3439,8 +3208,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2144.1,
-                6741.6
+                2139.7,
+                6748.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3477,8 +3246,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3497,7 +3266,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"93.3,7796.0 190.2,430.5 6129.8,410.2 6025.4,7796.0 93.3,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"76.1,7796.0 173.0,425.1 6141.1,404.7 6036.7,7796.0 76.1,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -3511,8 +3280,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2055.9,
-                415.5
+                2047.7,
+                408.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3532,8 +3301,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3948.1,
-                415.5
+                3947.4,
+                408.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3570,8 +3339,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3590,7 +3359,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6407.0,7339.4 163.7,7334.9 580.6,0.0 6407.0,0.0 6407.0,7339.4\" /></svg>"
+          "value": "<svg><polygon points=\"580.5,0.0 6407.0,0.0 6407.0,7796.0 -0.0,7427.7 164.0,7332.0 580.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3604,8 +3373,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                163.7,
-                7333.3
+                164.0,
+                7332.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3625,8 +3394,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5862.3,
-                7333.3
+                5859.1,
+                7332.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3663,8 +3432,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3683,7 +3452,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"253.0,361.6 5975.7,336.8 5916.0,7796.0 173.1,7796.0 253.0,361.6\" /></svg>"
+          "value": "<svg><polygon points=\"155.5,7486.1 232.1,352.9 5975.1,328.0 5915.4,7796.0 152.1,7796.0 155.2,7512.6 155.5,7486.1\" /></svg>"
         }
       },
       "body": {
@@ -3697,8 +3466,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4146.4,
-                336.8
+                4139.4,
+                328.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3718,8 +3487,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5975.7,
-                336.8
+                5975.1,
+                328.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3756,8 +3525,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3776,7 +3545,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5389.1,7081.5 -0.0,6814.6 -0.0,0.0 448.8,7.3 434.2,305.2 6184.6,524.3 5879.3,7030.8 5508.4,7033.8 5510.7,7248.5 5389.1,7081.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 444.6,0.0 430.8,282.5 6178.1,501.6 5872.0,7029.0 4712.3,7038.3 4722.2,7796.0 -0.0,7618.3 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3790,8 +3559,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2185.0,
-                7163.4
+                2179.7,
+                7160.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3811,8 +3580,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4045.7,
-                7163.4
+                4039.4,
+                7160.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3849,8 +3618,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3869,7 +3638,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"633.5,7796.0 632.8,343.1 6407.0,329.7 6407.0,7796.0 633.5,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"639.5,7796.0 631.9,340.0 6407.0,321.3 6407.0,7796.0 639.5,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -3883,8 +3652,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2320.4,
-                343.1
+                4003.4,
+                340.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3895,8 +3664,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.945022,
-                42.379788
+                -82.944103,
+                42.380118
               ]
             }
           },
@@ -3904,8 +3673,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                632.8,
-                343.1
+                631.9,
+                340.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3935,15 +3704,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3962,7 +3731,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"912.7,7080.6 915.0,6857.4 377.7,6857.2 756.6,248.0 6407.0,567.8 6407.0,7796.0 5472.0,7796.0 5522.3,6963.5 2189.2,6843.9 2218.5,7083.2 912.7,7080.6\" /></svg>"
+          "value": "<svg><polygon points=\"915.8,7079.2 918.1,6855.8 372.9,6855.6 752.5,228.7 6407.0,554.1 6407.0,7796.0 5468.8,7796.0 5519.1,6962.0 2185.0,6842.2 2214.3,7081.8 915.8,7079.2\" /></svg>"
         }
       },
       "body": {
@@ -3976,8 +3745,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2203.9,
-                6962.0
+                2199.7,
+                6960.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3997,8 +3766,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5522.3,
-                6962.0
+                5519.1,
+                6960.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4035,8 +3804,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4055,7 +3824,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6386.5,6110.5 626.5,6127.9 626.7,1674.1 6407.0,1683.8 6386.5,6110.5\" /></svg>"
+          "value": "<svg><polygon points=\"621.0,6122.9 627.2,1668.9 6407.0,1686.4 6370.5,6113.3 621.0,6122.9\" /></svg>"
         }
       },
       "body": {
@@ -4069,8 +3838,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3976.4,
-                1680.7
+                2303.6,
+                6124.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.945022,
+                42.379788
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3975.4,
+                1680.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4083,27 +3873,6 @@
               "coordinates": [
                 -82.945296,
                 42.381921
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                626.5,
-                6127.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.945945,
-                42.379455
               ]
             }
           }
@@ -4128,8 +3897,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4177,8 +3946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9763165537007,
-                42.37405932030927
+                -82.97633525880119,
+                42.37407032808802
               ]
             }
           },
@@ -4198,8 +3967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9728017207747,
-                42.37536507819789
+                -82.97268093915166,
+                42.375427909541216
               ]
             }
           },
@@ -4219,8 +3988,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97066685065936,
-                42.37222285332098
+                -82.97046121289874,
+                42.37216077804727
               ]
             }
           },
@@ -4240,8 +4009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97418168358536,
-                42.37091709543237
+                -82.97411553254827,
+                42.37080319659407
               ]
             }
           },
@@ -4249,8 +4018,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                465.9,
-                979.1
+                463.9,
+                975.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4287,8 +4056,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4307,7 +4076,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"628.1,1513.0 5552.2,1063.0 5499.9,6864.3 3931.8,6859.0 2276.0,7323.7 2276.0,7796.0 592.8,7796.0 628.1,1513.0\" /></svg>"
+          "value": "<svg><polygon points=\"5124.9,7796.0 -0.0,7796.0 -0.0,1358.3 5657.5,1184.3 5124.9,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -4321,8 +4090,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5553.8,
-                1063.8
+                2303.6,
+                1284.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4333,8 +4102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.976311,
-                42.3642979
+                -82.9779957,
+                42.3634758
               ]
             }
           },
@@ -4342,8 +4111,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                626.5,
-                1513.9
+                627.9,
+                1284.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4363,99 +4132,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3811.4,0.0 5358.4,0.0 6407.0,805.6 6407.0,7408.1 4491.0,7376.6 4479.1,7796.0 -0.0,7796.0 0.0,0.0 516.2,0.0 512.7,932.4 3811.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2181.8,
-                7311.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9743462,
-                42.3583187
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                519.5,
-                7311.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.975259,
-                42.357967
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/georef",
       "type": "Annotation",
       "@context": [
@@ -4466,15 +4142,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4493,7 +4169,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"659.5,1183.1 6407.0,534.6 6407.0,4897.3 5648.2,4897.3 5635.3,7524.6 6407.0,7526.4 6407.0,7796.0 758.8,7796.0 659.5,1183.1\" /></svg>"
+          "value": "<svg><polygon points=\"5519.2,627.9 5723.8,7796.0 753.7,7796.0 654.4,1177.1 5519.2,627.9\" /></svg>"
         }
       },
       "body": {
@@ -4507,8 +4183,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5648.2,
-                4897.3
+                5647.1,
+                4896.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4528,8 +4204,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                698.9,
-                4897.3
+                695.9,
+                4896.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4549,6 +4225,99 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,553.8 5577.3,604.9 5395.8,7374.5 -0.0,7329.9 -0.0,553.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2239.7,
+                7336.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9717386,
+                42.3592695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                647.9,
+                7336.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9726006,
+                42.3589503
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/georef",
       "type": "Annotation",
       "@context": [
@@ -4559,15 +4328,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4586,7 +4355,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"128.7,7796.0 135.4,5196.3 886.2,5194.5 876.1,877.8 6075.6,284.9 6050.1,5929.9 5762.8,7796.0 128.7,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,871.6 6087.0,372.6 5881.4,6008.9 5396.9,7757.1 -0.0,7796.0 -0.0,871.6\" /></svg>"
         }
       },
       "body": {
@@ -4600,8 +4369,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3242.9,
-                5196.3
+                136.0,
+                860.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4612,8 +4381,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97086,
-                42.364414
+                -82.973729,
+                42.3655229
               ]
             }
           },
@@ -4621,8 +4390,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                135.4,
-                5196.3
+                6087.0,
+                372.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4633,8 +4402,167 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9725798,
-                42.3637904
+                -82.9706256,
+                42.3669931
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"208.9,844.2 5597.1,686.0 5592.3,1102.3 5878.6,1033.4 5989.2,1169.9 5967.4,1504.1 5764.8,1553.5 5580.9,1208.5 5518.5,7513.2 5225.2,7510.3 5221.9,7796.0 899.7,7796.0 899.7,7467.7 29.7,7459.2 208.9,844.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9721553124618,
+                42.36300834624276
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96852178002844,
+                42.364354731976576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96630661773966,
+                42.36108590714971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96994015017302,
+                42.35973952141589
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1671.7,
+                7476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.969083,
+                42.360225
               ]
             }
           }
@@ -4659,8 +4587,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4679,7 +4607,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"325.9,6880.4 438.8,399.0 3158.5,139.1 6407.0,111.3 6407.0,7377.7 154.4,7362.3 325.9,6880.4\" /></svg>"
+          "value": "<svg><polygon points=\"427.4,0.0 5830.2,0.0 5830.3,133.0 6407.0,125.2 6407.0,7796.0 28.9,7796.0 363.1,6377.7 427.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4693,8 +4621,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3762.3,
-                5249.8
+                3759.4,
+                5248.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4714,8 +4642,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                431.3,
-                5249.8
+                2027.7,
+                276.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4726,8 +4654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9693106,
-                42.3650003
+                -82.9697756,
+                42.3673852
               ]
             }
           }
@@ -4745,15 +4673,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4772,7 +4700,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7554.3 23.6,0.0 6377.7,0.0 6378.7,425.1 5632.7,426.9 5610.5,7553.7 -0.0,7554.3\" /></svg>"
+          "value": "<svg><polygon points=\"5629.3,456.5 5607.1,7552.0 -0.0,7552.6 -0.0,1002.6 288.6,1320.5 396.0,1281.8 414.7,933.1 297.7,792.1 -0.0,867.3 -0.0,433.2 5629.3,456.5\" /></svg>"
         }
       },
       "body": {
@@ -4786,8 +4714,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                321.1,
-                7553.7
+                320.0,
+                7552.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4807,8 +4735,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5610.5,
-                7553.7
+                5607.1,
+                7552.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4821,99 +4749,6 @@
               "coordinates": [
                 -82.963824,
                 42.362122
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p59",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5230.6,388.0 6173.9,578.4 6179.8,0.0 6346.0,0.0 6346.0,7795.0 1243.7,7795.0 1219.0,441.2 5230.6,388.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4249.6,
-                5418.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.964228,
-                42.366806
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4249.6,
-                399.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9656433,
-                42.3689608
               ]
             }
           }
@@ -4938,8 +4773,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4958,7 +4793,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"256.9,465.9 6346.0,519.1 6346.0,7795.0 -0.0,7795.0 -0.0,7569.9 170.0,7571.5 256.9,465.9\" /></svg>"
+          "value": "<svg><polygon points=\"168.1,7567.0 251.4,763.6 971.6,773.1 981.8,0.0 6346.0,0.0 6346.0,7795.0 597.1,7795.0 599.1,7570.3 168.1,7567.0\" /></svg>"
         }
       },
       "body": {
@@ -4987,8 +4822,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96597636757303,
-                42.36514514897063
+                -82.96605951140953,
+                42.36526387878703
               ]
             }
           },
@@ -5008,8 +4843,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9625105330486,
-                42.36642175247269
+                -82.96245797971817,
+                42.36659046915425
               ]
             }
           },
@@ -5029,8 +4864,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96039019915504,
-                42.36327415038568
+                -82.96025336746816,
+                42.363317746700645
               ]
             }
           },
@@ -5050,8 +4885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96385603367949,
-                42.36199754688362
+                -82.96385489915951,
+                42.36199115633344
               ]
             }
           },
@@ -5059,8 +4894,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                170.0,
-                7571.5
+                168.1,
+                7567.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5097,8 +4932,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5117,7 +4952,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,823.8 3342.6,2015.7 3436.8,0.0 6127.2,0.0 5962.8,3014.3 5340.5,2978.3 5294.0,6990.3 -0.0,6751.6 -0.0,823.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,818.8 5937.1,3011.8 5315.1,3008.4 5295.4,6522.7 -0.0,6319.7 -0.0,818.8\" /></svg>"
         }
       },
       "body": {
@@ -5146,8 +4981,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96128427254943,
-                42.37009312932897
+                -82.96141300191925,
+                42.370089487802524
               ]
             }
           },
@@ -5167,8 +5002,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95788493672302,
-                42.371464020131754
+                -82.957884896047,
+                42.37151990390754
               ]
             }
           },
@@ -5188,8 +5023,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95560799934285,
-                42.36837681084168
+                -82.95550773958207,
+                42.36831390371199
               ]
             }
           },
@@ -5209,8 +5044,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95900733516926,
-                42.3670059200389
+                -82.95903584545432,
+                42.36688348760697
               ]
             }
           },
@@ -5218,8 +5053,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4768.9,
-                2556.4
+                4765.5,
+                2559.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5249,15 +5084,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5276,34 +5111,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,190.0 96.6,0.0 6346.0,0.0 6346.0,7329.2 -0.0,7328.1 -0.0,190.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7279.2 -0.0,-0.0 6346.0,0.0 6346.0,7337.6 -0.0,7279.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1948.5,
-                7329.1
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.956646,
-                42.364712
+                -82.95989253749816,
+                42.36734002844589
               ]
             }
           },
@@ -5311,8 +5149,71 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5181.3,
-                7329.1
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95629288558567,
+                42.36866940566848
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95408364196213,
+                42.36539839137546
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95768329387464,
+                42.364069014152875
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5177.6,
+                7327.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5349,8 +5250,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5369,7 +5270,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7242.2 2047.5,1758.7 3715.6,1870.2 3722.6,1677.0 2119.2,1566.8 2521.8,488.8 5941.4,627.3 5713.8,7463.8 4083.2,7409.2 4070.3,7795.0 -0.0,7795.0 -0.0,7242.2\" /></svg>"
+          "value": "<svg><polygon points=\"3721.8,7795.0 -0.0,7795.0 -0.0,7136.9 2061.3,1755.7 3751.8,1882.6 3760.5,1688.7 2134.8,1563.8 2547.3,487.1 5979.0,627.8 5715.6,6968.6 6346.0,6998.1 6346.0,7531.9 3733.2,7446.4 3721.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5383,8 +5284,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                198.3,
-                6712.0
+                164.1,
+                6711.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5404,8 +5305,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2637.9,
-                179.4
+                2664.8,
+                176.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5442,8 +5343,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5462,7 +5363,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7253.1 -0.0,589.8 422.1,592.8 422.4,766.5 685.8,766.1 1739.8,175.4 5676.1,133.0 5634.6,7254.1 -0.0,7253.1\" /></svg>"
+          "value": "<svg><polygon points=\"612.0,6725.0 -0.0,6721.8 -0.0,1336.9 -0.0,1306.8 -0.0,567.5 221.3,567.4 220.4,-0.0 5675.2,-0.0 5633.8,7198.3 633.5,7242.2 612.0,6725.0\" /></svg>"
         }
       },
       "body": {
@@ -5476,8 +5377,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5634.6,
-                3396.9
+                5633.8,
+                3395.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5497,8 +5398,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5634.6,
-                6756.1
+                5633.8,
+                6751.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5535,8 +5436,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5555,7 +5456,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2639.1,410.2 6266.1,460.7 6264.5,642.5 4382.2,573.5 4445.0,7795.0 612.4,7795.0 2549.6,1942.2 2639.1,410.2\" /></svg>"
+          "value": "<svg><polygon points=\"2672.4,566.6 2918.7,574.7 2916.2,416.6 4203.5,477.1 4210.9,7795.0 578.7,7795.0 2561.2,1999.7 2672.4,566.6\" /></svg>"
         }
       },
       "body": {
@@ -5569,8 +5470,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1337.8,
-                5581.8
+                1320.4,
+                5583.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5590,8 +5491,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2546.6,
-                1992.8
+                2560.8,
+                1999.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5621,15 +5522,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5648,7 +5549,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5316.7,7162.2 1333.9,7199.0 266.5,7795.0 -0.0,7795.0 -0.0,985.5 5325.1,1008.4 5316.7,7162.2\" /></svg>"
+          "value": "<svg><polygon points=\"5324.0,-0.0 5313.9,7027.4 -0.0,7019.3 -0.0,0.0 5324.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5677,8 +5578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9477855806799,
-                42.37056624861092
+                -82.94768651341549,
+                42.37070522713109
               ]
             }
           },
@@ -5698,8 +5599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94608074151112,
-                42.36799553521169
+                -82.94591492499956,
+                42.36803385451869
               ]
             }
           },
@@ -5719,8 +5620,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95035048598717,
-                42.36644723413504
+                -82.9503543819195,
+                42.366424006908225
               ]
             }
           },
@@ -5740,8 +5641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95205532515594,
-                42.369017947534275
+                -82.95212597033542,
+                42.36909537952062
               ]
             }
           },
@@ -5749,8 +5650,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5316.7,
-                7162.2
+                5313.7,
+                7159.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5770,7 +5671,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -5780,15 +5681,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "681.5"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6346.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7113.5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5797,7 +5714,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/info.json",
@@ -5807,11 +5724,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5666.1,7577.8 -0.0,7584.4 -0.0,2318.8 522.4,2316.5 479.4,4162.5 624.8,4164.5 690.1,607.9 5681.2,314.1 5666.1,7577.8\" /></svg>"
+          "value": "<svg><polygon points=\"680.4,681.5 5673.2,681.5 5662.0,7795.0 1371.5,7795.0 1266.0,7578.5 1242.5,2106.3 625.4,2109.0 680.4,681.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0069__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5821,8 +5738,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3843.5,
-                7577.8
+                3837.2,
+                7575.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5842,8 +5759,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5666.1,
-                7577.8
+                5661.8,
+                7575.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5863,7 +5780,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -5873,15 +5790,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "532.7"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6346.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7262.3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5890,7 +5823,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/info.json",
@@ -5900,11 +5833,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"403.7,414.4 853.9,391.0 830.2,0.0 6346.0,0.0 6346.0,161.2 5704.6,207.4 6133.0,7052.4 6346.0,7039.1 6346.0,7579.7 396.3,7576.6 403.7,414.4\" /></svg>"
+          "value": "<svg><polygon points=\"316.1,7571.1 317.1,532.7 5854.9,532.7 6346.0,7570.4 316.1,7571.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0070__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5914,8 +5847,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2571.8,
-                7577.8
+                4761.5,
+                7571.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5926,8 +5859,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.942537,
-                42.369778
+                -82.941345,
+                42.370204
               ]
             }
           },
@@ -5935,8 +5868,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2571.8,
-                393.5
+                316.1,
+                7571.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5947,8 +5880,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.944495,
-                42.3727707
+                -82.943763,
+                42.36934
               ]
             }
           }
@@ -5973,8 +5906,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5993,7 +5926,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3024.8,285.3 6346.0,414.3 6346.0,7795.0 -0.0,7795.0 -0.0,516.6 682.4,510.3 693.0,339.5 815.7,512.7 816.3,292.0 1739.3,295.6 1736.4,520.8 3053.7,526.9 3024.8,285.3\" /></svg>"
+          "value": "<svg><polygon points=\"3049.4,522.7 3020.5,281.2 6346.0,410.2 6346.0,7795.0 -0.0,7578.9 -0.0,283.8 1742.4,291.4 1739.5,514.4 3049.4,522.7\" /></svg>"
         }
       },
       "body": {
@@ -6007,8 +5940,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3037.6,
-                406.1
+                3033.0,
+                399.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6028,8 +5961,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4901.2,
-                406.1
+                4897.5,
+                399.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6066,8 +5999,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6086,7 +6019,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"645.7,51.1 6346.0,0.0 6346.0,7795.0 4834.2,7795.0 4841.3,7477.0 -0.0,7482.4 -0.0,595.7 612.4,605.0 645.7,51.1\" /></svg>"
+          "value": "<svg><polygon points=\"464.2,729.1 410.0,0.0 6346.0,0.0 6346.0,7795.0 4765.6,7795.0 4772.0,7464.9 -0.0,7483.3 -0.0,723.3 464.2,729.1\" /></svg>"
         }
       },
       "body": {
@@ -6100,8 +6033,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1111.2,
-                7477.0
+                1108.3,
+                7475.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6121,8 +6054,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4841.3,
-                7477.0
+                6041.9,
+                7475.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6133,8 +6066,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.936254,
-                42.368594
+                -82.935541,
+                42.368847
               ]
             }
           }
@@ -6142,13 +6075,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p73 [1]",
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p73 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -6164,7 +6097,7 @@
         },
         {
           "label": "split_canvas_y",
-          "value": "3930.0"
+          "value": "3939.9"
         },
         {
           "label": "split_canvas_w",
@@ -6172,11 +6105,11 @@
         },
         {
           "label": "split_canvas_h",
-          "value": "3865.0"
+          "value": "3855.1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6185,7 +6118,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073/info.json",
@@ -6195,11 +6128,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6346.0,3930.0 6346.0,7795.0 -0.0,7795.0 -0.0,4151.4 1984.9,4127.9 1979.3,3930.0 6346.0,3930.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,3939.9 321.4,3939.9 321.4,4110.0 6346.0,4160.9 6346.0,7795.0 -0.0,7795.0 0.0,3939.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -6209,8 +6142,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2471.0,
-                4122.0
+                2460.8,
+                4115.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6230,8 +6163,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5669.2,
-                4122.0
+                940.3,
+                4115.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6242,8 +6175,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.970019,
-                42.359887
+                -82.9726006,
+                42.3589503
               ]
             }
           }
@@ -6268,8 +6201,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6288,7 +6221,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,-0.0 312.8,0.0 312.8,252.5 5732.2,251.9 5734.3,476.8 6346.0,471.3 6346.0,7795.0 -0.0,7795.0 0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,249.1 6346.0,247.3 6346.0,7795.0 -0.0,7795.0 -0.0,249.1\" /></svg>"
         }
       },
       "body": {
@@ -6302,8 +6235,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                632.7,
-                251.9
+                624.2,
+                248.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6323,8 +6256,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5902.2,
-                251.9
+                5897.9,
+                248.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6361,8 +6294,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6410,8 +6343,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96402569515986,
-                42.362198441744056
+                -82.96403146520805,
+                42.36220067348339
               ]
             }
           },
@@ -6431,8 +6364,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96055986063543,
-                42.36347504524611
+                -82.96042993351669,
+                42.36352726385061
               ]
             }
           },
@@ -6452,8 +6385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95843952674187,
-                42.3603274431591
+                -82.95822532126668,
+                42.360254541397005
               ]
             }
           },
@@ -6473,8 +6406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96190536126632,
-                42.359050839657044
+                -82.96182685295804,
+                42.3589279510298
               ]
             }
           },
@@ -6482,8 +6415,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                220.3,
-                299.1
+                216.1,
+                296.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6517,11 +6450,11 @@
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6540,7 +6473,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6040.7,425.0 6020.5,7795.0 -0.0,7795.0 -0.0,0.0 898.5,0.0 898.8,427.2 6040.7,425.0\" /></svg>"
+          "value": "<svg><polygon points=\"6037.9,423.9 6019.5,7795.0 -0.0,7795.0 0.0,-0.0 676.8,0.0 681.1,427.5 6037.9,423.9\" /></svg>"
         }
       },
       "body": {
@@ -6554,8 +6487,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2811.0,
-                7313.3
+                2808.9,
+                7311.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6575,8 +6508,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6040.7,
-                425.0
+                6037.9,
+                423.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6613,8 +6546,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6633,7 +6566,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4891.5,7299.2 478.8,7314.6 482.2,446.1 4888.3,432.2 4891.5,7299.2\" /></svg>"
+          "value": "<svg><polygon points=\"4892.7,7296.9 474.3,7312.3 477.8,445.3 4889.5,431.3 4892.7,7296.9\" /></svg>"
         }
       },
       "body": {
@@ -6647,8 +6580,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2140.5,
-                7313.3
+                2136.7,
+                7311.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6668,8 +6601,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2140.5,
-                440.8
+                2136.7,
+                439.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6706,8 +6639,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6726,7 +6659,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5541.4,7356.6 -0.0,7359.0 -0.0,459.2 4906.8,485.7 5006.8,5375.5 5444.8,6301.7 5541.4,7356.6\" /></svg>"
+          "value": "<svg><polygon points=\"5541.0,7348.6 -0.0,7350.9 -0.0,450.6 4892.8,477.2 4992.6,5349.7 5444.2,6293.6 5541.0,7348.6\" /></svg>"
         }
       },
       "body": {
@@ -6740,8 +6673,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                635.9,
-                7351.1
+                632.2,
+                7343.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6761,8 +6694,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                635.9,
-                456.5
+                632.2,
+                447.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6792,15 +6725,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6819,7 +6752,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"419.2,6262.4 -0.0,5327.0 -0.0,425.9 6335.0,544.1 6335.0,1457.0 5152.7,1430.7 5077.8,7071.1 446.3,6981.0 419.2,6262.4\" /></svg>"
+          "value": "<svg><polygon points=\"415.7,6302.3 -0.0,5385.5 -0.0,688.8 6335.0,807.0 6335.0,1685.4 4967.5,1655.2 4883.6,7795.0 470.5,7795.0 415.7,6302.3\" /></svg>"
         }
       },
       "body": {
@@ -6848,8 +6781,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94986854753954,
-                42.3673565624981
+                -82.94995617035855,
+                42.36747056359722
               ]
             }
           },
@@ -6869,8 +6802,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9464265813125,
-                42.36865555125106
+                -82.94637685002638,
+                42.36882139374438
               ]
             }
           },
@@ -6890,8 +6823,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94426477805784,
-                42.36552341131436
+                -82.94412912010432,
+                42.365564748077226
               ]
             }
           },
@@ -6911,8 +6844,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94770674428489,
-                42.36422442256141
+                -82.94770844043649,
+                42.36421391793006
               ]
             }
           },
@@ -6920,8 +6853,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                494.3,
-                7319.6
+                487.9,
+                7319.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6958,8 +6891,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6978,7 +6911,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1163.2,415.6 5714.7,443.9 5675.5,6959.0 -0.0,6930.8 -0.0,1312.2 1175.2,1322.8 1163.2,415.6\" /></svg>"
+          "value": "<svg><polygon points=\"5673.9,7795.0 688.9,7795.0 689.8,7642.8 -0.0,7652.2 -0.0,7262.7 -0.0,1310.0 1412.8,1321.9 1403.4,632.3 5709.9,660.8 5673.9,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -6992,8 +6925,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3863.3,
-                7313.3
+                3863.4,
+                7307.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7013,8 +6946,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5714.7,
-                443.9
+                5711.1,
+                439.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7051,8 +6984,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7071,7 +7004,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5855.5,7344.4 396.4,7355.1 394.8,495.4 5816.1,503.7 5855.5,7344.4\" /></svg>"
+          "value": "<svg><polygon points=\"5836.6,7342.7 393.2,7353.3 391.6,490.8 5816.2,499.1 5836.6,7342.7\" /></svg>"
         }
       },
       "body": {
@@ -7085,8 +7018,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2610.2,
-                7344.8
+                2607.6,
+                7343.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7106,8 +7039,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2610.2,
-                500.6
+                2607.6,
+                495.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7144,8 +7077,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7164,7 +7097,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,860.2 464.2,859.3 462.8,355.7 4915.6,343.7 4905.1,7795.0 -0.0,7795.0 -0.0,860.2\" /></svg>"
+          "value": "<svg><polygon points=\"3724.4,4505.0 -0.0,4365.1 -0.0,860.2 461.3,859.5 459.9,352.0 4933.0,339.7 4927.3,4378.9 3848.4,4384.1 3724.4,4505.0\" /></svg>"
         }
       },
       "body": {
@@ -7178,8 +7111,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2144.2,
-                355.7
+                2143.7,
+                352.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7199,8 +7132,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                462.8,
-                355.7
+                459.9,
+                352.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7237,8 +7170,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7257,7 +7190,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5317.3,406.1 5436.5,7795.0 -0.0,7795.0 -0.0,414.5 5317.3,406.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,408.2 5347.2,399.9 5468.5,4139.2 5408.0,4152.8 5467.3,7795.0 1619.0,7795.0 -0.0,6674.7 -0.0,408.2\" /></svg>"
         }
       },
       "body": {
@@ -7271,8 +7204,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                620.3,
-                406.1
+                611.9,
+                399.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7292,8 +7225,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5318.0,
-                406.1
+                5347.2,
+                399.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7323,15 +7256,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7350,7 +7283,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5640.5,0.0 5642.6,350.3 6335.0,350.3 6335.0,708.2 5644.9,721.6 5645.9,879.3 6335.0,875.1 6335.0,3441.5 5567.1,3441.8 5613.7,7085.8 1185.6,7077.9 1023.2,0.0 5640.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,723.6 6335.0,3438.1 5597.4,3438.3 5601.8,7085.4 1185.6,7077.5 1069.1,826.0 6335.0,723.6\" /></svg>"
         }
       },
       "body": {
@@ -7364,8 +7297,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3271.4,
-                5802.2
+                3271.5,
+                5799.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7385,8 +7318,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1183.9,
-                5802.2
+                1183.8,
+                5799.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7420,11 +7353,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7443,7 +7376,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1963.6,7795.0 -0.0,7795.0 -0.0,3454.0 730.9,3454.7 734.0,869.6 39.9,873.0 39.1,714.2 734.2,701.5 734.7,341.0 37.3,340.1 35.6,0.0 5769.2,0.0 5811.9,7159.4 1964.7,7196.0 1963.6,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"1967.8,7795.0 -0.0,7795.0 -0.0,3454.6 739.9,3455.2 743.0,885.5 5761.6,862.4 5810.2,7171.7 1969.0,7163.6 1967.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7457,8 +7390,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3734.2,
-                5840.0
+                3731.4,
+                5831.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7478,8 +7411,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3734.2,
-                3463.0
+                3731.4,
+                3463.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7516,8 +7449,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7536,7 +7469,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4050.2,7224.3 4060.9,6347.5 289.7,6334.4 293.6,6025.0 -0.0,6026.0 -0.0,-0.0 6101.6,0.0 6011.3,7217.5 4050.2,7224.3\" /></svg>"
+          "value": "<svg><polygon points=\"4045.6,7221.3 4056.2,6347.9 281.0,6334.8 284.3,6071.2 -0.0,6068.3 -0.0,-0.0 6099.0,0.0 6008.8,7214.5 4045.6,7221.3\" /></svg>"
         }
       },
       "body": {
@@ -7550,8 +7483,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2178.4,
-                311.7
+                2171.7,
+                304.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7571,8 +7504,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6097.6,
-                311.7
+                6095.1,
+                304.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7609,8 +7542,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7629,7 +7562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5256.3,391.6 5296.2,7138.4 40.7,7162.3 -0.0,403.5 5256.3,391.6\" /></svg>"
+          "value": "<svg><polygon points=\"5247.9,390.1 5294.4,7144.3 40.4,7168.2 -0.0,401.9 5247.9,390.1\" /></svg>"
         }
       },
       "body": {
@@ -7643,8 +7576,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4335.6,
-                5830.5
+                4327.3,
+                5831.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7664,8 +7597,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4335.6,
-                393.5
+                4327.3,
+                391.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7695,15 +7628,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7722,7 +7655,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,380.6 4987.9,375.2 4980.6,703.1 6335.0,691.2 6252.3,7795.0 1242.4,7795.0 1245.1,7098.2 -0.0,7109.1 -0.0,380.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7117.5 -0.0,368.6 4999.2,368.0 4991.6,703.2 6335.0,708.0 6335.0,7121.0 1241.6,7109.7 1238.3,7795.0 1045.4,7795.0 1046.9,7120.0 -0.0,7117.5\" /></svg>"
         }
       },
       "body": {
@@ -7736,8 +7669,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1250.0,
-                5805.3
+                1247.8,
+                5807.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7757,8 +7690,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3126.6,
-                374.6
+                4999.2,
+                368.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7769,8 +7702,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.937278,
-                42.368221
+                -82.936254,
+                42.368594
               ]
             }
           }
@@ -7795,8 +7728,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7815,7 +7748,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6120.4,694.9 6121.8,0.0 6335.0,0.0 6335.0,7795.0 1055.0,7795.0 1057.5,7122.3 883.8,7123.6 884.7,12.7 1081.2,0.0 1079.4,701.2 6120.4,694.9\" /></svg>"
+          "value": "<svg><polygon points=\"1055.4,7117.2 882.9,7117.3 883.8,688.7 1077.0,688.3 1079.3,0.0 6335.0,0.0 6335.0,7795.0 1053.1,7795.0 1055.4,7117.2\" /></svg>"
         }
       },
       "body": {
@@ -7829,8 +7762,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1073.7,
-                2924.7
+                1071.8,
+                2919.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7850,8 +7783,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4823.7,
-                2924.7
+                4823.2,
+                2919.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7864,6 +7797,99 @@
               "coordinates": [
                 -82.933654,
                 42.364666
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p93",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1597.7,381.5 2625.8,367.0 2677.0,311.7 3146.1,285.1 3201.0,1375.7 3962.2,1847.8 5206.2,1785.3 5291.6,3473.5 6335.0,4785.2 6335.0,7795.0 -0.0,7795.0 -0.0,0.0 982.6,0.0 1597.7,381.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0093/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2667.6,
+                328.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9501374,
+                42.3615651
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4115.4,
+                328.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.948284,
+                42.3621447
               ]
             }
           }
@@ -7888,8 +7914,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7908,7 +7934,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5521.9,7795.0 -0.0,7795.0 -0.0,951.9 1145.2,952.3 1143.7,0.0 5554.4,0.0 5521.9,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"1150.8,6321.4 -0.0,4714.1 -0.0,892.6 1142.5,893.0 1141.2,0.0 5537.0,0.0 5516.5,7795.0 1153.1,7795.0 1150.8,6321.4\" /></svg>"
         }
       },
       "body": {
@@ -7922,8 +7948,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3227.3,
-                2915.3
+                3223.5,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7943,8 +7969,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5516.4,
-                2915.3
+                5511.1,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7974,15 +8000,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8001,37 +8027,34 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"275.1,577.9 2230.8,596.5 2237.6,0.0 6069.7,0.0 6059.4,7795.0 150.0,7795.0 275.1,577.9\" /></svg>"
+          "value": "<svg><polygon points=\"6123.2,7066.5 5984.6,7066.5 5984.9,7795.0 165.8,7795.0 194.8,640.2 2177.2,636.1 2177.0,0.0 6046.6,0.0 6123.2,7066.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0095/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                3951.4,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9433963573186,
-                42.36257391929449
+                -82.940444,
+                42.362206
               ]
             }
           },
@@ -8039,71 +8062,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6335.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93993918369854,
-                42.36385063511262
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93781444751079,
-                42.360704656666236
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94127162113085,
-                42.35942794084811
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5982.4,
-                2915.3
+                5983.1,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8140,8 +8100,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8160,7 +8120,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -8174,8 +8134,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2122.2,
-                2912.1
+                2115.7,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8195,8 +8155,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4301.0,
-                2912.1
+                4295.3,
+                2911.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8209,99 +8169,6 @@
               "coordinates": [
                 -82.936924,
                 42.363479
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p97",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5395.8,981.9 5309.1,7772.0 -0.0,7795.0 -0.0,967.1 5395.8,981.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3088.8,
-                2210.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.942135,
-                42.358519
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                991.8,
-                2210.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.943284,
-                42.358105
               ]
             }
           }
@@ -8326,8 +8193,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8346,7 +8213,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5912.2,901.3 5913.1,2175.4 6335.0,2173.5 6335.0,7795.0 -0.0,7795.0 72.4,971.2 5912.2,901.3\" /></svg>"
+          "value": "<svg><polygon points=\"5910.2,874.4 5911.1,2175.7 5788.8,2175.7 5788.9,7795.0 -0.0,7795.0 -0.0,948.1 98.3,948.2 98.4,876.3 5910.2,874.4\" /></svg>"
         }
       },
       "body": {
@@ -8360,8 +8227,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3872.8,
-                2175.4
+                96.0,
+                2175.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8372,8 +8239,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.938809,
-                42.359714
+                -82.940874,
+                42.358974
               ]
             }
           },
@@ -8381,8 +8248,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5913.1,
-                2175.4
+                5911.1,
+                2175.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8412,15 +8279,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T19:06:49Z",
-      "modified": "2026-06-10T19:06:49Z",
+      "created": "2026-07-17T16:35:37Z",
+      "modified": "2026-07-17T16:35:37Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8439,37 +8306,34 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6335.0,775.9 6335.0,2041.4 5707.2,2034.1 5690.0,7795.0 -0.0,7795.0 -0.0,7527.5 477.7,7535.2 567.4,1974.8 150.0,1970.0 169.4,709.6 6335.0,775.9\" /></svg>"
+          "value": "<svg><polygon points=\"254.5,0.0 258.5,739.7 6335.0,707.1 6335.0,7795.0 -0.0,7795.0 -0.0,1991.7 120.0,1991.7 118.6,0.0 254.5,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0099/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                120.0,
+                1991.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.93832411510802,
-                42.360873911993664
+                -82.937701,
+                42.360111
               ]
             }
           },
@@ -8477,71 +8341,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6335.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93487415152855,
-                42.36216124801358
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93273174098701,
-                42.3590218306008
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.93618170456648,
-                42.35773449458089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                119.6,
-                3856.6
+                120.0,
+                3855.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",

--- a/gallery/grand_rapids_mi_1953_vol7.iiif.json
+++ b/gallery/grand_rapids_mi_1953_vol7.iiif.json
@@ -1,178 +1,19 @@
 {
-  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn05791_053/main-content//generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn04023_023/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Mosaic of main content, Brooklyn, N.Y. | 1939 | Vol. 1",
+  "label": "Mosaic of main content, Grand Rapids, Mich. | 1953 | Vol. 7",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p1",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.02329946235103,
-                40.67718446758965
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.02041525312393,
-                40.6796283326228
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01565946488587,
-                40.676397560306384
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01854367411298,
-                40.67395369527323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5491.0,
-                7724.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.016028,
-                40.676563
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p10",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p701",
       "metadata": [
         {
           "label": "streets",
@@ -180,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -193,21 +34,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5599.0,8268.0 5373.8,8268.0 5361.4,7291.8 4422.2,7303.7 4411.2,7664.0 0.0,7664.4 0.0,-0.0 5599.0,0.0 5599.0,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"1947.9,0.0 4321.5,0.0 4321.9,356.4 5029.9,351.3 5111.1,1782.6 4323.6,1796.2 4328.1,5744.7 4475.0,8070.0 1423.8,8070.0 990.1,263.8 1964.7,331.6 1947.9,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -217,8 +58,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4411.2,
-                7664.0
+                3248.0,
+                4614.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -229,8 +70,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9994446,
-                40.6916676
+                -85.665309,
+                42.925539
               ]
             }
           },
@@ -238,8 +79,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                555.9,
-                7664.0
+                5272.0,
+                4614.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -250,8 +91,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -85.664046,
+                42.925516
               ]
             }
           }
@@ -259,358 +100,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p11",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,382.0 4893.0,460.7 4896.0,1361.4 5599.0,1359.0 5599.0,8268.0 -0.0,8268.0 -0.0,382.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2459.6,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.015425,
-                40.675199
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5351.0,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.013855,
-                40.674128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p13",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,261.1 5227.9,415.5 5059.5,-0.0 5612.0,-0.0 5612.0,261.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0138049615332,
-                40.67445210987348
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01057182377127,
-                40.67226350816088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01482175977381,
-                40.668649624515666
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01805489753573,
-                40.67083822622827
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                320.0,
-                456.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.013855,
-                40.674128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5522.4,5644.3 5534.2,6829.3 338.8,6828.9 320.0,1619.1 5384.9,1611.8 5369.4,5386.5 5522.4,5644.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5372.0,
-                2928.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01206,
-                40.675781
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                328.0,
-                4224.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.015401,
-                40.677098
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p2",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p702",
       "metadata": [
         {
           "label": "streets",
@@ -618,11 +114,197 @@
         },
         {
           "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1206.5,6114.6 1203.5,1092.7 4065.1,1257.9 4022.4,2011.8 4398.4,2033.1 4536.0,8043.9 5227.3,8028.1 5223.4,6259.4 6660.0,6341.8 6660.0,8070.0 2221.8,8070.0 2222.9,6143.7 1206.5,6114.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0702/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3232.0,
+                2183.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.665196,
+                42.923505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3232.0,
+                6174.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.665113,
+                42.921653
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54270/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54270/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"694.2,1853.6 624.0,591.9 -0.0,595.7 0.0,-0.0 6660.0,0.0 6660.0,6506.3 6003.4,6533.1 5960.9,5999.4 4005.0,6155.1 4034.8,7074.4 4328.2,8070.0 1055.6,8070.0 955.6,6397.7 208.3,6457.1 336.6,8070.0 -0.0,8070.0 -0.0,7394.9 127.1,7395.1 -0.0,5432.8 -0.0,1864.8 694.2,1853.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54270/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2412.0,
+                591.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.662865,
+                42.927449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                624.0,
+                591.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.664131,
+                42.927471
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54273/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p704",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
           "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -631,21 +313,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54273/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5095.1,7668.0 -0.0,7685.4 0.0,-0.0 5599.0,0.0 5599.0,4888.0 5095.1,4888.0 5095.1,7668.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 6660.0,0.0 6660.0,617.8 4342.5,8070.0 -0.0,8070.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54273/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -655,8 +337,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                4888.0
+                5104.0,
+                4618.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -667,8 +349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0156533,
-                40.6791877
+                -85.661237,
+                42.922483
               ]
             }
           },
@@ -676,8 +358,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                7668.0
+                4628.0,
+                2351.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -688,8 +370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0141485,
-                40.678165
+                -85.661605,
+                42.92349
               ]
             }
           }
@@ -697,397 +379,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54274/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p20",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p705",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"194.7,7341.8 186.5,4776.4 -0.0,4777.6 -0.0,0.0 1237.0,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.5 5212.2,4302.1 5208.9,7333.7 194.7,7341.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1240.0,
-                916.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0104477,
-                40.6804294
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5184.0,
-                916.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.008302,
-                40.67897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1185.4,0.0 2742.9,0.0 2756.5,248.9 5463.7,250.7 5407.8,4902.0 4729.6,7042.0 4418.9,6266.1 2591.4,7001.0 2093.5,6980.3 1692.5,7140.9 1793.0,7313.3 230.3,7911.5 266.5,247.3 1184.4,247.9 1185.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2831.5,
-                4184.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007061,
-                40.680042
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5423.0,
-                1436.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007303,
-                40.682123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p22",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5621
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5621.0,4303.3 5621.0,7056.8 4971.2,6433.3 4983.6,8125.1 4290.6,7601.9 -0.0,5893.5 861.7,3570.3 1068.5,3632.3 1239.2,3638.9 1285.9,3494.7 -0.0,3077.7 -0.0,-0.0 1975.4,0.0 1992.4,432.0 5153.6,412.0 5185.3,4308.0 5621.0,4303.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5184.9,
-                4308.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0039713,
-                40.6823752
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1992.4,
-                432.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0051587,
-                40.6850009
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2073.6,448.4 2329.2,297.3 4764.0,304.0 4759.5,4110.0 3818.6,4493.1 5273.3,8268.0 -0.0,8268.0 -0.0,-0.0 900.8,0.0 899.9,458.2 2073.6,448.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3468.0,
-                3076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.011181,
-                40.674223
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4764.0,
-                304.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01206,
-                40.675781
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
+          "value": "7"
         },
         {
           "label": "intersections",
           "value": "15"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1096,21 +406,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54274/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1326.4,7230.1 305.1,4610.0 1252.5,4218.3 1236.3,377.8 5612.0,378.3 5612.0,3186.2 3759.9,3183.6 2638.7,3670.2 3714.1,6239.4 1326.4,7230.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,2185.4 429.6,2220.0 425.9,354.4 1444.6,378.2 1453.4,2308.6 6660.0,2189.6 6660.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54274/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1120,8 +430,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3832.0,
-                392.0
+                2288.0,
+                5726.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1132,8 +442,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.010793,
-                40.676834
+                -85.665126,
+                42.9191848
               ]
             }
           },
@@ -1141,8 +451,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1248.0,
-                3172.0
+                2456.0,
+                399.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1153,8 +463,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.010554,
-                40.674758
+                -85.665113,
+                42.921653
               ]
             }
           }
@@ -1162,25 +472,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p706",
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1189,21 +499,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5622
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4974.6,1732.5 5130.1,7428.0 2371.2,7532.0 2309.8,6321.6 2956.9,4602.8 725.2,3765.7 1904.1,586.6 4974.6,1732.5\" /></svg>"
+          "value": "<svg><polygon points=\"6096.0,0.0 6105.4,266.1 5817.6,274.1 5920.8,4017.8 6248.0,4027.4 6403.5,8070.0 764.8,8070.0 -0.0,8070.0 -0.0,0.0 6096.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1213,8 +523,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1071.6,
-                1648.0
+                4492.0,
+                6838.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1225,8 +535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0089209,
-                40.6784355
+                -85.6586894,
+                42.9211064
               ]
             }
           },
@@ -1234,8 +544,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2371.2,
-                7532.0
+                596.0,
+                3863.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1246,8 +556,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0096123,
-                40.6751413
+                -85.661237,
+                42.922483
               ]
             }
           }
@@ -1255,25 +565,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54276/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p26",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p707",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1282,21 +592,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54276/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5464
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5464,0 5464,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,5694.5 5777.6,5724.3 5857.2,8070.0 1084.5,8070.0 1014.8,6874.6 -0.0,6897.5 0.0,0.0 5553.0,50.8 5566.9,449.8 6394.6,453.4 6660.0,5694.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54276/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1306,8 +616,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1688.0,
-                676.0
+                2568.0,
+                431.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1318,8 +628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044835,
-                40.6692758
+                -85.656707,
+                42.927389
               ]
             }
           },
@@ -1327,8 +637,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3296.0,
-                676.0
+                640.0,
+                431.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1339,8 +649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0033677,
-                40.6689515
+                -85.657948,
+                42.927394
               ]
             }
           }
@@ -1348,13 +658,106 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54277/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p27",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p708",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54277/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4293.8,6936.6 2343.0,6775.0 2326.7,6562.6 357.8,6617.8 337.5,3886.5 -0.0,3867.2 -0.0,-0.0 297.3,0.0 305.0,957.9 6660.0,1348.1 6660.0,8070.0 4305.3,8070.0 4293.8,6936.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54277/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4268.0,
+                1203.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.655207,
+                42.923758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                360.0,
+                6854.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6574901,
+                42.9210914
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54279/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p709",
       "metadata": [
         {
           "label": "streets",
@@ -1365,8 +768,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1375,21 +778,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54279/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5497
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5264.0,7862.3 2688.5,7920.0 2688.5,6019.3 0.0,6053.4 0.0,654.2 2688.5,1700.9 2688.5,440.0 5255.1,397.5 5264.0,7862.3\" /></svg>"
+          "value": "<svg><polygon points=\"6535.6,4378.1 6380.6,7200.2 374.1,7224.9 392.5,6803.8 -0.0,6798.9 0.0,0.0 2661.4,-0.0 2626.0,565.3 4478.2,561.3 4426.2,1402.2 5267.4,1451.8 5292.0,4397.6 6535.6,4378.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54279/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1399,8 +802,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                440.0
+                2384.0,
+                4418.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1411,8 +814,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.008337,
-                40.6732973
+                -85.64798,
+                42.926454
               ]
             }
           },
@@ -1420,8 +823,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                7920.0
+                500.0,
+                4418.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1432,8 +835,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0032316,
-                40.6718496
+                -85.6480304,
+                42.927337
               ]
             }
           }
@@ -1441,25 +844,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54280/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p28",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p710",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "6"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1468,21 +871,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54280/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"234.7,246.2 5229.0,178.5 5270.6,6865.4 5612.0,7294.5 5612.0,7875.2 5355.6,7755.2 4616.9,7714.3 266.2,7818.7 234.7,246.2\" /></svg>"
+          "value": "<svg><polygon points=\"6258.4,2607.5 6260.5,2759.9 6529.6,2756.2 6420.0,5342.7 5660.4,5339.8 5658.7,7163.4 430.0,7246.2 397.8,8070.0 -0.0,8070.0 0.0,0.0 699.9,-0.0 686.8,417.1 6227.0,325.2 6237.7,1103.4 6599.8,1096.8 6660.0,1376.0 6536.1,2608.7 6258.4,2607.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54280/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1492,8 +895,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5264.0,
-                5072.0
+                6420.0,
+                5342.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1504,8 +907,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0031933,
-                40.6762708
+                -85.6529012,
+                42.9245605
               ]
             }
           },
@@ -1513,8 +916,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3992.0,
-                2744.0
+                432.0,
+                7246.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1525,8 +928,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0050803,
-                40.6760699
+                -85.654244,
+                42.927368
               ]
             }
           }
@@ -1534,25 +937,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54281/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p711",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "13"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1561,21 +964,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54281/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8267,
-          "width": 5490
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2681.0,196.0 2651.9,0.0 3081.1,0.0 3532.8,202.9 5490.0,200.3 5490.0,7681.2 1356.1,7659.8 1250.8,7732.9 192.5,6777.4 242.7,162.5 2681.0,196.0\" /></svg>"
+          "value": "<svg><polygon points=\"624.7,6378.8 -0.0,6331.6 11.2,-0.0 6660.0,0.0 6660.0,721.6 6263.8,692.4 6277.5,2559.0 6660.0,2592.0 6660.0,8070.0 -0.0,8070.0 -0.0,6648.7 617.4,6664.5 624.7,6378.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/54281/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1585,8 +988,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1440.5,
-                4959.4
+                5332.0,
+                2335.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1597,8 +1000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0028805,
-                40.6769149
+                -85.634793,
+                42.925639
               ]
             }
           },
@@ -1606,8 +1009,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2681.0,
-                196.0
+                6276.0,
+                2335.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1618,8 +1021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0058614,
-                40.678464
+                -85.633643,
+                42.925687
               ]
             }
           }
@@ -1627,106 +1030,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p3",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"471.8,7725.0 471.9,4936.0 977.5,4936.0 977.7,32.1 5599.0,0.0 5599.0,7531.0 3056.6,7529.9 3057.8,7726.7 471.8,7725.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1763.7,
-                4936.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0150289,
-                40.6797166
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                471.9,
-                4936.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0156533,
-                40.6791877
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p30",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p712",
       "metadata": [
         {
           "label": "streets",
@@ -1737,8 +1047,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1747,21 +1057,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"536.0,7706.8 502.4,1046.7 1385.7,0.0 3068.1,0.0 2443.3,641.5 4984.2,660.2 4987.3,7701.9 536.0,7706.8\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,2869.4 6660.0,8070.0 4568.8,8070.0 4216.7,8070.0 -0.0,6900.0 -0.0,3013.2 -0.0,821.4 2368.0,-0.0 4234.8,-0.0 6660.0,471.7 6660.0,2869.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1771,8 +1081,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3892.0,
-                4992.0
+                2368.0,
+                3495.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1783,8 +1093,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.001018,
-                40.680792
+                -85.643079,
+                42.92638
               ]
             }
           },
@@ -1792,8 +1102,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5180.0,
-                228.0
+                2364.0,
+                351.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1804,8 +1114,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0039713,
-                40.6823752
+                -85.641088,
+                42.926355
               ]
             }
           }
@@ -1813,13 +1123,1325 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/54283/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p713",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54283/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1473.5,6959.5 1400.5,2454.3 -0.0,2394.6 0.0,0.0 2699.9,0.0 2697.6,759.2 6660.0,923.6 6660.0,2662.6 5306.6,2602.0 5363.7,6520.4 5071.8,6530.2 5081.0,6808.9 1473.5,6959.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54283/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65465980224279,
+                42.92488366371091
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65035249975533,
+                42.924973048968326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65020443851557,
+                42.9211532216208
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65451174100303,
+                42.92106383636339
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                968.0,
+                2439.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.653989,
+                42.923742
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54284/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p714",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54284/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6339.8,4669.6 6660.0,4734.7 6660.0,6481.5 -0.0,6242.1 0.0,-0.0 6660.0,0.0 6659.0,3967.5 6339.8,4669.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54284/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5540.0,
+                3955.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.647737,
+                42.923003
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3680.0,
+                487.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.648968,
+                42.9245228
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p715",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4946.8 -0.0,1223.7 675.4,0.0 6660.0,0.0 6660.0,977.5 5986.2,5611.1 5953.8,7327.9 1765.2,7028.0 1777.5,5321.5 -0.0,4946.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                680.0,
+                567.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.647868,
+                42.924834
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                680.0,
+                6950.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.647667,
+                42.921901
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54870/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p716",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "10"
+        },
+        {
+          "label": "intersections",
+          "value": "21"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54870/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7185.0 -0.0,641.8 2457.2,765.0 6660.0,1315.7 6660.0,1639.3 6660.0,3350.7 6660.0,7503.2 6660.0,8070.0 2425.0,8070.0 -0.0,7185.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54870/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2472.0,
+                7294.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.642826,
+                42.9218255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                1263.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.640966,
+                42.924587
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54871/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p717",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54871/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5077.4 1115.0,5096.8 1164.1,2252.8 600.0,2219.1 597.4,1790.0 -0.0,1779.6 -0.0,1405.1 596.5,1429.4 590.2,0.0 2533.6,0.0 2550.1,181.0 2804.4,271.1 4476.0,365.9 4472.8,1486.2 5317.5,1497.2 5392.7,7586.4 6660.0,7570.7 6660.0,8070.0 -0.0,8070.0 -0.0,5077.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54871/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2376.0,
+                4071.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.656222,
+                42.9193653
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4476.0,
+                367.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.655031,
+                42.921135
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54872/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p718",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54872/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1996.5 1478.1,2034.0 1529.9,0.0 5213.4,0.0 5146.8,7848.5 6660.0,7861.3 6660.0,8070.0 -0.0,8070.0 -0.0,1996.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54872/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2976.0,
+                3287.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6525184,
+                42.9201334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1000.0,
+                6698.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.653617,
+                42.918487
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/54873/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p719",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54873/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,0.0 2502.2,0.0 5616.0,259.9 5511.9,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/54873/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1708.0,
+                3867.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6500182,
+                42.9201024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5616.0,
+                259.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.647667,
+                42.921901
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/55521/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p720",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "14"
+        },
+        {
+          "label": "intersections",
+          "value": "25"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/55521/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,4483.2 657.3,4429.7 385.8,432.2 4238.3,439.0 4268.3,822.6 5752.6,746.9 5859.0,2134.8 6660.0,2073.4 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/55521/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2716.0,
+                6242.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.644906,
+                42.916556
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6192.0,
+                5386.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.640555,
+                42.917275
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/80433__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3841.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2818.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3227.2"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/80433__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3841.2,3227.2 3841.2,0.0 6098.5,0.0 6108.2,419.9 6660.0,443.3 6660.0,3227.2 3841.2,3227.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/80433__3/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3841.2,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65888817117374,
+                42.92032934389923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6570651111259,
+                42.920383215148505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                3227.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65698083393976,
+                42.918856293230704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3841.2,
+                3227.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6588038939876,
+                42.91880242198143
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6108.2,
+                419.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.657411,
+                42.920174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/80433__5/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p721 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4707.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3222.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1952.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4848.0"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/80433__5/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,7212.9 4901.1,7377.8 4896.4,7001.6 4707.6,7017.9 4707.6,3222.0 6660.0,3222.0 6660.0,7212.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/80433__5/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5661.8,
+                7306.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6337063,
+                42.9264326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6436.4,
+                5332.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.631198,
+                42.925647
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3994.2"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5062.9,3994.2 -0.0,3994.2 -0.0,0.0 6660.0,-0.0 6660.0,526.8 5062.9,3994.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2128.0,
+                3710.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6659127,
+                42.9113354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5732.0,
+                527.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6617495,
+                42.9081234
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p724 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "3993.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "4077.0"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5479.1,7245.0 3894.6,7316.2 3909.1,7675.8 6660.0,7564.9 6660.0,8070.0 -0.0,8070.0 -0.0,4227.5 3192.9,4088.8 3196.4,3993.0 5578.0,3993.0 5479.1,7245.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3952.0,
+                7314.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6656163,
+                42.905052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1852.0,
+                4148.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6616891,
+                42.9069272
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/78642__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p725 [3]",
       "metadata": [
         {
           "label": "streets",
@@ -1827,11 +2449,27 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "9"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1840,21 +2478,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/78642__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5589
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5372.8,225.6 5343.9,7743.6 0.0,7735.7 0.0,234.5 5372.8,225.6\" /></svg>"
+          "value": "<svg><polygon points=\"2818.4,5856.6 2291.7,5837.6 2251.4,3331.1 2082.5,3244.6 1063.1,3198.1 1001.6,2482.5 -0.0,1469.5 -0.0,541.2 2728.6,671.9 2719.0,117.4 -0.0,164.5 -0.0,-0.0 6660.0,0.0 6660.0,6871.6 6323.6,6872.4 6336.7,8070.0 5333.3,8070.0 5306.0,6634.0 2833.9,6753.2 2818.4,5856.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/78642__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1864,8 +2502,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2768.5,
-                5016.0
+                3488.0,
+                703.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1876,8 +2514,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.000048,
-                40.682803
+                -85.660361,
+                42.912888
               ]
             }
           },
@@ -1885,8 +2523,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1480.3,
-                5016.0
+                2276.0,
+                4538.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1897,8 +2535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.000371,
-                40.682133
+                -85.6617997,
+                42.9093233
               ]
             }
           }
@@ -1906,13 +2544,215 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/78677__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p32",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p726 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/78677__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7097.2 -0.0,1040.1 2898.1,1145.8 2962.2,-0.0 6660.0,-0.0 6660.0,7303.8 3338.8,7031.9 3316.3,7220.0 -0.0,7097.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/78677__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                668.0,
+                7122.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6616891,
+                42.9069272
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3328.0,
+                7122.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6615655,
+                42.905713
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p727",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 6270.8,8070.0 6163.6,6066.5 2437.8,6265.9 2439.9,5397.0 -0.0,5402.5 -0.0,0.0 6660.0,-0.0 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0727/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3500.0,
+                5394.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65659,
+                42.905649
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                572.0,
+                5394.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.656628,
+                42.906977
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -1920,11 +2760,27 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "7"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3891.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1933,21 +2789,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5481
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"10.9,7891.7 49.2,345.9 5237.7,343.1 4774.5,7893.4 10.9,7891.7\" /></svg>"
+          "value": "<svg><polygon points=\"1549.9,7296.1 1544.6,8070.0 927.5,8070.0 925.1,7236.5 -0.0,7163.2 -0.0,0.0 360.2,0.0 367.5,1586.3 3616.0,1816.1 3643.9,1122.9 3891.6,1112.7 3891.6,6670.9 3725.1,6669.8 3726.6,7428.5 1549.9,7296.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1957,8 +2813,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                4012.0
+                1739.8,
+                7314.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1969,8 +2825,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9998606,
-                40.685029
+                -85.663619,
+                42.898537
               ]
             }
           },
@@ -1978,8 +2834,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                7884.0
+                3715.6,
+                1823.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1990,8 +2846,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9972144,
-                40.6842975
+                -85.661407,
+                42.903557
               ]
             }
           }
@@ -1999,25 +2855,41 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p728 [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "24"
+          "value": "7"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3814.8"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2845.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2026,21 +2898,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1088.0,173.8 2129.4,195.1 2131.5,0.0 4225.2,0.0 4220.1,237.7 4780.1,249.1 4694.3,7755.5 555.3,7725.9 1088.0,173.8\" /></svg>"
+          "value": "<svg><polygon points=\"3814.8,8070.0 3814.8,7529.0 5622.3,7586.6 5746.0,3693.0 3814.8,3631.5 3814.8,612.7 5893.5,715.5 5887.1,0.0 6660.0,0.0 6660.0,8070.0 3814.8,8070.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0728__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2050,8 +2922,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                820.0,
-                3852.0
+                4945.7,
+                675.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2062,8 +2934,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9989348,
-                40.6869431
+                -85.662391,
+                42.898516
               ]
             }
           },
@@ -2071,8 +2943,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4732.0,
-                5004.0
+                5932.7,
+                5982.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2083,8 +2955,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9971968,
-                40.6887645
+                -85.6609396,
+                42.8935229
               ]
             }
           }
@@ -2092,106 +2964,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/78655/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"754.2,314.2 4647.6,363.6 4663.3,0.0 5612.0,0.0 5612.0,8268.0 5434.2,8268.0 5480.8,7851.2 732.0,7840.0 754.2,314.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2048.0,
-                2808.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9984232,
-                40.6898645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                7840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9953209,
-                40.6882386
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p35",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p729 [1]",
       "metadata": [
         {
           "label": "streets",
@@ -2202,8 +2981,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2212,21 +2991,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/78655/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,1891.1 5612.0,4804.8 5292.1,4802.2 5309.9,6611.2 5612.0,6613.0 5612.0,8268.0 0.0,8268.0 0.0,-0.0 5299.1,0.0 5275.2,1888.2 5612.0,1891.1\" /></svg>"
+          "value": "<svg><polygon points=\"606.6,7542.9 339.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,7538.5 606.6,7542.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/78655/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2236,8 +3015,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1676.0,
-                4784.0
+                3200.0,
+                2731.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2248,8 +3027,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0021257,
-                40.6694201
+                -85.663421,
+                42.894445
               ]
             }
           },
@@ -2257,8 +3036,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                1868.0
+                592.0,
+                6690.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2269,8 +3048,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0038317,
-                40.670616
+                -85.66506,
+                42.8926442
               ]
             }
           }
@@ -2278,25 +3057,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31402/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p36",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p809",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "19"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2305,21 +3084,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31402/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"494.2,3522.1 482.7,612.1 5612.0,509.1 5612.0,681.0 5153.3,677.7 5214.7,3218.5 4938.3,3508.6 5612.0,3517.2 5134.0,4009.8 5136.5,5814.3 4614.9,5816.6 4232.1,8257.3 1138.8,7317.5 168.8,8268.0 0.0,8268.0 0.0,6983.0 507.9,6981.0 501.4,5328.1 199.6,5327.4 174.8,3520.8 494.2,3522.1\" /></svg>"
+          "value": "<svg><polygon points=\"1705.3,8070.0 -0.0,8070.0 0.0,0.0 3962.2,0.0 3970.3,697.3 4773.6,727.8 4782.9,1767.9 5788.3,1759.0 5809.0,7672.8 6660.0,7669.8 6660.0,8070.0 5625.1,8070.0 5675.2,6415.4 3559.9,6351.4 1705.3,8070.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31402/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2329,8 +3108,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1436.0,
-                5328.0
+                3092.0,
+                3411.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2341,8 +3120,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9996512,
-                40.6716259
+                -85.7070799,
+                42.9303961
               ]
             }
           },
@@ -2350,8 +3129,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3896.0,
-                596.0
+                4800.0,
+                5150.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2362,8 +3141,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0023003,
-                40.6738155
+                -85.7048594,
+                42.9288694
               ]
             }
           }
@@ -2371,13 +3150,199 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31406/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p37",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p810",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "15"
+        },
+        {
+          "label": "intersections",
+          "value": "25"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31406/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"856.4,1357.0 853.2,2277.8 1294.7,2275.4 1282.1,0.0 1718.5,0.0 1716.0,794.4 3610.9,800.5 3611.9,0.0 4388.0,0.0 4388.5,803.0 4671.2,803.9 4671.8,993.6 5310.6,991.8 5323.5,4404.0 5550.2,4403.1 5551.7,7758.7 6660.0,7758.2 6660.0,8070.0 -0.0,8070.0 0.0,0.0 520.8,0.0 531.8,1339.3 856.4,1357.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31406/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3856.0,
+                6682.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6986358,
+                42.9280609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2072.0,
+                1427.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70121,
+                42.932893
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31409/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p811",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31409/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1290.7 1218.5,1291.9 1228.4,0.0 4977.6,0.0 4967.6,1610.7 3577.1,2313.9 3574.6,2579.8 4962.1,1892.6 4957.7,8070.0 -0.0,8070.0 -0.0,1290.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31409/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4960.0,
+                4382.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69383,
+                42.932096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4960.0,
+                6334.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.693769,
+                42.931178
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p812",
       "metadata": [
         {
           "label": "streets",
@@ -2388,8 +3353,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2398,21 +3363,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31410/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"852.5,1497.4 1315.6,1497.2 1314.2,1323.7 3403.1,1370.7 3655.9,1490.2 3658.1,916.8 4584.1,1683.9 4603.5,6674.9 876.0,6683.4 859.3,4861.6 1345.1,4353.1 657.7,4357.2 934.5,4062.1 852.5,1497.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1124.5 4647.4,1180.0 4648.0,1395.7 6660.0,1519.5 6660.0,8070.0 -0.0,8070.0 -0.0,1124.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31410/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2422,8 +3387,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3312.0,
-                6680.0
+                3080.0,
+                6278.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2434,8 +3399,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9977713,
-                40.6747317
+                -85.694549,
+                42.928007
               ]
             }
           },
@@ -2443,8 +3408,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4592.0,
-                4352.0
+                4648.0,
+                1395.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2455,8 +3420,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.999033,
-                40.6758417
+                -85.69371,
+                42.930265
               ]
             }
           }
@@ -2464,25 +3429,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31411/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p38",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p813",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "14"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "15"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2491,21 +3456,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31411/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"679.6,6733.5 694.4,1728.3 516.6,1556.6 622.7,1482.2 4592.3,1487.6 4611.7,6725.0 679.6,6733.5\" /></svg>"
+          "value": "<svg><polygon points=\"1309.2,668.2 301.5,633.1 282.9,0.0 3234.6,0.0 3240.8,425.1 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,3981.0 1396.5,3943.8 1309.2,668.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31411/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2515,8 +3480,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1932.0,
-                4404.0
+                4772.0,
+                5326.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2527,8 +3492,380 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9987227,
-                40.6764868
+                -85.6880369,
+                42.9260606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3792.0,
+                3243.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.689305,
+                42.927944
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31505/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p814",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31505/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"676.6,3338.4 -0.0,3681.6 -0.0,3551.3 678.0,3200.3 675.1,2389.6 -0.0,2417.4 -0.0,1826.6 668.0,1867.5 650.6,886.3 435.1,70.1 545.0,0.0 6660.0,0.0 6660.0,618.1 6267.7,618.2 5929.3,736.6 5929.3,618.4 3577.0,619.4 3578.3,3584.3 3516.0,3583.9 3502.1,5923.6 698.7,5866.1 676.6,3338.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31505/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1548.0,
+                1027.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.692884,
+                42.935516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                668.0,
+                1867.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6939932,
+                42.9346772
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31506/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p815",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31506/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6253.1 0.0,-0.0 4961.0,0.0 4960.9,249.3 5674.7,0.0 6660.0,0.0 6646.9,6295.5 -0.0,6253.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31506/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5764.0,
+                5998.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.686522,
+                42.93336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5764.0,
+                7478.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6864856,
+                42.9326869
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31507/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p816",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31507/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31507/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5800.0,
+                1163.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6864856,
+                42.9326869
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5800.0,
+                6574.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.686372,
+                42.930182
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p817",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "17"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,16.0 1413.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,16.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3628.0,
+                168.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.699625,
+                42.93718
               ]
             }
           },
@@ -2537,7 +3874,7 @@
             "properties": {
               "resourceCoords": [
                 684.0,
-                4404.0
+                3747.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2548,8 +3885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.999033,
-                40.6758417
+                -85.701383,
+                42.9354749
               ]
             }
           }
@@ -2557,1513 +3894,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31509/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p818",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"413.4,1147.3 5170.3,1142.4 5170.3,1142.5 5225.9,1142.5 5157.6,6627.0 3158.6,6396.0 438.4,6390.8 413.4,1147.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                4064.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9972734,
-                40.6794993
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                1144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9992597,
-                40.6800511
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2687.5,
-                7784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0104477,
-                40.6804294
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5243.1,
-                7784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0091934,
-                40.6815021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7448.2 2323.3,7030.9 2394.5,6437.7 1380.1,6255.2 1380.4,6917.5 0.0,6751.4 0.0,1245.0 5612.0,1256.8 5612.0,7448.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                4168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9965238,
-                40.6810573
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                1248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9985089,
-                40.6816069
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1442.6,7683.6 678.9,1543.7 5107.7,992.1 5291.6,3902.5 4612.7,3986.2 4622.4,7685.3 1442.6,7683.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                4144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9949023,
-                40.6844304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                7680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992623,
-                40.683544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"196.9,7688.7 239.6,3988.9 919.8,3914.8 777.1,1001.4 4906.0,536.6 5208.5,3450.5 4144.5,3565.7 4093.3,7747.2 196.9,7688.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3280.0,
-                724.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9957232,
-                40.6873919
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2796.0,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,4060.9 4962.5,8177.7 5328.8,8134.6 5339.7,8268.0 8.0,8268.0 0.0,-0.0 5612.0,0.0 5612.0,321.7 5032.6,500.3 5612.0,2380.6 5136.6,2510.2 5155.4,2572.1 5612.0,2821.9 5612.0,4060.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2400.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9948535,
-                40.6668553
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                8872.0,
-                4848.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0010146,
-                40.6762923
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,8268.0 2263.0,8268.0 1264.0,7221.7 -0.0,6288.8 449.6,5762.1 18.7,5505.7 440.7,5513.7 429.9,367.0 5612.0,386.5 5612.0,1675.6 4280.0,1672.0 4277.5,6825.4 5612.0,6829.9 5612.0,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                5536.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9940294,
-                40.6678529
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                1672.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992527,
-                40.669655
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1142.0 5612.0,269.1 5612.0,7978.6 0.0,7638.3 0.0,1142.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4168.0,
-                508.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.997447,
-                40.6754
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.0,
-                1060.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.998388,
-                40.673471
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"864.0,7245.6 867.9,868.3 4664.0,880.0 4665.3,7257.4 864.0,7245.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                4716.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991023,
-                40.671458
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                880.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9895109,
-                40.6732702
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5361.3,1138.6 5096.5,7386.7 3840.5,7339.1 3956.0,4496.0 2691.0,4551.4 2748.0,1589.4 5361.3,1138.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3956.0,
-                4496.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9941559,
-                40.6772043
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2748.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9964751,
-                40.6774341
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p5",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5325.3,7857.1 -0.0,7573.3 -0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.0,8268.0 5325.3,7857.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2815.5,
-                6624.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0085336,
-                40.6829405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2815.5,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0079286,
-                40.6825753
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2500.9,8268.0 2508.1,6769.7 1984.4,6768.8 1637.6,811.2 3472.2,418.2 3517.8,2740.1 4507.0,2658.1 4503.2,4888.7 5612.0,4887.7 5612.0,8268.0 2500.9,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.0,
-                6768.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991384,
-                40.674998
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1524.0,
-                6768.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992369,
-                40.673813
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"696.2,849.0 2694.6,725.3 2770.3,728.2 4149.9,647.9 4033.1,0.0 5057.5,0.0 5092.3,592.9 4916.1,603.4 5036.5,3972.9 5281.2,3956.0 5461.0,7306.9 4275.9,7366.0 452.1,7227.1 696.2,849.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1744.0,
-                7272.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99137,
-                40.67755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3456.0,
-                680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.994889,
-                40.6802
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"828.7,7382.1 817.8,4031.0 572.8,4035.6 622.1,668.9 4667.8,658.9 4694.9,7367.7 828.7,7382.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4692.0,
-                4024.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.990865,
-                40.6820655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2112.0,
-                7376.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.989559,
-                40.679946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4780.0,7464.0 883.8,7481.9 895.7,719.6 4794.7,731.8 4780.0,7464.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4780.0,
-                7464.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98743,
-                40.683126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3496.0,
-                728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992192,
-                40.684178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"687.3,667.8 4590.3,680.2 4579.3,7402.5 690.6,7366.3 690.2,6478.3 639.9,6478.1 687.3,667.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3272.0,
-                7380.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.986564,
-                40.684389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1984.0,
-                668.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
+          "value": "9"
         },
         {
           "label": "intersections",
           "value": "20"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4072,21 +3921,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31509/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1216.7,3600.5 914.9,705.1 5612.0,191.8 5612.0,7981.5 110.4,7870.6 159.4,3715.4 1216.7,3600.5\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,1856.7 6240.5,5665.0 4867.5,6775.7 2487.9,8070.0 -0.0,8070.0 -0.0,38.9 6660.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31509/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4096,8 +3945,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2784.0,
-                5616.0
+                2508.0,
+                3775.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4108,8 +3957,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991509,
-                40.687959
+                -85.6964447,
+                42.9354816
               ]
             }
           },
@@ -4117,8 +3966,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3484.0,
-                424.0
+                5288.0,
+                168.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4129,8 +3978,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9946743,
-                40.6895809
+                -85.694771,
+                42.937238
               ]
             }
           }
@@ -4138,13 +3987,199 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31884/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p56",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p820 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "12"
+        },
+        {
+          "label": "intersections",
+          "value": "20"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31884/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2604.2,8070.0 2604.1,7041.2 1809.8,7004.0 1807.9,6314.2 -0.0,6298.3 -0.0,-0.0 6660.0,0.0 6660.0,2561.7 5375.3,2558.7 5367.3,3489.1 6065.1,3526.9 6053.6,4442.8 5359.5,4405.7 5347.8,5772.6 4906.7,5770.3 4907.2,8070.0 4460.9,8070.0 4469.1,7139.5 4141.1,7119.8 4137.3,5766.2 3610.9,5763.4 3598.6,8070.0 2604.2,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31884/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4124.0,
+                4338.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7033757,
+                42.9354789
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3372.0,
+                7082.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70415,
+                42.93291
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31514/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p821",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31514/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4843.0,646.1 6660.0,795.5 6660.0,7073.6 5531.0,7012.0 5538.2,8070.0 -0.0,8070.0 -0.0,-0.0 4844.9,0.0 4843.0,646.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31514/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5524.0,
+                5638.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66523,
+                42.8963374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5524.0,
+                683.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6653419,
+                42.8986154
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31518/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p822",
       "metadata": [
         {
           "label": "streets",
@@ -4152,11 +4187,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "6"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4165,21 +4200,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31518/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"796.0,708.4 4977.9,738.0 4969.1,0.0 5612.0,0.0 5608.3,7408.4 768.0,7400.0 796.0,708.4\" /></svg>"
+          "value": "<svg><polygon points=\"5429.5,922.6 5671.7,7379.6 5068.3,7377.7 5070.5,7906.3 6660.0,7899.8 6660.0,8070.0 3052.6,8070.0 3040.1,5445.6 -0.0,5450.2 -0.0,1170.9 5429.5,922.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31518/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4189,8 +4224,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3348.0,
-                4064.0
+                5492.0,
+                2551.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4201,8 +4236,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.987429,
-                40.687138
+                -85.665137,
+                42.8944719
               ]
             }
           },
@@ -4210,8 +4245,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                768.0,
-                7400.0
+                2160.0,
+                5450.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4222,8 +4257,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9861154,
-                40.6850247
+                -85.667242,
+                42.893156
               ]
             }
           }
@@ -4231,118 +4266,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31520/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p57",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p823",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
           "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5630
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2546.0,1273.8 5477.7,1555.7 5281.8,3702.2 5630.0,3734.0 5630.0,4232.6 4228.4,4129.7 4158.9,4873.6 3525.3,4814.7 3453.3,5795.6 4058.6,5793.3 4039.0,7169.1 3501.3,7168.5 3499.3,8267.0 0.0,8267.0 0.0,0.0 2665.1,-0.0 2546.0,1273.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2079.3,
-                5791.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983895,
-                40.6761473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4058.6,
-                5791.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.986308,
-                40.677081
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "1"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4351,44 +4293,47 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31520/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5556
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3046.8,7167.8 3131.8,8268.0 1339.1,8268.0 1361.7,7108.2 0.0,7081.0 0.0,969.6 2712.3,1023.4 5103.8,856.5 5337.1,4087.8 4089.3,4175.5 4293.8,7110.3 3046.8,7167.8\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,6562.6 4396.1,6510.3 4395.9,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31520/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2828.0,
-                4264.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9882559,
-                40.6778311
+                -85.67310007362457,
+                42.898799973678976
               ]
             }
           },
@@ -4396,92 +4341,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1412.0,
-                1012.0
+                6660.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9908957,
-                40.6781021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p59",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5516
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2069.9,4236.1 2068.0,904.0 5516.0,897.0 5516.0,8268.0 2074.0,8268.0 2073.3,7259.7 777.6,7260.4 783.4,4234.5 2069.9,4236.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3360.0,
-                7264.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984998,
-                40.678977
+                -85.66879174625086,
+                42.89885709013223
               ]
             }
           },
@@ -4489,92 +4362,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2068.0,
-                904.0
+                6660.0,
+                8070.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.989559,
-                40.679946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2531.5,
-                7656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0054824,
-                40.6843278
+                -85.66869713632163,
+                42.89503635388907
               ]
             }
           },
@@ -4582,92 +4383,20 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5099.1,
-                7656.0
+                0.0,
+                8070.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p60",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5503
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1503.2,910.7 4478.2,879.1 4509.1,7226.8 5503.0,7219.2 5503.0,8267.0 1543.3,8236.8 1503.2,910.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3215.4,
-                4231.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.985672,
-                40.681642
+                -85.67300546369532,
+                42.89497923743581
               ]
             }
           },
@@ -4675,8 +4404,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1955.6,
-                7239.1
+                4364.0,
+                359.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4687,8 +4416,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.984139,
-                40.680246
+                -85.6702728,
+                42.898667
               ]
             }
           }
@@ -4696,385 +4425,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
+      "id": "https://oldinsurancemaps.net/iiif/resource/31521/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5629
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1873.2,7221.5 877.6,7215.7 932.3,858.9 4787.9,929.2 4742.3,7250.1 5629.0,7258.9 5629.0,8268.0 1859.1,8268.0 1873.2,7221.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.6,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984371,
-                40.6835414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4748.8,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9839511,
-                40.6841757
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5549
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"677.2,7342.4 664.8,939.4 5549.0,934.4 5549.0,8268.0 1584.0,8268.0 1575.5,7343.2 677.2,7342.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1964.4,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983522,
-                40.684816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3264.6,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983092,
-                40.685451
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p7",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5235.1,
-                5688.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0044976,
-                40.6863169
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5235.1,
-                6968.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4242.0,7595.1 1044.2,7590.7 1030.5,7153.5 -0.0,7145.5 -0.0,-0.0 4234.9,0.0 4242.0,7595.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4231.2,
-                3696.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0020408,
-                40.6864013
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1031.8,
-                6284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p9",
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p824",
       "metadata": [
         {
           "label": "streets",
@@ -5085,8 +4442,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5095,21 +4452,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/selector",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31521/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/info.json",
+          "id": null,
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8070,
+          "width": 6660
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,1494.8 1621.4,1457.4 1587.9,0.0 3769.2,0.0 3819.5,1226.9 3923.9,1222.6 3905.5,5099.9 6660.0,5108.8 6660.0,8070.0 -0.0,8070.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/gcps",
+        "id": "https://oldinsurancemaps.net/iiif/resource/31521/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5119,8 +4476,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.2,
-                7760.0
+                3680.0,
+                5098.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5131,8 +4488,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -85.668751,
+                42.893167
               ]
             }
           },
@@ -5140,8 +4497,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1051.8,
-                7760.0
+                1700.0,
+                5098.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5152,8 +4509,1823 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0013897,
-                40.6877592
+                -85.67012,
+                42.893172
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31879/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p825",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31879/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31879/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6464.0,
+                3623.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.679111,
+                42.926211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6464.0,
+                7186.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.679066,
+                42.924551
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31883__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p826 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "1639.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5020.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31883__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1639.2,1179.5 2434.0,775.8 2414.5,199.2 1639.2,225.4 1639.2,0.0 6660.0,0.0 6660.0,579.1 4785.2,7428.0 4777.9,8070.0 2680.2,8070.0 2658.2,7418.9 1639.2,3810.0 1639.2,1179.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31883__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3885.8,
+                3839.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.678129,
+                42.926201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2338.8,
+                3839.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.679111,
+                42.926211
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p827",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3856.0 642.3,582.0 2510.5,0.0 6660.0,0.0 6453.3,1504.6 5632.0,3848.2 5863.4,8070.0 5007.1,8070.0 5011.3,7141.2 1929.5,7127.3 1925.2,8070.0 -0.0,8070.0 -0.0,3856.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4660.0,
+                3859.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.674567,
+                42.926132
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                844.0,
+                3859.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.676997,
+                42.926177
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31837/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p828",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31837/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31837/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2148.0,
+                279.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.675728,
+                42.924565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4216.0,
+                279.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6751187,
+                42.9245517
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31838/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p829",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "18"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31838/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3757.7,8070.0 -0.0,8070.0 20.4,1161.8 940.2,1225.1 939.8,302.7 -0.0,250.4 -0.0,-0.0 6660.0,0.0 6660.0,380.3 5753.3,339.2 5468.3,6623.5 3756.1,6545.3 3757.7,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31838/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3744.0,
+                4302.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67148,
+                42.925773
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3744.0,
+                451.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.671562,
+                42.927625
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31839/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p830",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31839/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6623.0,335.2 5664.7,257.0 6002.5,7997.6 -0.0,8019.6 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31839/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                992.0,
+                2299.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.669636,
+                42.926635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5908.0,
+                6054.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.666546,
+                42.9248589
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31840/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p831",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31840/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5388.7,0.0 5787.1,8070.0 -0.0,8070.0 -0.0,1719.2 3714.6,1549.4 3645.2,0.0 5388.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31840/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                804.0,
+                383.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.673263,
+                42.924532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3872.0,
+                5070.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.671324,
+                42.922295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31841/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p832",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31841/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5938.0,1251.7 5931.3,8070.0 -0.0,8070.0 -0.0,998.9 5938.0,1251.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31841/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5936.0,
+                6238.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.666397,
+                42.921649
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5936.0,
+                1251.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6665019,
+                42.9239545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31928/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p834 [3]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "13"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31928/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,542.2 559.3,1043.4 762.7,1104.2 4579.1,1183.0 4649.9,-0.0 6660.0,-0.0 6660.0,7165.1 5326.8,7149.5 5316.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31928/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2576.0,
+                3703.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.713678,
+                42.922711
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2340.0,
+                7430.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.718364,
+                42.922819
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31842/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p835",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31842/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5789.3,420.2 6660.0,353.9 6660.0,631.8 6317.5,803.0 6582.0,3701.8 6582.3,3701.8 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 5757.2,0.0 5789.3,420.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31842/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                652.0,
+                5686.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.769131,
+                42.906578
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2708.0,
+                5686.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.767833,
+                42.906562
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31843/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p836",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31843/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1666.2 360.5,1527.5 386.1,1247.8 1065.0,1257.9 4447.7,0.0 6527.0,0.0 6524.0,239.2 6660.0,241.9 6660.0,3238.0 6539.6,3233.6 6530.2,3822.8 6531.4,4321.8 6660.0,4325.9 6660.0,5316.4 6550.8,5252.9 6532.4,4765.1 5761.9,4736.1 5639.5,8070.0 -0.0,8070.0 -0.0,1666.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31843/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3752.0,
+                7290.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7629051,
+                42.9063545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1928.0,
+                7074.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7640512,
+                42.9063906
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31934__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p837 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31934__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4324.5,5838.6 4328.0,6986.5 1513.2,8070.0 -0.0,8070.0 0.0,-0.0 6660.0,0.0 6660.0,2344.6 4328.0,2327.4 4341.0,1046.2 3616.3,1042.5 3591.7,5834.8 4324.5,5838.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31934__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4328.0,
+                2327.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7632658,
+                42.9118028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4328.0,
+                6986.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.763088,
+                42.909606
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31844/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p838",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31844/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"326.1,3895.1 -0.0,3905.3 -0.0,2979.8 657.6,2972.4 2996.8,2000.7 2968.1,0.0 6660.0,0.0 6660.0,8070.0 6292.5,8070.0 6298.0,7050.0 552.7,7019.1 462.0,4124.8 330.5,4126.2 326.1,3895.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31844/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2992.0,
+                6014.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.759734,
+                42.908827
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5452.0,
+                2135.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.758253,
+                42.910712
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31845/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p839",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31845/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1501.4 756.6,1502.1 792.2,1979.7 901.6,2038.2 708.5,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1501.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31845/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3416.0,
+                4330.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.759531,
+                42.906329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5792.0,
+                499.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.758111,
+                42.908156
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31931/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p840 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31931/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3980.8,4333.9 3962.8,4187.4 -0.0,4120.0 0.0,-0.0 6660.0,0.0 6660.0,1052.9 5524.3,1060.5 5559.4,6339.0 5292.1,6337.6 5289.5,7097.9 3550.8,7017.5 3560.1,5073.1 3828.9,5087.4 3842.4,4487.1 3980.8,4333.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31931/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5216.0,
+                2207.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7196157,
+                42.9238818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5296.0,
+                5170.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.719418,
+                42.921139
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31932/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p841 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "12"
+        },
+        {
+          "label": "intersections",
+          "value": "35"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31932/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 1008.6,0.0 1016.0,886.1 1961.6,927.8 1960.0,1143.5 4083.9,1168.8 4089.5,708.4 5472.6,764.6 5471.4,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31932/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2884.0,
+                3875.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.722539,
+                42.916444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2884.0,
+                5066.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.722509,
+                42.915347
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31846/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p842",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "20"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31846/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6167.0,6149.1 4392.3,6185.3 4414.8,8070.0 -0.0,8070.0 -0.0,-0.0 318.8,-0.0 607.7,232.2 1817.4,238.8 1797.8,780.4 5714.7,732.4 5737.5,-0.0 6660.0,-0.0 6660.0,4263.0 6228.0,4254.9 6167.0,6149.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31846/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6228.0,
+                4254.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.723772,
+                42.91914
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1732.0,
+                2459.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.722668,
+                42.921213
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/31862/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p843",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31862/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2365.5,7442.8 1172.0,7396.2 1153.7,3616.9 1229.0,3344.9 1722.3,2771.2 -0.0,2806.8 0.0,0.0 969.3,0.0 1024.6,1829.6 2731.8,1778.0 4539.0,0.0 6660.0,0.0 6660.0,8070.0 2378.4,8070.0 2365.5,7442.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/31862/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1172.0,
+                3491.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71049,
+                42.924506
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1172.0,
+                7398.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.710436,
+                42.920942
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://oldinsurancemaps.net/iiif/resource/78681__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p845 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5072.7"
+        }
+      ],
+      "created": "2026-07-17T16:46:45Z",
+      "modified": "2026-07-17T16:46:45Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/78681__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": null,
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3227.5,1360.0 3220.5,0.0 6660.0,0.0 6660.0,1951.1 6234.5,1946.3 6241.1,4069.5 3748.4,5072.7 -0.0,5072.7 0.0,-0.0 766.8,0.0 760.0,1356.2 3227.5,1360.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://oldinsurancemaps.net/iiif/resource/78681__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6240.0,
+                1356.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.759932,
+                42.911935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                760.0,
+                1356.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7632658,
+                42.9118028
               ]
             }
           }

--- a/gallery/hudson_co_nj_1950_vol_9.iiif.json
+++ b/gallery/hudson_co_nj_1950_vol_9.iiif.json
@@ -1,31 +1,31 @@
 {
-  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn05791_053/main-content//generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn05511_036/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Mosaic of main content, Brooklyn, N.Y. | 1939 | Vol. 1",
+  "label": "Mosaic of main content, Hudson Co., N.J. | 1950 | Vol. 9",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p1",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p11",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "9"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,119 +34,32 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8149,
+          "width": 5696
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 0.0,-0.0 5696.0,0.0 5696.0,8149.0 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.02329946235103,
-                40.67718446758965
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.02041525312393,
-                40.6796283326228
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5599.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01565946488587,
-                40.676397560306384
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01854367411298,
-                40.67395369527323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5491.0,
-                7724.0
+                3528.0,
+                1960.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -157,8 +70,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.016028,
-                40.676563
+                -74.089248,
+                40.7137296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1924.0,
+                1668.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0899757,
+                40.7132465
               ]
             }
           }
@@ -166,13 +100,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p10",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p15",
       "metadata": [
         {
           "label": "streets",
@@ -180,11 +114,11 @@
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "6"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -193,21 +127,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8149,
+          "width": 5696
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5599.0,8268.0 5373.8,8268.0 5361.4,7291.8 4422.2,7303.7 4411.2,7664.0 0.0,7664.4 0.0,-0.0 5599.0,0.0 5599.0,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"1011.9,7261.0 1037.4,662.5 5471.7,436.0 5451.3,7896.9 5696.0,7897.5 5696.0,8149.0 3982.2,8149.0 3984.0,7256.9 1011.9,7261.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0015/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -217,8 +151,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4411.2,
-                7664.0
+                2496.0,
+                7256.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -229,8 +163,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9994446,
-                40.6916676
+                -74.0922662,
+                40.7072462
               ]
             }
           },
@@ -238,8 +172,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                555.9,
-                7664.0
+                3984.0,
+                7256.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -250,8 +184,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -74.0916701,
+                40.7077517
               ]
             }
           }
@@ -259,277 +193,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p11",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p16",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,382.0 4893.0,460.7 4896.0,1361.4 5599.0,1359.0 5599.0,8268.0 -0.0,8268.0 -0.0,382.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2459.6,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.015425,
-                40.675199
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5351.0,
-                460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.013855,
-                40.674128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p13",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
           "value": "1"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,261.1 5227.9,415.5 5059.5,-0.0 5612.0,-0.0 5612.0,261.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0138049615332,
-                40.67445210987348
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01057182377127,
-                40.67226350816088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5612.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01482175977381,
-                40.668649624515666
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8268.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01805489753573,
-                40.67083822622827
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                320.0,
-                456.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.013855,
-                40.674128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -538,21 +220,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8150,
+          "width": 5714
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5522.4,5644.3 5534.2,6829.3 338.8,6828.9 320.0,1619.1 5384.9,1611.8 5369.4,5386.5 5522.4,5644.3\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 5714.0,-0.0 5714.0,7191.8 5059.1,7222.8 5074.7,8150.0 0.0,8150.0 0.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -562,8 +244,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5372.0,
-                2928.0
+                3513.2,
+                3927.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -574,8 +256,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01206,
-                40.675781
+                -74.0916998,
+                40.7100698
               ]
             }
           },
@@ -583,8 +265,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                328.0,
-                4224.0
+                3513.2,
+                2127.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -595,8 +277,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.015401,
-                40.677098
+                -74.0908653,
+                40.7095012
               ]
             }
           }
@@ -604,13 +286,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p2",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p17",
       "metadata": [
         {
           "label": "streets",
@@ -618,11 +300,197 @@
         },
         {
           "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4712.0,898.1 4709.0,1791.4 5696.0,1792.8 5696.0,4625.4 5529.1,4623.1 5440.1,6242.0 3818.8,7084.7 3165.7,7227.5 1790.1,7162.6 1144.2,7380.5 566.9,7832.7 246.7,7596.3 276.5,908.8 4712.0,898.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1736.0,
+                896.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0928589,
+                40.7067408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4712.0,
+                896.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0916701,
+                40.7077517
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5689.0,668.9 5689.0,5677.7 3392.8,5013.6 2680.9,4971.2 1845.3,7951.7 1455.2,7321.9 1217.4,8149.0 -0.0,8149.0 -0.0,1980.2 331.7,1974.6 287.6,611.4 5689.0,668.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2344.4,
+                6252.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.097152,
+                40.7061443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1928.3,
+                7692.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0979312,
+                40.7057672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p20",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
           "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -631,21 +499,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8150,
+          "width": 5755
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5095.1,7668.0 -0.0,7685.4 0.0,-0.0 5599.0,0.0 5599.0,4888.0 5095.1,4888.0 5095.1,7668.0\" /></svg>"
+          "value": "<svg><polygon points=\"2087.6,567.9 2087.6,2027.5 4686.6,2069.0 4703.3,6807.6 1010.0,5691.1 1019.8,554.5 2087.6,567.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -655,8 +523,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                4888.0
+                2087.6,
+                2027.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -667,8 +535,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0156533,
-                40.6791877
+                -74.0934371,
+                40.7062418
               ]
             }
           },
@@ -676,8 +544,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5095.1,
-                7668.0
+                2087.6,
+                567.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -688,8 +556,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0141485,
-                40.678165
+                -74.0928589,
+                40.7067408
               ]
             }
           }
@@ -697,25 +565,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p20",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p21",
       "metadata": [
         {
           "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
           "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -724,21 +592,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5689
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"194.7,7341.8 186.5,4776.4 -0.0,4777.6 -0.0,0.0 1237.0,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.5 5212.2,4302.1 5208.9,7333.7 194.7,7341.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1060.8 4044.8,1112.0 4282.1,797.8 5090.3,1927.8 5152.7,2220.8 5039.2,6707.6 5689.0,7414.5 5689.0,8149.0 4992.8,8149.0 5006.8,7286.1 -0.0,5749.0 -0.0,1060.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -748,8 +616,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1240.0,
-                916.0
+                3040.5,
+                4648.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -760,8 +628,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0104477,
-                40.6804294
+                -74.0923216,
+                40.7032847
               ]
             }
           },
@@ -769,8 +637,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5184.0,
-                916.0
+                3404.6,
+                3380.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -781,8 +649,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.008302,
-                40.67897
+                -74.0916507,
+                40.7036145
               ]
             }
           }
@@ -790,490 +658,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p22",
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1185.4,0.0 2742.9,0.0 2756.5,248.9 5463.7,250.7 5407.8,4902.0 4729.6,7042.0 4418.9,6266.1 2591.4,7001.0 2093.5,6980.3 1692.5,7140.9 1793.0,7313.3 230.3,7911.5 266.5,247.3 1184.4,247.9 1185.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2831.5,
-                4184.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007061,
-                40.680042
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5423.0,
-                1436.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007303,
-                40.682123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p22",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5621
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5621.0,4303.3 5621.0,7056.8 4971.2,6433.3 4983.6,8125.1 4290.6,7601.9 -0.0,5893.5 861.7,3570.3 1068.5,3632.3 1239.2,3638.9 1285.9,3494.7 -0.0,3077.7 -0.0,-0.0 1975.4,0.0 1992.4,432.0 5153.6,412.0 5185.3,4308.0 5621.0,4303.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5184.9,
-                4308.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0039713,
-                40.6823752
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1992.4,
-                432.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0051587,
-                40.6850009
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2073.6,448.4 2329.2,297.3 4764.0,304.0 4759.5,4110.0 3818.6,4493.1 5273.3,8268.0 -0.0,8268.0 -0.0,-0.0 900.8,0.0 899.9,458.2 2073.6,448.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3468.0,
-                3076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.011181,
-                40.674223
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4764.0,
-                304.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01206,
-                40.675781
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1326.4,7230.1 305.1,4610.0 1252.5,4218.3 1236.3,377.8 5612.0,378.3 5612.0,3186.2 3759.9,3183.6 2638.7,3670.2 3714.1,6239.4 1326.4,7230.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3832.0,
-                392.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.010793,
-                40.676834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1248.0,
-                3172.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.010554,
-                40.674758
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5622
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4974.6,1732.5 5130.1,7428.0 2371.2,7532.0 2309.8,6321.6 2956.9,4602.8 725.2,3765.7 1904.1,586.6 4974.6,1732.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1071.6,
-                1648.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0089209,
-                40.6784355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2371.2,
-                7532.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0096123,
-                40.6751413
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1282,21 +685,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5464
+          "height": 8150,
+          "width": 5755
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5464,0 5464,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"5425.4,8150.0 834.5,8122.7 753.1,693.2 3370.2,749.9 5425.4,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1306,8 +709,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1688.0,
-                676.0
+                815.9,
+                5458.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1318,8 +721,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044835,
-                40.6692758
+                -74.0956968,
+                40.7016045
               ]
             }
           },
@@ -1327,8 +730,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3296.0,
-                676.0
+                815.9,
+                7206.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1339,8 +742,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0033677,
-                40.6689515
+                -74.0965855,
+                40.7011754
               ]
             }
           }
@@ -1348,13 +751,199 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p27",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p23",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"533.5,860.2 1236.0,702.7 4906.2,715.6 4954.5,8137.7 -0.0,8149.0 -0.0,3482.9 554.3,3985.2 533.5,860.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                564.1,
+                2196.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.097152,
+                40.7061443
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                564.1,
+                3712.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0979312,
+                40.7057672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5225.1,715.8 5250.4,8150.0 -0.0,8150.0 -0.0,639.9 5225.1,715.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5223.1,
+                3735.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0948208,
+                40.7020491
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5223.1,
+                715.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0932937,
+                40.7027988
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p26",
       "metadata": [
         {
           "label": "streets",
@@ -1365,8 +954,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1375,21 +964,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5497
+          "height": 8150,
+          "width": 5747
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5264.0,7862.3 2688.5,7920.0 2688.5,6019.3 0.0,6053.4 0.0,654.2 2688.5,1700.9 2688.5,440.0 5255.1,397.5 5264.0,7862.3\" /></svg>"
+          "value": "<svg><polygon points=\"859.9,742.7 1515.9,706.2 1519.8,0.0 3912.0,0.0 3878.6,7583.8 3297.6,7742.8 3311.5,5543.2 802.8,5519.5 859.9,742.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1399,8 +988,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                440.0
+                3303.4,
+                2935.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1411,8 +1000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.008337,
-                40.6732973
+                -74.0973521,
+                40.7007884
               ]
             }
           },
@@ -1420,8 +1009,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2688.5,
-                7920.0
+                2023.6,
+                5534.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1432,8 +1021,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0032316,
-                40.6718496
+                -74.0971575,
+                40.6994919
               ]
             }
           }
@@ -1441,25 +1030,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p28",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p27",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1468,21 +1057,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5674
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"234.7,246.2 5229.0,178.5 5270.6,6865.4 5612.0,7294.5 5612.0,7875.2 5355.6,7755.2 4616.9,7714.3 266.2,7818.7 234.7,246.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 5674.0,0.0 5674.0,2831.1 4963.2,7592.4 693.0,7558.8 -0.0,4464.2 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1492,8 +1081,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5264.0,
-                5072.0
+                2148.8,
+                7584.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1504,8 +1093,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0031933,
-                40.6762708
+                -74.0992049,
+                40.6985058
               ]
             }
           },
@@ -1513,8 +1102,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3992.0,
-                2744.0
+                3537.2,
+                7584.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1525,8 +1114,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0050803,
-                40.6760699
+                -74.0984995,
+                40.69885
               ]
             }
           }
@@ -1534,106 +1123,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2681.0,196.0 2651.9,0.0 3081.1,0.0 3532.8,202.9 5490.0,200.3 5490.0,7681.2 1356.1,7659.8 1250.8,7732.9 192.5,6777.4 242.7,162.5 2681.0,196.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1440.5,
-                4959.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0028805,
-                40.6769149
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2681.0,
-                196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0058614,
-                40.678464
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p3",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p28",
       "metadata": [
         {
           "label": "streets",
@@ -1641,11 +1137,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1654,21 +1150,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8150,
+          "width": 5747
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"471.8,7725.0 471.9,4936.0 977.5,4936.0 977.7,32.1 5599.0,0.0 5599.0,7531.0 3056.6,7529.9 3057.8,7726.7 471.8,7725.0\" /></svg>"
+          "value": "<svg><polygon points=\"607.9,7414.2 607.9,697.8 2311.2,695.4 2380.6,7414.9 607.9,7414.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0028/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1678,8 +1174,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1763.7,
-                4936.0
+                607.9,
+                695.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1690,8 +1186,725 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0150289,
-                40.6797166
+                -74.096511,
+                40.699802
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                607.9,
+                7414.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.099953,
+                40.698155
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8150.0 0.0,0.0 5547.5,0.0 5747.0,593.8 5276.0,828.7 3610.5,7531.0 3196.8,7655.1 3080.5,8150.0 -0.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4779.2,
+                2795.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.099953,
+                40.698155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5275.1,
+                827.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.100595,
+                40.698936
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,2677.1 2426.3,2825.2 3424.9,8150.0 -0.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4855.2,
+                4610.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0978855,
+                40.6904043
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4227.3,
+                2935.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0972861,
+                40.6911174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,3443.6 3272.2,3188.6 3459.4,3263.2 5747.0,6275.0 5747.0,7578.4 4538.1,7676.3 2343.0,7854.2 2385.3,8150.0 -0.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3459.4,
+                3263.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.095942,
+                40.693365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2675.5,
+                1739.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0953543,
+                40.6940276
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2927.6,7793.8 -0.0,7760.6 -0.0,1309.7 5716.0,1362.1 5716.0,4987.3 4514.4,4974.7 4616.0,7796.6 5716.0,7787.9 5716.0,8149.0 3132.1,8149.0 2927.6,7793.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09526429047108,
+                40.699480839959925
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09330548721385,
+                40.697183787303445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09762721156268,
+                40.69506824211766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0995860148199,
+                40.697365294774144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2728.0,
+                1344.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0950423,
+                40.6980356
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p36",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4965.8 1225.8,5022.0 1248.3,4396.5 4351.6,4485.4 5650.4,8093.0 -0.0,7849.4 -0.0,4965.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4095.3,
+                3759.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0942954,
+                40.6951253
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4571.2,
+                5190.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0948523,
+                40.6945579
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p37",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2018.7,779.4 5716.0,716.5 5716.0,5270.3 4539.7,5870.5 4533.3,6201.0 4033.2,6138.5 2004.5,7199.0 181.7,7763.1 2018.7,779.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1396.0,
+                3116.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0950423,
+                40.6980356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2004.0,
+                7200.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0930069,
+                40.6969752
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p38",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3425.1,6842.5 2151.6,7188.0 2167.5,5874.8 1873.6,6143.4 681.4,1736.1 3328.6,970.5 4388.2,5272.1 3425.1,6842.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2151.6,
+                7186.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0918671,
+                40.698469
               ]
             }
           },
@@ -1700,7 +1913,7 @@
             "properties": {
               "resourceCoords": [
                 471.9,
-                4936.0
+                7426.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1711,8 +1924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0156533,
-                40.6791877
+                -74.0926437,
+                40.6979767
               ]
             }
           }
@@ -1720,13 +1933,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p30",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p39",
       "metadata": [
         {
           "label": "streets",
@@ -1734,11 +1947,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "1"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1747,44 +1960,47 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5716
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"536.0,7706.8 502.4,1046.7 1385.7,0.0 3068.1,0.0 2443.3,641.5 4984.2,660.2 4987.3,7701.9 536.0,7706.8\" /></svg>"
+          "value": "<svg><polygon points=\"5659.3,8149.0 1470.8,8149.0 1266.2,1490.3 1129.0,1099.0 202.2,-0.0 4356.5,-0.0 4660.2,4793.4 4519.7,6995.8 5659.3,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3892.0,
-                4992.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.001018,
-                40.680792
+                -74.09030376084753,
+                40.70442096791083
               ]
             }
           },
@@ -1792,8 +2008,71 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5180.0,
-                228.0
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08771980919948,
+                40.702511458820844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09131240073421,
+                40.69972074135131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09389635238226,
+                40.70163025044129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1372.0,
+                676.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1804,8 +2083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0039713,
-                40.6823752
+                -74.0899816,
+                40.7037311
               ]
             }
           }
@@ -1813,25 +2092,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p40",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "5"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1840,21 +2119,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5589
+          "height": 8150,
+          "width": 5747
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5372.8,225.6 5343.9,7743.6 0.0,7735.7 0.0,234.5 5372.8,225.6\" /></svg>"
+          "value": "<svg><polygon points=\"2228.0,1857.4 3914.6,1890.5 5096.7,1398.2 5041.8,3815.6 5327.6,3840.9 5324.0,6612.6 951.1,6644.4 1196.4,2357.1 1586.3,2064.8 2228.0,1857.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1864,8 +2143,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2768.5,
-                5016.0
+                695.9,
+                2267.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1876,8 +2155,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.000048,
-                40.682803
+                -74.0904528,
+                40.7042068
               ]
             }
           },
@@ -1885,8 +2164,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1480.3,
-                5016.0
+                3575.4,
+                3707.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1897,8 +2176,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.000371,
-                40.682133
+                -74.088647,
+                40.704772
               ]
             }
           }
@@ -1906,25 +2185,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p32",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p41",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1933,21 +2212,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5481
+          "height": 8149,
+          "width": 5716
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"10.9,7891.7 49.2,345.9 5237.7,343.1 4774.5,7893.4 10.9,7891.7\" /></svg>"
+          "value": "<svg><polygon points=\"1047.2,4276.5 1039.3,1950.4 1753.4,1541.3 1817.2,0.0 5716.0,0.0 5676.5,6963.5 1388.8,6959.1 1322.7,4293.6 1047.2,4276.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1957,8 +2236,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                4012.0
+                2568.0,
+                4244.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1969,8 +2248,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9998606,
-                40.685029
+                -74.0873795,
+                40.7057945
               ]
             }
           },
@@ -1978,8 +2257,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1308.2,
-                7884.0
+                4160.0,
+                3948.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1990,8 +2269,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9972144,
-                40.6842975
+                -74.0868394,
+                40.706452
               ]
             }
           }
@@ -1999,199 +2278,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "24"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1088.0,173.8 2129.4,195.1 2131.5,0.0 4225.2,0.0 4220.1,237.7 4780.1,249.1 4694.3,7755.5 555.3,7725.9 1088.0,173.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                820.0,
-                3852.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9989348,
-                40.6869431
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4732.0,
-                5004.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9971968,
-                40.6887645
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"754.2,314.2 4647.6,363.6 4663.3,0.0 5612.0,0.0 5612.0,8268.0 5434.2,8268.0 5480.8,7851.2 732.0,7840.0 754.2,314.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2048.0,
-                2808.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9984232,
-                40.6898645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                7840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9953209,
-                40.6882386
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p35",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p42",
       "metadata": [
         {
           "label": "streets",
@@ -2202,8 +2295,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2212,21 +2305,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8150,
+          "width": 5747
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,1891.1 5612.0,4804.8 5292.1,4802.2 5309.9,6611.2 5612.0,6613.0 5612.0,8268.0 0.0,8268.0 0.0,-0.0 5299.1,0.0 5275.2,1888.2 5612.0,1891.1\" /></svg>"
+          "value": "<svg><polygon points=\"2445.9,8150.0 3015.4,0.0 5747.0,0.0 5747.0,108.3 3592.8,6.2 3430.1,3441.4 4719.2,3275.1 4505.2,8054.4 2445.9,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2236,8 +2329,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1676.0,
-                4784.0
+                3295.4,
+                3459.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2248,8 +2341,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0021257,
-                40.6694201
+                -74.0861447,
+                40.7073089
               ]
             }
           },
@@ -2257,8 +2350,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                1868.0
+                4719.2,
+                3275.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2269,8 +2362,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0038317,
-                40.670616
+                -74.0856905,
+                40.70788
               ]
             }
           }
@@ -2278,292 +2371,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"494.2,3522.1 482.7,612.1 5612.0,509.1 5612.0,681.0 5153.3,677.7 5214.7,3218.5 4938.3,3508.6 5612.0,3517.2 5134.0,4009.8 5136.5,5814.3 4614.9,5816.6 4232.1,8257.3 1138.8,7317.5 168.8,8268.0 0.0,8268.0 0.0,6983.0 507.9,6981.0 501.4,5328.1 199.6,5327.4 174.8,3520.8 494.2,3522.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1436.0,
-                5328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9996512,
-                40.6716259
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3896.0,
-                596.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0023003,
-                40.6738155
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p37",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"852.5,1497.4 1315.6,1497.2 1314.2,1323.7 3403.1,1370.7 3655.9,1490.2 3658.1,916.8 4584.1,1683.9 4603.5,6674.9 876.0,6683.4 859.3,4861.6 1345.1,4353.1 657.7,4357.2 934.5,4062.1 852.5,1497.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3312.0,
-                6680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9977713,
-                40.6747317
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4592.0,
-                4352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.999033,
-                40.6758417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"679.6,6733.5 694.4,1728.3 516.6,1556.6 622.7,1482.2 4592.3,1487.6 4611.7,6725.0 679.6,6733.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1932.0,
-                4404.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9987227,
-                40.6764868
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                684.0,
-                4404.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.999033,
-                40.6758417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p43",
       "metadata": [
         {
           "label": "streets",
@@ -2571,11 +2385,11 @@
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2584,21 +2398,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5716
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"413.4,1147.3 5170.3,1142.4 5170.3,1142.5 5225.9,1142.5 5157.6,6627.0 3158.6,6396.0 438.4,6390.8 413.4,1147.3\" /></svg>"
+          "value": "<svg><polygon points=\"1304.0,3273.4 -0.0,3508.2 0.0,-0.0 3631.7,0.0 3665.0,2876.3 4416.0,2743.6 4446.8,7246.1 5716.0,7289.1 5716.0,8149.0 1316.6,8149.0 1304.0,3273.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2608,8 +2422,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3588.0,
-                4064.0
+                1304.0,
+                3272.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2620,8 +2434,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9972734,
-                40.6794993
+                -74.0856905,
+                40.70788
               ]
             }
           },
@@ -2629,8 +2443,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3588.0,
-                1144.0
+                4416.0,
+                2744.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2641,8 +2455,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9992597,
-                40.6800511
+                -74.0846988,
+                40.7091072
               ]
             }
           }
@@ -2650,13 +2464,199 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5785
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"764.1,3213.7 -0.0,3339.5 -0.0,0.0 1267.4,0.0 1267.4,0.0 5785.0,0.0 5785.0,8150.0 2027.1,8150.0 2119.4,7845.9 742.4,7783.3 764.1,3213.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4896.8,
+                2591.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0833898,
+                40.7106997
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                764.1,
+                3215.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0846988,
+                40.7091072
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5785
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 5785.0,-0.0 5785.0,237.2 3801.3,383.9 5135.1,4214.9 5308.1,6318.1 381.5,6239.1 530.5,8150.0 -0.0,8150.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4352.8,
+                2059.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0781256,
+                40.7065111
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5180.9,
+                4754.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0788466,
+                40.705278
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p48",
       "metadata": [
         {
           "label": "streets",
@@ -2664,11 +2664,11 @@
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2677,21 +2677,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8150,
+          "width": 5785
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"2015.4,6233.1 2107.1,4839.6 -0.0,4702.7 -0.0,979.6 5230.9,1471.6 5231.3,6554.8 2015.4,6233.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2701,8 +2701,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2687.5,
-                7784.0
+                5232.9,
+                6486.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2713,8 +2713,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0104477,
-                40.6804294
+                -74.0811987,
+                40.7028627
               ]
             }
           },
@@ -2722,8 +2722,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5243.1,
-                7784.0
+                5232.9,
+                1471.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2734,8 +2734,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0091934,
-                40.6815021
+                -74.0794322,
+                40.7046727
               ]
             }
           }
@@ -2743,25 +2743,211 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p49",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1075.6,6924.8 1097.5,932.2 4520.3,915.8 4487.2,6950.8 1075.6,6924.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2703.1,
+                3964.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0859316,
+                40.7029712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1075.6,
+                6924.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0852096,
+                40.7015321
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p50",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1280.2,6976.9 1328.9,991.1 5789.0,1172.9 5789.0,6978.0 4424.8,6976.9 4406.7,8149.0 2823.1,8149.0 2842.2,6971.5 1280.2,6976.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1280.2,
+                6976.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0838689,
+                40.7027096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4424.8,
+                6976.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0826385,
+                40.7038128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
         },
         {
           "label": "intersections",
           "value": "15"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2770,21 +2956,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5724
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7448.2 2323.3,7030.9 2394.5,6437.7 1380.1,6255.2 1380.4,6917.5 0.0,6751.4 0.0,1245.0 5612.0,1256.8 5612.0,7448.2\" /></svg>"
+          "value": "<svg><polygon points=\"934.4,7224.7 927.6,2276.9 2105.2,2287.5 2093.7,703.9 4071.0,716.7 4585.0,7253.7 934.4,7224.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2794,8 +2980,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1376.0,
-                4168.0
+                2368.0,
+                3836.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2806,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9965238,
-                40.6810573
+                -74.0832122,
+                40.7022839
               ]
             }
           },
@@ -2815,8 +3001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1376.0,
-                1248.0
+                932.0,
+                5640.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2827,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9985089,
-                40.6816069
+                -74.0845856,
+                40.7020851
               ]
             }
           }
@@ -2836,13 +3022,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p52",
       "metadata": [
         {
           "label": "streets",
@@ -2850,11 +3036,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "5"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2863,21 +3049,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5789
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1442.6,7683.6 678.9,1543.7 5107.7,992.1 5291.6,3902.5 4612.7,3986.2 4622.4,7685.3 1442.6,7683.6\" /></svg>"
+          "value": "<svg><polygon points=\"4858.5,7223.3 1018.8,6857.1 1011.4,831.9 3710.5,811.6 3739.5,2365.8 4850.9,2390.5 4858.5,7223.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2887,8 +3073,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3324.0,
-                4144.0
+                2512.4,
+                7008.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2899,8 +3085,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9949023,
-                40.6844304
+                -74.089687,
+                40.7007253
               ]
             }
           },
@@ -2908,8 +3094,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3324.0,
-                7680.0
+                4008.7,
+                808.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2920,8 +3106,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.992623,
-                40.683544
+                -74.0865693,
+                40.7024237
               ]
             }
           }
@@ -2929,25 +3115,835 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p53",
       "metadata": [
         {
           "label": "streets",
           "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"22.4,6260.4 987.1,1033.3 4189.5,140.8 5626.4,5469.9 3179.2,8149.0 1204.2,8149.0 490.0,8149.0 22.4,6260.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1828.0,
+                6024.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0866053,
+                40.6982793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4188.0,
+                140.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.087406,
+                40.7011057
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2928.5,1096.1 2973.3,0.0 4507.4,0.0 4355.7,6866.1 3439.2,6863.0 1270.4,6526.3 1436.4,1058.2 2928.5,1096.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4444.8,
+                3240.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0852096,
+                40.7015321
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2928.5,
+                1096.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.086807,
+                40.7016256
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2046.2,6650.4 815.8,3171.5 971.9,872.7 4809.7,1014.9 4854.9,7324.1 3191.3,8009.6 3176.6,8149.0 2849.3,8149.0 2046.2,6650.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4868.0,
+                2684.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0893795,
+                40.6993837
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3300.0,
+                6980.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0918671,
+                40.698469
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5066.1,2153.1 5789.0,2011.3 5789.0,6651.3 5086.1,6621.5 5091.1,7533.2 509.0,6811.1 13.9,478.7 5081.2,330.0 5066.1,2153.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3128.5,
+                3720.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0889051,
+                40.6979104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5072.9,
+                3720.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0881258,
+                40.6972512
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3303.0 -0.0,54.3 3218.8,78.0 3183.9,1744.8 4841.4,755.4 4803.2,5839.4 2879.7,6335.3 1900.7,2508.0 -0.0,3303.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2244.0,
+                6516.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0924233,
+                40.6941796
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1916.0,
+                2500.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0938855,
+                40.6956034
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p58",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"668.3,7548.9 1330.2,2664.2 3193.0,1404.4 4854.6,1423.5 4051.1,7523.5 2323.3,7351.2 668.3,7548.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4276.7,
+                5624.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0904698,
+                40.6968215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4660.8,
+                2992.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0913363,
+                40.6978599
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0059/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p59",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0059/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0059/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1705.4,6116.8 1531.7,5961.2 745.5,-0.0 4656.6,-0.0 4645.3,6841.5 1705.4,6116.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0059/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4664.0,
+                4344.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.093912,
+                40.6929496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1272.0,
+                4216.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0953543,
+                40.6940276
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0006/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p6",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0006/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0006/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5715
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5715.0,7475.7 -0.0,7618.1 0.0,-0.0 5715.0,0.0 5715.0,7475.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0006/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.1000002561381,
+                40.71062675161062
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5715.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09765840633426,
+                40.712707808776166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5715.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09374306055484,
+                40.71017856595401
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09608491035868,
+                40.70809750878846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2727.5,
+                7556.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0952509,
+                40.7092752
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0060/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p60",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
         },
         {
           "label": "intersections",
           "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2956,21 +3952,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0060/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0060/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5789
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"196.9,7688.7 239.6,3988.9 919.8,3914.8 777.1,1001.4 4906.0,536.6 5208.5,3450.5 4144.5,3565.7 4093.3,7747.2 196.9,7688.7\" /></svg>"
+          "value": "<svg><polygon points=\"1333.4,6844.0 612.9,821.5 5050.0,1259.7 4803.7,7244.5 1333.4,6844.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0060/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2980,8 +3976,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3280.0,
-                724.0
+                944.2,
+                3676.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2992,8 +3988,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9957232,
-                40.6873919
+                -74.0936134,
+                40.6932082
               ]
             }
           },
@@ -3001,8 +3997,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2796.0,
-                7728.0
+                1332.2,
+                6844.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3013,8 +4009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991332,
-                40.685448
+                -74.0949237,
+                40.6921215
               ]
             }
           }
@@ -3022,25 +4018,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p44",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p61",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3049,21 +4045,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5724
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,4060.9 4962.5,8177.7 5328.8,8134.6 5339.7,8268.0 8.0,8268.0 0.0,-0.0 5612.0,0.0 5612.0,321.7 5032.6,500.3 5612.0,2380.6 5136.6,2510.2 5155.4,2572.1 5612.0,2821.9 5612.0,4060.9\" /></svg>"
+          "value": "<svg><polygon points=\"998.7,7020.2 965.1,2741.8 4627.7,352.3 4520.0,561.1 4612.5,7198.4 998.7,7020.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -3073,8 +4069,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2400.0,
-                1588.0
+                2544.0,
+                7104.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3085,8 +4081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9948535,
-                40.6668553
+                -74.0947934,
+                40.6903121
               ]
             }
           },
@@ -3094,8 +4090,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                8872.0,
-                4848.0
+                1384.0,
+                2460.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3106,8 +4102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0010146,
-                40.6762923
+                -74.096871,
+                40.6917766
               ]
             }
           }
@@ -3115,292 +4111,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,8268.0 2263.0,8268.0 1264.0,7221.7 -0.0,6288.8 449.6,5762.1 18.7,5505.7 440.7,5513.7 429.9,367.0 5612.0,386.5 5612.0,1675.6 4280.0,1672.0 4277.5,6825.4 5612.0,6829.9 5612.0,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                5536.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9940294,
-                40.6678529
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                1672.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992527,
-                40.669655
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1142.0 5612.0,269.1 5612.0,7978.6 0.0,7638.3 0.0,1142.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4168.0,
-                508.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.997447,
-                40.6754
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.0,
-                1060.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.998388,
-                40.673471
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"864.0,7245.6 867.9,868.3 4664.0,880.0 4665.3,7257.4 864.0,7245.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                4716.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991023,
-                40.671458
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                880.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9895109,
-                40.6732702
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p62",
       "metadata": [
         {
           "label": "streets",
@@ -3408,11 +4125,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "8"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3421,21 +4138,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5789
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5361.3,1138.6 5096.5,7386.7 3840.5,7339.1 3956.0,4496.0 2691.0,4551.4 2748.0,1589.4 5361.3,1138.6\" /></svg>"
+          "value": "<svg><polygon points=\"1473.9,935.6 4963.2,1802.8 5789.0,6441.9 5789.0,8149.0 -0.0,8149.0 -0.0,1526.4 915.2,1757.1 1331.8,530.4 1473.9,935.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -3445,8 +4162,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3956.0,
-                4496.0
+                1764.3,
+                1968.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3457,8 +4174,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9941559,
-                40.6772043
+                -74.0972861,
+                40.6911174
               ]
             }
           },
@@ -3466,8 +4183,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2748.0,
-                1588.0
+                5164.9,
+                5620.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3478,8 +4195,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9964751,
-                40.6774341
+                -74.0972549,
+                40.6887782
               ]
             }
           }
@@ -3487,118 +4204,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p5",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p68",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
           "value": "3"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5325.3,7857.1 -0.0,7573.3 -0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.0,8268.0 5325.3,7857.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2815.5,
-                6624.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0085336,
-                40.6829405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2815.5,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0079286,
-                40.6825753
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
         },
         {
           "label": "intersections",
           "value": "2"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3607,21 +4231,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8149,
+          "width": 5789
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2500.9,8268.0 2508.1,6769.7 1984.4,6768.8 1637.6,811.2 3472.2,418.2 3517.8,2740.1 4507.0,2658.1 4503.2,4888.7 5612.0,4887.7 5612.0,8268.0 2500.9,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"5789.0,8149.0 0.0,8149.0 -0.0,-0.0 5697.2,0.0 5445.3,552.1 5789.0,718.4 5789.0,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -3631,8 +4255,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3472.0,
-                6768.0
+                3060.5,
+                6088.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3643,8 +4267,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991384,
-                40.674998
+                -74.0938821,
+                40.688018
               ]
             }
           },
@@ -3652,8 +4276,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1524.0,
-                6768.0
+                5444.9,
+                552.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3664,8 +4288,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.992369,
-                40.673813
+                -74.0955886,
+                40.689966
               ]
             }
           }
@@ -3673,13 +4297,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p69",
       "metadata": [
         {
           "label": "streets",
@@ -3687,11 +4311,941 @@
         },
         {
           "label": "intersections",
+          "value": "16"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5708
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4994.0,5066.2 4669.5,5134.7 4657.6,5606.5 5708.0,5632.9 5708.0,8149.0 54.8,8149.0 3520.4,6658.8 1036.7,883.2 5032.7,1061.8 4994.0,5066.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2768.0,
+                992.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0945123,
+                40.6904395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                712.0,
+                5968.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0938821,
+                40.688018
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p70",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"231.3,2658.6 328.2,-0.0 5333.9,-0.0 5346.3,7253.4 854.7,6895.8 231.3,2658.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5360.9,
+                3255.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0890056,
+                40.6936476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5360.9,
+                1523.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0882002,
+                40.6941499
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5701
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5701.0,8150.0 531.1,6800.0 1033.9,3026.5 1208.5,-0.0 5701.0,-0.0 5701.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3452.6,
+                5874.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0880959,
+                40.6925422
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3452.6,
+                7558.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0888073,
+                40.6919702
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p72",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1081.6,7882.1 173.0,181.5 5757.0,194.3 5757.0,8150.0 5272.3,8150.0 5193.7,7818.7 1081.6,7882.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                676.1,
+                4366.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0917239,
+                40.6919777
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3872.7,
+                2435.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0897589,
+                40.6912295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p73",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5307.2,8150.0 -0.0,8150.0 -0.0,5400.2 3934.5,5303.8 3878.8,3043.8 2868.3,3027.7 3083.9,920.1 5359.4,1055.6 5307.2,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3773.3,
+                611.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0888235,
+                40.6967735
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5345.9,
+                3043.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0853595,
+                40.6962211
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0074/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p74",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0074/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0074/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5757.0,8150.0 -0.0,8150.0 -0.0,7711.1 739.8,7715.2 822.6,1303.0 2101.3,1565.5 2103.8,2675.4 3107.4,2684.5 3000.2,4859.7 5757.0,4995.6 5757.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0074/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2708.5,
+                2675.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0837104,
+                40.6974977
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                804.1,
+                2675.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0853595,
+                40.6962211
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0075/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p75",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0075/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0075/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"463.7,8150.0 842.7,3019.6 554.1,571.9 5224.4,1333.6 5073.2,8150.0 463.7,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0075/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                740.3,
+                3731.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0842419,
+                40.6999055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5113.8,
+                4618.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0827378,
+                40.6982291
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p76",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1241.9,8150.0 1125.7,3394.9 1179.1,1594.5 5757.0,1432.9 5757.0,8150.0 1241.9,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1184.2,
+                6690.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0827378,
+                40.6982291
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1184.2,
+                1587.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.080498,
+                40.6998002
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p77",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5064.9,6808.2 782.4,6522.7 1475.4,1855.9 5089.9,1263.8 5064.9,6808.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3337.2,
+                1555.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.082334,
+                40.7016873
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2805.0,
+                5054.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.081077,
+                40.7003877
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p78",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3898.9,7297.3 563.0,6858.0 559.2,1401.2 5212.8,715.5 5249.0,7264.3 3898.9,7297.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3576.6,
+                7246.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0778951,
+                40.7013988
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3588.6,
+                931.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0805969,
+                40.7034842
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p79",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
           "value": "17"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3700,21 +5254,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8150,
+          "width": 5730
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"696.2,849.0 2694.6,725.3 2770.3,728.2 4149.9,647.9 4033.1,0.0 5057.5,0.0 5092.3,592.9 4916.1,603.4 5036.5,3972.9 5281.2,3956.0 5461.0,7306.9 4275.9,7366.0 452.1,7227.1 696.2,849.0\" /></svg>"
+          "value": "<svg><polygon points=\"1372.7,7425.0 1256.5,8150.0 -0.0,8150.0 -0.0,7379.2 312.6,7386.2 289.7,7235.0 1349.2,836.6 5140.6,821.9 5052.1,7101.7 1372.7,7425.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -3724,8 +5278,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1744.0,
-                7272.0
+                2420.8,
+                3823.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3736,8 +5290,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.99137,
-                40.67755
+                -74.0781473,
+                40.703675
               ]
             }
           },
@@ -3745,8 +5299,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3456.0,
-                680.0
+                312.1,
+                7386.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3757,8 +5311,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.994889,
-                40.6802
+                -74.0771603,
+                40.7019361
               ]
             }
           }
@@ -3766,292 +5320,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0080/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"828.7,7382.1 817.8,4031.0 572.8,4035.6 622.1,668.9 4667.8,658.9 4694.9,7367.7 828.7,7382.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4692.0,
-                4024.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.990865,
-                40.6820655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2112.0,
-                7376.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.989559,
-                40.679946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4780.0,7464.0 883.8,7481.9 895.7,719.6 4794.7,731.8 4780.0,7464.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4780.0,
-                7464.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98743,
-                40.683126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3496.0,
-                728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992192,
-                40.684178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"687.3,667.8 4590.3,680.2 4579.3,7402.5 690.6,7366.3 690.2,6478.3 639.9,6478.1 687.3,667.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3272.0,
-                7380.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.986564,
-                40.684389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1984.0,
-                668.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p55",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p80",
       "metadata": [
         {
           "label": "streets",
@@ -4059,11 +5334,11 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "19"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4072,21 +5347,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0080/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0080/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8150,
+          "width": 5757
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1216.7,3600.5 914.9,705.1 5612.0,191.8 5612.0,7981.5 110.4,7870.6 159.4,3715.4 1216.7,3600.5\" /></svg>"
+          "value": "<svg><polygon points=\"1702.0,7445.6 1722.0,1269.9 5757.0,192.6 5757.0,7059.3 4795.1,7060.1 1702.0,7445.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0080/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4096,8 +5371,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2784.0,
-                5616.0
+                1164.2,
+                1275.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4108,8 +5383,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991509,
-                40.687959
+                -74.0788466,
+                40.705278
               ]
             }
           },
@@ -4117,8 +5392,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3484.0,
-                424.0
+                1664.3,
+                5722.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4129,8 +5404,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9946743,
-                40.6895809
+                -74.0764765,
+                40.7042276
               ]
             }
           }
@@ -4138,25 +5413,118 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0081/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p56",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p81",
       "metadata": [
         {
           "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0081/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0081/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5730
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1278.4,6233.1 531.0,1552.5 5524.7,1856.0 5730.0,1730.0 5730.0,6669.0 1278.4,6233.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0081/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2729.0,
+                7446.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0765563,
+                40.7014709
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1268.4,
+                5786.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0765913,
+                40.7024832
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p82",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
           "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4165,21 +5533,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8150,
+          "width": 5757
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"796.0,708.4 4977.9,738.0 4969.1,0.0 5612.0,0.0 5608.3,7408.4 768.0,7400.0 796.0,708.4\" /></svg>"
+          "value": "<svg><polygon points=\"1302.2,1341.0 2051.9,1220.9 1856.3,-0.0 5757.0,-0.0 5757.0,8150.0 679.3,8150.0 1302.2,1341.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4189,8 +5557,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3348.0,
-                4064.0
+                1008.2,
+                4227.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4201,8 +5569,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.987429,
-                40.687138
+                -74.0786564,
+                40.7009756
               ]
             }
           },
@@ -4210,8 +5578,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                768.0,
-                7400.0
+                1104.2,
+                3551.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4222,8 +5590,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9861154,
-                40.6850247
+                -74.0783206,
+                40.7011646
               ]
             }
           }
@@ -4231,850 +5599,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5630
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2546.0,1273.8 5477.7,1555.7 5281.8,3702.2 5630.0,3734.0 5630.0,4232.6 4228.4,4129.7 4158.9,4873.6 3525.3,4814.7 3453.3,5795.6 4058.6,5793.3 4039.0,7169.1 3501.3,7168.5 3499.3,8267.0 0.0,8267.0 0.0,0.0 2665.1,-0.0 2546.0,1273.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2079.3,
-                5791.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983895,
-                40.6761473
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4058.6,
-                5791.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.986308,
-                40.677081
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5556
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3046.8,7167.8 3131.8,8268.0 1339.1,8268.0 1361.7,7108.2 0.0,7081.0 0.0,969.6 2712.3,1023.4 5103.8,856.5 5337.1,4087.8 4089.3,4175.5 4293.8,7110.3 3046.8,7167.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2828.0,
-                4264.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9882559,
-                40.6778311
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1412.0,
-                1012.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9908957,
-                40.6781021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p59",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5516
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2069.9,4236.1 2068.0,904.0 5516.0,897.0 5516.0,8268.0 2074.0,8268.0 2073.3,7259.7 777.6,7260.4 783.4,4234.5 2069.9,4236.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3360.0,
-                7264.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984998,
-                40.678977
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2068.0,
-                904.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.989559,
-                40.679946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2531.5,
-                7656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0054824,
-                40.6843278
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5099.1,
-                7656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p60",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5503
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1503.2,910.7 4478.2,879.1 4509.1,7226.8 5503.0,7219.2 5503.0,8267.0 1543.3,8236.8 1503.2,910.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3215.4,
-                4231.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.985672,
-                40.681642
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1955.6,
-                7239.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984139,
-                40.680246
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5629
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1873.2,7221.5 877.6,7215.7 932.3,858.9 4787.9,929.2 4742.3,7250.1 5629.0,7258.9 5629.0,8268.0 1859.1,8268.0 1873.2,7221.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.6,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984371,
-                40.6835414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4748.8,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9839511,
-                40.6841757
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5549
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"677.2,7342.4 664.8,939.4 5549.0,934.4 5549.0,8268.0 1584.0,8268.0 1575.5,7343.2 677.2,7342.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1964.4,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983522,
-                40.684816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3264.6,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983092,
-                40.685451
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p7",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5235.1,
-                5688.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0044976,
-                40.6863169
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5235.1,
-                6968.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p8",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4242.0,7595.1 1044.2,7590.7 1030.5,7153.5 -0.0,7145.5 -0.0,-0.0 4234.9,0.0 4242.0,7595.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4231.2,
-                3696.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0020408,
-                40.6864013
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1031.8,
-                6284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p9",
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p83",
       "metadata": [
         {
           "label": "streets",
@@ -5085,8 +5616,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5095,21 +5626,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8150,
+          "width": 5723
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1079.3 3032.9,466.0 2979.3,0.0 5723.0,0.0 5723.0,8150.0 -0.0,8150.0 -0.0,6345.9 139.8,6337.4 -0.0,6137.9 -0.0,1079.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5119,8 +5650,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.2,
-                7760.0
+                2051.6,
+                579.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5131,8 +5662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -74.0746712,
+                40.7050221
               ]
             }
           },
@@ -5140,8 +5671,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1051.8,
-                7760.0
+                5119.1,
+                4195.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5152,8 +5683,101 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0013897,
-                40.6877592
+                -74.0718418,
+                40.7049109
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p9",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T16:54:57Z",
+      "modified": "2026-07-17T16:54:57Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5711
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5711.0,8149.0 0.0,8149.0 -0.0,-0.0 5711.0,0.0 5711.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2031.6,
+                2044.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0956783,
+                40.7153869
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3583.4,
+                1748.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0952921,
+                40.7160456
               ]
             }
           }

--- a/gallery/kansas_city_mo_1951_vol_4.iiif.json
+++ b/gallery/kansas_city_mo_1951_vol_4.iiif.json
@@ -1,0 +1,11805 @@
+{
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn04720_021/main-content//generated",
+  "type": "AnnotationPage",
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld"
+  ],
+  "label": "Mosaic of main content, Kansas City, Mo. | 1951 | Vol. 4",
+  "items": [
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p452",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6367
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"272.0,7464.0 274.9,7796.0 -0.0,7796.0 -0.0,512.1 198.7,519.8 195.5,214.3 5977.7,511.0 6100.0,0.0 6367.0,0.0 6367.0,7520.9 272.0,7464.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5995.1,
+                2296.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.603925,
+                39.062859
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                272.0,
+                7464.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6072733,
+                39.0605726
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p453",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5140.5,5834.7 4997.1,7244.4 629.4,7569.2 394.3,1279.9 -0.0,1294.6 -0.0,-0.0 6553.0,0.0 6553.0,684.1 6064.1,719.9 6241.0,3883.5 5140.5,5834.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6241.0,
+                3883.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.591297,
+                39.069458
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                240.0,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.595977,
+                39.067766
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0454/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p454",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0454/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0454/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6367
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5195.7,7796.0 401.1,7658.6 671.4,6038.0 2124.8,3735.1 2118.7,188.2 2686.8,183.0 2698.5,0.0 3959.9,0.0 4033.4,172.0 6208.5,141.9 6367.0,981.3 6011.4,1739.4 6066.6,7508.8 5195.7,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0454/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6047.1,
+                3908.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.588804,
+                39.06933
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4031.4,
+                172.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5899448,
+                39.0712099
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0455/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p455",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0455/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0455/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6223.1,7795.0 966.1,7795.0 2153.7,4616.6 2255.6,135.9 6313.0,172.0 6223.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0455/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2192.3,
+                4215.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.596094,
+                39.065904
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6313.0,
+                172.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59359,
+                39.067688
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p456",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6367
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6135.0,6668.0 258.2,6649.5 256.0,136.0 5088.2,158.3 6119.7,303.6 6135.0,6668.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0456/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                256.0,
+                136.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59359,
+                39.067688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6135.0,
+                6668.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.590323,
+                39.064603
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p457",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1956.1,5819.9 1209.5,5416.8 351.2,5529.0 257.1,7731.0 -0.0,7795.0 -0.0,0.0 278.0,-0.0 263.0,302.2 6239.5,523.7 6553.0,1607.2 6553.0,6016.8 1956.1,5819.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5851290261071,
+                39.071342049177716
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58512033160301,
+                39.068176078071495
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58997634062764,
+                39.06816805264427
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58998503513173,
+                39.07133402375049
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2976.5,
+                4879.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.588166,
+                39.069899
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p458",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6406
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2346.7,6607.9 2047.1,5652.7 796.6,5627.3 611.1,1225.1 249.6,126.0 6056.2,126.0 5979.2,7664.3 2289.0,7658.0 2346.7,6607.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1483.5,
+                3863.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.587793,
+                39.067805
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                247.9,
+                128.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.585447,
+                39.068327
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p459",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7355.4 -0.0,0.0 344.3,-0.0 343.0,145.3 6553.0,198.7 6553.0,7268.9 -0.0,7355.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                472.1,
+                316.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5818218,
+                39.070903
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                472.1,
+                7339.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58532,
+                39.071032
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p460",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6406
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2204.7,4538.2 2597.8,4544.5 2599.2,4598.8 5419.5,4524.7 5408.4,5603.3 6069.0,5610.1 6041.2,5649.8 6008.7,6308.9 5338.5,6328.0 5330.9,7374.3 2183.8,7374.8 2204.7,4538.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1635.5,
+                7375.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.585402,
+                39.06921
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6210.1,
+                7375.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58563,
+                39.064802
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p461",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6192.4,7795.0 -0.0,7795.0 -0.0,846.8 5893.7,735.5 6192.4,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5000.0,
+                2831.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.579027,
+                39.068583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5832.0,
+                6807.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.581352,
+                39.06831
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p462",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "25"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6371
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6079.1,7796.0 -0.0,7796.0 -0.0,587.0 5543.7,808.0 6321.0,623.8 6079.1,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4255.3,
+                720.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.577955,
+                39.066226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6287.0,
+                4808.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.580329,
+                39.065343
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p463",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6536.0,5364.0 6103.9,5366.3 6084.1,7357.5 -0.0,7405.5 51.5,889.0 4101.6,881.9 4099.1,1411.2 6536.0,1391.7 6536.0,5364.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4080.0,
+                5375.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.576645,
+                39.068873
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4088.0,
+                3403.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.575498,
+                39.068828
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p464",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "36"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6371
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5243.6,7416.1 -0.0,7423.1 -0.0,5425.9 433.2,5419.3 395.5,1629.2 6119.4,1570.0 6131.9,4374.1 6082.4,4375.3 6007.5,7201.3 5243.6,7416.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0464/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1959.7,
+                3392.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.575577,
+                39.067027
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1959.7,
+                5396.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.576739,
+                39.067077
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p465",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6536.0,7526.4 4115.6,7554.3 4116.2,7026.6 78.5,7047.8 -0.0,333.0 6536.0,414.3 6536.0,7526.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0465/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4120.0,
+                2551.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57142,
+                39.06867
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4120.0,
+                5571.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.573182,
+                39.068737
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p466",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "18"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"455.3,7795.0 474.2,465.7 668.2,465.5 666.7,-0.0 6201.8,-0.0 6197.1,2526.7 6344.5,3005.8 6180.3,7795.0 455.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0466/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2016.6,
+                5607.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.573273,
+                39.066938
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6109.9,
+                651.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.570498,
+                39.064991
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p467",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 5860.0,8.7 5735.6,7510.4 -0.0,7389.5 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4008.0,
+                1975.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566805,
+                39.068528
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                164.0,
+                5215.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.568683,
+                39.070411
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p468",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6101.6,7089.1 797.2,7160.0 804.6,7606.1 -0.0,7617.5 -0.0,77.4 5821.7,-0.0 6101.6,7089.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6021.9,
+                7715.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.570498,
+                39.064991
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5929.9,
+                4071.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.568285,
+                39.064934
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p469",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6198.1,7795.0 360.8,7795.0 259.1,0.0 6154.1,0.0 6198.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2304.0,
+                3887.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5644585,
+                39.068454
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6172.0,
+                3887.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.562188,
+                39.068373
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p470",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"118.2,0.0 5453.5,0.0 5521.7,7224.9 2154.6,7259.7 2148.7,7643.0 184.1,7643.0 118.2,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2148.7,
+                7643.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.561095,
+                39.066513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                184.1,
+                7643.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56228,
+                39.066558
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p471",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"394.7,7280.5 -0.0,7280.8 -0.0,293.3 375.2,296.8 374.9,179.7 -0.0,209.8 -0.0,-0.0 6536.0,0.0 6536.0,304.0 5967.9,300.7 5954.0,7607.9 395.7,7634.4 394.7,7280.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2268.0,
+                3931.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55755,
+                39.06821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2268.0,
+                7643.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5576415,
+                39.0664127
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p472",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6155.8,0.0 6188.7,7795.0 237.7,7795.0 206.9,0.0 6155.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2200.7,
+                3883.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5540884,
+                39.068094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6185.9,
+                3883.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.551758,
+                39.068012
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p473",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6531
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6254.3,0.0 6265.8,7796.0 253.7,7796.0 275.1,0.0 6254.3,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2255.7,
+                3824.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.550625,
+                39.0679838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6247.0,
+                3824.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5483382,
+                39.0679157
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p474 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2594.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2841.6"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2270.5,2681.5 0.0,2841.6 -0.0,-0.0 1943.3,0.0 1951.5,471.2 2250.8,1328.7 2270.5,2681.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59882254319015,
+                39.062570982588646
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2594.8,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5972105956279,
+                39.062500297650395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2594.8,
+                2841.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59731043108766,
+                39.06113017433688
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2841.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59892237864992,
+                39.06120085927513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2270.5,
+                2681.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5975063,
+                39.0612162
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p474 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6386.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5274.8 -0.0,630.7 1196.1,646.4 1085.3,864.0 6335.3,832.9 6386.0,6715.3 6300.4,6715.1 6291.8,7795.0 294.8,7795.0 300.1,6185.2 -0.0,5274.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0474__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6314.0,
+                2911.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5938524,
+                39.0632582
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                296.1,
+                7615.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5975063,
+                39.0612162
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0475/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p475",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0475/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0475/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6531
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"327.9,204.0 6226.1,179.6 6275.5,7245.8 466.3,7307.8 327.9,204.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0475/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2275.7,
+                4356.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.592753,
+                39.062809
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                327.9,
+                204.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593761,
+                39.064732
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p476",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6041.4,51.7 6081.0,7795.0 182.8,7795.0 155.7,16.1 6041.4,51.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4185.3,
+                3867.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.588001,
+                39.063873
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6089.9,
+                3867.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.586882,
+                39.063831
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p477",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "10"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6531
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6261.9,7652.3 361.9,7796.0 330.2,260.2 2338.3,241.9 2336.3,0.0 4491.4,0.0 4540.8,1380.4 5898.7,1437.4 6389.2,1775.2 6257.3,2264.4 6261.9,7652.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4339.3,
+                3976.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5844916,
+                39.0637457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6263.0,
+                3976.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.583332,
+                39.063703
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p478",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1411.1 -0.0,0.0 6402.0,49.4 6247.4,100.1 6306.2,7795.0 310.0,7795.0 289.0,2208.9 424.3,1701.3 -0.0,1411.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                300.1,
+                3983.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.583332,
+                39.063703
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6290.0,
+                3983.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.579852,
+                39.063567
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p479",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6327.5,7795.0 326.4,7795.0 263.8,33.6 6246.9,0.0 6327.5,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2303.3,
+                3919.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.578691,
+                39.063518
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6310.1,
+                3919.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.576359,
+                39.063426
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p480",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"109.4,0.0 6402.0,27.6 6325.2,7795.0 190.7,7795.0 109.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2184.7,
+                3911.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.575201,
+                39.06338
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4205.3,
+                3911.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574038,
+                39.063334
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1999.0,149.3 2481.3,0.0 6030.7,0.0 6090.4,7795.0 4524.2,7795.0 4523.9,7569.6 526.5,7578.7 631.4,22.0 1999.0,149.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2435.2,
+                3895.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.571723,
+                39.063246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                391.9,
+                3895.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.572903,
+                39.063289
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p482",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3803.8,6945.4 3802.6,7372.4 -0.0,7287.9 -0.0,408.3 5612.3,370.2 5635.3,6949.0 3803.8,6945.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                288.1,
+                3887.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.569438,
+                39.0631685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1992.6,
+                3887.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5683065,
+                39.063134
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6494.0,7588.5 3696.9,7636.6 249.2,7633.3 340.9,163.6 6494.0,146.8 6494.0,7588.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4094.7,
+                152.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5611903,
+                39.0647144
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4094.7,
+                7595.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565786,
+                39.064872
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6185.9,127.3 6402.0,7600.8 976.0,7610.0 980.8,98.1 6185.9,127.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2376.7,
+                2011.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5624604,
+                39.0629423
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2376.7,
+                7607.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565883,
+                39.063058
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p485",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6494.0,73.1 6494.0,7600.5 -0.0,7573.2 -0.0,3851.8 360.5,3854.1 400.9,64.7 6494.0,73.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4170.7,
+                5775.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5600759,
+                39.0646765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4170.7,
+                1967.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5577442,
+                39.0646067
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p486",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6155.6,5789.0 5760.4,5791.6 5761.3,7664.3 854.5,7654.1 794.1,268.1 6129.4,251.1 6155.6,5789.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2315.3,
+                1979.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5578333,
+                39.0627891
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2315.3,
+                7647.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5612878,
+                39.0629145
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0487/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p487",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0487/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0487/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"485.8,176.0 6494.0,167.6 6494.0,3885.0 5703.8,3888.6 5693.6,7594.5 491.7,7597.4 485.8,176.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0487/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4210.7,
+                3895.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5542754,
+                39.0644915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4210.7,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5565848,
+                39.0645647
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p488",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6086.6,5803.3 6085.8,7795.0 796.5,7795.0 795.6,7620.8 -0.0,7623.5 -0.0,3866.1 801.2,3860.2 790.9,91.2 5765.4,60.8 5882.9,5807.5 6086.6,5803.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2295.3,
+                5759.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5555349,
+                39.0627132
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2295.3,
+                7615.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5566761,
+                39.0627518
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p489",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6494.0,7564.6 228.5,7547.0 192.1,7546.7 156.8,7546.6 167.4,1669.9 178.7,1669.9 189.3,-0.0 6494.0,-0.0 6494.0,7564.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4226.7,
+                5599.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5508051,
+                39.0643694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                247.9,
+                5599.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5507198,
+                39.066179
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0490/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p490",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0490/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0490/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6430.0,7564.1 645.8,7580.3 593.7,-0.0 6320.0,-0.0 6430.0,3622.4 6430.0,7564.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0490/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2343.3,
+                3611.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5497424,
+                39.0625278
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2343.3,
+                5587.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5508905,
+                39.0625665
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0491/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p491",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0491/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0491/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6414.8,7300.5 6317.9,7452.4 261.8,7241.9 258.5,6594.9 149.2,6590.0 95.4,7795.0 -0.0,7795.0 -0.0,427.4 226.4,428.2 224.7,99.9 6401.3,181.9 6414.8,7300.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0491/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2247.3,
+                3811.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6061096,
+                39.05888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                275.9,
+                3811.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.607263,
+                39.0588881
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"167.9,7552.0 259.6,7400.4 -0.0,-0.0 6414.0,0.0 6156.8,7620.3 167.9,7552.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3990.8,
+                4992.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.601424,
+                39.058333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                167.9,
+                7552.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6037473,
+                39.0572111
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p493 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3559.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "3654.7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3469.2,3654.7 -0.0,3654.7 -0.0,2493.7 257.4,2494.7 102.2,157.6 3447.6,136.0 3469.2,3654.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3447.6,
+                3966.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.599912,
+                39.059743
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3447.6,
+                136.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.597599,
+                39.059649
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p493 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6452.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"620.1,3533.6 3755.4,3528.4 3744.4,1197.0 6325.9,1184.8 6332.0,7581.0 -0.0,7423.1 -0.0,7081.1 606.5,7083.4 620.1,3533.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3752.0,
+                7583.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600113,
+                39.058286
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6332.0,
+                7583.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600188,
+                39.057088
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4423.5,2820.0 6430.0,7224.3 6430.0,7629.8 159.1,7611.5 216.2,-0.0 2535.1,-0.0 4144.3,157.9 4144.8,2940.7 4423.5,2820.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4434.6,
+                7655.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600177,
+                39.05514
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                167.9,
+                4675.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.598328,
+                39.057024
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p495",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6248.0,7599.0 200.0,7599.0 202.2,1104.7 6255.4,1063.1 6248.0,7599.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                200.0,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.597687,
+                39.058193
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6248.0,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.594158,
+                39.058067
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p496",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"317.9,0.0 6224.9,0.0 6198.1,7623.0 277.3,7629.9 317.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                295.9,
+                4427.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.594069,
+                39.059516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6198.1,
+                7623.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.590703,
+                39.057958
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0497/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p497",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "18"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0497/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0497/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2149.1,6836.9 1075.3,7558.0 1327.4,5226.3 1321.4,2899.6 -0.0,2882.9 -0.0,233.3 5640.0,248.0 5670.4,6805.8 2149.1,6836.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0497/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1912.0,
+                6851.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.595344,
+                39.055113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5640.0,
+                248.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593002,
+                39.058027
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0498/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p498",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0498/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0498/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4510.3,7795.0 3750.2,6746.8 1313.0,6789.9 1219.5,235.5 5157.2,177.3 5189.3,7594.2 4510.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0498/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3950.8,
+                4867.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.591552,
+                39.055865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5198.4,
+                2863.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5907628,
+                39.0567415
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p499",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"128.0,168.0 6500.0,163.5 6500.0,7608.8 117.8,7670.0 128.0,168.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                128.0,
+                3895.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58811,
+                39.062068
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                128.0,
+                168.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.585784,
+                39.061983
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p500",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5636.1,42.3 5960.2,40.6 6124.2,39.3 6162.4,7665.8 3435.2,7756.6 1250.8,7672.4 1222.6,64.9 5877.2,-0.0 5636.1,42.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2315.3,
+                3883.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.588334,
+                39.058473
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2315.3,
+                2055.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.587218,
+                39.058429
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p501",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4118.1,7351.6 6094.2,7795.0 85.5,7795.0 -0.0,0.0 6500.0,65.0 6500.0,1873.1 4124.0,1855.8 4118.1,7351.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4124.0,
+                5871.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.584697,
+                39.060138
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4124.0,
+                1855.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.582355,
+                39.060063
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p502",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2023.1,-0.0 6435.1,-0.0 5699.7,976.8 6454.0,4457.7 6454.0,7035.0 2997.2,7795.0 973.3,7795.0 61.3,3710.3 1829.1,3327.0 1527.7,1983.5 -0.0,2323.5 -0.0,672.1 2069.9,213.0 2023.1,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6342.0,
+                3943.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.583775,
+                39.056491
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2399.3,
+                140.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.580176,
+                39.05817
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p503",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5859.7,2371.3 5861.0,4445.7 6500.0,5295.0 6500.0,6372.1 5862.1,6372.4 5862.3,6629.0 69.4,6642.7 55.0,269.0 5858.5,249.0 5859.3,1642.9 6300.4,2368.7 5859.7,2371.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                164.0,
+                2347.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574137,
+                39.061547
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                164.0,
+                6375.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.576466,
+                39.061634
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p504",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6318.3,7795.0 1859.9,7795.0 1857.8,6614.5 -0.0,6617.8 -0.0,6360.7 639.1,6360.7 639.7,5281.4 -0.0,4558.7 -0.0,2350.6 441.5,2348.6 -0.0,1621.0 0.0,0.0 6307.7,-0.0 6318.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6310.0,
+                2327.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574469,
+                39.056167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6310.0,
+                6367.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5768,
+                39.056253
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p505",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6500.0,113.5 6500.0,7580.3 5807.4,7578.4 5806.8,7795.0 -0.0,7795.0 -0.0,3925.1 218.0,3925.3 298.5,100.5 6500.0,113.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4192.0,
+                3919.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.570725,
+                39.059615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4192.0,
+                104.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.568447,
+                39.059536
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p506",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6278.1,160.0 6279.5,7321.8 1078.6,7307.1 1078.4,122.2 6278.1,160.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6278.1,
+                7615.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5733076,
+                39.0561255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6278.1,
+                160.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.568682,
+                39.055965
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p507",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"499.7,106.8 6477.0,128.4 6477.0,7657.7 455.3,7624.2 456.0,5783.1 -0.0,5782.6 -0.0,3827.8 693.4,3828.4 499.7,106.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4196.6,
+                5791.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.567297,
+                39.059498
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4196.6,
+                112.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.563765,
+                39.059385
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p508",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "17"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6153.3,334.0 5882.1,7777.4 823.6,7574.6 1041.4,135.6 6153.3,334.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2247.3,
+                7627.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56856,
+                39.05774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3630.9,
+                3851.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566193,
+                39.057042
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p509",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,7669.0 419.7,7679.0 399.1,3974.0 -0.0,3971.8 -0.0,2098.2 395.6,2095.8 383.4,-0.0 6255.6,-0.0 6260.2,1161.7 5599.4,1164.3 5603.3,2356.7 6477.0,2352.8 6477.0,7669.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4192.6,
+                5843.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5626551,
+                39.0593451
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4192.6,
+                7663.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.563765,
+                39.059385
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p510",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6401
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"867.4,7641.4 885.0,2256.8 -0.0,2257.9 -0.0,1050.2 669.3,1049.7 668.5,-0.0 6401.0,-0.0 6263.3,7683.5 867.4,7641.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6265.0,
+                5787.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5628563,
+                39.0557502
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6265.0,
+                503.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5596779,
+                39.055644
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p511",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,6557.9 224.0,6533.0 224.0,667.9 3590.4,664.9 3592.3,456.5 6477.0,452.7 6477.0,6557.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                224.0,
+                6695.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5590804,
+                39.06102
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                224.0,
+                667.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5556314,
+                39.0609067
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p512",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6366.5,6698.3 439.1,6616.8 519.0,478.8 6231.1,578.0 6423.0,725.9 6366.5,6698.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2111.7,
+                2539.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.556886,
+                39.057436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2111.7,
+                495.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.555698,
+                39.057409
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p513",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3434.7,7600.5 3429.1,7795.0 -0.0,7795.0 -0.0,1878.3 683.7,1918.9 673.2,2024.5 765.8,1923.8 380.8,1900.8 413.1,310.0 6477.0,88.4 6477.0,7655.0 3434.7,7600.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4176.6,
+                1975.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5522397,
+                39.0590036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                236.0,
+                5783.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5544614,
+                39.0608714
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p514",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6423.0,-0.0 6423.0,7663.2 6117.3,7529.1 895.4,7662.0 526.9,187.9 1220.9,139.1 1209.1,-0.0 6423.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2151.7,
+                7623.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.555698,
+                39.057409
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2151.7,
+                136.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.551183,
+                39.057155
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p515",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6326.7,7195.3 459.8,7265.9 492.3,7795.0 -0.0,7795.0 -0.0,-0.0 117.1,0.0 143.2,653.2 6270.9,592.3 6326.7,7195.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2184.3,
+                4963.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6062441,
+                39.05535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2184.3,
+                615.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.606109,
+                39.057299
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p516",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3519.2,7795.0 1626.0,7795.0 1632.4,7138.6 -0.0,7131.3 54.3,558.3 6423.0,606.5 6379.6,7142.5 3520.8,7148.6 3519.2,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5443.2,
+                7155.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600759,
+                39.054148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1879.7,
+                571.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6026871,
+                39.0571745
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p517",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,4735.3 6477.0,6127.5 5483.1,6001.3 5255.1,7795.0 4061.4,7795.0 2264.8,7569.3 2236.0,7795.0 1178.4,7795.0 1222.3,7438.4 562.3,7355.4 915.9,4435.6 703.7,4408.0 756.6,3993.6 -0.0,1519.2 5063.5,56.4 6477.0,4735.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                916.1,
+                4435.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600214,
+                39.054138
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5064.8,
+                56.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.597548,
+                39.052491
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p518 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6438.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6240.2 360.3,4929.6 316.3,170.3 2147.8,187.1 2149.8,-0.0 2574.9,-0.0 2811.9,213.5 6438.0,197.2 6438.0,1533.6 6256.9,1499.5 5517.5,3172.6 5641.3,3324.2 3461.6,7746.2 -0.0,6240.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3854.8,
+                6884.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60044,
+                39.049913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4386.6,
+                176.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.596697,
+                39.05078
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p519",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6433
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"452.1,805.9 2825.3,754.6 2822.8,447.5 5415.0,1544.1 4905.0,2396.6 5853.1,7369.5 2876.0,7488.8 2870.5,6711.2 1998.2,6732.4 1060.6,7795.0 493.6,7795.0 452.1,805.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0519/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5508.9,
+                1583.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.595717,
+                39.055129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                452.1,
+                807.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.598621,
+                39.054657
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p520",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5243.8 144.5,5245.8 178.1,1666.8 392.0,1435.8 397.8,1016.2 772.1,1025.3 1721.4,0.0 2581.6,0.0 2568.4,766.8 5925.1,765.1 5895.9,4095.3 4209.1,7793.9 137.6,5919.1 -0.0,5243.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5918.2,
+                3036.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593615,
+                39.051837
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                187.9,
+                1492.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5970813,
+                39.0515121
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p521",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5200.5 -0.0,197.7 176.0,0.0 1462.8,0.0 6413.5,3263.2 6481.0,5816.5 6219.6,6570.3 6181.0,7557.0 29.6,7557.0 408.2,5313.5 -0.0,5200.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6181.0,
+                7559.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.590533,
+                39.053295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                28.0,
+                7559.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593615,
+                39.051837
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p522",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1108.3,7422.5 516.5,7408.5 645.3,3264.8 248.7,2259.7 3843.9,0.0 6213.4,0.0 6438.0,360.7 6438.0,1038.7 5157.6,1843.0 6265.2,3582.4 6438.0,7796.0 1097.7,7796.0 1108.3,7422.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2507.2,
+                868.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5923013,
+                39.0524461
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.2,
+                7516.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59045,
+                39.0494522
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p523",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "17"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2059.7,3976.9 -0.0,4014.8 -0.0,3806.8 1369.3,2913.1 849.3,2046.4 650.7,1254.4 -0.0,153.1 608.8,0.0 641.3,761.3 692.7,562.4 2905.9,575.5 3473.8,1544.2 4929.7,558.5 5211.5,728.7 6481.0,730.9 6481.0,6375.4 6299.2,6107.1 4300.5,7412.8 3722.6,6515.1 2167.0,7585.4 1031.6,5849.5 2304.8,5016.1 2292.3,4335.5 2059.7,3976.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4704.7,
+                3383.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.588629,
+                39.053039
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3052.5,
+                5479.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5896155,
+                39.0521293
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p524",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6137.1,7796.0 44.6,7796.0 -0.0,3685.8 1566.6,2717.0 2090.3,3626.2 4114.2,2440.8 4279.6,2712.9 4384.4,1383.1 6438.0,1501.1 6137.1,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                -12.0,
+                3692.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.590161,
+                39.051206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1567.5,
+                2716.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58925,
+                39.05166
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p525",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"67.5,5597.5 390.4,287.4 6203.7,603.4 5881.9,5872.7 4504.5,5814.6 4239.2,5639.3 2795.6,6533.4 2285.7,5576.4 150.5,5476.9 67.5,5597.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                280.0,
+                2247.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.590818,
+                39.055838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4240.7,
+                5639.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5884497,
+                39.0542918
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p526 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6438.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2308.8,6861.6 185.2,6884.2 198.8,268.2 2275.3,260.0 2273.5,0.0 3880.3,0.0 3901.4,5594.8 2303.3,5608.0 2308.8,6861.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2275.3,
+                260.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.586105,
+                39.056576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2303.3,
+                5608.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.586246,
+                39.054169
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p526 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4290.3"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "1426.8"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2147.7"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2832.8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6323.7,4259.6 4290.3,4259.6 4290.3,1426.8 6341.7,1426.8 6323.7,4259.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4410.0,
+                2665.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.587506,
+                39.053048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6334.2,
+                2665.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.586315,
+                39.053011
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p527 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6043.2,7795.0 264.6,7795.0 651.8,1310.1 1888.9,246.7 759.9,-0.0 6481.0,-0.0 6481.0,1301.8 6000.9,1299.8 6043.2,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0527/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                644.1,
+                5359.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.583775,
+                39.056491
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6000.9,
+                1299.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5815891,
+                39.0540216
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0529/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p529",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0529/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0529/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,188.2 5884.0,184.0 5874.3,7637.8 6456.0,7641.4 6456.0,7641.4 4884.4,7724.4 4884.4,7631.4 910.2,7605.5 916.2,139.2 1358.0,144.0 1359.0,-0.0 6456.0,-0.0 6456.0,188.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0529/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5884.0,
+                3903.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.584061,
+                39.051691
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5884.0,
+                184.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.581741,
+                39.051619
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p530",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5922.5,7683.4 6454.0,7683.0 6454.0,7796.0 5807.8,7796.0 5801.2,7682.7 909.2,7655.4 914.5,213.2 1485.4,217.0 1485.3,29.2 6442.1,-0.0 6454.0,2075.4 5898.4,2077.5 5922.5,7683.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5894.2,
+                5832.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5853774,
+                39.0493156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5894.2,
+                216.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5818691,
+                39.0492051
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p531",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5752.5,829.1 5814.5,6921.2 6456.0,6922.5 6456.0,7795.0 -0.0,7795.0 -0.0,6283.5 194.2,6284.0 201.3,828.5 5752.5,829.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                196.0,
+                2851.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.575639,
+                39.05621
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                196.0,
+                6887.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.577973,
+                39.056291
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0532/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p532",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0532/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0532/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6360.2,920.3 6330.0,6932.0 6454.0,6933.5 6454.0,7796.0 625.1,7746.0 633.8,6883.5 -0.0,6875.8 -0.0,853.1 6360.2,920.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0532/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6330.0,
+                4892.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.577105,
+                39.050865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6330.0,
+                6932.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.578299,
+                39.050897
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0533/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p533",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0533/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0533/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,781.4 6456.0,6985.2 224.5,6979.9 235.4,770.6 6456.0,781.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0533/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4140.0,
+                2951.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.572228,
+                39.054322
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4140.0,
+                6983.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574571,
+                39.054402
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0534/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p534",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0534/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0534/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6342.0,6992.0 637.8,6989.0 633.9,777.0 6342.0,772.0 6342.0,6992.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0534/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6342.0,
+                6992.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574781,
+                39.050789
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6342.0,
+                772.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.571171,
+                39.050664
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0535/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p535",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0535/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0535/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5176.6,7604.9 454.9,7577.8 499.1,296.9 5214.9,323.9 5176.6,7604.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0535/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4192.0,
+                376.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566448,
+                39.054085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4088.0,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.570965,
+                39.054276
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0536/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p536",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0536/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0536/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7632.4 -0.0,312.3 1118.2,207.2 6384.1,206.5 6386.0,7624.0 -0.0,7632.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0536/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7624.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.571171,
+                39.050664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                360.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566651,
+                39.050505
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0537/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p537",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0537/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0537/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5814.1,-0.0 5797.2,3848.5 6456.0,3849.2 6456.0,7795.0 192.9,7795.0 194.0,441.6 482.8,438.2 373.8,-0.0 5814.1,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0537/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4160.0,
+                5823.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5652667,
+                39.054048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                208.0,
+                5823.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5651728,
+                39.0558331
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0538/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p538",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0538/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0538/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6472.0,1945.7 6321.0,1946.5 6325.9,7795.0 677.6,7795.0 660.7,3945.0 -0.0,3947.1 0.0,0.0 6081.8,-0.0 6081.9,527.0 6472.0,526.2 6472.0,1945.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0538/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2356.0,
+                3939.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.564213,
+                39.052211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6320.0,
+                3939.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.564317,
+                39.050426
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p539",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,168.1 6456.0,7795.0 4536.3,7795.0 4536.3,7795.0 276.7,7795.0 275.7,7601.9 160.0,7601.0 168.6,130.7 6456.0,168.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                160.0,
+                1991.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574781,
+                39.050789
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                160.0,
+                7599.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.578299,
+                39.050897
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p540",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6472.0,7795.0 1352.2,7795.0 1290.7,6061.8 1429.4,5918.6 1282.3,5822.1 1082.6,190.5 716.7,202.0 710.5,-0.0 5958.8,47.5 6038.8,1150.4 6472.0,730.3 6472.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2264.0,
+                2015.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574994,
+                39.047183
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                7900.0,
+                120.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5740706,
+                39.0443708
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p541",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,768.1 6456.0,7093.5 148.0,7087.1 151.9,796.8 6456.0,768.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                148.0,
+                5075.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57243,
+                39.050708
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                148.0,
+                7087.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.573614,
+                39.050749
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p543",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,278.1 6456.0,2213.2 5678.2,2212.7 5516.8,7566.0 282.9,7580.9 300.5,265.5 6456.0,278.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4104.0,
+                4119.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.567909,
+                39.048751
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4104.0,
+                2211.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566751,
+                39.048713
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p544",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6262.1,7795.0 881.4,7795.0 875.3,7575.8 -0.0,7600.8 -0.0,2266.4 774.4,2243.5 716.3,317.0 6066.4,156.3 6076.6,495.9 6472.0,485.5 6472.0,3954.6 6152.2,3967.7 6262.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2256.0,
+                2199.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.566851,
+                39.046905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6256.0,
+                7535.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.570272,
+                39.045201
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p545",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6211.6,7795.0 341.7,7795.0 -0.0,6852.6 -0.0,3776.1 218.4,3777.5 272.5,0.0 2116.8,0.0 2211.5,164.3 6456.0,362.0 6456.0,3716.8 6282.0,3715.5 6211.6,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6280.0,
+                3715.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.575172,
+                39.043626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2268.0,
+                1779.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.577457,
+                39.044544
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p546",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"515.8,3734.4 456.3,585.9 1483.6,614.3 1066.5,159.7 2200.0,0.0 6188.6,0.0 6100.8,7084.6 6472.0,7083.3 6472.0,7212.6 6101.0,7210.2 6097.7,7633.2 -0.0,7795.0 -0.0,7572.8 358.5,7623.7 352.5,3736.2 515.8,3734.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4160.0,
+                3719.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.572832,
+                39.043547
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2168.0,
+                3719.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.574056,
+                39.043592
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p547",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6433
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6433.0,7795.0 156.9,7795.0 280.1,0.0 2143.3,0.0 6281.0,144.0 6285.2,490.1 6433.0,494.3 6433.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                280.0,
+                144.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.571479,
+                39.045242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6281.0,
+                144.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5680985,
+                39.045127
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p548",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5430.0,6235.8 2767.2,6080.0 2666.9,7795.0 2599.8,7795.0 2718.8,5337.6 -0.0,5220.6 -0.0,3554.8 747.6,3575.9 567.5,3268.0 533.5,2909.7 707.8,2573.4 801.4,2513.0 849.2,478.3 -0.0,435.3 0.0,0.0 6472.0,-0.0 6472.0,7795.0 6232.7,7795.0 5430.0,6235.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4448.0,
+                6835.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5700359,
+                39.0401218
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4448.0,
+                1727.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.563748,
+                39.040144
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p552 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6472.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6472.0,7795.0 -0.0,7795.0 -0.0,444.1 2181.3,424.6 2181.9,0.0 6472.0,0.0 6472.0,5357.2 6111.2,5566.3 3439.1,7149.5 3467.1,7629.4 6472.0,7453.6 6472.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2224.0,
+                4235.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.571855,
+                39.039828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                248.0,
+                4235.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5730642,
+                39.0398786
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p553",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2724.3,164.2 4523.1,254.3 4147.9,7712.6 -0.0,7795.0 -0.0,7697.6 1283.8,7768.8 1309.8,7300.0 800.0,7299.1 1112.9,84.5 2731.4,-0.0 2724.3,164.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                800.0,
+                7299.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.607312,
+                39.0543593
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5300.0,
+                5679.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6063331,
+                39.052261
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p554",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5551.5,190.0 5535.0,5655.6 6512.0,5637.8 6512.0,7795.0 -0.0,7795.0 -0.0,238.8 5551.5,190.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5520.0,
+                5579.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.606401,
+                39.050205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5520.0,
+                755.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.603537,
+                39.050097
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p555 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6400.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1264.4,0.0 3178.2,0.0 3181.7,1770.0 3329.5,2927.5 5097.8,2926.5 5100.7,7719.2 1260.6,7584.1 1264.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3184.0,
+                2927.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60198,
+                39.05212
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1244.0,
+                2927.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6031001,
+                39.052156
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p556",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6512.0,4730.2 6512.0,7795.0 741.0,7795.0 601.4,0.0 4381.2,0.0 4740.4,2603.3 6512.0,4730.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                600.0,
+                3867.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593243,
+                39.04786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                600.0,
+                244.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593204,
+                39.04869
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p557",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6400.0,4320.6 6074.1,4320.4 6123.9,7795.0 1001.1,7795.0 1004.2,5973.0 -0.0,5989.5 -0.0,953.5 6400.0,921.1 6400.0,4320.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4288.0,
+                5919.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6065223,
+                39.0482767
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4288.0,
+                927.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6036385,
+                39.0481718
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0558/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p558",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0558/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0558/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4298.9 324.2,4303.8 372.7,921.7 2368.0,943.9 2374.4,116.3 6512.0,153.5 6512.0,7795.0 -0.0,7795.0 -0.0,4298.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0558/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                3243.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.605154,
+                39.044561
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2368.0,
+                943.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6037424,
+                39.0463263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0559/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p559",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "14"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0559/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0559/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5859.0,5071.4 6051.5,6744.2 -0.0,6752.6 178.9,2239.2 6400.0,2261.1 6400.0,5070.0 5859.0,5071.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0559/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4316.0,
+                6743.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6036385,
+                39.0481718
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                136.0,
+                2883.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.601326,
+                39.049954
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p560 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "29"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6522.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2380.7,6711.1 -0.0,6435.9 -0.0,4769.5 532.2,4829.3 846.1,2101.9 3004.4,1350.5 6522.0,1783.6 6522.0,2580.9 5490.3,4377.1 6043.7,4694.7 6522.0,4749.8 6522.0,6344.7 2473.4,5885.4 2380.7,6711.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                936.3,
+                2071.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.601122,
+                39.047122
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2380.7,
+                6711.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6037424,
+                39.0463263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p560 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3158.2"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "6137.6"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3363.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "1657.4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3158.2,7795.0 3158.2,7219.5 3332.6,7126.0 3158.2,6721.4 3158.2,6137.6 6522.0,6137.6 6522.0,7795.0 3158.2,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0560__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5038.1,
+                7575.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.601592,
+                39.043973
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3526.2,
+                7575.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.602452,
+                39.044295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p561",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6400.0,940.6 6400.0,7688.3 6176.6,7795.0 -0.0,7795.0 16.8,3801.5 173.7,2950.0 -0.0,2861.9 -0.0,1043.2 6400.0,940.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3932.0,
+                6879.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.600531,
+                39.048125
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3932.0,
+                951.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.597075,
+                39.048
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p562",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"599.3,945.5 6485.1,977.1 6522.0,6389.1 5940.6,7725.7 5852.4,6934.5 2313.8,6893.6 551.2,7736.3 599.3,945.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2336.7,
+                2975.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5983515,
+                39.0461391
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6337.9,
+                2975.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5984431,
+                39.0443415
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0563/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p563",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0563/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0563/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5793.9 195.2,5709.0 248.0,535.9 622.4,537.9 610.0,-0.0 1987.9,-0.0 1987.9,545.5 5763.3,471.4 5733.1,7219.3 -0.0,7260.7 -0.0,5793.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0563/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5344.0,
+                5207.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5959535,
+                39.047324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                248.0,
+                535.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.593159,
+                39.0495222
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0564/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p564",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0564/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0564/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6522
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7197.9 -0.0,528.9 223.0,530.4 220.6,-0.0 6413.7,-0.0 6522.0,7222.0 -0.0,7197.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0564/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2408.7,
+                5211.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5960203,
+                39.0460592
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6394.0,
+                5211.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5961152,
+                39.0442605
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p565",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6392
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3456.3,7527.9 2983.4,7795.0 727.0,7795.0 556.6,338.4 6331.1,185.9 6392.0,7795.0 5431.7,7795.0 4650.0,6471.7 4136.6,6690.2 3456.3,7527.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                608.0,
+                3159.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5866108,
+                39.0480113
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4408.0,
+                224.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5841981,
+                39.0492785
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p566 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6517.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6517.0,7796.0 6414.0,7561.0 582.3,7488.8 597.5,7796.0 -0.0,7796.0 -0.0,-0.0 6517.0,0.0 6517.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1200.2,
+                2232.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.606755,
+                39.066151
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6056.9,
+                5676.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6040711,
+                39.0645071
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0567/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p567",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0567/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0567/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"551.1,7795.0 545.7,4974.9 -0.0,4855.0 -0.0,6.2 6360.0,114.5 6360.0,7795.0 551.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0567/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3592.0,
+                188.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5782135,
+                39.061706
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                560.0,
+                188.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.579959,
+                39.061768
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p568",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6517.0,7796.0 292.6,7796.0 245.1,0.0 6517.0,0.0 6517.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2112.3,
+                3856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5472635,
+                39.0678799
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                256.0,
+                3856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5483382,
+                39.0679157
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p569",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,916.4 4242.3,1091.0 4244.7,1035.6 5857.2,1131.1 5919.7,0.0 6360.0,0.0 6360.0,7795.0 -0.0,7795.0 -0.0,916.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4240.0,
+                1143.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5486956,
+                39.0606496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6072.0,
+                1143.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5476177,
+                39.0606594
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p571",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6360.0,7442.2 189.7,7435.3 184.0,240.0 4161.1,238.4 4161.9,389.2 5579.5,389.5 5578.8,0.0 6360.0,0.0 6360.0,7442.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                184.0,
+                4215.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565576,
+                39.048672
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                184.0,
+                240.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565472,
+                39.050465
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0572/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p572",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0572/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0572/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"841.7,7316.8 -0.0,7796.0 -0.0,4785.3 352.1,4784.0 333.9,0.0 6517.0,0.0 6517.0,7680.4 2261.4,7796.0 1793.3,7378.8 841.7,7316.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0572/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4284.7,
+                808.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.563356,
+                39.046768
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                352.1,
+                4784.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.565776,
+                39.045037
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0573__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p573 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6360.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0573__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0573/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,5575.2 346.5,5518.0 318.7,2419.3 1518.3,2403.2 1507.9,1625.1 1155.8,1245.7 988.9,935.7 950.8,431.5 261.1,440.8 255.1,0.0 5687.5,0.0 5761.1,6140.4 6040.5,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0573__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                68.0,
+                5519.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5934061,
+                39.0441666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5756.0,
+                5903.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5868182,
+                39.0435627
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p574 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "19"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1255.0,3201.3 1626.0,2769.2 1855.1,2714.9 2205.9,3372.0 2670.8,3392.1 2795.6,0.0 6408.4,0.0 6454.9,174.4 6406.0,118.2 6244.8,3647.8 6433.4,3658.2 6393.6,5366.1 6292.9,5364.5 6280.1,6783.3 6434.0,7219.8 6517.0,7202.7 6517.0,7796.0 -0.0,7796.0 -0.0,7369.4 101.8,7372.5 -0.0,6715.4 -0.0,3276.7 1015.3,3323.4 1255.0,3201.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4604.7,
+                2128.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.580833,
+                39.046854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1256.2,
+                3200.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.585052,
+                39.045875
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p576",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6491
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 6491.0,0.0 6491.0,7706.0 -0.0,7795.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1175.8,
+                3951.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.598676,
+                39.069691
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5939.1,
+                5735.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.595925,
+                39.068688
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p577 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6337.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
+        }
+      ],
+      "created": "2026-07-17T17:49:47Z",
+      "modified": "2026-07-17T17:49:47Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6337
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5551.6,5546.1 4686.8,7795.0 -0.0,7795.0 -0.0,214.2 5702.7,306.8 5707.9,4521.3 5551.6,5546.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1080.2,
+                4427.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.598811,
+                39.066002
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1080.2,
+                304.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5986846,
+                39.0678771
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/gallery/nashville_tn_1957_vol1a.iiif.json
+++ b/gallery/nashville_tn_1957_vol1a.iiif.json
@@ -1,31 +1,31 @@
 {
-  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn05791_053/main-content//generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn08356_019/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Mosaic of main content, Brooklyn, N.Y. | 1939 | Vol. 1",
+  "label": "Mosaic of main content, Nashville, Tenn. | 1957 | Vol. 1a",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0010/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p1",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p10",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "3"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +34,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0010/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0010/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8040.0 0.0,0.0 5603.5,0.0 5679.6,8040.0 2781.5,8040.0 2500.4,7625.9 2498.7,8040.0 1026.7,8040.0 -0.0,8040.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0010/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02329946235103,
-                40.67718446758965
+                -86.78250033170485,
+                36.16864915720646
               ]
             }
           },
@@ -82,7 +82,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5599.0,
+                6600.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02041525312393,
-                40.6796283326228
+                -86.780704058303,
+                36.169391821884716
               ]
             }
           },
@@ -103,8 +103,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5599.0,
-                8268.0
+                6600.0,
+                8040.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01565946488587,
-                40.676397560306384
+                -86.77958396251518,
+                36.16762442424559
               ]
             }
           },
@@ -125,7 +125,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8268.0
+                8040.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01854367411298,
-                40.67395369527323
+                -86.78138023591703,
+                36.16688175956733
               ]
             }
           },
@@ -145,8 +145,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5491.0,
-                7724.0
+                5620.0,
+                2136.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -157,8 +157,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.016028,
-                40.676563
+                -86.7806732,
+                36.168812
               ]
             }
           }
@@ -166,13 +166,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0011/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p10",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p11",
       "metadata": [
         {
           "label": "streets",
@@ -180,11 +180,11 @@
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "4"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -193,21 +193,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0011/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0011/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5599.0,8268.0 5373.8,8268.0 5361.4,7291.8 4422.2,7303.7 4411.2,7664.0 0.0,7664.4 0.0,-0.0 5599.0,0.0 5599.0,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7083.7 -0.0,5604.4 143.4,5812.7 1428.0,5784.2 1379.5,2174.2 -0.0,2180.1 -0.0,0.0 6600.0,0.0 6600.0,8040.0 4084.1,8040.0 3987.5,6536.1 1085.3,6602.5 1114.6,7059.0 616.3,7081.4 -0.0,7083.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0010/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -217,8 +217,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4411.2,
-                7664.0
+                3024.0,
+                3124.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -229,8 +229,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9994446,
-                40.6916676
+                -86.7796837,
+                36.1692225
               ]
             }
           },
@@ -238,8 +238,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                555.9,
-                7664.0
+                3024.0,
+                1200.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -250,8 +250,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -86.780276,
+                36.1701663
               ]
             }
           }
@@ -259,25 +259,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0013/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p11",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p13",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "6"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -286,21 +286,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0013/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0013/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,382.0 4893.0,460.7 4896.0,1361.4 5599.0,1359.0 5599.0,8268.0 -0.0,8268.0 -0.0,382.0\" /></svg>"
+          "value": "<svg><polygon points=\"1770.9,6475.6 1778.2,8040.0 -0.0,8040.0 -0.0,352.1 4988.7,771.8 2439.3,6478.0 1770.9,6475.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0011/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0013/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -310,8 +310,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2459.6,
-                460.0
+                1756.0,
+                3508.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -322,8 +322,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.015425,
-                40.675199
+                -86.7989413,
+                36.1569371
               ]
             }
           },
@@ -331,8 +331,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5351.0,
-                460.0
+                5000.0,
+                5876.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -343,8 +343,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.013855,
-                40.674128
+                -86.7966284,
+                36.156783
               ]
             }
           }
@@ -352,25 +352,211 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p13",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p14",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1677.1,0.0 4900.3,0.0 5224.6,1357.5 6159.9,1764.9 5321.4,1763.0 6600.0,7114.9 6600.0,8040.0 -0.0,8040.0 -0.0,1567.6 1677.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4888.0,
+                4340.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7951488,
+                36.1548017
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4888.0,
+                6840.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.794399,
+                36.1538023
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2614.0,6893.4 886.8,6617.9 895.4,1612.0 4604.2,1613.3 5303.2,0.0 5617.9,0.0 5891.0,1634.4 6600.0,1631.0 6600.0,8040.0 -0.0,8040.0 -0.0,7802.5 2576.7,7797.7 2614.0,6893.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3664.0,
+                4112.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7937625,
+                36.1554997
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3664.0,
+                1620.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7945183,
+                36.1565114
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -379,21 +565,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,261.1 5227.9,415.5 5059.5,-0.0 5612.0,-0.0 5612.0,261.1\" /></svg>"
+          "value": "<svg><polygon points=\"5936.0,6936.0 -0.0,7040.8 0.0,0.0 5721.4,0.0 5936.0,6936.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0013/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -418,8 +604,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0138049615332,
-                40.67445210987348
+                -86.79141699244411,
+                36.15688878899281
               ]
             }
           },
@@ -427,7 +613,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5612.0,
+                6600.0,
                 0.0
               ],
               "creator": {
@@ -439,8 +625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01057182377127,
-                40.67226350816088
+                -86.78961234545017,
+                36.15761808995978
               ]
             }
           },
@@ -448,8 +634,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5612.0,
-                8268.0
+                6600.0,
+                8040.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -460,8 +646,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01482175977381,
-                40.668649624515666
+                -86.7885124049722,
+                36.155842453337165
               ]
             }
           },
@@ -470,7 +656,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8268.0
+                8040.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -481,8 +667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01805489753573,
-                40.67083822622827
+                -86.79031705196616,
+                36.15511315237019
               ]
             }
           },
@@ -490,8 +676,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                320.0,
-                456.0
+                5936.0,
+                6936.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -502,8 +688,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.013855,
-                40.674128
+                -86.788845,
+                36.1560129
               ]
             }
           }
@@ -511,397 +697,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p19",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p17",
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5522.4,5644.3 5534.2,6829.3 338.8,6828.9 320.0,1619.1 5384.9,1611.8 5369.4,5386.5 5522.4,5644.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5372.0,
-                2928.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01206,
-                40.675781
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                328.0,
-                4224.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.015401,
-                40.677098
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p2",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5095.1,7668.0 -0.0,7685.4 0.0,-0.0 5599.0,0.0 5599.0,4888.0 5095.1,4888.0 5095.1,7668.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0002/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5095.1,
-                4888.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0156533,
-                40.6791877
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5095.1,
-                7668.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0141485,
-                40.678165
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p20",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"194.7,7341.8 186.5,4776.4 -0.0,4777.6 -0.0,0.0 1237.0,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.5 5212.2,4302.1 5208.9,7333.7 194.7,7341.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1240.0,
-                916.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0104477,
-                40.6804294
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5184.0,
-                916.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.008302,
-                40.67897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1185.4,0.0 2742.9,0.0 2756.5,248.9 5463.7,250.7 5407.8,4902.0 4729.6,7042.0 4418.9,6266.1 2591.4,7001.0 2093.5,6980.3 1692.5,7140.9 1793.0,7313.3 230.3,7911.5 266.5,247.3 1184.4,247.9 1185.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2831.5,
-                4184.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007061,
-                40.680042
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5423.0,
-                1436.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007303,
-                40.682123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p22",
-      "metadata": [
-        {
-          "label": "streets",
           "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -910,21 +724,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5621
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5621.0,4303.3 5621.0,7056.8 4971.2,6433.3 4983.6,8125.1 4290.6,7601.9 -0.0,5893.5 861.7,3570.3 1068.5,3632.3 1239.2,3638.9 1285.9,3494.7 -0.0,3077.7 -0.0,-0.0 1975.4,0.0 1992.4,432.0 5153.6,412.0 5185.3,4308.0 5621.0,4303.3\" /></svg>"
+          "value": "<svg><polygon points=\"6056.4,6991.6 478.3,7048.0 420.3,3380.8 -0.0,3374.6 -0.0,1057.1 2330.0,903.1 2217.8,0.0 6600.0,0.0 6600.0,629.0 6002.7,653.4 6056.4,6991.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -934,8 +748,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5184.9,
-                4308.0
+                2720.0,
+                3720.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -946,8 +760,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0039713,
-                40.6823752
+                -86.7885815,
+                36.1578752
               ]
             }
           },
@@ -955,8 +769,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1992.4,
-                432.0
+                3136.0,
+                6988.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -967,8 +781,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0051587,
-                40.6850009
+                -86.7874961,
+                36.1566099
               ]
             }
           }
@@ -976,292 +790,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2073.6,448.4 2329.2,297.3 4764.0,304.0 4759.5,4110.0 3818.6,4493.1 5273.3,8268.0 -0.0,8268.0 -0.0,-0.0 900.8,0.0 899.9,458.2 2073.6,448.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3468.0,
-                3076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.011181,
-                40.674223
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4764.0,
-                304.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.01206,
-                40.675781
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1326.4,7230.1 305.1,4610.0 1252.5,4218.3 1236.3,377.8 5612.0,378.3 5612.0,3186.2 3759.9,3183.6 2638.7,3670.2 3714.1,6239.4 1326.4,7230.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3832.0,
-                392.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.010793,
-                40.676834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1248.0,
-                3172.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.010554,
-                40.674758
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5622
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4974.6,1732.5 5130.1,7428.0 2371.2,7532.0 2309.8,6321.6 2956.9,4602.8 725.2,3765.7 1904.1,586.6 4974.6,1732.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1071.6,
-                1648.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0089209,
-                40.6784355
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2371.2,
-                7532.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0096123,
-                40.6751413
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p26",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p18",
       "metadata": [
         {
           "label": "streets",
@@ -1272,8 +807,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1282,21 +817,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5464
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5464,0 5464,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6935.5 -0.0,753.7 582.7,734.8 587.9,121.4 -0.0,116.4 0.0,0.0 6600.0,0.0 6600.0,566.2 6172.0,548.0 6172.0,6940.0 -0.0,6935.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -1306,8 +841,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1688.0,
-                676.0
+                6172.0,
+                6940.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1318,8 +853,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044835,
-                40.6692758
+                -86.7827584,
+                36.1586196
               ]
             }
           },
@@ -1327,8 +862,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3296.0,
-                676.0
+                6172.0,
+                548.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1339,8 +874,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0033677,
-                40.6689515
+                -86.7845343,
+                36.1613251
               ]
             }
           }
@@ -1348,850 +883,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p27",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5497
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5264.0,7862.3 2688.5,7920.0 2688.5,6019.3 0.0,6053.4 0.0,654.2 2688.5,1700.9 2688.5,440.0 5255.1,397.5 5264.0,7862.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0027/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2688.5,
-                440.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.008337,
-                40.6732973
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2688.5,
-                7920.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0032316,
-                40.6718496
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p28",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"234.7,246.2 5229.0,178.5 5270.6,6865.4 5612.0,7294.5 5612.0,7875.2 5355.6,7755.2 4616.9,7714.3 266.2,7818.7 234.7,246.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0028/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5264.0,
-                5072.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0031933,
-                40.6762708
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3992.0,
-                2744.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0050803,
-                40.6760699
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2681.0,196.0 2651.9,0.0 3081.1,0.0 3532.8,202.9 5490.0,200.3 5490.0,7681.2 1356.1,7659.8 1250.8,7732.9 192.5,6777.4 242.7,162.5 2681.0,196.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1440.5,
-                4959.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0028805,
-                40.6769149
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2681.0,
-                196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0058614,
-                40.678464
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p3",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"471.8,7725.0 471.9,4936.0 977.5,4936.0 977.7,32.1 5599.0,0.0 5599.0,7531.0 3056.6,7529.9 3057.8,7726.7 471.8,7725.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1763.7,
-                4936.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0150289,
-                40.6797166
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                471.9,
-                4936.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0156533,
-                40.6791877
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p30",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"536.0,7706.8 502.4,1046.7 1385.7,0.0 3068.1,0.0 2443.3,641.5 4984.2,660.2 4987.3,7701.9 536.0,7706.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0030/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3892.0,
-                4992.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.001018,
-                40.680792
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5180.0,
-                228.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0039713,
-                40.6823752
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5589
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5372.8,225.6 5343.9,7743.6 0.0,7735.7 0.0,234.5 5372.8,225.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2768.5,
-                5016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.000048,
-                40.682803
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1480.3,
-                5016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.000371,
-                40.682133
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"10.9,7891.7 49.2,345.9 5237.7,343.1 4774.5,7893.4 10.9,7891.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1308.2,
-                4012.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9998606,
-                40.685029
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1308.2,
-                7884.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9972144,
-                40.6842975
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "24"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1088.0,173.8 2129.4,195.1 2131.5,0.0 4225.2,0.0 4220.1,237.7 4780.1,249.1 4694.3,7755.5 555.3,7725.9 1088.0,173.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                820.0,
-                3852.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9989348,
-                40.6869431
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4732.0,
-                5004.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9971968,
-                40.6887645
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"754.2,314.2 4647.6,363.6 4663.3,0.0 5612.0,0.0 5612.0,8268.0 5434.2,8268.0 5480.8,7851.2 732.0,7840.0 754.2,314.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2048.0,
-                2808.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9984232,
-                40.6898645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                7840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9953209,
-                40.6882386
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p35",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p19",
       "metadata": [
         {
           "label": "streets",
@@ -2199,11 +897,11 @@
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "2"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2212,21 +910,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,1891.1 5612.0,4804.8 5292.1,4802.2 5309.9,6611.2 5612.0,6613.0 5612.0,8268.0 0.0,8268.0 0.0,-0.0 5299.1,0.0 5275.2,1888.2 5612.0,1891.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1523.5 0.0,0.0 3464.4,0.0 6600.0,4638.2 6600.0,7029.0 4284.6,8040.0 2874.9,8040.0 2377.5,6908.6 -0.0,7944.0 -0.0,1627.7 -0.0,1523.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2236,8 +934,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1676.0,
-                4784.0
+                3632.0,
+                300.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2248,8 +946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0021257,
-                40.6694201
+                -86.796239,
+                36.1596339
               ]
             }
           },
@@ -2257,8 +955,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2912.0,
-                1868.0
+                5716.0,
+                7420.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2269,8 +967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0038317,
-                40.670616
+                -86.7945183,
+                36.1565114
               ]
             }
           }
@@ -2278,385 +976,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"494.2,3522.1 482.7,612.1 5612.0,509.1 5612.0,681.0 5153.3,677.7 5214.7,3218.5 4938.3,3508.6 5612.0,3517.2 5134.0,4009.8 5136.5,5814.3 4614.9,5816.6 4232.1,8257.3 1138.8,7317.5 168.8,8268.0 0.0,8268.0 0.0,6983.0 507.9,6981.0 501.4,5328.1 199.6,5327.4 174.8,3520.8 494.2,3522.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1436.0,
-                5328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9996512,
-                40.6716259
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3896.0,
-                596.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0023003,
-                40.6738155
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p37",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"852.5,1497.4 1315.6,1497.2 1314.2,1323.7 3403.1,1370.7 3655.9,1490.2 3658.1,916.8 4584.1,1683.9 4603.5,6674.9 876.0,6683.4 859.3,4861.6 1345.1,4353.1 657.7,4357.2 934.5,4062.1 852.5,1497.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0037/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3312.0,
-                6680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9977713,
-                40.6747317
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4592.0,
-                4352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.999033,
-                40.6758417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"679.6,6733.5 694.4,1728.3 516.6,1556.6 622.7,1482.2 4592.3,1487.6 4611.7,6725.0 679.6,6733.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1932.0,
-                4404.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9987227,
-                40.6764868
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                684.0,
-                4404.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.999033,
-                40.6758417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"413.4,1147.3 5170.3,1142.4 5170.3,1142.5 5225.9,1142.5 5157.6,6627.0 3158.6,6396.0 438.4,6390.8 413.4,1147.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                4064.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9972734,
-                40.6794993
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                1144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9992597,
-                40.6800511
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -2665,10 +991,26 @@
         {
           "label": "intersections",
           "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3372.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2677,21 +1019,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"2643.2,1022.4 2702.7,6484.4 516.1,7024.0 516.1,932.0 2643.2,1022.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -2701,8 +1043,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2687.5,
-                7784.0
+                516.1,
+                932.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2713,8 +1055,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0104477,
-                40.6804294
+                -86.7845343,
+                36.1613251
               ]
             }
           },
@@ -2722,8 +1064,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5243.1,
-                7784.0
+                516.1,
+                7024.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2734,8 +1076,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0091934,
-                40.6815021
+                -86.7835433,
+                36.1598224
               ]
             }
           }
@@ -2743,478 +1085,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7448.2 2323.3,7030.9 2394.5,6437.7 1380.1,6255.2 1380.4,6917.5 0.0,6751.4 0.0,1245.0 5612.0,1256.8 5612.0,7448.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                4168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9965238,
-                40.6810573
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                1248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9985089,
-                40.6816069
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1442.6,7683.6 678.9,1543.7 5107.7,992.1 5291.6,3902.5 4612.7,3986.2 4622.4,7685.3 1442.6,7683.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                4144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9949023,
-                40.6844304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                7680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992623,
-                40.683544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"196.9,7688.7 239.6,3988.9 919.8,3914.8 777.1,1001.4 4906.0,536.6 5208.5,3450.5 4144.5,3565.7 4093.3,7747.2 196.9,7688.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3280.0,
-                724.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9957232,
-                40.6873919
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2796.0,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,4060.9 4962.5,8177.7 5328.8,8134.6 5339.7,8268.0 8.0,8268.0 0.0,-0.0 5612.0,0.0 5612.0,321.7 5032.6,500.3 5612.0,2380.6 5136.6,2510.2 5155.4,2572.1 5612.0,2821.9 5612.0,4060.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2400.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9948535,
-                40.6668553
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                8872.0,
-                4848.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0010146,
-                40.6762923
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,8268.0 2263.0,8268.0 1264.0,7221.7 -0.0,6288.8 449.6,5762.1 18.7,5505.7 440.7,5513.7 429.9,367.0 5612.0,386.5 5612.0,1675.6 4280.0,1672.0 4277.5,6825.4 5612.0,6829.9 5612.0,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                5536.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9940294,
-                40.6678529
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4280.0,
-                1672.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992527,
-                40.669655
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p1 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -3222,290 +1099,27 @@
         },
         {
           "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1142.0 5612.0,269.1 5612.0,7978.6 0.0,7638.3 0.0,1142.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4168.0,
-                508.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.997447,
-                40.6754
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.0,
-                1060.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.998388,
-                40.673471
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"864.0,7245.6 867.9,868.3 4664.0,880.0 4665.3,7257.4 864.0,7245.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                4716.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991023,
-                40.671458
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                880.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9895109,
-                40.6732702
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5361.3,1138.6 5096.5,7386.7 3840.5,7339.1 3956.0,4496.0 2691.0,4551.4 2748.0,1589.4 5361.3,1138.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3956.0,
-                4496.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9941559,
-                40.6772043
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2748.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9964751,
-                40.6774341
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p5",
-      "metadata": [
-        {
-          "label": "streets",
           "value": "4"
         },
         {
-          "label": "intersections",
-          "value": "3"
+          "label": "split_canvas_x",
+          "value": "3370.4"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3229.6"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3514,21 +1128,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5325.3,7857.1 -0.0,7573.3 -0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.0,8268.0 5325.3,7857.1\" /></svg>"
+          "value": "<svg><polygon points=\"6212.3,7378.0 3370.4,7197.2 3742.1,668.0 6600.0,143.0 6212.3,7378.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -3538,493 +1152,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2815.5,
-                6624.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0085336,
-                40.6829405
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2815.5,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0079286,
-                40.6825753
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2500.9,8268.0 2508.1,6769.7 1984.4,6768.8 1637.6,811.2 3472.2,418.2 3517.8,2740.1 4507.0,2658.1 4503.2,4888.7 5612.0,4887.7 5612.0,8268.0 2500.9,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.0,
-                6768.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991384,
-                40.674998
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1524.0,
-                6768.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992369,
-                40.673813
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"696.2,849.0 2694.6,725.3 2770.3,728.2 4149.9,647.9 4033.1,0.0 5057.5,0.0 5092.3,592.9 4916.1,603.4 5036.5,3972.9 5281.2,3956.0 5461.0,7306.9 4275.9,7366.0 452.1,7227.1 696.2,849.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1744.0,
-                7272.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99137,
-                40.67755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3456.0,
-                680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.994889,
-                40.6802
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"828.7,7382.1 817.8,4031.0 572.8,4035.6 622.1,668.9 4667.8,658.9 4694.9,7367.7 828.7,7382.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4692.0,
-                4024.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.990865,
-                40.6820655
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2112.0,
-                7376.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.989559,
-                40.679946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4780.0,7464.0 883.8,7481.9 895.7,719.6 4794.7,731.8 4780.0,7464.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4780.0,
-                7464.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.98743,
-                40.683126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3496.0,
-                728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992192,
-                40.684178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"687.3,667.8 4590.3,680.2 4579.3,7402.5 690.6,7366.3 690.2,6478.3 639.9,6478.1 687.3,667.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3272.0,
-                7380.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.986564,
-                40.684389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1984.0,
+                3742.1,
                 668.0
               ],
               "creator": {
@@ -4036,80 +1164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1216.7,3600.5 914.9,705.1 5612.0,191.8 5612.0,7981.5 110.4,7870.6 159.4,3715.4 1216.7,3600.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2784.0,
-                5616.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991509,
-                40.687959
+                -86.7835433,
+                36.1598224
               ]
             }
           },
@@ -4117,8 +1173,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3484.0,
-                424.0
+                6212.3,
+                7376.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4129,8 +1185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9946743,
-                40.6895809
+                -86.7820973,
+                36.1589021
               ]
             }
           }
@@ -4138,118 +1194,118 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p56",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p2",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"796.0,708.4 4977.9,738.0 4969.1,0.0 5612.0,0.0 5608.3,7408.4 768.0,7400.0 796.0,708.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0056/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3348.0,
-                4064.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.987429,
-                40.687138
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                768.0,
-                7400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9861154,
-                40.6850247
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p57",
-      "metadata": [
-        {
-          "label": "streets",
           "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1056.5,7406.9 841.4,1024.0 5560.4,894.2 5652.0,7116.0 1056.5,7406.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0002/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2816.0,
+                948.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7833579,
+                36.1618106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5652.0,
+                7116.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7817868,
+                36.1607987
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p20",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "2"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4258,21 +1314,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/info.json",
           "type": "ImageService2",
-          "height": 8267,
-          "width": 5630
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2546.0,1273.8 5477.7,1555.7 5281.8,3702.2 5630.0,3734.0 5630.0,4232.6 4228.4,4129.7 4158.9,4873.6 3525.3,4814.7 3453.3,5795.6 4058.6,5793.3 4039.0,7169.1 3501.3,7168.5 3499.3,8267.0 0.0,8267.0 0.0,0.0 2665.1,-0.0 2546.0,1273.8\" /></svg>"
+          "value": "<svg><polygon points=\"1845.7,7449.3 1573.1,5857.3 1297.6,5853.3 1496.7,5411.5 650.0,467.6 3636.8,634.8 3609.5,0.0 6600.0,0.0 6600.0,837.7 5484.5,748.8 5194.8,1931.5 5367.0,7487.4 6600.0,7476.9 6600.0,8040.0 2526.1,8040.0 2534.5,7456.0 1845.7,7449.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0057/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4282,8 +1338,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2079.3,
-                5791.3
+                3244.0,
+                7468.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4294,8 +1350,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.983895,
-                40.6761473
+                -86.792671,
+                36.1574039
               ]
             }
           },
@@ -4303,8 +1359,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4058.6,
-                5791.3
+                2204.0,
+                584.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4315,8 +1371,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.986308,
-                40.677081
+                -86.7954035,
+                36.1599861
               ]
             }
           }
@@ -4324,13 +1380,106 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2851.8,7028.7 1576.2,6981.8 1531.4,2372.4 1657.8,1228.1 2012.7,18.6 3162.1,162.7 3169.5,0.0 6600.0,0.0 6600.0,6401.5 5680.5,6287.3 5680.6,7189.3 3370.1,7056.3 3248.0,8040.0 -0.0,8040.0 -0.0,7483.2 2825.5,7610.9 2851.8,7028.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                3736.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7906744,
+                36.1602998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5680.0,
+                7156.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7895437,
+                36.1589722
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p23",
       "metadata": [
         {
           "label": "streets",
@@ -4341,8 +1490,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4351,21 +1500,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5556
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3046.8,7167.8 3131.8,8268.0 1339.1,8268.0 1361.7,7108.2 0.0,7081.0 0.0,969.6 2712.3,1023.4 5103.8,856.5 5337.1,4087.8 4089.3,4175.5 4293.8,7110.3 3046.8,7167.8\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,5510.7 5953.0,5272.5 5446.0,6753.5 514.8,6640.7 620.7,8040.0 -0.0,8040.0 0.0,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4375,8 +1524,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2828.0,
-                4264.0
+                3720.0,
+                3608.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4387,8 +1536,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9882559,
-                40.6778311
+                -86.7999356,
+                36.1597506
               ]
             }
           },
@@ -4396,8 +1545,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1412.0,
-                1012.0
+                5360.0,
+                3608.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4408,8 +1557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.9908957,
-                40.6781021
+                -86.799082,
+                36.1601152
               ]
             }
           }
@@ -4417,25 +1566,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p59",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p25",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "1"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4444,21 +1593,180 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5516
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2069.9,4236.1 2068.0,904.0 5516.0,897.0 5516.0,8268.0 2074.0,8268.0 2073.3,7259.7 777.6,7260.4 783.4,4234.5 2069.9,4236.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6084.6 0.0,0.0 6600.0,0.0 6600.0,7658.9 716.0,7072.0 690.2,6432.4 -0.0,6084.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79764142591385,
+                36.160974880783414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7959765414066,
+                36.16189587200982
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79458749137697,
+                36.16025775113997
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79625237588422,
+                36.159336759913565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                716.0,
+                7072.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.796239,
+                36.1596339
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5895.8,664.0 5896.0,7276.0 818.5,7348.9 1009.6,590.4 -0.0,599.5 -0.0,0.0 6600.0,0.0 6600.0,675.6 5895.8,664.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0029/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4468,7 +1776,214 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3360.0,
+                5896.0,
+                3476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7803391,
+                36.1658103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5896.0,
+                7276.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.779847,
+                36.1650635
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p3",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5796.0,6924.0 1087.3,7287.6 796.9,915.9 5576.9,684.8 5796.0,6924.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0003/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3184.0,
+                784.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7820307,
+                36.1623803
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5796.0,
+                6924.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7805982,
+                36.1613389
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p30",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"849.2,641.2 6048.2,814.8 5696.0,7264.0 629.8,7175.1 849.2,641.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0030/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                756.0,
+                3420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7803391,
+                36.1658103
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
                 7264.0
               ],
               "creator": {
@@ -4480,29 +1995,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -73.984998,
-                40.678977
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2068.0,
-                904.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.989559,
-                40.679946
+                -86.7786104,
+                36.1656154
               ]
             }
           }
@@ -4510,385 +2004,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p6",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0006/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2531.5,
-                7656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0054824,
-                40.6843278
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5099.1,
-                7656.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0048438,
-                40.6856737
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p60",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5503
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1503.2,910.7 4478.2,879.1 4509.1,7226.8 5503.0,7219.2 5503.0,8267.0 1543.3,8236.8 1503.2,910.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3215.4,
-                4231.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.985672,
-                40.681642
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1955.6,
-                7239.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984139,
-                40.680246
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5629
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1873.2,7221.5 877.6,7215.7 932.3,858.9 4787.9,929.2 4742.3,7250.1 5629.0,7258.9 5629.0,8268.0 1859.1,8268.0 1873.2,7221.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.6,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984371,
-                40.6835414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4748.8,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9839511,
-                40.6841757
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5549
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"677.2,7342.4 664.8,939.4 5549.0,934.4 5549.0,8268.0 1584.0,8268.0 1575.5,7343.2 677.2,7342.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1964.4,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983522,
-                40.684816
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3264.6,
-                4300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.983092,
-                40.685451
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p7",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p31",
       "metadata": [
         {
           "label": "streets",
@@ -4899,8 +2021,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4909,21 +2031,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"398.3,8040.0 804.0,1699.8 -0.0,1684.2 -0.0,643.3 6600.0,916.2 6600.0,8040.0 398.3,8040.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0007/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0031/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4933,8 +2055,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5235.1,
-                5688.0
+                3636.0,
+                7704.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4945,8 +2067,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0044976,
-                40.6863169
+                -86.7777793,
+                36.1660114
               ]
             }
           },
@@ -4954,8 +2076,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5235.1,
-                6968.0
+                412.0,
+                7704.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4966,8 +2088,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
+                -86.7786104,
+                36.1656154
               ]
             }
           }
@@ -4975,13 +2097,3070 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p8",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5648.8,7118.6 -0.0,7139.4 0.0,0.0 4507.6,0.0 4516.1,710.0 5667.3,691.3 5648.8,7118.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2896.0,
+                7128.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7833579,
+                36.1618106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2896.0,
+                736.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7842337,
+                36.16316
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5782.4,7334.5 1064.0,7284.0 1160.4,807.0 -0.0,815.6 0.0,0.0 5106.5,0.0 5102.4,781.4 5868.0,784.0 5782.4,7334.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                784.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7823048,
+                36.1640093
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1064.0,
+                7284.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7826394,
+                36.1621171
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"852.0,7228.0 852.0,621.4 5614.6,661.3 5684.5,7192.9 852.0,7228.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                852.0,
+                620.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7823048,
+                36.1640093
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                852.0,
+                7228.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.781416,
+                36.1626363
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1095.2,865.0 5924.0,796.0 5924.0,7332.0 1116.9,7408.7 1095.2,865.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5924.0,
+                7332.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7789569,
+                36.1637129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5924.0,
+                796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.779847,
+                36.1650635
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p36",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"740.0,732.0 5593.2,603.9 5598.0,949.7 6600.0,895.0 6600.0,5906.1 5608.4,5916.8 5611.9,7132.5 807.7,7242.4 740.0,732.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0036/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3172.0,
+                7188.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7783534,
+                36.1639801
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                740.0,
+                732.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.779847,
+                36.1650635
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p38",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"788.0,974.0 5549.8,887.7 5611.7,7067.4 788.0,7092.0 788.0,974.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0038/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                788.0,
+                7092.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7805982,
+                36.1613389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                788.0,
+                976.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.781416,
+                36.1626363
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5856.0,940.0 5856.0,7028.0 1251.1,6967.4 1299.6,1013.0 5856.0,940.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5856.0,
+                7028.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7780823,
+                36.1623856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5856.0,
+                940.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7789569,
+                36.1637129
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0004/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p4",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0004/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0004/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2537.2,6751.1 2659.2,0.0 6600.0,0.0 6600.0,6184.2 4067.7,6155.5 4050.7,6733.1 2537.2,6751.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0004/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77849571904534,
+                36.164244324924475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77493612988464,
+                36.16578054765666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7726191803085,
+                36.16227818021504
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77617876946921,
+                36.160741957482855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2648.0,
+                544.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7769108,
+                36.1646237
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p40",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0040/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"938.8,7012.0 950.8,782.9 5629.0,733.4 5620.0,7012.0 938.8,7012.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3224.0,
+                7012.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7774798,
+                36.1626456
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5620.0,
+                7012.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7768481,
+                36.1629182
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p41 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3480.8"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"476.1,5624.0 483.2,0.0 2857.1,10.4 2755.7,5629.4 476.1,5624.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                476.1,
+                5624.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7768481,
+                36.1629182
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                476.1,
+                892.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7777305,
+                36.1642557
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p41 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "3469.6"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3130.4"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6580.5,1189.1 6456.1,6988.0 3713.5,6988.0 3823.8,1166.4 6580.5,1189.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0041__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3713.5,
+                6988.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7759731,
+                36.1615489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.1,
+                6988.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7751818,
+                36.161894
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0042/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5604.0,540.0 5298.9,7230.8 756.0,7200.0 763.3,715.8 5604.0,540.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                756.0,
+                7200.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7820973,
+                36.1589021
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5604.0,
+                540.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7817868,
+                36.1607987
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0043/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p43",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0043/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0043/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4158.5,7410.8 992.0,7436.0 1220.1,827.5 4982.7,729.7 4158.5,7410.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0043/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                992.0,
+                7436.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7809449,
+                36.1593996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5900.0,
+                704.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7805982,
+                36.1613389
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0044/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0044/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7434.5 -0.0,817.6 5658.0,148.5 6583.8,8040.0 974.5,8040.0 892.0,7428.0 -0.0,7434.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                892.0,
+                7428.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7798865,
+                36.1598307
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                892.0,
+                684.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7805982,
+                36.1613389
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0046/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"672.0,7488.3 679.2,665.6 5636.0,728.0 5636.0,7444.0 672.0,7488.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                728.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7780823,
+                36.1623856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5636.0,
+                7444.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7771869,
+                36.1610249
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0047/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1281.5,1276.2 5884.0,1592.0 5380.3,8040.0 717.7,8040.0 909.9,5510.2 -0.0,5445.1 -0.0,2399.4 1125.3,2629.6 1281.5,1276.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77896660340704,
+                36.16057807451386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7772629435322,
+                36.161451580926105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77594551066962,
+                36.159775308017096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77764917054446,
+                36.15890180160485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5884.0,
+                1592.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7771869,
+                36.1610249
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5884.0,
+                1592.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7771869,
+                36.1610249
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p48",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0048/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0048/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5576.0,7448.0 737.9,7416.1 677.5,6907.1 800.0,708.0 5719.0,741.3 5576.0,7448.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0048/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                800.0,
+                708.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7780823,
+                36.1623856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5576.0,
+                7448.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7759731,
+                36.1615489
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0049/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1116.0,1452.0 5828.0,1452.0 5814.0,8040.0 1093.9,8040.0 1116.0,1452.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                1452.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7759731,
+                36.1615489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1116.0,
+                1452.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7771869,
+                36.1610249
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0050/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p50",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0050/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0050/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"784.0,7144.0 759.5,699.3 6600.0,869.0 6600.0,7166.8 784.0,7144.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0050/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                784.0,
+                3968.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7751818,
+                36.161894
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                784.0,
+                7144.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7759731,
+                36.1615489
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"946.3,6912.4 -0.0,7339.2 0.0,0.0 417.7,0.0 406.6,404.3 5941.6,405.9 5895.5,6674.6 1218.0,6648.7 946.3,6912.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5888.0,
+                5008.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7862099,
+                36.1546124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5888.0,
+                7352.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7855402,
+                36.1536013
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"528.0,7240.0 582.2,222.8 6600.0,252.6 6341.2,845.8 6313.2,2726.2 6600.0,3007.2 6600.0,4910.6 5218.4,4906.3 3702.1,8040.0 2754.6,8040.0 2642.0,7264.1 528.0,7240.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                528.0,
+                4872.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7862099,
+                36.1546124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                528.0,
+                7240.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7855402,
+                36.1536013
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "15"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1894.5,4912.8 1833.4,3090.6 1408.0,2983.9 1150.8,2725.2 1116.4,820.3 1367.1,210.8 5564.9,114.0 5671.0,7375.0 3152.0,7468.0 3126.2,5312.2 1894.5,4912.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3152.0,
+                2612.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7827243,
+                36.1573212
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3152.0,
+                7468.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7814528,
+                36.1552396
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1198.7,5745.1 1112.1,6027.4 1083.2,444.8 5044.8,334.1 5632.0,388.0 5642.3,722.0 6600.0,821.3 6600.0,2704.2 5693.3,2728.8 5791.6,7154.3 1198.7,5745.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3468.0,
+                388.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7809449,
+                36.1593996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5632.0,
+                388.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7798865,
+                36.1598307
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6162.3,0.0 6151.1,2537.1 6600.0,2504.9 6600.0,4954.0 768.0,4908.0 774.8,0.0 6162.3,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77948748607828,
+                36.15882786291815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77771099521344,
+                36.15960094754032
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77654501970083,
+                36.15785301442657
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77832151056568,
+                36.157079929804404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                768.0,
+                4908.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.778569,
+                36.1578508
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5273.1,7211.3 1465.7,7297.7 1475.8,5429.9 -0.0,5446.2 -0.0,4137.1 1483.9,3931.0 3808.0,3923.9 3814.4,3456.2 5303.7,3445.3 5273.1,7211.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3788.0,
+                5400.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7746692,
+                36.1595482
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2584.0,
+                7312.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7747683,
+                36.1584689
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0058/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p58",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0058/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0058/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2444.2,7331.4 975.3,7174.7 974.2,3408.5 2490.8,3384.6 2538.8,0.0 6600.0,0.0 6600.0,8040.0 2452.6,8040.0 2444.2,7331.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0058/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                968.0,
+                5344.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7738921,
+                36.1598917
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                968.0,
+                632.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7751818,
+                36.161894
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0059__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p59 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6600.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8040.0"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0059__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0059/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5017.1,263.2 6446.9,1313.9 6502.0,2804.0 6600.0,2655.5 6600.0,8040.0 -0.0,8040.0 -0.0,624.1 5017.1,263.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0059__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3144.0,
+                628.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7848859,
+                36.1526002
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                712.0,
+                628.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7855402,
+                36.1536013
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0060/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p60",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0060/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0060/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8040.0 315.6,2121.9 2124.0,944.3 3463.8,1002.1 6600.0,3087.9 6600.0,4750.9 6106.9,7315.8 6600.0,7357.2 6600.0,8040.0 -0.0,8040.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0060/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4968.0,
+                5692.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7830242,
+                36.1517009
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                316.0,
+                2120.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7855402,
+                36.1536013
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0061/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p61",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0061/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0061/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,2184.7 127.7,2176.8 138.5,1679.8 2717.4,1511.3 2740.6,2014.3 4407.9,1910.7 4519.3,1615.3 4115.0,1161.0 4067.5,0.0 6600.0,0.0 6600.0,2881.3 6243.6,3412.0 6312.9,6022.8 94.1,7296.8 241.1,8040.0 0.0,8040.0 0.0,2184.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0061/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1740.0,
+                1568.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7823657,
+                36.1516366
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                900.0,
+                7132.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.779233,
+                36.1508275
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p62",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 5701.8,0.0 6300.9,1248.0 6600.0,1103.2 6600.0,1521.7 6466.8,1586.2 6600.0,2859.9 4661.4,3748.4 5756.4,5988.3 4423.9,6524.5 3884.0,6504.5 4129.0,6889.3 4067.2,7264.1 3830.8,7501.7 3453.7,7563.0 3055.9,8040.0 2420.3,8040.0 2425.2,6990.0 2224.1,7085.1 788.0,7076.0 1228.7,4562.0 1676.1,4120.1 2232.7,1363.4 0.0,910.7 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2000.0,
+                7076.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7793984,
+                36.1540195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                788.0,
+                7076.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7793691,
+                36.1534343
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p63",
       "metadata": [
         {
           "label": "streets",
@@ -4992,8 +5171,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5002,21 +5181,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4242.0,7595.1 1044.2,7590.7 1030.5,7153.5 -0.0,7145.5 -0.0,-0.0 4234.9,0.0 4242.0,7595.1\" /></svg>"
+          "value": "<svg><polygon points=\"1584.2,3881.5 1238.9,3777.6 846.6,3961.2 931.4,3455.2 0.0,0.0 4175.5,0.0 5728.3,4788.7 6600.0,4519.6 6600.0,7440.4 5978.0,7265.4 5653.7,7444.8 4077.8,6334.1 3980.9,5778.7 2113.5,5527.3 2191.2,4929.1 1584.2,3881.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0008/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5026,8 +5205,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4231.2,
-                3696.0
+                5728.0,
+                4788.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5038,8 +5217,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0020408,
-                40.6864013
+                -86.7766648,
+                36.1549221
               ]
             }
           },
@@ -5047,8 +5226,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1031.8,
-                6284.0
+                3532.0,
+                6504.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5059,8 +5238,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0048438,
-                40.6856737
+                -86.7778472,
+                36.1538731
               ]
             }
           }
@@ -5068,25 +5247,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p9",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p64",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "5"
         }
       ],
-      "created": "2026-07-17T16:20:43Z",
-      "modified": "2026-07-17T16:20:43Z",
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5095,21 +5274,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/info.json",
           "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
+          "height": 8040,
+          "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+          "value": "<svg><polygon points=\"716.0,7412.0 682.0,443.6 3715.2,419.5 3708.7,0.0 4391.1,0.0 4395.0,406.5 5884.0,376.0 5883.8,8040.0 1496.5,8040.0 1694.0,7421.4 716.0,7412.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0009/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5119,8 +5298,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.2,
-                7760.0
+                716.0,
+                7412.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5131,8 +5310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0004427,
-                40.6896644
+                -86.7766648,
+                36.1549221
               ]
             }
           },
@@ -5140,8 +5319,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1051.8,
-                7760.0
+                5884.0,
+                376.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5152,8 +5331,287 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0013897,
-                40.6877592
+                -86.7758725,
+                36.1590163
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p65",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"770.6,6647.0 840.9,1115.1 4732.9,1034.5 6232.5,1210.4 6232.6,1291.2 6233.7,2024.2 6600.0,1938.6 6600.0,8040.0 -0.0,8040.0 -0.0,6960.0 765.9,6968.8 767.1,6889.4 770.6,6647.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3160.0,
+                6536.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77269,
+                36.1564939
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1984.0,
+                1132.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7747683,
+                36.1584689
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p67",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3263.1,0.0 3446.9,580.4 5293.8,1542.1 5615.1,1303.4 6306.1,1401.0 6117.4,0.0 6600.0,0.0 6600.0,8040.0 290.1,8040.0 249.7,205.7 151.2,0.0 3263.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6368.0,
+                5272.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7757245,
+                36.151844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6368.0,
+                7224.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7756839,
+                36.1509257
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p8",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T17:04:52Z",
+      "modified": "2026-07-17T17:04:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5677.1,7299.3 -0.0,7221.4 -0.0,0.0 4883.7,142.4 4883.4,726.3 5866.6,717.9 5677.1,7299.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0008/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                792.0,
+                3460.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7828053,
+                36.1647679
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                792.0,
+                7220.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7823048,
+                36.1640093
               ]
             }
           }

--- a/gallery/new_orleans_la_1896_vol_2.iiif.json
+++ b/gallery/new_orleans_la_1896_vol_2.iiif.json
@@ -17,15 +17,31 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "8"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6387.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7795.0"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +60,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"432.9,4482.7 627.6,2118.7 -0.0,1847.8 -0.0,1282.6 653.9,1558.1 900.1,0.0 6387.0,0.0 6387.0,6877.3 5937.1,7040.5 6068.3,7315.2 3169.7,7491.3 3178.1,7795.0 2626.5,7795.0 2540.1,7480.8 443.6,7498.4 432.9,4482.7\" /></svg>"
+          "value": "<svg><polygon points=\"299.5,4279.2 514.0,1763.6 -0.0,1539.5 -0.0,936.2 543.7,1166.9 748.9,0.0 6387.0,0.0 6387.0,7002.3 6149.2,7019.0 6288.0,7311.8 3221.2,7402.7 3229.7,7795.0 2622.7,7795.0 2532.7,7477.0 301.4,7489.2 299.5,4279.2\" /></svg>"
         }
       },
       "body": {
@@ -58,8 +74,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1757.3,
-                4766.5
+                2531.6,
+                7479.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -70,8 +86,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0659476,
-                29.9497429
+                -90.0659214,
+                29.9484512
               ]
             }
           },
@@ -79,8 +95,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                434.5,
-                4482.1
+                763.9,
+                1259.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -91,8 +107,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0665842,
-                29.9500266
+                -90.065976,
+                29.9512304
               ]
             }
           }
@@ -110,15 +126,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "22"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +153,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5542.9,7450.2 843.2,7441.6 868.2,1905.2 1145.8,0.0 6097.6,0.0 5834.8,1519.2 5185.4,1235.0 5177.6,1799.6 5800.7,2078.9 5573.8,4437.6 5542.9,7450.2\" /></svg>"
+          "value": "<svg><polygon points=\"5530.0,7442.9 833.3,7434.2 858.2,1901.6 1134.9,0.0 6428.0,0.0 6428.0,428.0 6026.1,423.6 5821.7,1515.9 5314.1,1294.0 5307.9,1859.8 5787.7,2075.2 5560.9,4432.3 5530.0,7442.9\" /></svg>"
         }
       },
       "body": {
@@ -151,8 +167,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3303.5,
-                3862.4
+                3292.0,
+                3855.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,8 +188,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3303.5,
-                2469.5
+                3292.0,
+                2463.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -207,11 +223,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +246,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"173.1,7310.1 2029.2,8.9 4206.5,259.9 6428.0,1863.1 6428.0,7795.0 3539.1,7795.0 1698.6,7407.4 173.1,7310.1\" /></svg>"
+          "value": "<svg><polygon points=\"1966.5,0.0 4152.9,220.6 6428.0,1750.7 6428.0,7795.0 3597.0,7795.0 1702.9,7402.6 173.6,7318.5 1966.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -244,8 +260,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                789.1,
-                4884.7
+                772.0,
+                4883.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -265,8 +281,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5632.5,
-                3945.4
+                2448.0,
+                5039.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -277,8 +293,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0700736,
-                29.9537006
+                -90.069797,
+                29.9522091
               ]
             }
           }
@@ -296,15 +312,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,7 +339,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"851.2,7544.3 772.6,241.5 6157.1,171.8 4920.2,7535.3 851.2,7544.3\" /></svg>"
+          "value": "<svg><polygon points=\"845.7,7502.1 779.9,238.7 6136.0,178.6 4893.1,7500.1 845.7,7502.1\" /></svg>"
         }
       },
       "body": {
@@ -337,8 +353,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3044.7,
-                226.8
+                3040.0,
+                5083.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0703357,
+                29.9504786
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3040.0,
+                228.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -351,27 +388,6 @@
               "coordinates": [
                 -90.0728094,
                 29.9510458
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5332.2,
-                5089.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.070038,
-                29.951481
               ]
             }
           }
@@ -396,8 +412,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,7 +432,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6428.0,7795.0 2259.3,7426.6 1614.3,3737.9 1474.2,1626.8 1217.7,1622.1 774.8,270.0 942.2,268.9 896.1,0.0 6428.0,0.0 6428.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"1670.6,2635.5 642.3,283.5 941.6,281.6 893.4,0.0 6428.0,0.0 6428.0,7795.0 2255.7,7421.0 1610.7,3732.0 1670.6,2635.5\" /></svg>"
         }
       },
       "body": {
@@ -430,8 +446,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5606.9,
-                1594.1
+                5604.0,
+                1587.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -451,8 +467,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5606.9,
-                7807.8
+                5604.0,
+                7799.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -489,8 +505,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +525,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4042.5,0.0 5923.1,824.0 6283.9,0.0 6496.0,0.0 6496.0,1663.3 6345.2,2294.9 6496.0,2367.4 6496.0,2675.8 5857.4,4248.2 4967.4,7635.5 0.0,7572.9 914.1,1972.6 542.3,1473.8 1041.6,1414.4 1269.5,0.0 4042.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1337.5,0.0 6496.0,0.0 6496.0,3096.6 5950.6,4242.7 5033.1,7651.1 0.0,7558.5 605.5,3846.9 619.4,3847.1 979.9,1920.3 607.9,1415.4 1111.7,1358.4 1337.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -523,8 +539,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1510.6,
-                7584.2
+                1548.0,
+                7579.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -544,8 +560,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5921.1,
-                3871.9
+                2108.0,
+                3867.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -556,8 +572,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0739419,
-                29.9541167
+                -90.0744161,
+                29.9523963
               ]
             }
           }
@@ -575,15 +591,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -602,7 +618,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"339.8,14.6 3990.3,625.7 3994.4,2862.5 6183.1,2854.8 6152.2,7630.8 868.6,7769.6 869.6,7643.9 361.7,7610.5 339.8,14.6\" /></svg>"
+          "value": "<svg><polygon points=\"1815.3,7795.0 1553.9,7656.5 338.1,7649.5 295.3,0.0 3964.5,511.4 3990.3,2849.4 6423.8,2834.2 6428.0,7654.3 1815.3,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -616,8 +632,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3990.3,
-                7616.1
+                3988.0,
+                5447.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -628,8 +644,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.073751,
-                29.9479258
+                -90.0734605,
+                29.9488979
               ]
             }
           },
@@ -637,8 +653,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3990.3,
-                626.2
+                332.0,
+                5447.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -649,8 +665,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0728094,
-                29.9510458
+                -90.0753256,
+                29.9493252
               ]
             }
           }
@@ -668,15 +684,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +711,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"954.5,7551.0 912.0,0.0 5724.3,0.0 5836.1,7492.4 954.5,7551.0\" /></svg>"
+          "value": "<svg><polygon points=\"949.8,7549.8 908.0,259.3 5727.0,217.2 5836.7,7491.2 949.8,7549.8\" /></svg>"
         }
       },
       "body": {
@@ -709,8 +725,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3322.7,
-                7536.2
+                3320.5,
+                7535.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -730,8 +746,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5760.4,
-                2670.7
+                5760.9,
+                2663.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -768,8 +784,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -788,7 +804,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5741.6,563.1 5739.0,7280.9 421.1,7325.7 -0.0,7158.6 -0.0,533.0 5741.6,563.1\" /></svg>"
+          "value": "<svg><polygon points=\"5733.3,7279.3 847.7,7279.1 846.8,6934.4 339.1,6769.0 846.0,6592.2 830.2,529.7 5735.9,562.3 5733.3,7279.3\" /></svg>"
         }
       },
       "body": {
@@ -802,8 +818,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                852.8,
-                7280.7
+                847.7,
+                7279.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -823,8 +839,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3296.4,
-                7280.7
+                3291.0,
+                7279.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -861,8 +877,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +897,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"727.3,7271.0 709.2,508.0 5602.4,504.4 5646.1,7274.6 727.3,7271.0\" /></svg>"
+          "value": "<svg><polygon points=\"704.0,7255.1 704.0,503.9 5589.6,513.4 5615.2,7271.7 704.0,7255.1\" /></svg>"
         }
       },
       "body": {
@@ -895,8 +911,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3197.7,
-                7261.5
+                704.0,
+                7255.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -907,8 +923,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0708922,
-                29.9441047
+                -90.0721429,
+                29.9443845
               ]
             }
           },
@@ -916,8 +932,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                709.2,
-                508.0
+                704.0,
+                503.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -951,11 +967,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "19"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -974,7 +990,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4858.8,1008.3 5412.2,1027.6 5396.7,3270.6 6350.0,7293.8 303.8,7121.9 423.6,568.0 4783.2,690.0 4858.8,1008.3\" /></svg>"
+          "value": "<svg><polygon points=\"4733.7,648.9 6350.0,6579.0 6350.0,7251.9 373.9,7214.2 348.6,623.1 4733.7,648.9\" /></svg>"
         }
       },
       "body": {
@@ -988,8 +1004,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4577.2,
-                5590.7
+                2731.1,
+                3191.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1000,8 +1016,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0666095,
-                29.9462969
+                -90.0672659,
+                29.9475596
               ]
             }
           },
@@ -1009,8 +1025,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4781.7,
-                690.0
+                6525.9,
+                7239.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1021,8 +1037,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0659214,
-                29.9484512
+                -90.0658675,
+                29.9453563
               ]
             }
           }
@@ -1040,15 +1056,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1067,7 +1083,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2771.7,150.3 3035.3,138.4 3013.2,0.0 6340.0,0.0 6340.0,7795.0 3530.4,7795.0 3354.1,7090.1 975.0,7046.2 -0.0,3055.1 -0.0,523.0 2894.9,427.9 2771.7,150.3\" /></svg>"
+          "value": "<svg><polygon points=\"2740.6,154.6 3003.2,141.9 2980.0,0.0 6340.0,0.0 6340.0,7795.0 3528.3,7795.0 3342.7,7063.2 868.9,7025.1 876.5,6385.4 -0.0,3036.4 -0.0,453.4 2864.2,430.6 2740.6,154.6\" /></svg>"
         }
       },
       "body": {
@@ -1081,8 +1097,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1098.7,
-                3022.2
+                1084.0,
+                3019.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1102,8 +1118,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                -626.0,
-                495.2
+                2184.0,
+                7047.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1114,8 +1130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0659214,
-                29.9484512
+                -90.0652822,
+                29.9452167
               ]
             }
           }
@@ -1133,15 +1149,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,7 +1176,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5702.6,235.5 5709.1,7545.5 4815.5,7795.0 4082.2,7795.0 4084.0,6941.1 3717.0,6946.4 599.2,7795.0 551.1,4388.0 531.8,4394.7 532.0,0.0 597.3,249.2 5702.6,235.5\" /></svg>"
+          "value": "<svg><polygon points=\"4077.3,6851.0 580.1,7795.0 590.7,232.8 5711.8,227.7 5706.0,7557.8 4850.7,7795.0 4073.7,7795.0 4077.3,6851.0\" /></svg>"
         }
       },
       "body": {
@@ -1174,8 +1190,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4094.7,
-                1967.9
+                4096.0,
+                1963.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1195,8 +1211,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                597.3,
-                249.2
+                5704.0,
+                7559.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1207,8 +1223,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0696556,
-                29.9438175
+                -90.0652822,
+                29.9452167
               ]
             }
           }
@@ -1226,15 +1242,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1253,7 +1269,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,3437.6 798.1,3220.0 809.5,801.1 3928.4,0.0 4294.1,0.0 4280.1,850.8 5010.8,861.3 5904.8,625.5 5896.3,1799.4 5187.3,1982.9 5209.9,4815.6 6305.0,4806.9 6305.0,7795.0 1683.8,7795.0 1683.8,7795.0 0.0,7795.0 0.0,3437.6\" /></svg>"
+          "value": "<svg><polygon points=\"808.8,3241.6 797.4,819.9 3579.0,68.9 4251.6,0.0 4250.3,816.2 5021.0,814.6 5868.9,577.6 5877.6,1749.3 5141.9,1951.1 5197.4,4790.9 6305.0,4769.2 6305.0,7795.0 0.0,7795.0 0.0,3474.9 808.8,3241.6\" /></svg>"
         }
       },
       "body": {
@@ -1267,29 +1283,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4276.8,
-                1054.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0652692,
-                29.9444506
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                795.3,
-                2006.3
+                788.1,
+                2027.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1302,6 +1297,27 @@
               "coordinates": [
                 -90.0652255,
                 29.9428089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.9,
+                575.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0652822,
+                29.9452167
               ]
             }
           }
@@ -1323,11 +1339,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1346,7 +1362,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3668.2,7532.8 0.0,7563.8 0.0,3709.2 612.7,2044.6 826.8,236.1 6349.0,199.9 6349.0,6814.4 4027.9,7734.9 3668.2,7532.8\" /></svg>"
+          "value": "<svg><polygon points=\"7.4,3670.0 606.4,2039.4 820.7,228.5 6349.0,192.5 6349.0,6816.2 4026.4,7737.1 3666.2,7534.7 0.0,7565.5 7.4,3670.0\" /></svg>"
         }
       },
       "body": {
@@ -1360,8 +1376,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2232.4,
-                2692.4
+                2228.4,
+                2688.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1381,8 +1397,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2232.4,
-                7550.1
+                2228.4,
+                7552.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1412,15 +1428,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "12"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1439,7 +1455,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3877.6,1832.5 6349.0,1866.6 4224.1,7207.3 3411.2,7117.2 3142.7,7796.0 0.0,7796.0 0.0,4526.2 465.1,4525.3 562.1,277.7 3373.3,1413.6 3877.6,1832.5\" /></svg>"
+          "value": "<svg><polygon points=\"3408.2,1358.6 3921.1,1786.6 6349.0,1822.2 6349.0,2169.6 4261.0,7263.3 3417.1,7167.8 3156.1,7796.0 0.0,7796.0 0.0,4521.6 437.4,4521.8 431.7,385.5 546.5,194.4 3408.2,1358.6\" /></svg>"
         }
       },
       "body": {
@@ -1453,8 +1469,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5359.0,
-                1830.0
+                4128.7,
+                4916.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1465,8 +1481,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0675167,
-                29.9428649
+                -90.0658096,
+                29.9424745
               ]
             }
           },
@@ -1474,8 +1490,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3656.7,
-                5978.7
+                6489.0,
+                1832.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1486,167 +1502,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0652134,
-                29.9423435
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p119",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6262
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6262.0,0.0 6262.0,6066.4 5988.0,7427.1 6262.0,7434.4 6262.0,7796.0 0.0,7796.0 0.0,2294.0 2280.3,2243.3 3125.3,0.0 6262.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0119/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06768210720418,
-                29.935060702188814
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6262.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06806143121695,
-                29.937882704895525
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6262.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06400528407559,
-                29.938292038572936
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.06362596006284,
-                29.935470035866224
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6143.8,
-                210.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0679446,
-                29.9378405
+                -90.0675695,
+                29.9433411
               ]
             }
           }
@@ -1671,8 +1528,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1691,7 +1548,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2617.0,0.0 3765.8,0.0 6249.5,985.1 6143.2,5331.6 5667.3,5331.7 5663.3,7795.0 172.7,7795.0 177.4,7551.3 0.0,7543.2 206.7,6014.2 312.9,451.0 1811.4,893.8 2617.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"156.2,2577.5 0.0,2516.6 0.0,1035.4 342.7,184.2 2051.5,614.1 2617.9,0.0 3759.3,0.0 6248.0,986.7 6141.7,5330.9 5702.6,5331.1 5704.5,7795.0 0.0,7795.0 8.6,2636.4 156.2,2577.5\" /></svg>"
         }
       },
       "body": {
@@ -1705,8 +1562,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4682.1,
-                5331.9
+                4680.7,
+                5331.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1726,8 +1583,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4682.1,
-                2606.9
+                4680.7,
+                2607.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1764,8 +1621,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1784,7 +1641,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2937.0,0.0 2933.2,1269.0 6288.0,1394.6 6288.0,7796.0 3158.8,7796.0 3184.4,6199.8 -0.0,4885.8 -0.0,2569.3 1300.1,3124.3 2561.7,0.0 2937.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1070.0,3071.6 1238.1,3138.8 2483.6,0.0 6288.0,0.0 6288.0,7796.0 3148.2,7796.0 3212.0,6198.1 286.3,5043.0 1070.0,3071.6\" /></svg>"
         }
       },
       "body": {
@@ -1798,8 +1655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2092.8,
-                5739.2
+                3212.0,
+                6200.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1810,8 +1667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0665659,
-                29.9331141
+                -90.0659629,
+                29.9329822
               ]
             }
           },
@@ -1819,8 +1676,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                9.6,
-                4860.9
+                -20.0,
+                4920.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1857,8 +1714,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1877,7 +1734,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3572.2,6832.5 1322.6,6815.6 1319.1,546.3 4757.5,553.2 5408.2,2176.7 5532.3,2786.0 5520.8,7282.8 3572.0,7268.5 3572.2,6832.5\" /></svg>"
+          "value": "<svg><polygon points=\"1304.1,7795.0 1312.2,543.9 4753.6,550.5 5529.1,2783.8 5517.5,7281.7 5307.2,7280.1 5302.1,7795.0 1304.1,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1891,8 +1748,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1319.1,
-                546.3
+                1312.2,
+                543.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1912,8 +1769,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1319.1,
-                7251.9
+                1312.2,
+                7251.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1950,8 +1807,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1970,7 +1827,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"605.5,7230.4 631.2,2757.7 452.7,2007.9 3320.8,815.1 2981.9,0.0 6481.0,0.0 6481.0,6904.8 3235.7,6862.4 3235.7,7258.3 605.5,7230.4\" /></svg>"
+          "value": "<svg><polygon points=\"594.1,7276.5 536.1,2799.6 269.5,2068.8 3131.7,894.2 2764.6,0.0 6481.0,0.0 6481.0,6840.6 3221.1,6859.2 3228.5,7255.1 594.1,7276.5\" /></svg>"
         }
       },
       "body": {
@@ -1984,8 +1841,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3235.7,
-                2804.9
+                536.1,
+                2799.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1996,8 +1853,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0645199,
-                29.9316046
+                -90.065851,
+                29.93191
               ]
             }
           },
@@ -2005,8 +1862,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3235.7,
-                7258.3
+                3228.5,
+                7255.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2036,15 +1893,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2063,7 +1920,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3088.0 -0.0,434.8 2212.7,434.7 2212.9,0.0 4454.7,0.0 4457.7,434.4 6245.0,434.0 6245.0,6964.4 4469.1,5825.8 4457.7,4870.5 2897.5,4896.4 -0.0,3088.0\" /></svg>"
+          "value": "<svg><polygon points=\"4302.0,5643.3 4318.4,7796.0 -0.0,7796.0 372.1,3286.4 -0.0,3063.3 -0.0,433.6 6245.0,406.4 6245.0,6836.9 4302.0,5643.3\" /></svg>"
         }
       },
       "body": {
@@ -2077,8 +1934,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4459.3,
-                4870.5
+                372.1,
+                3288.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2089,8 +1946,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0680026,
-                29.9281795
+                -90.0709895,
+                29.9303133
               ]
             }
           },
@@ -2098,8 +1955,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4459.3,
-                434.4
+                372.1,
+                432.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2110,8 +1967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0674202,
-                29.9301443
+                -90.0708129,
+                29.930899
               ]
             }
           }
@@ -2136,8 +1993,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2156,7 +2013,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2871.1,399.5 2865.9,0.0 6447.0,0.0 6447.0,7795.0 204.2,7795.0 200.8,7064.9 75.9,6987.1 60.3,406.4 2871.1,399.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5865.2 -0.0,406.2 2866.8,399.2 2861.6,0.0 6447.0,0.0 6447.0,7795.0 2949.0,7795.0 -0.0,5865.2\" /></svg>"
         }
       },
       "body": {
@@ -2170,8 +2027,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2904.0,
-                2667.6
+                2899.6,
+                2667.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2191,8 +2048,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                201.3,
-                2667.6
+                196.0,
+                2667.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2229,8 +2086,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2249,7 +2106,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7796.0 -0.0,-0.0 180.3,0.0 125.6,797.0 6146.0,1112.5 6146.0,7796.0 -0.0,7796.0\" /></svg>"
+          "value": "<svg><polygon points=\"6146.0,1134.6 6146.0,7796.0 -0.0,7796.0 -0.0,-0.0 188.9,0.0 137.2,798.6 6146.0,1134.6\" /></svg>"
         }
       },
       "body": {
@@ -2263,8 +2120,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                437.6,
-                4745.9
+                436.1,
+                4748.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2284,8 +2141,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5015.2,
-                1079.5
+                5013.6,
+                1076.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2322,8 +2179,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2342,7 +2199,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2963.7,792.0 5508.4,733.8 5560.2,3487.8 4949.7,3888.6 6448.0,6194.2 6448.0,7796.0 -0.0,7796.0 -0.0,1105.4 2963.7,792.0\" /></svg>"
+          "value": "<svg><polygon points=\"5493.7,729.4 5526.1,1207.9 6320.9,671.5 6270.1,0.0 6448.0,0.0 6448.0,7796.0 -0.0,7796.0 -0.0,1115.0 2960.0,794.9 5493.7,729.4\" /></svg>"
         }
       },
       "body": {
@@ -2356,8 +2213,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5560.2,
-                3487.6
+                5552.0,
+                3472.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2377,8 +2234,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2963.7,
-                792.1
+                2960.0,
+                796.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2415,8 +2272,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2435,7 +2292,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,391.9 6335.0,294.4 6335.0,7324.4 -0.0,7426.9 -0.0,391.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7408.6 -0.0,374.9 5904.5,342.0 6051.1,3488.2 5370.3,3752.2 5457.7,4757.5 6126.8,4752.6 6239.5,7343.4 5828.2,7354.0 5871.4,7796.0 5641.8,7796.0 5613.5,7359.3 -0.0,7408.6\" /></svg>"
         }
       },
       "body": {
@@ -2449,8 +2306,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2919.9,
-                2596.5
+                2915.5,
+                2588.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2470,8 +2327,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2919.9,
-                7387.2
+                2915.5,
+                4776.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2482,8 +2339,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0715174,
-                29.9252972
+                -90.0723193,
+                29.9262406
               ]
             }
           }
@@ -2505,11 +2362,11 @@
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2528,7 +2385,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4600.2,0.0 5380.6,0.0 5423.2,885.8 6444.0,885.8 6444.0,1449.0 5477.0,2100.0 5596.0,5540.4 6444.0,6866.3 5703.6,7377.6 5665.9,6897.4 3121.4,6991.2 635.9,7358.8 1260.3,409.3 3778.9,363.4 4600.2,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"663.9,4808.7 -0.0,4755.9 -0.0,3751.7 697.8,3548.6 823.9,416.7 3912.7,325.0 3506.5,550.1 4629.5,2233.4 5464.4,1667.1 5504.4,2734.9 6444.0,2108.1 6444.0,6887.4 5708.0,7395.6 5670.2,6914.3 3120.0,7007.7 552.2,7387.1 663.9,4808.7\" /></svg>"
         }
       },
       "body": {
@@ -2542,7 +2399,28 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3121.4,
+                3120.0,
+                4804.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0700313,
+                29.9278532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3120.0,
                 412.0
               ],
               "creator": {
@@ -2556,27 +2434,6 @@
               "coordinates": [
                 -90.0715553,
                 29.9293384
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3121.4,
-                6991.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0692666,
-                29.927108
               ]
             }
           }
@@ -2601,8 +2458,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2621,7 +2478,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5824.8,607.3 6037.5,7256.3 170.8,7225.6 162.9,7795.0 -0.0,7795.0 69.0,604.9 5824.8,607.3\" /></svg>"
+          "value": "<svg><polygon points=\"5819.0,608.9 6032.7,7247.4 168.7,7216.7 162.4,7795.0 -0.0,7795.0 55.2,606.3 5819.0,608.9\" /></svg>"
         }
       },
       "body": {
@@ -2635,8 +2492,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3094.6,
-                2865.6
+                3092.0,
+                2863.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2656,8 +2513,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                744.1,
-                2865.6
+                744.0,
+                2863.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2687,15 +2544,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "23"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2714,7 +2571,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4909.0,407.0 6157.2,2257.9 6444.0,7796.0 4744.0,7796.0 193.1,7331.6 481.0,757.8 4909.0,407.0\" /></svg>"
+          "value": "<svg><polygon points=\"470.5,638.1 4352.9,673.0 4950.1,353.1 6013.5,1984.3 6444.0,1704.2 6444.0,6799.5 5652.0,5583.6 4617.4,6251.1 4624.0,6454.1 3343.9,7231.3 77.4,7278.1 470.5,638.1\" /></svg>"
         }
       },
       "body": {
@@ -2728,8 +2585,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2463.2,
-                5135.6
+                5748.0,
+                5728.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2740,8 +2597,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0723245,
-                29.930088
+                -90.0708129,
+                29.930899
               ]
             }
           },
@@ -2749,8 +2606,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2463.2,
-                7326.5
+                4624.0,
+                6456.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2761,8 +2618,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0715553,
-                29.9293384
+                -90.0709895,
+                29.9303133
               ]
             }
           }
@@ -2787,8 +2644,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2807,7 +2664,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"192.2,3000.2 1810.5,325.3 3800.4,316.3 3800.1,0.0 6022.1,0.0 6023.1,323.4 6358.0,323.1 6358.0,5561.9 6038.7,5563.2 6044.2,7443.2 1533.6,7446.8 1532.1,4849.8 1530.9,3005.1 192.2,3000.2\" /></svg>"
+          "value": "<svg><polygon points=\"1527.1,4277.4 4308.7,0.0 6015.6,0.0 6016.5,317.2 6358.0,317.0 6358.0,5555.8 6032.2,5557.1 6037.8,7437.1 981.4,7436.7 984.2,7795.0 0.0,7795.0 0.0,5746.4 1528.0,5752.1 1527.1,4277.4\" /></svg>"
         }
       },
       "body": {
@@ -2821,8 +2678,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3802.0,
-                316.3
+                1527.5,
+                4843.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0698804,
+                29.9306916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3794.8,
+                312.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2835,27 +2713,6 @@
               "coordinates": [
                 -90.0718767,
                 29.9321959
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1533.6,
-                7446.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0685676,
-                29.9303995
               ]
             }
           }
@@ -2877,11 +2734,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2900,7 +2757,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1279.6,336.3 5509.9,348.5 5502.5,1446.2 4957.4,1446.5 4961.2,6696.7 3197.0,7456.9 938.1,7499.8 939.3,5608.1 1260.7,5607.9 1279.6,336.3\" /></svg>"
+          "value": "<svg><polygon points=\"1261.0,5613.2 1280.0,337.0 5505.3,349.5 5498.0,1440.7 4944.3,1441.0 4948.9,7796.0 3192.5,7796.0 3191.4,7464.1 931.6,7506.8 932.8,5613.4 1261.0,5613.2\" /></svg>"
         }
       },
       "body": {
@@ -2914,8 +2771,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                942.5,
-                4867.3
+                936.0,
+                4872.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2935,8 +2792,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                942.5,
-                335.3
+                936.0,
+                336.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2973,8 +2830,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2993,7 +2850,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5990.2,818.1 6013.7,7275.1 186.0,7289.2 188.3,6791.7 -0.0,6791.2 -0.0,2899.0 220.5,2969.8 216.6,3328.5 1071.4,805.2 5990.2,818.1\" /></svg>"
+          "value": "<svg><polygon points=\"182.8,7278.5 185.3,6745.7 -0.0,6745.3 -0.0,3954.2 1061.8,804.5 6321.0,813.8 6321.0,7263.5 182.8,7278.5\" /></svg>"
         }
       },
       "body": {
@@ -3007,8 +2864,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4925.2,
-                5248.8
+                4920.8,
+                3027.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3019,8 +2876,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0707327,
-                29.9360426
+                -90.0704448,
+                29.9370144
               ]
             }
           },
@@ -3028,8 +2885,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4925.2,
-                821.0
+                4920.8,
+                815.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3063,11 +2920,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3086,7 +2943,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6443.0,7437.1 6270.2,7436.6 6270.0,7796.0 -0.0,7796.0 -0.0,831.8 1501.0,836.4 1503.4,1466.5 3326.9,1292.0 4037.3,2995.5 6365.7,2987.1 6443.0,7437.1\" /></svg>"
+          "value": "<svg><polygon points=\"1549.4,0.0 6443.0,0.0 6443.0,7429.1 6263.9,7428.6 6263.7,7796.0 -0.0,7796.0 -0.0,7250.0 318.0,7252.4 341.2,830.1 1682.9,676.6 1549.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3100,8 +2957,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1594.0,
-                5250.6
+                1599.8,
+                5244.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3121,8 +2978,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1594.0,
-                779.3
+                1599.8,
+                776.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3156,11 +3013,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "15"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3179,7 +3036,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2733.7,7055.2 960.1,6462.6 2185.5,2871.9 2806.6,3036.3 2802.1,4079.4 3109.5,3209.9 3097.3,1063.0 1982.7,668.9 3095.0,672.7 3092.9,303.6 4250.5,410.5 6349.0,1106.8 6349.0,7038.6 3122.2,7015.0 3122.7,6020.2 2796.6,5909.0 2733.7,7055.2\" /></svg>"
+          "value": "<svg><polygon points=\"2845.4,6272.2 2816.8,7796.0 2662.8,7796.0 2679.7,7054.8 932.2,6438.4 2206.0,2901.9 2818.6,3075.0 2796.7,4118.8 3115.7,3264.2 3139.3,1128.7 1945.0,683.2 2994.1,700.6 3147.7,372.9 4824.6,614.0 6349.0,1218.3 6349.0,1786.2 5963.9,1833.0 6349.0,4998.9 6349.0,7100.2 3065.3,7021.4 3078.2,6276.5 2845.4,6272.2\" /></svg>"
         }
       },
       "body": {
@@ -3193,29 +3050,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3123.4,
-                4736.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0722086,
-                29.939583
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1504.2,
-                4845.0
+                1496.2,
+                4844.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3228,6 +3064,27 @@
               "coordinates": [
                 -90.0730958,
                 29.9397251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3120.5,
+                3044.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0719774,
+                29.9403949
               ]
             }
           }
@@ -3245,15 +3102,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3272,7 +3129,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1387.8,441.4 5252.9,850.1 5036.9,3217.2 5358.6,4305.9 6453.0,4844.4 6453.0,6412.5 6065.2,6519.1 6416.1,7796.0 4555.7,7796.0 4614.3,7158.8 772.5,6781.0 1387.8,441.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 5548.1,0.0 5155.0,2965.2 5508.6,4370.2 6453.0,4895.8 6453.0,7154.5 4613.5,6902.6 4666.1,7796.0 -0.0,7350.7 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -3286,8 +3143,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4881.3,
-                4733.2
+                4876.8,
+                4884.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3307,8 +3164,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6302.9,
-                6579.2
+                6597.0,
+                7312.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3345,8 +3202,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3365,7 +3222,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"227.2,3934.6 1392.1,3927.0 1388.7,3623.9 223.7,3637.0 190.8,896.6 6340.0,795.9 6340.0,3832.3 6340.0,7054.2 4221.1,7795.0 3253.8,7795.0 4286.9,7434.6 4232.3,6762.7 252.8,6806.5 227.2,3934.6\" /></svg>"
+          "value": "<svg><polygon points=\"1388.3,3923.5 1384.3,3617.7 222.5,3633.2 188.1,893.1 6340.0,789.6 6340.0,7050.1 4211.9,7795.0 3245.7,7795.0 4289.7,7430.2 4234.6,6758.4 253.3,6804.0 226.1,3931.6 1388.3,3923.5\" /></svg>"
         }
       },
       "body": {
@@ -3379,8 +3236,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1973.9,
-                862.6
+                1972.0,
+                859.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3400,8 +3257,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                223.6,
-                3756.9
+                224.0,
+                3755.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3435,11 +3292,11 @@
         },
         {
           "label": "intersections",
-          "value": "17"
+          "value": "23"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3458,7 +3315,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"778.9,4004.7 1679.8,1428.3 4798.5,2416.0 5818.0,0.0 6014.9,0.0 6010.8,7408.4 0.0,7421.0 0.0,6232.1 778.9,4004.7 778.9,4004.7\" /></svg>"
+          "value": "<svg><polygon points=\"1670.3,1390.8 4436.7,2272.6 4341.9,2508.4 4677.1,2687.9 5821.3,0.0 6031.2,0.0 6001.1,7411.1 357.9,7400.1 0.0,7239.7 0.0,6103.3 1670.3,1390.8\" /></svg>"
         }
       },
       "body": {
@@ -3472,8 +3329,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6010.8,
-                4923.0
+                6009.9,
+                4915.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3493,8 +3350,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6010.8,
-                7408.4
+                1768.6,
+                1423.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3505,8 +3362,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0708922,
-                29.9441047
+                -90.0744359,
+                29.942928
               ]
             }
           }
@@ -3531,8 +3388,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3551,7 +3408,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 307.1,-0.0 301.6,1180.8 5199.9,1175.1 4869.8,-0.0 5236.1,-0.0 5576.9,1001.4 6353.0,740.6 6353.0,3407.8 6241.5,3066.5 6009.7,3070.1 6353.0,4083.6 6353.0,7795.0 6179.6,7795.0 6168.6,6763.2 339.1,6753.7 349.9,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"339.9,7795.0 -0.0,7795.0 0.0,0.0 310.0,-0.0 302.5,1177.5 5203.2,1179.5 5454.3,1934.6 5609.9,1878.9 5087.4,328.8 5324.2,249.0 5580.7,1006.4 6353.0,753.0 6353.0,4083.1 6353.0,7795.0 6172.4,7795.0 6163.1,6768.9 330.8,6750.3 339.9,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -3565,8 +3422,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3232.4,
-                4942.2
+                3228.5,
+                4943.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3586,8 +3443,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                325.8,
-                3050.9
+                320.1,
+                3047.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3617,15 +3474,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3644,7 +3501,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"420.7,6056.4 373.9,2764.0 -0.0,2760.8 -0.0,-0.0 793.5,0.0 792.3,501.1 5567.1,469.5 5578.1,5030.6 5253.1,5032.1 5256.9,7265.6 2405.8,7261.8 420.7,6056.4\" /></svg>"
+          "value": "<svg><polygon points=\"446.5,6062.4 404.5,2999.4 73.2,2783.2 -0.0,2782.6 -0.0,-0.0 820.7,0.0 819.2,534.6 5570.9,505.2 5579.5,5044.0 5262.2,5045.3 5265.1,7267.8 2309.3,7194.7 446.5,6062.4\" /></svg>"
         }
       },
       "body": {
@@ -3658,8 +3515,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                -1230.0,
-                5063.6
+                5575.1,
+                2767.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3670,8 +3527,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0750091,
-                29.9339224
+                -90.0712888,
+                29.9341652
               ]
             }
           },
@@ -3679,8 +3536,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5574.8,
-                7264.7
+                5575.1,
+                7267.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3714,11 +3571,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "12"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3737,7 +3594,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7165.1 -0.0,-0.0 158.8,0.0 147.5,873.8 5510.6,910.7 5750.9,7177.2 -0.0,7165.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7200.0 -0.0,-0.0 114.5,0.0 109.4,877.8 5507.0,877.5 5896.7,7163.2 -0.0,7200.0\" /></svg>"
         }
       },
       "body": {
@@ -3751,8 +3608,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3092.5,
-                2680.3
+                3088.0,
+                4895.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3763,8 +3620,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0771788,
-                29.9318703
+                -90.0764823,
+                29.9310691
               ]
             }
           },
@@ -3772,8 +3629,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                718.8,
-                4897.4
+                3088.0,
+                7171.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3784,8 +3641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0774603,
-                29.9304185
+                -90.0757692,
+                29.9302489
               ]
             }
           }
@@ -3803,15 +3660,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "11"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "23"
+          "value": "25"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3830,7 +3687,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"175.8,911.1 3665.7,781.3 5417.9,249.0 5655.8,585.9 6426.0,351.6 6426.0,1256.6 6229.3,1398.1 6426.0,1706.2 3859.7,3608.5 4035.7,5867.1 4539.5,6583.0 3969.1,6925.3 160.1,7076.8 175.8,911.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7109.0 202.5,775.6 3796.0,807.4 5622.4,343.6 5852.0,702.4 6426.0,556.3 6426.0,1998.9 3862.1,3720.7 3932.3,5917.0 4420.6,6808.4 3818.1,7133.0 -0.0,7109.0\" /></svg>"
         }
       },
       "body": {
@@ -3844,29 +3701,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4538.4,
-                6584.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0730192,
-                29.9324496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1980.2,
-                2619.6
+                1976.6,
+                2615.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3879,6 +3715,27 @@
               "coordinates": [
                 -90.0754149,
                 29.9330997
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3817.2,
+                2615.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0747115,
+                29.9336558
               ]
             }
           }
@@ -3903,8 +3760,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3923,7 +3780,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"41.7,7795.0 169.4,1267.3 6036.4,756.6 6188.2,2503.4 6220.0,7795.0 41.7,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6221.0,7795.0 -0.0,7795.0 -0.0,1258.4 6037.8,733.8 6189.8,2484.2 6221.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -3937,8 +3794,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3321.7,
-                4865.5
+                3316.0,
+                4851.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3958,8 +3815,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6202.7,
-                4865.5
+                6204.0,
+                4851.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3996,8 +3853,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4016,7 +3873,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5914.9 173.2,4364.9 -0.0,4859.0 -0.0,1660.9 187.0,1660.1 172.0,621.3 5986.7,607.4 6001.9,1636.7 6174.8,1636.0 6168.2,-0.0 6432.0,-0.0 6432.0,3702.1 6034.2,3833.9 6033.5,5695.6 5588.0,7413.5 -0.0,5914.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5908.1 171.5,4358.4 -0.0,4314.6 -0.0,1659.4 185.5,1658.4 170.5,616.7 5985.2,602.5 6000.2,1625.5 6180.3,1624.5 6171.2,-0.0 6432.0,-0.0 6432.0,3695.0 6032.5,3827.3 6031.6,5688.1 5586.1,7405.1 -0.0,5908.1\" /></svg>"
         }
       },
       "body": {
@@ -4030,8 +3887,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3129.8,
-                5028.4
+                3128.0,
+                5023.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4051,8 +3908,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6013.6,
-                2437.5
+                6012.0,
+                2431.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4089,8 +3946,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4109,7 +3966,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"472.4,977.0 4617.8,1295.7 5800.8,1184.7 5806.8,7067.4 -0.0,6868.1 -0.0,-0.0 481.7,0.0 472.4,977.0\" /></svg>"
+          "value": "<svg><polygon points=\"450.2,0.0 441.1,1017.6 4608.3,1336.0 6396.0,1101.3 6396.0,3973.2 6385.1,3974.3 6330.1,6995.0 -0.0,6934.4 0.0,-0.0 450.2,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4123,8 +3980,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2731.6,
-                2897.6
+                376.0,
+                4751.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4135,8 +3992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.080941,
-                29.936242
+                -90.0813341,
+                29.9349573
               ]
             }
           },
@@ -4144,8 +4001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                383.4,
-                7044.3
+                2732.0,
+                1203.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4156,8 +4013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0805955,
-                29.9341069
+                -90.0814841,
+                29.9368699
               ]
             }
           }
@@ -4175,15 +4032,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4202,7 +4059,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5478.7,5373.5 4266.8,5806.4 4322.8,5962.5 1538.2,6926.4 2061.5,6928.6 542.3,7271.3 529.6,7093.9 -0.0,7075.2 -0.0,1211.4 1963.9,912.9 3662.5,279.3 5478.7,5373.5\" /></svg>"
+          "value": "<svg><polygon points=\"1983.0,0.0 3719.6,0.0 5718.4,5237.7 1788.9,6916.1 1809.7,7119.7 44.0,7349.3 -0.0,484.9 1983.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4216,8 +4073,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5539.4,
-                5539.6
+                3808.6,
+                6187.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4228,8 +4085,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0765327,
-                29.9376778
+                -90.0770518,
+                29.9369759
               ]
             }
           },
@@ -4237,8 +4094,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3661.0,
-                277.9
+                1788.3,
+                6919.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4249,8 +4106,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.078991,
-                29.939051
+                -90.0775951,
+                29.936274
               ]
             }
           }
@@ -4268,15 +4125,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "7"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4295,7 +4152,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"932.5,7104.8 907.1,2243.8 -0.0,2242.5 -0.0,1820.0 905.9,1831.7 901.0,-0.0 5786.5,-0.0 5785.8,162.9 5368.8,161.9 5367.7,7073.7 5803.3,7073.7 5806.0,7590.3 3030.9,7592.2 932.5,7104.8\" /></svg>"
+          "value": "<svg><polygon points=\"892.9,-0.0 5776.6,-0.0 5769.4,1966.5 6380.0,1968.3 6380.0,2093.1 5769.7,2090.8 5756.7,7795.0 765.3,7795.0 931.6,7099.7 901.3,2241.1 -0.0,2240.8 -0.0,1818.5 899.7,1829.2 892.9,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -4309,8 +4166,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                913.7,
-                3923.1
+                908.0,
+                3919.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4330,8 +4187,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5785.8,
-                162.9
+                5776.0,
+                156.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4368,8 +4225,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4388,7 +4245,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"428.1,6489.3 435.1,7795.0 -0.0,7795.0 -0.0,890.5 416.5,891.4 420.5,-0.0 3121.6,-0.0 3121.2,895.6 5904.6,914.2 5854.8,7542.4 6017.6,7543.6 6014.7,7795.0 5848.1,7795.0 5850.3,6501.7 428.1,6489.3\" /></svg>"
+          "value": "<svg><polygon points=\"5842.0,6511.2 970.2,6485.7 385.6,7795.0 416.7,2822.7 1026.0,2827.4 1026.5,2702.9 416.9,2698.6 437.5,-0.0 3136.2,-0.0 3132.9,903.9 5912.9,931.0 5842.0,6511.2\" /></svg>"
         }
       },
       "body": {
@@ -4402,8 +4259,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                405.7,
-                4680.2
+                408.1,
+                4675.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4423,8 +4280,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3124.3,
-                6498.0
+                3120.5,
+                6499.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4461,8 +4318,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4481,7 +4338,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1460.6,5044.6 1417.7,210.1 5282.2,173.5 5281.6,2114.0 4775.3,2118.2 4778.7,2292.0 5281.7,2288.4 5310.4,7715.3 2205.8,7717.5 2182.5,5041.5 1460.6,5044.6\" /></svg>"
+          "value": "<svg><polygon points=\"1447.7,5046.9 1396.3,206.2 5267.5,158.8 5272.5,2101.9 4771.5,2107.5 4773.9,2281.4 5273.0,2276.5 5317.1,7710.5 2217.5,7721.1 2178.5,5041.9 1447.7,5046.9\" /></svg>"
         }
       },
       "body": {
@@ -4495,8 +4352,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5281.0,
-                4999.7
+                5280.0,
+                4991.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4516,8 +4373,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3073.4,
-                210.8
+                1248.0,
+                208.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4528,8 +4385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.079033,
-                29.943062
+                -90.0795526,
+                29.942373
               ]
             }
           }
@@ -4554,8 +4411,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4574,7 +4431,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1909.9,0.0 6443.0,0.0 6443.0,4007.3 6014.1,4142.6 6121.0,5013.5 5977.6,5058.8 5741.8,7588.4 415.2,7574.3 493.3,2251.8 -0.0,2245.5 -0.0,2075.1 496.7,2080.8 535.2,177.9 1928.1,141.6 1909.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1889.6,197.2 1862.5,0.0 6104.1,0.0 5972.3,168.3 6088.2,164.6 6091.6,2362.1 5736.2,2351.8 5664.1,3309.3 6443.0,4333.1 6443.0,4853.4 6124.1,4958.2 6165.4,5085.1 5949.6,5070.8 5721.9,7796.0 5358.6,7796.0 5373.9,7553.1 455.9,7588.0 485.2,2304.6 -0.0,2302.8 -0.0,2133.6 487.0,2134.8 508.0,245.8 1889.6,197.2\" /></svg>"
         }
       },
       "body": {
@@ -4588,8 +4445,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2670.5,
-                7588.4
+                455.9,
+                4944.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4600,8 +4457,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0744359,
-                29.942928
+                -90.0762884,
+                29.9427094
               ]
             }
           },
@@ -4609,8 +4466,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5743.4,
-                7588.4
+                455.9,
+                7588.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4621,8 +4478,210 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.073562,
-                29.944138
+                -90.075084,
+                29.942043
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p153",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6380
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2407.7,961.8 6380.0,905.3 6380.0,7795.0 -0.0,7795.0 -0.0,365.5 2422.8,333.6 2407.7,961.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2528.0,
+                2955.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0783631,
+                29.948933
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2528.0,
+                6191.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.078733,
+                29.9477565
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p154 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6443.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "7796.0"
+        }
+      ],
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6443
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"325.5,5264.9 -0.0,5726.6 -0.0,2145.4 778.4,0.0 2935.6,0.0 4538.0,606.0 4822.5,920.7 6443.0,1273.9 6443.0,3358.8 4905.3,7796.0 2860.8,7796.0 2049.9,7076.6 2302.1,6764.2 325.5,5264.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0154__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2099.7,
+                3520.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0760493,
+                29.9469191
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3243.5,
+                252.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0756308,
+                29.948309
               ]
             }
           }
@@ -4644,11 +4703,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4667,7 +4726,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,117.2 -0.0,-0.0 1341.0,0.0 1284.3,400.1 5864.6,1335.5 6378.0,1430.6 6378.0,6110.3 6184.2,6121.9 6105.0,7796.0 -0.0,7796.0 -0.0,131.9 -0.0,117.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 1263.4,0.0 1230.1,267.4 6211.8,1203.8 6378.0,810.9 6378.0,4461.4 6189.2,7796.0 -0.0,7796.0 52.4,44.6 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -4681,8 +4740,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                137.3,
-                2963.8
+                3341.0,
+                3500.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4693,8 +4752,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0805377,
-                29.9527262
+                -90.0789813,
+                29.9520883
               ]
             }
           },
@@ -4702,8 +4761,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6279.0,
-                4516.0
+                1900.6,
+                432.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4714,8 +4773,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0775949,
-                29.9513804
+                -90.0793069,
+                29.9535853
               ]
             }
           }
@@ -4740,8 +4799,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4760,7 +4819,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7159.8 329.6,7155.4 387.1,5463.7 594.6,5414.9 519.7,723.7 744.7,762.3 1069.0,0.0 1874.3,0.0 1884.5,957.8 3316.9,1173.2 3382.3,1677.6 3882.6,1296.2 5821.4,1626.1 5824.2,6453.2 4047.7,6432.7 4062.9,7795.0 -0.0,7795.0 -0.0,7159.8\" /></svg>"
+          "value": "<svg><polygon points=\"271.5,7795.0 488.2,264.6 600.4,0.0 1909.5,0.0 1924.8,933.5 3297.7,1138.6 3363.4,1645.4 3866.1,1262.1 5814.2,1593.6 5811.7,7795.0 271.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -4774,8 +4833,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5819.8,
-                1626.1
+                5814.2,
+                1591.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4795,8 +4854,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5819.8,
-                7168.8
+                5814.2,
+                7163.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4833,8 +4892,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4853,7 +4912,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1545.0,7795.0 353.1,2488.1 3252.8,1670.5 2929.9,0.0 5892.1,0.0 6125.9,0.0 6425.0,1612.3 6425.0,7795.0 1545.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"37.0,2627.2 6272.2,859.5 6425.0,1626.4 6425.0,7295.7 5299.2,7795.0 1187.7,7795.0 37.0,2627.2\" /></svg>"
         }
       },
       "body": {
@@ -4882,8 +4941,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0807849763607,
-                29.954287251796703
+                -90.08067435137059,
+                29.954396733470546
               ]
             }
           },
@@ -4903,8 +4962,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07873817826332,
-                29.956600681943566
+                -90.07873641301504,
+                29.956592151056483
               ]
             }
           },
@@ -4924,8 +4983,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.07549867282371,
-                29.954448850777975
+                -90.07566153408808,
+                29.954554350515274
               ]
             }
           },
@@ -4945,8 +5004,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0775454709211,
-                29.952135420631112
+                -90.07759947244364,
+                29.95235893292934
               ]
             }
           },
@@ -4954,8 +5013,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6166.2,
-                329.1
+                6169.0,
+                332.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4985,15 +5044,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5012,7 +5071,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"358.9,480.0 5771.1,444.0 5780.9,0.0 6373.0,0.0 6373.0,7575.3 1392.7,7543.7 1434.1,7795.0 1277.8,7795.0 878.6,6910.0 685.5,6997.1 358.9,480.0\" /></svg>"
+          "value": "<svg><polygon points=\"684.9,7022.4 432.5,981.1 627.6,923.3 494.7,475.3 5767.6,439.8 5777.3,0.0 6373.0,0.0 6373.0,7563.8 1396.7,7532.3 1440.0,7795.0 1161.0,7795.0 785.8,6976.2 684.9,7022.4\" /></svg>"
         }
       },
       "body": {
@@ -5027,7 +5086,7 @@
             "properties": {
               "resourceCoords": [
                 3408.5,
-                6101.8
+                6087.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5048,7 +5107,7 @@
             "properties": {
               "resourceCoords": [
                 3408.5,
-                476.0
+                471.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5085,8 +5144,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5105,7 +5164,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6424.0,567.1 6345.8,6961.6 3250.5,6086.7 3106.7,7795.0 439.9,7795.0 316.3,6454.4 199.2,6471.0 457.1,3722.6 -0.0,3607.2 -0.0,1327.0 6424.0,567.1\" /></svg>"
+          "value": "<svg><polygon points=\"6424.0,7795.0 354.9,7795.0 182.3,6545.2 -0.0,6622.3 -0.0,3416.9 1255.1,3787.0 1158.1,1156.6 6424.0,551.4 6310.2,7287.3 6424.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5119,8 +5178,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                329.0,
-                4865.5
+                328.0,
+                4835.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5140,8 +5199,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6296.2,
-                7293.4
+                6296.0,
+                7283.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5171,15 +5230,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "26"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5198,7 +5257,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6343.4,954.9 6333.4,7247.3 890.1,7286.2 -0.0,3951.8 -0.0,968.4 6343.4,954.9\" /></svg>"
+          "value": "<svg><polygon points=\"1019.2,7316.1 -0.0,3622.4 -0.0,1186.8 3884.2,1193.6 3878.0,854.0 6161.7,839.0 6149.7,0.0 6423.0,0.0 6423.0,6788.8 6233.8,6791.1 6229.8,7215.5 1019.2,7316.1\" /></svg>"
         }
       },
       "body": {
@@ -5212,8 +5271,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3957.3,
-                571.8
+                1735.7,
+                2715.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5224,8 +5283,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0804577,
-                29.9593942
+                -90.0803989,
+                29.9580493
               ]
             }
           },
@@ -5233,8 +5292,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3957.3,
-                7280.7
+                3955.4,
+                7275.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5247,6 +5306,99 @@
               "coordinates": [
                 -90.077693,
                 29.957514
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p161",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"266.8,4916.1 -0.0,4912.2 -0.0,-0.0 6414.0,0.0 6414.0,7795.0 224.5,7795.0 266.8,4916.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6294.0,
+                3107.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0838375,
+                29.9526685
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2991.1,
+                3107.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0846189,
+                29.9515574
               ]
             }
           }
@@ -5268,11 +5420,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5291,7 +5443,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"554.1,783.3 2838.4,1092.4 3016.0,649.9 5734.7,1296.1 5775.3,7795.0 -0.0,7795.0 -0.0,5658.5 288.0,4998.5 527.0,3200.8 554.1,783.3\" /></svg>"
+          "value": "<svg><polygon points=\"637.6,0.0 3165.2,0.0 2765.6,1191.2 5841.6,1304.6 6355.2,7795.0 4030.2,7795.0 4258.0,6712.8 833.3,5991.6 833.3,5991.6 415.8,5903.7 1042.1,4140.0 1161.0,3085.5 841.3,3049.0 637.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -5305,8 +5457,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4142.5,
-                932.8
+                4139.4,
+                927.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5326,8 +5478,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5886.4,
-                1332.2
+                379.9,
+                5999.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5338,8 +5490,101 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.080185,
-                29.953962
+                -90.0838375,
+                29.9526685
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p164",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6432
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3587.1,6454.5 -0.0,6811.3 -0.0,1974.6 2995.7,1672.4 4421.6,5031.1 5699.6,4488.7 3587.1,6454.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0164/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4400.0,
+                1655.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.078733,
+                29.9477565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6076.0,
+                6691.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0760493,
+                29.9469191
               ]
             }
           }
@@ -5364,8 +5609,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5384,7 +5629,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4395.7,5773.6 3975.5,5776.0 3979.4,6678.3 487.9,6708.1 494.1,3799.2 -0.0,3861.6 -0.0,1330.1 389.5,1415.4 465.1,1082.9 466.9,1447.0 6058.9,1419.8 6095.3,6660.3 4389.2,6674.7 4395.7,5773.6\" /></svg>"
+          "value": "<svg><polygon points=\"445.8,1447.4 6053.5,1428.3 6090.3,6655.1 4385.1,6669.3 4391.5,5774.9 3971.8,5776.8 3975.7,6672.8 487.6,6702.1 493.9,3795.9 -0.0,3858.2 -0.0,3126.9 444.8,1171.5 445.8,1447.4\" /></svg>"
         }
       },
       "body": {
@@ -5398,8 +5643,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2309.4,
-                6692.8
+                2307.3,
+                6687.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5419,7 +5664,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6059.4,
+                6054.1,
                 1015.9
               ],
               "creator": {
@@ -5457,8 +5702,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5477,7 +5722,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3937.1,6679.0 -0.0,6670.2 11.6,1187.0 5331.3,1122.6 5320.8,1599.7 6431.0,1610.6 6431.0,6479.1 3937.1,6679.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6659.7 10.5,1180.1 5326.5,1115.8 5316.7,1560.3 6185.1,1559.9 5697.4,6420.4 5309.4,6420.1 5336.8,6620.3 -0.0,6659.7\" /></svg>"
         }
       },
       "body": {
@@ -5491,8 +5736,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1769.9,
-                5226.5
+                1767.7,
+                5215.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5512,8 +5757,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3939.1,
-                5226.5
+                3935.4,
+                5215.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5547,11 +5792,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5570,7 +5815,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1303.6,7562.2 1226.4,3427.3 1079.2,3433.5 960.9,2586.4 3338.0,1706.7 3107.7,1264.2 5841.3,259.1 6329.8,1512.2 6474.0,3154.2 6474.0,7795.0 1993.2,7795.0 1993.5,7552.9 1303.6,7562.2\" /></svg>"
+          "value": "<svg><polygon points=\"5401.6,7795.0 1908.3,7795.0 1910.6,7533.2 1216.4,7535.0 1184.0,3399.7 1036.6,3404.3 875.0,2148.2 2625.2,1949.3 3315.6,1702.3 3089.9,1257.1 5490.6,404.2 5401.6,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5584,8 +5829,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4442.7,
-                760.3
+                4429.4,
+                767.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5605,8 +5850,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5733.0,
-                7539.4
+                1216.4,
+                7535.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5617,8 +5862,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0842066,
-                29.93831
+                -90.0856,
+                29.9399131
               ]
             }
           }
@@ -5640,11 +5885,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "16"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5663,7 +5908,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5589.6,207.0 6060.8,3369.8 5814.9,7543.5 4832.6,7551.7 4837.0,7795.0 1018.4,7795.0 1001.3,3143.9 850.0,1491.2 2990.0,1199.2 5589.6,207.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,360.3 345.5,231.9 841.9,1490.4 933.5,2201.2 5612.3,425.1 5847.0,1554.7 5785.2,1583.8 6051.1,3366.1 5805.7,7535.8 4788.1,7544.4 4792.5,7795.0 -0.0,7795.0 -0.0,360.3\" /></svg>"
         }
       },
       "body": {
@@ -5677,8 +5922,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                271.5,
-                7561.8
+                264.1,
+                7555.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5698,8 +5943,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5959.7,
-                5248.8
+                5953.8,
+                5243.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5733,11 +5978,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "22"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5756,7 +6001,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 110.5,0.0 114.8,1240.1 4157.0,1212.0 4147.6,779.5 5317.8,347.3 6120.5,6698.9 4866.0,6875.5 4872.4,7022.8 736.6,7104.6 746.6,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,1229.6 753.0,1238.9 4170.0,1215.5 4161.9,782.7 5334.8,353.9 6119.2,6711.1 4862.7,6884.0 4868.7,7031.4 727.7,7100.4 735.7,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5770,8 +6015,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3031.0,
-                7060.2
+                3024.9,
+                3175.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0858677,
+                29.9419577
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3024.9,
+                7063.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5784,27 +6050,6 @@
               "coordinates": [
                 -90.0846515,
                 29.9405491
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                744.2,
-                1245.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0874232,
-                29.9420438
               ]
             }
           }
@@ -5826,11 +6071,11 @@
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "25"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5849,7 +6094,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 635.9,0.0 635.3,987.6 2067.3,985.9 4066.8,6425.5 4059.3,6865.4 -0.0,6879.7 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"632.5,814.9 1959.0,821.3 4048.5,6437.7 4056.4,6866.2 -0.0,6880.3 -0.0,0.0 633.0,0.0 632.5,814.9\" /></svg>"
         }
       },
       "body": {
@@ -5863,8 +6108,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2922.4,
-                4771.5
+                2919.5,
+                4772.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5884,8 +6129,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2922.4,
-                996.5
+                2919.5,
+                996.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5922,8 +6167,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5942,7 +6187,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"553.1,4013.0 517.6,1236.0 -0.0,1041.3 8.7,0.0 5974.7,-0.0 5988.0,7795.0 186.5,7795.0 775.1,6187.6 502.9,6088.7 557.4,4425.9 684.8,4425.6 663.6,4011.6 553.1,4013.0\" /></svg>"
+          "value": "<svg><polygon points=\"539.2,469.1 5988.2,518.7 5973.7,7795.0 -0.0,7795.0 623.7,6097.6 512.0,6056.6 572.8,4401.8 -0.0,4405.6 -0.0,3981.8 570.2,3990.8 539.2,469.1\" /></svg>"
         }
       },
       "body": {
@@ -5956,8 +6201,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4164.8,
-                2328.9
+                2368.7,
+                2319.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5968,8 +6213,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0853843,
-                29.9456512
+                -90.0861748,
+                29.9460959
               ]
             }
           },
@@ -5977,8 +6222,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5985.3,
-                2328.9
+                5985.8,
+                6107.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5989,8 +6234,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0845904,
-                29.9452046
+                -90.0856569,
+                29.94377
               ]
             }
           }
@@ -6015,8 +6260,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6035,7 +6280,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"228.8,341.0 6143.5,361.7 6145.3,2183.4 6476.0,2184.9 6476.0,7795.0 212.3,6370.8 228.8,341.0\" /></svg>"
+          "value": "<svg><polygon points=\"218.2,6360.3 226.7,339.9 6132.7,352.6 6136.9,2171.4 6476.0,2172.5 6476.0,7795.0 218.2,6360.3\" /></svg>"
         }
       },
       "body": {
@@ -6049,29 +6294,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                226.8,
-                2159.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0845904,
-                29.9452046
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2012.8,
-                335.4
+                2008.0,
+                332.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6084,6 +6308,27 @@
               "coordinates": [
                 -90.0832916,
                 29.945462
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                228.0,
+                5923.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0856569,
+                29.94377
               ]
             }
           }
@@ -6108,8 +6353,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6128,7 +6373,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5800.4,-0.0 5717.4,5416.4 5913.4,5417.4 5903.6,7136.4 -0.0,7054.2 -0.0,0.0 5800.4,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7519.0 0.0,-0.0 6474.0,-0.0 6474.0,2531.7 5749.0,2453.8 5734.4,5415.2 5734.4,5415.2 5723.5,7627.3 -0.0,7519.0\" /></svg>"
         }
       },
       "body": {
@@ -6142,8 +6387,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4091.4,
-                5408.6
+                4089.3,
+                5407.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6163,8 +6408,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4091.4,
-                7606.5
+                4089.3,
+                7603.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6194,15 +6439,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6221,7 +6466,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"194.5,5455.2 -0.0,5457.2 -0.0,0.0 6421.0,-0.0 6421.0,4097.9 5941.7,4092.0 6046.4,7639.6 215.7,7654.6 194.5,5455.2\" /></svg>"
+          "value": "<svg><polygon points=\"6039.6,7637.0 -0.0,7588.8 -0.0,2421.5 724.4,2495.7 712.1,-0.0 4763.5,-0.0 4945.0,584.7 6421.0,126.8 6421.0,4078.8 5971.4,4068.6 6039.6,7637.0\" /></svg>"
         }
       },
       "body": {
@@ -6235,8 +6480,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1974.2,
-                7638.5
+                176.0,
+                5379.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6247,8 +6492,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0832916,
-                29.945462
+                -90.0834504,
+                29.9467467
               ]
             }
           },
@@ -6256,8 +6501,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5964.2,
-                7638.5
+                5956.9,
+                7635.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6291,11 +6536,11 @@
         },
         {
           "label": "intersections",
-          "value": "21"
+          "value": "36"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6314,7 +6559,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5375.5,7795.0 -0.0,7795.0 -0.0,3753.5 1573.5,-0.0 1837.7,-0.0 1928.8,-0.0 4367.1,-0.0 6325.1,4494.9 6352.0,7606.5 5375.5,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6467.0,7765.5 -0.0,7795.0 -0.0,530.0 1773.6,-0.0 2146.8,1041.2 2996.5,731.1 2693.1,-0.0 4726.3,-0.0 5642.6,2416.6 5077.4,2616.5 5232.7,3034.3 5795.7,2820.7 6341.9,4474.2 6467.0,4473.8 6467.0,7765.5\" /></svg>"
         }
       },
       "body": {
@@ -6328,8 +6573,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                -47.9,
-                843.4
+                1379.8,
+                5367.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6340,8 +6585,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.088397,
-                29.948348
+                -90.0898782,
+                29.9466074
               ]
             }
           },
@@ -6349,8 +6594,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6352.0,
-                7606.5
+                4335.3,
+                5367.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6361,8 +6606,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0892624,
-                29.9441746
+                -90.0889983,
+                29.9455901
               ]
             }
           }
@@ -6387,8 +6632,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6407,7 +6652,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5591.8,1236.9 5273.9,2195.3 6421.0,2193.1 6421.0,7795.0 641.8,7795.0 643.6,6170.5 2175.4,6743.7 2165.7,2720.9 0.0,2698.8 0.0,2216.1 2159.9,2189.5 2150.6,1610.6 0.0,1186.3 45.8,273.0 2246.5,1004.9 2493.5,105.3 5591.8,1236.9\" /></svg>"
+          "value": "<svg><polygon points=\"3166.4,7795.0 2449.4,7795.0 637.9,7795.0 -0.0,7795.0 -0.0,923.3 29.8,-0.0 6421.0,-0.0 6421.0,489.4 4653.1,7720.6 3166.4,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -6421,8 +6666,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                51.1,
-                6833.4
+                3124.5,
+                6831.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6433,8 +6678,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0864543,
-                29.9472487
+                -90.0872464,
+                29.947698
               ]
             }
           },
@@ -6442,8 +6687,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3124.2,
-                6833.4
+                932.1,
+                6831.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6454,8 +6699,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.087599,
-                29.947895
+                -90.088397,
+                29.948348
               ]
             }
           }
@@ -6480,8 +6725,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6500,7 +6745,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6199.9,0.0 6537.0,2996.4 6537.0,7795.0 -0.0,7795.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6344.3,1460.3 6537.0,1425.4 6360.6,1643.4 6537.0,7749.0 -0.0,7795.0 0.0,0.0 6211.4,0.0 6344.3,1460.3\" /></svg>"
         }
       },
       "body": {
@@ -6514,8 +6759,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3508.1,
-                5015.6
+                3360.5,
+                5011.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6535,8 +6780,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6287.8,
-                776.3
+                6281.0,
+                771.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6556,7 +6801,7 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -6566,15 +6811,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "9"
+          "value": "10"
         },
         {
           "label": "intersections",
-          "value": "25"
+          "value": "57"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6583,7 +6828,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
@@ -6593,11 +6838,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4461.5,0.0 6537.0,590.3 5947.4,7417.3 3196.3,7795.0 1007.0,7795.0 -0.0,7488.9 -0.0,4616.3 235.7,4700.5 1787.0,0.0 4461.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1453.6,0.0 4866.2,0.0 6489.2,191.4 6457.5,325.7 6263.0,286.0 6067.9,6988.6 3401.8,7466.3 3401.3,7795.0 2316.8,7795.0 352.7,7337.5 1453.6,0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -6607,8 +6852,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1022.4,
-                3431.1
+                2880.4,
+                1743.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6619,8 +6864,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.085551,
-                29.953695
+                -90.0859187,
+                29.9548331
               ]
             }
           },
@@ -6628,8 +6873,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1955.3,
-                -712.4
+                6265.0,
+                288.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6640,8 +6885,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.087376,
-                29.954773
+                -90.0858303,
+                29.9565209
               ]
             }
           }
@@ -6659,15 +6904,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6686,7 +6931,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6336.9,85.5 6461.0,114.6 6461.0,7146.4 6430.0,7139.0 6272.7,7795.0 5659.9,7795.0 5622.2,6817.8 -0.0,7774.9 436.8,1087.1 6204.1,2398.2 6336.9,85.5\" /></svg>"
+          "value": "<svg><polygon points=\"6190.8,2370.6 6247.7,478.3 4028.9,0.0 6461.0,95.9 6461.0,7012.5 6187.6,7795.0 5688.3,7795.0 5626.9,6797.5 122.7,7775.7 410.0,1106.3 6190.8,2370.6\" /></svg>"
         }
       },
       "body": {
@@ -6700,8 +6945,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3235.3,
-                3900.7
+                3232.5,
+                3895.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6721,8 +6966,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                261.9,
-                4210.6
+                260.0,
+                4231.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6752,15 +6997,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "3"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6779,7 +7024,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5365.5,7188.6 5240.8,7188.7 3073.0,7190.6 527.9,7795.0 470.5,6556.1 -0.0,6524.8 -0.0,795.3 5696.0,975.0 5592.6,7188.4 5365.5,7188.6\" /></svg>"
+          "value": "<svg><polygon points=\"2886.8,0.0 6537.0,654.3 6537.0,5758.3 6233.8,7795.0 296.3,7795.0 416.2,6445.6 -0.0,6370.2 0.0,0.0 2886.8,0.0\" /></svg>"
         }
       },
       "body": {
@@ -6793,8 +7038,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4626.4,
-                2923.1
+                356.1,
+                4895.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6805,8 +7050,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0878336,
-                29.9574288
+                -90.0882572,
+                29.9552086
               ]
             }
           },
@@ -6814,8 +7059,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4278.1,
-                801.9
+                352.1,
+                7159.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6826,8 +7071,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0888245,
-                29.9578871
+                -90.087376,
+                29.954773
               ]
             }
           }
@@ -6852,8 +7097,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6872,7 +7117,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,804.0 4632.3,755.6 4848.5,765.1 4876.7,920.7 6325.4,903.6 6333.0,4765.8 5371.7,4772.5 5800.3,7094.0 -0.0,7191.4 -0.0,804.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,801.4 4608.7,690.7 4826.9,697.3 4860.6,870.2 5942.1,852.8 6045.0,4717.8 5456.7,5163.1 5872.4,7062.8 -0.0,7241.0 -0.0,801.4\" /></svg>"
         }
       },
       "body": {
@@ -6886,8 +7131,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2389.4,
-                4833.5
+                2400.0,
+                4831.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6907,8 +7152,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4740.5,
-                760.3
+                1608.0,
+                759.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6919,8 +7164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.086852,
-                29.960089
+                -90.087843,
+                29.958988
               ]
             }
           }
@@ -6945,8 +7190,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6965,7 +7210,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6347.5,309.9 6408.5,7795.0 283.8,7795.0 172.6,763.7 585.8,759.8 579.0,343.8 -0.0,353.3 -0.0,0.0 6343.7,-0.0 6504.0,-0.0 6504.0,377.5 6347.5,309.9\" /></svg>"
+          "value": "<svg><polygon points=\"6469.0,-0.0 6449.5,7795.0 304.6,7795.0 244.0,312.0 663.0,312.7 661.3,-0.0 6469.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -6979,8 +7224,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2348.0,
-                309.9
+                244.0,
+                2703.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6991,8 +7236,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.083932,
-                29.9633687
+                -90.085748,
+                29.9629622
               ]
             }
           },
@@ -7000,8 +7245,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6347.5,
-                309.9
+                244.0,
+                312.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7012,8 +7257,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0822737,
-                29.962235
+                -90.0849824,
+                29.9638223
               ]
             }
           }
@@ -7035,11 +7280,11 @@
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "21"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7058,7 +7303,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"62.7,7676.3 37.0,-0.0 6483.0,-0.0 6483.0,316.1 6483.0,317.4 6483.0,6150.6 62.7,7676.3\" /></svg>"
+          "value": "<svg><polygon points=\"5321.0,325.1 6135.1,312.0 6153.5,2528.1 6483.0,2521.5 6483.0,6215.5 148.9,7774.0 -0.0,0.0 5320.6,59.8 5321.0,325.1\" /></svg>"
         }
       },
       "body": {
@@ -7072,8 +7317,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                31.9,
-                316.2
+                40.0,
+                2644.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7084,8 +7329,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0824092,
-                29.96209
+                -90.0831828,
+                29.9612279
               ]
             }
           },
@@ -7093,8 +7338,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6141.3,
-                316.2
+                6135.1,
+                312.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7131,8 +7376,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7151,7 +7396,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6374.0,-0.0 6377.4,315.8 6025.9,313.8 6157.6,7600.9 6393.7,7602.8 6395.7,7795.0 53.0,7795.0 50.4,7559.0 -0.0,7795.0 -0.0,0.0 6374.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"610.1,7373.2 609.8,7560.8 35.8,7557.7 -0.0,0.0 6372.0,-0.0 6375.7,301.9 6122.7,300.8 6152.2,4987.7 6427.0,4988.4 6454.3,7593.9 6096.6,7591.4 6092.4,7410.9 610.1,7373.2\" /></svg>"
         }
       },
       "body": {
@@ -7165,8 +7410,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4350.7,
-                4999.7
+                4354.7,
+                4991.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7186,8 +7431,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2660.9,
-                297.1
+                2655.2,
+                288.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7217,15 +7462,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7244,7 +7489,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3596.0,7479.4 285.8,7437.3 288.2,7618.0 -0.0,7614.3 -0.0,319.7 255.4,322.4 253.5,-0.0 6490.0,-0.0 6490.0,422.4 6070.6,419.4 6092.8,7693.2 3598.8,7660.9 3596.0,7479.4\" /></svg>"
+          "value": "<svg><polygon points=\"274.9,5005.7 -0.0,5003.3 -0.0,317.4 253.0,320.1 251.2,-0.0 6490.0,-0.0 6490.0,421.0 6068.0,418.0 6089.4,7795.0 285.3,7795.0 274.9,5005.7\" /></svg>"
         }
       },
       "body": {
@@ -7258,8 +7503,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3567.6,
-                5044.4
+                3565.1,
+                5039.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7279,8 +7524,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3567.6,
-                373.8
+                3565.1,
+                372.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7317,8 +7562,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7337,7 +7582,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,433.4 5576.5,227.8 6529.0,4916.3 6529.0,7629.6 5447.0,7637.4 5446.2,7795.0 829.2,7795.0 -0.0,3230.9 -0.0,433.4\" /></svg>"
+          "value": "<svg><polygon points=\"6529.0,4852.4 6529.0,7627.6 5464.0,7638.4 5517.7,7795.0 1324.5,7677.6 848.0,326.9 5627.4,214.6 6529.0,4852.4\" /></svg>"
         }
       },
       "body": {
@@ -7351,8 +7596,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6235.1,
-                3341.6
+                6241.0,
+                3335.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7372,8 +7617,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6660.0,
-                5613.0
+                6673.0,
+                5607.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7407,11 +7652,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7430,7 +7675,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"224.5,136.4 6098.7,110.3 6079.6,3242.5 5908.0,3246.2 5998.4,7796.0 4623.2,7796.0 4598.2,7648.0 4393.1,7636.6 1084.3,7630.1 1102.7,4913.6 224.5,136.4\" /></svg>"
+          "value": "<svg><polygon points=\"5646.5,5581.6 5669.9,7796.0 4651.9,7796.0 4622.8,7632.8 4417.6,7623.2 1091.4,7648.0 1092.5,4875.2 183.7,174.7 5882.1,37.1 5707.9,91.0 5795.7,5580.4 5646.5,5581.6\" /></svg>"
         }
       },
       "body": {
@@ -7444,8 +7689,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3586.4,
-                1865.2
+                1235.8,
+                5620.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7456,8 +7701,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0896713,
-                29.96143
+                -90.088838,
+                29.959452
               ]
             }
           },
@@ -7465,8 +7710,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1564.9,
-                7629.9
+                4519.3,
+                7628.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7477,8 +7722,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.087843,
-                29.958988
+                -90.086852,
+                29.960089
               ]
             }
           }
@@ -7496,15 +7741,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7523,7 +7768,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.1,410.9 6500.0,481.3 6500.0,6517.6 3.3,7515.3 0.1,410.9\" /></svg>"
+          "value": "<svg><polygon points=\"6500.0,6471.8 -0.0,7513.7 -0.0,187.3 586.3,199.0 589.3,7.4 6188.7,126.7 6190.4,311.2 6500.0,317.8 6500.0,6471.8\" /></svg>"
         }
       },
       "body": {
@@ -7537,8 +7782,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6171.0,
-                3341.6
+                6168.0,
+                3367.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7558,8 +7803,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2593.6,
-                7098.6
+                2592.0,
+                7103.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7589,15 +7834,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "5"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7616,7 +7861,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,1134.8 6350.6,-0.0 6484.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6026.2,7795.0 -0.0,7795.0 -0.0,-0.0 179.5,-0.0 176.9,1036.8 6053.5,109.8 6026.2,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7630,8 +7875,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2513.7,
-                667.7
+                2508.0,
+                671.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7651,8 +7896,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                469.5,
-                1047.9
+                6132.0,
+                6095.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7663,8 +7908,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0942946,
-                29.961915
+                -90.093526,
+                29.9582782
               ]
             }
           }
@@ -7689,8 +7934,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T19:05:39Z",
-      "modified": "2026-06-10T19:05:39Z",
+      "created": "2026-07-17T18:21:52Z",
+      "modified": "2026-07-17T18:21:52Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7709,7 +7954,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5687.8,7684.7 5688.6,7795.0 -0.0,7795.0 -0.0,-0.0 5651.8,99.5 6457.5,7647.5 5687.8,7684.7\" /></svg>"
+          "value": "<svg><polygon points=\"6500.0,7795.0 -0.0,7795.0 -0.0,-0.0 6500.0,14.0 6500.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7723,8 +7968,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.9,
-                3233.0
+                3484.0,
+                7655.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7735,8 +7980,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0920489,
-                29.9575989
+                -90.090733,
+                29.95573
               ]
             }
           },
@@ -7744,8 +7989,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6103.9,
-                5581.1
+                5072.0,
+                140.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7756,8 +8001,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0909289,
-                29.9570938
+                -90.093526,
+                29.9582782
               ]
             }
           }

--- a/gallery/new_orleans_la_1951_vol_5.iiif.json
+++ b/gallery/new_orleans_la_1951_vol_5.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 83.0,397.2 3606.0,395.8 3738.3,5792.8 5700.0,5413.9 5700.0,8150.0 -0.0,8150.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3625.6,402.8 3759.0,7567.6 5700.0,7531.5 5700.0,8150.0 -0.0,8150.0 -0.0,-0.0 67.7,397.1 3625.6,402.8\" /></svg>"
         }
       },
       "body": {
@@ -58,8 +58,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                977.1,
-                2773.8
+                976.0,
+                2771.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -79,8 +79,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2819.1,
-                423.9
+                2812.0,
+                419.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -117,8 +117,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +137,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,983.9 668.2,1000.0 4609.6,48.9 4461.6,6831.2 5637.0,6856.8 5637.0,8149.0 1904.4,8149.0 1956.6,6018.4 -0.0,6346.9 -0.0,983.9\" /></svg>"
+          "value": "<svg><polygon points=\"644.5,994.6 4817.9,0.0 4821.8,2407.5 5637.0,2217.6 5637.0,8149.0 -0.0,8149.0 -0.0,996.2 644.5,994.6\" /></svg>"
         }
       },
       "body": {
@@ -151,8 +151,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2776.4,
-                2897.9
+                2776.5,
+                2884.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -172,8 +172,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4817.3,
-                2437.4
+                4816.9,
+                -88.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -184,8 +184,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1161816,
-                29.9164473
+                -90.1159036,
+                29.9175779
               ]
             }
           }
@@ -203,15 +203,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "4"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1332.8 5088.2,75.2 5238.7,2488.5 5681.0,2381.0 5681.0,8150.0 -0.0,8150.0 -0.0,1332.8\" /></svg>"
+          "value": "<svg><polygon points=\"251.7,3666.2 254.9,1308.2 -0.0,1282.4 5039.7,172.8 5146.2,2537.1 4159.5,2767.6 5377.3,8150.0 1037.3,8150.0 1051.0,3482.7 251.7,3666.2\" /></svg>"
         }
       },
       "body": {
@@ -244,8 +244,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                258.4,
-                3728.3
+                3296.6,
+                2967.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -256,8 +256,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1161816,
-                29.9164473
+                -90.1144781,
+                29.9164744
               ]
             }
           },
@@ -265,8 +265,117 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5240.1,
-                2487.4
+                256.0,
+                1219.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1159036,
+                29.9175779
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p428 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5637.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5637.0,1729.8 5637.0,8149.0 -0.0,8149.0 -0.0,303.4 5177.3,298.1 5095.3,1751.1 5637.0,1729.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3128.6,
+                296.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1123056,
+                29.9165059
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1024.2,
+                296.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -303,8 +412,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,7 +432,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3481.5,484.3 3421.8,5779.3 5681.0,5804.8 5681.0,8150.0 -0.0,8150.0 -0.0,465.1 3481.5,484.3\" /></svg>"
+          "value": "<svg><polygon points=\"971.3,471.2 2792.5,479.9 2741.2,1586.4 3454.8,1632.3 3434.3,3449.9 5681.0,3346.9 5681.0,8150.0 1369.8,8150.0 1429.7,1947.0 872.6,1963.6 971.3,471.2\" /></svg>"
         }
       },
       "body": {
@@ -337,8 +446,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2797.0,
-                482.9
+                2792.5,
+                479.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -358,8 +467,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4588.6,
-                482.9
+                4588.8,
+                479.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -396,8 +505,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,7 +525,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5637.0,8149.0 317.2,8149.0 0.0,-0.0 5637.0,-0.0 5637.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 2819.6,-0.0 3148.4,5756.7 5637.0,5561.7 5637.0,5875.2 3156.7,5903.1 3285.0,8149.0 312.7,8149.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -430,8 +539,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                308.8,
-                4914.1
+                300.1,
+                4904.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -451,8 +560,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                308.8,
-                7039.8
+                300.1,
+                7028.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -489,8 +598,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +618,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5681.0,8150.0 -0.0,8150.0 -0.0,5985.7 564.8,6030.0 1004.9,414.4 5681.0,319.8 5681.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"5681.0,1719.9 5681.0,8150.0 -0.0,8150.0 -0.0,1735.1 2914.0,1796.8 5681.0,1719.9\" /></svg>"
         }
       },
       "body": {
@@ -538,8 +647,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1061484243011,
-                29.91688132163911
+                -90.10877531170573,
+                29.916821755143875
               ]
             }
           },
@@ -559,8 +668,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10317384240481,
-                29.917116257246178
+                -90.10289708720465,
+                29.91728602346588
               ]
             }
           },
@@ -580,8 +689,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10278463605103,
-                29.91341885109922
+                -90.1021278419215,
+                29.909978300935084
               ]
             }
           },
@@ -601,8 +710,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10575921794731,
-                29.91318391549215
+                -90.10800606642258,
+                29.90951403261308
               ]
             }
           },
@@ -610,8 +719,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5094.1,
-                331.3
+                5100.9,
+                331.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -641,15 +750,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -668,22 +777,109 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5145.1,2565.0 5637.0,2439.8 5637.0,8149.0 -0.0,8149.0 -0.0,7715.6 1155.0,7719.8 1182.2,282.6 5151.3,286.4 5145.1,2565.0\" /></svg>"
+          "value": "<svg><polygon points=\"910.2,395.7 5148.9,284.0 5135.7,1578.7 5637.0,1442.3 5637.0,8149.0 3661.7,8138.6 3582.6,1735.2 816.4,1817.7 910.2,395.7\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0432/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                623.2,
-                286.4
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10658442003262,
+                29.91702214660604
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10074560275858,
+                29.91742033184686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10008102600018,
+                29.910108520706373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10591984327421,
+                29.909710335465554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5148.9,
+                284.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -694,8 +890,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.103466,
-                29.916941
+                -90.101228,
+                29.917131
               ]
             }
           },
@@ -703,8 +899,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5151.3,
-                286.4
+                5148.9,
+                284.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -734,15 +930,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
           "value": "1"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -790,8 +986,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10130511837345,
-                29.916634021793026
+                -90.10388982289986,
+                29.916673411606688
               ]
             }
           },
@@ -811,8 +1007,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09832297538917,
-                29.91678031373381
+                -90.09799665654332,
+                29.916962506626035
               ]
             }
           },
@@ -832,8 +1028,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0980806206709,
-                29.9130735091523
+                -90.09751765556592,
+                29.90963620859956
               ]
             }
           },
@@ -853,8 +1049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10106276365518,
-                29.912927217211518
+                -90.10341082192247,
+                29.909347113580218
               ]
             }
           },
@@ -862,8 +1058,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5026.7,
-                376.2
+                5024.9,
+                375.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -883,7 +1079,100 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p434",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8149 0,0 5637,0 5637,8149 0,8149\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0434/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2800.5,
+                412.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09753,
+                29.9167022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                632.1,
+                412.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0986553,
+                29.916593
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -898,10 +1187,26 @@
         {
           "label": "intersections",
           "value": "4"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5693.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -910,7 +1215,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/info.json",
@@ -920,11 +1225,11 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2337.0,1862.2 2432.4,418.4 3570.9,489.3 3922.9,2291.4 5693.0,2192.5 5693.0,8149.0 -0.0,8149.0 -0.0,2006.9 2337.0,1862.2\" /></svg>"
+          "value": "<svg><polygon points=\"0,8149 0,0 5693,0 5693,8149 0,8149\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0435__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -934,8 +1239,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2431.0,
-                418.4
+                2432.4,
+                416.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -955,8 +1260,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                303.2,
-                418.4
+                300.1,
+                416.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -986,15 +1291,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "1"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1013,22 +1318,109 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5637.0,972.8 5637.0,8149.0 655.4,8149.0 1825.1,2160.1 -0.0,1908.2 0.0,0.0 5637.0,972.8\" /></svg>"
+          "value": "<svg><polygon points=\"1411.7,223.0 3744.9,605.2 3588.1,618.6 3933.7,4638.3 5637.0,4491.8 5637.0,8149.0 -0.0,8149.0 -0.0,1046.3 1232.1,1259.7 1411.7,223.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0436/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3228.4,
-                525.1
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09652367734031,
+                29.917499141484832
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09086081178246,
+                29.918794124966613
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08869946616669,
+                29.911702653949508
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09436233172454,
+                29.910407670467727
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3232.6,
+                524.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1041,27 +1433,6 @@
               "coordinates": [
                 -90.0931377,
                 29.9177871
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5013.8,
-                862.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0922248,
-                29.9178626
               ]
             }
           }
@@ -1086,8 +1457,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1106,7 +1477,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4206.5,2537.6 4698.8,7073.9 5693.0,6965.9 5693.0,8149.0 -0.0,8149.0 -0.0,7288.2 1222.2,7360.1 1634.5,338.7 5693.0,1361.8 5693.0,2828.4 4206.5,2537.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 5693.0,1369.2 5693.0,8149.0 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -1120,8 +1491,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3177.7,
-                718.9
+                3176.6,
+                716.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1141,8 +1512,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5064.2,
-                1201.9
+                5064.9,
+                1208.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1162,99 +1533,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p438",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5655
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1137.9,3145.8 1237.0,744.2 431.6,685.9 464.9,-0.0 5655.0,-0.0 5655.0,8149.0 973.5,8149.0 1434.8,6664.4 -0.0,6508.6 1137.9,3145.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1190.5,
-                3094.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0879448,
-                29.9182181
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1985.1,
-                634.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0866588,
-                29.9183693
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0439/georef",
       "type": "Annotation",
       "@context": [
@@ -1265,15 +1543,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1292,7 +1570,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"899.7,395.9 4625.9,353.7 4669.4,7995.0 3416.1,7768.9 922.7,7144.0 899.7,395.9\" /></svg>"
+          "value": "<svg><polygon points=\"895.8,388.0 4610.0,330.4 4685.2,7946.7 4186.0,7835.9 4216.7,8149.0 3447.0,8149.0 3430.4,7667.2 946.9,7114.0 895.8,388.0\" /></svg>"
         }
       },
       "body": {
@@ -1306,8 +1584,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4654.1,
-                2605.9
+                4655.2,
+                4688.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1318,8 +1596,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.089966,
-                29.920442
+                -90.089624,
+                29.9195269
               ]
             }
           },
@@ -1327,8 +1605,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                898.3,
-                395.9
+                895.8,
+                388.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1358,15 +1636,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1385,7 +1663,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2405.4,8149.0 488.1,7541.2 1149.6,20.6 5655.0,150.2 5655.0,7391.7 5086.0,7384.1 4803.7,7384.3 4780.0,8149.0 2405.4,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"482.4,7546.6 1146.0,15.8 5655.0,146.3 5655.0,8149.0 -0.0,8149.0 -0.0,7388.7 482.4,7546.6\" /></svg>"
         }
       },
       "body": {
@@ -1399,7 +1677,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2611.3,
+                2607.5,
                 2336.3
               ],
               "creator": {
@@ -1420,8 +1698,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5031.7,
-                146.0
+                5031.1,
+                144.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1458,8 +1736,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1478,7 +1756,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5456.2,7258.8 654.8,7294.1 1313.0,568.3 5454.0,527.3 5456.2,7258.8\" /></svg>"
+          "value": "<svg><polygon points=\"714.7,572.4 5452.4,525.2 5455.0,7256.9 153.5,7296.2 714.7,572.4\" /></svg>"
         }
       },
       "body": {
@@ -1492,8 +1770,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3604.7,
-                2824.9
+                3603.4,
+                2824.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1513,8 +1791,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5457.6,
-                7258.8
+                5455.0,
+                7256.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1551,8 +1829,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1571,7 +1849,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1438.8,617.5 4983.0,710.8 4988.7,0.0 5655.0,0.0 5655.0,8149.0 5447.6,8149.0 5446.4,7521.6 845.3,7398.1 1438.8,617.5\" /></svg>"
+          "value": "<svg><polygon points=\"1400.2,662.8 4927.2,746.1 4931.1,0.0 5655.0,0.0 5655.0,8149.0 5408.0,8149.0 5405.0,7523.5 827.9,7412.9 1400.2,662.8\" /></svg>"
         }
       },
       "body": {
@@ -1585,8 +1863,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2369.8,
-                5256.7
+                2367.6,
+                732.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1597,8 +1875,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0900544,
-                29.9225644
+                -90.0909695,
+                29.9244594
               ]
             }
           },
@@ -1606,8 +1884,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4807.0,
-                7520.0
+                2367.6,
+                7512.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1618,8 +1896,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0884285,
-                29.9220625
+                -90.089584,
+                29.92164
               ]
             }
           }
@@ -1644,8 +1922,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1664,7 +1942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"705.1,7691.3 1265.5,6.0 5021.0,186.9 5055.9,7747.6 705.1,7691.3\" /></svg>"
+          "value": "<svg><polygon points=\"5686.0,153.3 5686.0,7758.6 772.2,7733.5 1310.7,30.9 5686.0,153.3\" /></svg>"
         }
       },
       "body": {
@@ -1678,8 +1956,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                926.6,
-                4369.3
+                2667.1,
+                3040.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1690,8 +1968,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0950365,
-                29.9249387
+                -90.094402,
+                29.9257763
               ]
             }
           },
@@ -1699,8 +1977,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3234.7,
-                7781.1
+                5130.2,
+                7777.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1711,8 +1989,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0933035,
-                29.9237647
+                -90.0923838,
+                29.9240378
               ]
             }
           }
@@ -1737,8 +2015,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1757,7 +2035,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5643.0,0.0 5643.0,7697.9 315.8,7942.2 303.3,0.0 5643.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5587.0,7689.5 2129.3,7885.0 825.0,7891.6 925.4,456.2 5474.8,135.0 5465.9,8.9 5643.0,0.0 5587.0,7689.5\" /></svg>"
         }
       },
       "body": {
@@ -1771,8 +2049,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                317.2,
-                7942.2
+                2123.6,
+                6102.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1783,8 +2061,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0923838,
-                29.9240378
+                -90.091751,
+                29.9250945
               ]
             }
           },
@@ -1792,8 +2070,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                314.4,
-                314.4
+                311.9,
+                303.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1830,8 +2108,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1850,7 +2128,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"702.0,7250.4 708.6,879.4 5027.1,870.9 5048.4,7249.6 702.0,7250.4\" /></svg>"
+          "value": "<svg><polygon points=\"694.3,7258.2 697.6,0.0 5022.7,0.0 5047.2,7254.9 694.3,7258.2\" /></svg>"
         }
       },
       "body": {
@@ -1864,8 +2142,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5037.4,
-                3948.1
+                695.8,
+                3948.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0994756,
+                29.9245022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5034.2,
+                3948.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1878,27 +2177,6 @@
               "coordinates": [
                 -90.0972027,
                 29.9246772
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                702.0,
-                7250.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0993223,
-                29.9230009
               ]
             }
           }
@@ -1916,15 +2194,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1943,7 +2221,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"564.3,7286.8 564.3,861.6 2719.5,887.4 4322.2,683.7 5259.4,7130.7 3548.8,7311.4 564.3,7286.8\" /></svg>"
+          "value": "<svg><polygon points=\"621.2,7295.3 557.9,873.8 2712.3,878.4 4312.1,659.0 5312.2,7093.0 3604.3,7290.4 621.2,7295.3\" /></svg>"
         }
       },
       "body": {
@@ -1957,8 +2235,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                564.3,
-                3964.1
+                2691.5,
+                5458.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1969,8 +2247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0972027,
-                29.9246772
+                -90.096042,
+                29.924085
               ]
             }
           },
@@ -1978,8 +2256,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                564.3,
-                5460.5
+                555.9,
+                871.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1990,8 +2268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0971303,
-                29.9240017
+                -90.0973526,
+                29.9260758
               ]
             }
           }
@@ -2016,8 +2294,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2036,7 +2314,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4844.2,671.4 4920.7,7324.7 -0.0,7358.5 -0.0,709.3 4844.2,671.4\" /></svg>"
+          "value": "<svg><polygon points=\"686.7,7347.7 643.2,700.9 4844.1,669.5 4918.6,7321.1 686.7,7347.7\" /></svg>"
         }
       },
       "body": {
@@ -2050,29 +2328,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2797.0,
-                2947.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0969436,
-                29.9221421
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2799.8,
-                7333.0
+                2796.5,
+                7330.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2085,6 +2342,27 @@
               "coordinates": [
                 -90.096755,
                 29.9201345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2796.5,
+                683.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.097042,
+                29.923178
               ]
             }
           }
@@ -2102,15 +2380,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2129,7 +2407,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"888.2,631.3 5643.0,684.4 5643.0,7407.9 1771.3,7502.9 39.6,7265.3 888.2,631.3\" /></svg>"
+          "value": "<svg><polygon points=\"30.4,7274.1 870.8,626.8 5042.9,737.7 5148.4,7461.6 1765.7,7509.5 30.4,7274.1\" /></svg>"
         }
       },
       "body": {
@@ -2143,7 +2421,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3453.2,
+                3447.4,
                 5238.7
               ],
               "creator": {
@@ -2164,8 +2442,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3453.2,
-                3051.7
+                1763.7,
+                755.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2176,8 +2454,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0943615,
-                29.9224374
+                -90.0954869,
+                29.9232919
               ]
             }
           }
@@ -2195,15 +2473,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2222,7 +2500,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2311.7,1137.6 4006.9,907.1 4841.9,6867.1 554.6,6911.6 554.5,1135.6 2311.7,1137.6\" /></svg>"
+          "value": "<svg><polygon points=\"544.0,1164.1 2287.6,1162.5 3969.0,930.4 4809.7,6842.9 555.9,6895.8 544.0,1164.1\" /></svg>"
         }
       },
       "body": {
@@ -2236,8 +2514,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                544.8,
-                5172.5
+                544.0,
+                5168.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2257,8 +2535,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4841.1,
-                6868.5
+                544.0,
+                1164.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2269,8 +2547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0931377,
-                29.9177871
+                -90.095634,
+                29.920218
               ]
             }
           }
@@ -2295,8 +2573,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2315,7 +2593,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"971.9,1042.8 4210.5,886.3 4754.6,7552.2 902.4,7019.0 971.9,1042.8\" /></svg>"
+          "value": "<svg><polygon points=\"897.6,7015.0 967.1,1038.4 4207.9,881.9 4752.4,7548.2 897.6,7015.0\" /></svg>"
         }
       },
       "body": {
@@ -2329,8 +2607,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2644.1,
-                5081.5
+                2640.5,
+                5078.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2350,8 +2628,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2644.1,
-                1027.5
+                2640.5,
+                1023.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2388,8 +2666,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2408,7 +2686,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"723.3,6057.5 724.1,1211.8 471.6,222.3 5692.0,249.4 5692.0,8149.0 -0.0,8149.0 -0.0,6058.8 723.3,6057.5\" /></svg>"
+          "value": "<svg><polygon points=\"5024.1,242.5 4972.9,7646.2 5692.0,7647.3 5692.0,8149.0 -0.0,8149.0 -0.0,6049.3 722.5,6047.9 723.4,1178.5 478.8,219.9 5024.1,242.5\" /></svg>"
         }
       },
       "body": {
@@ -2422,8 +2700,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2853.0,
-                2465.5
+                2848.0,
+                2460.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2443,8 +2721,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2850.2,
-                235.9
+                2848.0,
+                232.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2481,8 +2759,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2501,7 +2779,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2521.7,7706.0 2524.0,8150.0 1396.1,8150.0 1308.1,258.1 4966.7,241.9 4886.0,7547.4 2521.7,7706.0\" /></svg>"
+          "value": "<svg><polygon points=\"4969.3,244.9 4958.9,6058.5 5597.0,6053.0 5597.0,8150.0 1397.8,8150.0 1394.1,7681.9 671.4,7686.6 663.9,250.2 4969.3,244.9\" /></svg>"
         }
       },
       "body": {
@@ -2515,8 +2793,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4962.6,
-                4323.5
+                2820.5,
+                4314.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2527,8 +2805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0954591,
-                29.91839
+                -90.0965662,
+                29.918303
               ]
             }
           },
@@ -2536,8 +2814,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                640.0,
-                261.1
+                4960.9,
+                6058.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2548,8 +2826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0978691,
-                29.9200476
+                -90.0953774,
+                29.917602
               ]
             }
           }
@@ -2567,15 +2845,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2594,7 +2872,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4982.3,1138.0 4989.7,6379.6 5137.6,6941.8 765.1,6983.9 739.8,1150.8 4982.3,1138.0\" /></svg>"
+          "value": "<svg><polygon points=\"785.5,1132.2 5710.0,1234.9 5038.2,1408.3 5024.8,5039.8 5020.1,6373.9 5171.2,6959.8 782.4,6980.7 785.5,1132.2\" /></svg>"
         }
       },
       "body": {
@@ -2608,8 +2886,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2902.7,
-                5172.5
+                5038.2,
+                3368.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2620,8 +2898,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1035497,
-                29.9177624
+                -90.1025314,
+                29.9186713
               ]
             }
           },
@@ -2629,8 +2907,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2902.7,
-                1145.7
+                5038.2,
+                1140.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2641,8 +2919,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1037347,
-                29.9195986
+                -90.1026392,
+                29.9196843
               ]
             }
           }
@@ -2667,8 +2945,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2687,7 +2965,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1788.4,8149.0 2371.1,5890.4 -0.0,5271.4 -0.0,4701.6 1231.3,0.0 2262.9,0.0 5597.0,881.7 5597.0,1870.0 4436.7,6413.6 3758.3,6241.8 3271.4,8150.0 1788.4,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"1907.6,5757.0 -0.0,5269.9 -0.0,4679.1 1226.2,0.0 2248.9,0.0 5597.0,884.9 5597.0,1842.6 4430.0,6409.7 3751.6,6238.0 3263.4,8150.0 1229.5,8150.0 1907.6,5757.0\" /></svg>"
         }
       },
       "body": {
@@ -2701,8 +2979,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2801.3,
-                4216.8
+                2796.5,
+                4215.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2722,8 +3000,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2801.3,
-                2383.5
+                2796.5,
+                2383.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2760,8 +3038,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2780,7 +3058,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1204.7,7325.7 1211.5,678.5 5225.9,680.2 5225.3,7341.5 1204.7,7325.7\" /></svg>"
+          "value": "<svg><polygon points=\"5024.2,7326.7 242.1,7312.7 260.2,677.6 5018.0,674.8 5024.2,7326.7\" /></svg>"
         }
       },
       "body": {
@@ -2794,8 +3072,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                460.4,
-                2937.2
+                2859.0,
+                2936.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2806,8 +3084,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1028344,
-                29.9216881
+                -90.1014626,
+                29.9217926
               ]
             }
           },
@@ -2815,8 +3093,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                460.4,
-                679.6
+                2859.0,
+                676.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2827,8 +3105,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1029417,
-                29.9227198
+                -90.1015689,
+                29.9228264
               ]
             }
           }
@@ -2853,8 +3131,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2873,7 +3151,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"685.5,659.6 4343.2,655.2 4295.9,7380.8 695.8,7386.1 685.5,659.6\" /></svg>"
+          "value": "<svg><polygon points=\"697.7,7380.2 687.3,658.6 4990.7,653.4 4989.5,7373.8 697.7,7380.2\" /></svg>"
         }
       },
       "body": {
@@ -2887,8 +3165,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2802.4,
-                5116.3
+                2803.5,
+                5112.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2908,8 +3186,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2802.4,
-                657.1
+                2803.5,
+                656.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2946,8 +3224,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2966,7 +3244,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"618.0,7288.0 601.8,913.1 2703.0,904.1 2706.7,1953.9 4900.8,1948.4 4901.2,2423.7 5334.1,2422.6 5346.5,7273.2 618.0,7288.0\" /></svg>"
+          "value": "<svg><polygon points=\"626.4,0.0 4925.5,0.0 4913.0,1940.1 4345.4,1940.6 4311.7,7288.3 592.1,7273.0 626.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2980,8 +3258,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                612.0,
-                5453.3
+                607.8,
+                3956.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2992,8 +3270,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1041314,
-                29.9234657
+                -90.1042006,
+                29.9241385
               ]
             }
           },
@@ -3001,8 +3279,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2725.9,
-                7281.3
+                2723.0,
+                904.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3013,8 +3291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1029417,
-                29.9227198
+                -90.1032427,
+                29.9256126
               ]
             }
           }
@@ -3039,8 +3317,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3059,7 +3337,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"806.7,7279.8 803.6,2430.6 370.6,2430.9 372.0,908.6 5095.2,894.4 5095.3,7274.5 806.7,7279.8\" /></svg>"
+          "value": "<svg><polygon points=\"567.8,900.9 5293.1,882.1 5299.3,7267.0 -0.0,7278.6 -0.0,1928.6 567.9,1924.5 567.8,900.9\" /></svg>"
         }
       },
       "body": {
@@ -3073,8 +3351,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5093.8,
-                5453.3
+                567.9,
+                5448.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3085,8 +3363,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0994067,
-                29.9238274
+                -90.1018835,
+                29.9236378
               ]
             }
           },
@@ -3094,8 +3372,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5093.8,
-                893.0
+                567.9,
+                2424.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3106,8 +3384,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0996179,
-                29.9258963
+                -90.102022,
+                29.9250094
               ]
             }
           }
@@ -3129,11 +3407,11 @@
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "20"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3152,7 +3430,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5339.1,1834.3 5343.9,7171.9 2343.8,7129.5 236.8,6872.0 869.8,1940.1 5339.1,1834.3\" /></svg>"
+          "value": "<svg><polygon points=\"1045.2,544.2 3166.4,850.2 5332.5,818.4 5338.2,7168.3 2339.3,7126.0 233.2,6868.7 1045.2,544.2\" /></svg>"
         }
       },
       "body": {
@@ -3166,8 +3444,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3237.9,
-                3860.2
+                3233.1,
+                3859.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3187,8 +3465,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5347.0,
-                3860.2
+                5337.9,
+                3859.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3225,8 +3503,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3245,7 +3523,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"630.4,7250.4 629.4,848.3 4983.7,843.4 4980.1,7250.4 630.4,7250.4\" /></svg>"
+          "value": "<svg><polygon points=\"614.1,7243.7 631.6,836.3 4988.2,844.0 4966.1,7256.3 614.1,7243.7\" /></svg>"
         }
       },
       "body": {
@@ -3259,8 +3537,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                631.8,
-                7250.4
+                627.9,
+                3904.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3271,8 +3549,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1063124,
-                29.922458
+                -90.1064661,
+                29.9239641
               ]
             }
           },
@@ -3280,8 +3558,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4981.5,
-                7250.4
+                2807.5,
+                840.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3292,8 +3570,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1040459,
-                29.922634
+                -90.1054789,
+                29.9254367
               ]
             }
           }
@@ -3318,8 +3596,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3338,7 +3616,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"701.8,7385.2 711.4,688.1 4993.5,689.0 4980.8,7383.4 701.8,7385.2\" /></svg>"
+          "value": "<svg><polygon points=\"696.0,7387.0 705.5,681.4 4994.4,682.4 4981.6,7385.2 696.0,7387.0\" /></svg>"
         }
       },
       "body": {
@@ -3352,8 +3630,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2819.5,
-                5126.4
+                2817.0,
+                5126.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3373,8 +3651,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                702.1,
-                5126.4
+                696.2,
+                5126.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3411,8 +3689,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3431,7 +3709,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5647.0,686.4 5647.0,7454.0 4872.3,7656.4 4871.5,7387.7 601.2,7390.2 608.3,689.4 5647.0,686.4\" /></svg>"
+          "value": "<svg><polygon points=\"604.1,7378.0 609.4,691.7 4880.2,688.0 4863.9,7371.6 604.1,7378.0\" /></svg>"
         }
       },
       "body": {
@@ -3445,8 +3723,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2780.0,
-                5150.0
+                2775.5,
+                5140.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3466,8 +3744,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2780.0,
-                2959.7
+                4883.1,
+                2960.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3478,8 +3756,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10394,
-                29.9216042
+                -90.1028344,
+                29.9216881
               ]
             }
           }
@@ -3504,8 +3782,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3524,7 +3802,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5094.8,6966.8 445.6,6841.2 1202.9,878.9 3294.7,1155.2 5052.2,1132.1 5094.8,6966.8\" /></svg>"
+          "value": "<svg><polygon points=\"438.5,6834.8 1203.8,867.5 4345.0,1134.0 4403.0,6946.5 438.5,6834.8\" /></svg>"
         }
       },
       "body": {
@@ -3538,8 +3816,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3023.2,
-                3369.7
+                3024.5,
+                3360.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3559,8 +3837,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2787.4,
-                5175.3
+                2784.5,
+                5172.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3597,8 +3875,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3617,7 +3895,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"691.0,7006.7 717.7,1128.0 4997.8,1140.6 4988.3,7008.1 691.0,7006.7\" /></svg>"
+          "value": "<svg><polygon points=\"4986.6,6995.9 -0.0,6971.1 -0.0,1126.6 4992.0,1134.7 4986.6,6995.9\" /></svg>"
         }
       },
       "body": {
@@ -3631,8 +3909,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2813.7,
-                5189.3
+                2812.0,
+                5180.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3652,8 +3930,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4981.6,
-                3375.3
+                4976.0,
+                3368.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3690,8 +3968,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3710,7 +3988,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4059.0,8149.0 1037.3,8149.0 1189.4,7310.7 729.8,7337.8 1422.3,823.9 4952.8,860.7 4970.8,7084.5 3988.7,7142.7 4059.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"4971.6,7080.2 729.9,7342.0 1409.5,827.5 4941.2,857.1 4971.6,7080.2\" /></svg>"
         }
       },
       "body": {
@@ -3724,8 +4002,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2880.0,
-                4908.5
+                2872.5,
+                4908.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3745,8 +4023,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4960.1,
-                3077.6
+                4952.9,
+                3072.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3783,8 +4061,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3803,7 +4081,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"944.7,7151.3 961.7,884.6 4593.5,859.3 4563.1,6927.6 944.7,7151.3\" /></svg>"
+          "value": "<svg><polygon points=\"3527.4,6988.0 3497.0,8149.0 2781.2,8149.0 2761.4,7039.7 941.5,7148.0 958.5,887.4 4586.2,862.1 4555.8,6924.4 3527.4,6988.0\" /></svg>"
         }
       },
       "body": {
@@ -3817,8 +4095,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2777.2,
-                4961.8
+                2772.0,
+                4960.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3838,8 +4116,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                963.2,
-                4961.8
+                960.0,
+                4960.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3876,8 +4154,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3896,7 +4174,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1044.6,684.0 4649.1,656.0 4643.4,7411.3 1031.7,7437.8 1044.6,684.0\" /></svg>"
+          "value": "<svg><polygon points=\"1031.4,7435.4 1046.3,679.9 4653.2,653.1 4645.3,7410.0 1031.4,7435.4\" /></svg>"
         }
       },
       "body": {
@@ -3910,8 +4188,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2857.6,
-                5172.5
+                2860.5,
+                5168.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3931,8 +4209,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2857.6,
-                668.3
+                1036.2,
+                5168.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3943,8 +4221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1099501,
-                29.9224148
+                -90.1110066,
+                29.9203953
               ]
             }
           }
@@ -3969,8 +4247,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3989,7 +4267,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"805.7,7401.3 803.2,671.6 3797.9,581.6 4660.7,7180.2 2917.6,7418.9 805.7,7401.3\" /></svg>"
+          "value": "<svg><polygon points=\"799.4,7399.3 797.0,666.8 3792.5,576.7 4655.6,7178.1 2912.0,7416.9 799.4,7399.3\" /></svg>"
         }
       },
       "body": {
@@ -4003,8 +4281,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2917.6,
-                651.5
+                2912.0,
+                648.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4024,8 +4302,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2917.6,
-                7418.9
+                2912.0,
+                7416.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4062,8 +4340,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4082,7 +4360,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"791.5,7157.6 867.4,1561.4 4756.6,1571.3 5236.5,7128.3 693.6,7303.3 791.5,7157.6\" /></svg>"
+          "value": "<svg><polygon points=\"899.6,705.9 4695.3,710.1 5208.5,6584.0 886.4,6722.1 899.6,705.9\" /></svg>"
         }
       },
       "body": {
@@ -4096,8 +4374,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                769.1,
-                4880.4
+                5032.9,
+                4872.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4108,8 +4386,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.114746,
-                29.921929
+                -90.1125881,
+                29.9214831
               ]
             }
           },
@@ -4117,8 +4395,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                766.3,
-                716.1
+                4696.8,
+                712.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4129,8 +4407,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1142557,
-                29.9237625
+                -90.1122649,
+                29.9233598
               ]
             }
           }
@@ -4152,11 +4430,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4175,7 +4453,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4524.5,7385.9 978.1,7329.9 1680.6,574.4 4538.4,612.5 4524.5,7385.9\" /></svg>"
+          "value": "<svg><polygon points=\"4537.1,7387.8 979.1,7339.2 1726.6,0.0 4536.7,0.0 4537.1,7387.8\" /></svg>"
         }
       },
       "body": {
@@ -4189,8 +4467,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2439.3,
-                5113.5
+                4536.8,
+                5108.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4201,8 +4479,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1121041,
-                29.9204336
+                -90.1110066,
+                29.9203953
               ]
             }
           },
@@ -4210,8 +4488,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2439.3,
-                629.0
+                2436.4,
+                7372.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4222,8 +4500,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1120089,
-                29.922473
+                -90.1121565,
+                29.9194091
               ]
             }
           }
@@ -4241,15 +4519,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4268,7 +4546,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"840.0,952.0 4755.1,921.5 4807.3,6156.7 834.1,7127.7 840.0,952.0\" /></svg>"
+          "value": "<svg><polygon points=\"839.3,930.6 4742.1,884.5 4814.7,6052.6 858.1,7084.6 839.3,930.6\" /></svg>"
         }
       },
       "body": {
@@ -4282,8 +4560,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                844.9,
-                5048.9
+                2772.5,
+                6588.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4294,8 +4572,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1178037,
-                29.9184489
+                -90.1170136,
+                29.917551
               ]
             }
           },
@@ -4303,8 +4581,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4805.7,
-                6107.5
+                2772.5,
+                924.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4315,8 +4593,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1159036,
-                29.9175779
+                -90.1163355,
+                29.9200642
               ]
             }
           }
@@ -4341,8 +4619,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4361,7 +4639,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5287.4,6841.2 354.0,7879.1 476.8,539.0 4954.7,492.6 5287.4,6841.2\" /></svg>"
+          "value": "<svg><polygon points=\"334.8,7881.4 478.8,529.3 650.6,0.0 4939.0,0.0 5281.6,6855.9 334.8,7881.4\" /></svg>"
         }
       },
       "body": {
@@ -4375,8 +4653,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5181.8,
-                5026.4
+                5180.9,
+                5036.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4396,8 +4674,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                437.9,
-                2751.9
+                432.1,
+                2744.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4434,8 +4712,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4454,7 +4732,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7217.6 -0.0,939.3 948.6,950.7 2788.7,943.5 4545.3,974.2 4505.0,7105.4 4238.1,7250.3 -0.0,7217.6\" /></svg>"
+          "value": "<svg><polygon points=\"4247.6,7243.6 -0.0,7221.1 -0.0,0.0 493.9,0.0 491.6,947.4 4539.7,966.6 4514.1,7098.1 4247.6,7243.6\" /></svg>"
         }
       },
       "body": {
@@ -4468,8 +4746,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                940.3,
-                3004.6
+                939.7,
+                3004.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4489,8 +4767,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2787.3,
-                943.5
+                2783.0,
+                940.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4524,11 +4802,11 @@
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4547,7 +4825,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4569.0,1974.9 4586.7,7101.6 555.5,7108.5 559.7,8149.0 -0.0,8149.0 35.5,1961.5 4569.0,1974.9\" /></svg>"
+          "value": "<svg><polygon points=\"528.6,8149.0 -0.0,8149.0 22.2,1947.4 4591.5,1972.1 4596.6,7150.5 526.4,7149.2 528.6,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -4561,8 +4839,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2840.7,
-                949.1
+                2840.5,
+                5056.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4573,8 +4851,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1165182,
-                29.9268303
+                -90.1170088,
+                29.9250135
               ]
             }
           },
@@ -4582,8 +4860,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4586.7,
-                7101.6
+                4584.8,
+                1976.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4594,8 +4872,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1163615,
-                29.92391
+                -90.1157566,
+                29.9261943
               ]
             }
           }
@@ -4617,11 +4895,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "20"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4640,7 +4918,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"694.3,7959.2 663.5,0.0 4779.2,0.0 4768.8,4045.8 5283.0,4049.3 5328.8,8111.4 694.3,7959.2\" /></svg>"
+          "value": "<svg><polygon points=\"4767.4,4064.2 5282.1,4068.5 5321.6,8134.6 683.3,7974.8 665.0,0.0 4784.2,0.0 4767.4,4064.2\" /></svg>"
         }
       },
       "body": {
@@ -4654,8 +4932,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                662.4,
-                5989.6
+                655.8,
+                4068.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4666,8 +4944,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1163355,
-                29.9200642
+                -90.1173261,
+                29.9202617
               ]
             }
           },
@@ -4675,8 +4953,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                659.6,
-                443.7
+                5282.1,
+                4068.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4687,8 +4965,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1191767,
-                29.9206311
+                -90.116784,
+                29.922315
               ]
             }
           }
@@ -4710,11 +4988,11 @@
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "30"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4733,7 +5011,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4826.3,0.0 4816.9,4058.3 5398.9,4056.7 5401.4,8145.5 1260.5,8133.3 1215.4,4060.6 699.7,4057.0 711.0,0.8 4826.3,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1256.8,8124.7 1214.4,4054.8 698.9,4050.9 712.9,0.0 4826.2,0.0 4814.2,4054.9 5396.0,4053.7 5395.8,8139.7 1256.8,8124.7\" /></svg>"
         }
       },
       "body": {
@@ -4747,8 +5025,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2745.3,
-                4065.2
+                2743.5,
+                4059.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4768,8 +5046,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5400.7,
-                5985.5
+                5395.1,
+                5982.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4803,11 +5081,11 @@
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "26"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4826,7 +5104,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"931.2,7248.3 985.3,980.9 4792.0,1020.7 4808.4,4291.2 4985.8,4289.8 4956.3,7274.3 4757.1,7273.0 4757.0,7273.9 931.2,7248.3\" /></svg>"
+          "value": "<svg><polygon points=\"4956.6,7249.1 939.9,7241.2 965.9,988.6 4763.4,1011.3 4794.3,4273.8 4971.3,4271.7 4975.4,5315.5 4956.6,7249.1\" /></svg>"
         }
       },
       "body": {
@@ -4840,8 +5118,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                937.5,
-                5779.0
+                939.7,
+                3760.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.115882,
+                29.9257368
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                939.7,
+                5776.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4854,27 +5153,6 @@
               "coordinates": [
                 -90.1161206,
                 29.924828
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2885.5,
-                2763.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1147593,
-                29.9259915
               ]
             }
           }
@@ -4899,8 +5177,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4919,7 +5197,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"773.3,4282.6 692.1,0.0 4136.0,0.0 4828.1,8150.0 957.7,8150.0 953.4,4279.3 773.3,4282.6\" /></svg>"
+          "value": "<svg><polygon points=\"1017.6,4289.6 839.5,4292.7 788.1,906.1 2275.6,1003.8 2273.8,0.0 4164.2,0.0 4771.0,7286.8 1018.6,7284.0 1017.6,4289.6\" /></svg>"
         }
       },
       "body": {
@@ -4933,8 +5211,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5055.4,
-                5777.7
+                2551.6,
+                4271.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1130497,
+                29.9249415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5071.1,
+                5774.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4947,27 +5246,6 @@
               "coordinates": [
                 -90.111928,
                 29.9240055
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                822.5,
-                965.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1135133,
-                29.9265722
               ]
             }
           }
@@ -4989,11 +5267,11 @@
         },
         {
           "label": "intersections",
-          "value": "19"
+          "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5012,7 +5290,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4993.2,1161.7 4901.4,7191.9 429.7,7153.9 501.7,667.7 4993.2,1161.7\" /></svg>"
+          "value": "<svg><polygon points=\"1023.9,3556.6 1030.1,747.7 5390.7,1184.3 5322.6,7176.2 456.3,7180.5 429.0,3555.3 1023.9,3556.6\" /></svg>"
         }
       },
       "body": {
@@ -5026,8 +5304,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3789.9,
-                3566.2
+                3784.0,
+                3560.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5047,8 +5325,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5317.1,
-                5380.2
+                2284.0,
+                5380.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5059,8 +5337,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1098567,
-                29.9246322
+                -90.1099109,
+                29.9232501
               ]
             }
           }
@@ -5085,8 +5363,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5105,7 +5383,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,7239.8 0.0,1154.8 3754.2,1557.9 3766.9,2473.3 2914.9,2461.1 2846.4,7240.4 0.0,7239.8\" /></svg>"
+          "value": "<svg><polygon points=\"387.1,7242.1 423.0,1182.4 3760.1,1547.6 3787.6,3586.3 5687.0,3587.9 5687.0,5703.7 4538.4,8150.0 4136.9,8150.0 4536.2,7249.2 387.1,7242.1\" /></svg>"
         }
       },
       "body": {
@@ -5119,8 +5397,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3772.6,
-                3590.7
+                1939.7,
+                5406.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5131,8 +5409,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1107188,
-                29.926191
+                -90.1098198,
+                29.9253299
               ]
             }
           },
@@ -5140,8 +5418,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                390.2,
-                5407.1
+                383.9,
+                5406.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5171,15 +5449,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "10"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "22"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5198,7 +5476,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 906.6,0.0 4552.1,1038.4 4584.2,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 925.5,0.0 4550.7,1031.3 4582.8,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5212,8 +5490,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4575.9,
-                3521.3
+                4576.0,
+                3516.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5233,8 +5511,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4575.9,
-                6357.5
+                4576.0,
+                6356.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5271,8 +5549,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5291,7 +5569,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2864.8,1098.0 3781.5,1341.7 4870.7,1332.9 4874.1,1632.1 5687.0,1848.2 5687.0,2232.6 5119.5,2063.8 5133.0,5203.1 4882.1,5206.3 4924.2,6448.6 912.3,6469.7 876.9,975.8 2854.4,1349.1 2864.8,1098.0\" /></svg>"
+          "value": "<svg><polygon points=\"2802.9,1311.4 3697.3,1561.8 4951.5,1557.3 4951.3,1901.1 5687.0,2088.8 5687.0,2466.0 4958.6,2245.9 4958.3,5252.6 4717.9,5254.6 4752.9,6444.6 909.7,6447.8 899.1,1186.0 2791.5,1565.2 2802.9,1311.4\" /></svg>"
         }
       },
       "body": {
@@ -5305,8 +5583,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2851.9,
-                1507.6
+                907.8,
+                3091.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5317,8 +5595,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1140043,
-                29.9288979
+                -90.1151368,
+                29.9284771
               ]
             }
           },
@@ -5326,8 +5604,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                912.3,
-                6468.3
+                907.8,
+                7178.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5338,8 +5616,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1155403,
-                29.9269835
+                -90.1156293,
+                29.9266587
               ]
             }
           }
@@ -5357,15 +5635,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "16"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5384,7 +5662,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"393.2,5529.0 1021.5,2576.4 1520.3,2851.0 1598.8,2489.8 875.4,2138.7 1274.0,200.1 4160.6,800.5 5705.0,840.9 5705.0,7408.2 3366.4,7372.4 3478.0,6424.0 126.3,5712.0 156.8,5480.8 393.2,5529.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6754.9 1258.3,252.1 5705.0,634.8 5705.0,7345.5 3514.6,7419.0 -0.0,6754.9\" /></svg>"
         }
       },
       "body": {
@@ -5398,8 +5676,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3473.0,
-                6458.5
+                792.1,
+                2424.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5410,8 +5688,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1117082,
-                29.9266411
+                -90.1129911,
+                29.9285324
               ]
             }
           },
@@ -5419,8 +5697,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3366.3,
-                7371.2
+                88.0,
+                6880.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5431,8 +5709,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1117748,
-                29.9262256
+                -90.1135133,
+                29.9265722
               ]
             }
           }
@@ -5457,8 +5735,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5477,7 +5755,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5574.2,6481.1 5579.8,6875.0 4681.5,6493.1 4703.0,8150.0 -0.0,8150.0 -0.0,7311.4 1425.6,7280.2 1166.6,752.8 4563.4,678.7 4672.9,6114.2 5574.2,6481.1\" /></svg>"
+          "value": "<svg><polygon points=\"4670.4,6114.9 3146.7,5385.8 1250.1,5411.7 1302.3,748.6 4566.7,680.9 4670.4,6114.9\" /></svg>"
         }
       },
       "body": {
@@ -5491,8 +5769,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4648.7,
-                4969.2
+                4648.8,
+                4966.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5512,8 +5790,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1038.7,
-                2902.9
+                1040.2,
+                2899.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5550,8 +5828,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5570,7 +5848,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"684.8,4208.2 1515.2,4746.2 1578.2,4351.9 742.3,3828.4 1261.6,510.1 3385.1,862.6 4730.4,860.8 4565.1,8149.0 45.8,8149.0 684.8,4208.2\" /></svg>"
+          "value": "<svg><polygon points=\"299.7,6788.4 686.4,4246.4 1517.7,4767.8 1574.7,4372.1 738.3,3865.2 1208.4,535.0 3340.3,855.8 4687.6,833.8 4639.9,7103.7 2445.5,7117.1 299.7,6788.4\" /></svg>"
         }
       },
       "body": {
@@ -5584,8 +5862,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3026.6,
-                2979.4
+                688.1,
+                4244.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5596,8 +5874,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1076626,
-                29.9271257
+                -90.1088042,
+                29.9264565
               ]
             }
           },
@@ -5605,8 +5883,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                918.1,
-                2678.9
+                3340.6,
+                856.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5617,8 +5895,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.108772,
-                29.9271541
+                -90.107601,
+                29.928094
               ]
             }
           }
@@ -5636,15 +5914,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5663,7 +5941,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"708.8,930.7 5693.0,930.7 5693.0,7131.7 711.9,7138.4 708.8,930.7\" /></svg>"
+          "value": "<svg><polygon points=\"724.2,7184.8 699.1,968.4 5045.9,953.0 5065.6,7163.6 724.2,7184.8\" /></svg>"
         }
       },
       "body": {
@@ -5677,8 +5955,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                707.4,
-                932.1
+                708.1,
+                3099.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5689,8 +5967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1069043,
-                29.9281629
+                -90.1068039,
+                29.9271979
               ]
             }
           },
@@ -5698,8 +5976,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5047.3,
-                932.1
+                2892.5,
+                7174.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5710,8 +5988,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1046325,
-                29.9283389
+                -90.1054789,
+                29.9254367
               ]
             }
           }
@@ -5736,8 +6014,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5756,7 +6034,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4840.5,8150.0 2651.8,8150.0 2650.7,7103.3 1200.8,7105.9 1198.4,924.8 4853.1,923.4 4849.3,3050.2 5271.7,3050.2 5272.3,5095.3 5271.6,5218.7 4845.5,5218.4 4840.5,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"557.1,6214.1 587.0,933.4 5681.0,960.1 5681.0,7133.8 4835.4,7131.1 4842.1,6218.0 557.1,6214.1\" /></svg>"
         }
       },
       "body": {
@@ -5770,8 +6048,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                556.0,
-                7108.4
+                2672.5,
+                3067.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1034305,
+                29.9274573
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                552.1,
+                7110.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5784,27 +6083,6 @@
               "coordinates": [
                 -90.1043433,
                 29.925526
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                553.2,
-                926.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1046325,
-                29.9283389
               ]
             }
           }
@@ -5829,8 +6107,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5849,7 +6127,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"192.3,7379.0 195.3,5387.4 644.8,5387.7 645.5,5257.4 644.3,3099.4 198.7,3099.5 202.1,855.2 5164.5,851.6 5162.6,7365.7 192.3,7379.0\" /></svg>"
+          "value": "<svg><polygon points=\"5169.5,1051.8 5167.7,6985.2 1452.1,6995.1 1416.9,1054.4 5169.5,1051.8\" /></svg>"
         }
       },
       "body": {
@@ -5863,8 +6141,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                645.7,
-                3099.4
+                644.1,
+                3099.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5875,8 +6153,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1020559,
-                29.927563
+                -90.1022777,
+                29.9275459
               ]
             }
           },
@@ -5884,8 +6162,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5165.2,
-                3099.4
+                5168.9,
+                3099.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5922,8 +6200,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5942,7 +6220,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"701.8,925.1 5050.9,902.8 5074.9,7116.5 727.6,7147.5 701.8,925.1\" /></svg>"
+          "value": "<svg><polygon points=\"5072.9,6248.1 720.5,6270.0 695.9,921.8 5049.8,897.5 5072.9,6248.1\" /></svg>"
         }
       },
       "body": {
@@ -5956,8 +6234,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2891.4,
-                3060.1
+                2887.5,
+                3059.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5977,8 +6255,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                701.8,
-                926.5
+                695.9,
+                919.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6008,15 +6286,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6035,7 +6313,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"927.8,7146.3 930.0,934.4 3848.4,754.2 4681.4,6952.6 3081.1,7163.0 927.8,7146.3\" /></svg>"
+          "value": "<svg><polygon points=\"1054.0,7210.4 811.8,1023.9 3712.6,729.6 4786.4,6869.8 3200.2,7142.2 1054.0,7210.4\" /></svg>"
         }
       },
       "body": {
@@ -6049,8 +6327,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                929.2,
-                7147.7
+                2520.4,
+                3091.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6061,8 +6339,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0973526,
-                29.9260758
+                -90.09669,
+                29.927979
               ]
             }
           },
@@ -6070,8 +6348,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3848.7,
-                755.2
+                3200.6,
+                7142.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6082,8 +6360,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.096125,
-                29.929079
+                -90.0962292,
+                29.9261544
               ]
             }
           }
@@ -6108,8 +6386,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6128,7 +6406,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1434.5,363.5 3926.3,590.8 3703.0,7784.3 519.6,7522.1 1434.5,363.5\" /></svg>"
+          "value": "<svg><polygon points=\"4120.5,7800.2 534.7,7510.6 1436.6,366.2 3767.5,538.6 4120.5,7800.2\" /></svg>"
         }
       },
       "body": {
@@ -6142,8 +6420,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2734.2,
-                2706.4
+                2735.5,
+                2703.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6163,8 +6441,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                583.9,
-                7153.4
+                599.9,
+                7142.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6194,15 +6472,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "11"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6221,7 +6499,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5303.7,0.0 5717.0,0.0 5717.0,7694.6 715.7,7702.8 729.1,8025.5 -0.0,7988.2 -0.0,834.8 5346.2,660.3 5303.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5717.0,860.4 5717.0,8150.0 310.6,8150.0 326.1,7946.5 -0.0,7904.1 -0.0,595.5 5717.0,860.4\" /></svg>"
         }
       },
       "body": {
@@ -6235,8 +6513,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2619.8,
-                3006.8
+                2616.5,
+                863.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6247,8 +6525,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0935147,
-                29.9297593
+                -90.0939441,
+                29.930634
               ]
             }
           },
@@ -6256,8 +6534,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                673.9,
-                864.7
+                2616.5,
+                7582.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6268,8 +6546,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0948129,
-                29.9304011
+                -90.0926352,
+                29.9278979
               ]
             }
           }
@@ -6294,8 +6572,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6314,7 +6592,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"924.8,3172.4 1038.6,152.3 -0.0,103.7 -0.0,-0.0 5688.0,-0.0 5688.0,349.4 5293.7,329.5 5002.2,4650.0 4478.4,7374.9 274.7,6511.7 924.8,3172.4\" /></svg>"
+          "value": "<svg><polygon points=\"4826.2,7118.0 519.6,6711.5 807.0,3295.1 588.3,204.2 -0.0,246.1 0.0,0.0 4887.8,-0.0 5054.0,4330.9 4826.2,7118.0\" /></svg>"
         }
       },
       "body": {
@@ -6328,8 +6606,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2655.9,
-                5471.7
+                740.0,
+                4330.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6340,8 +6618,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.096387,
-                29.9330408
+                -90.096193,
+                29.9340671
               ]
             }
           },
@@ -6349,8 +6627,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                923.7,
-                3172.4
+                5056.0,
+                4330.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6361,8 +6639,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0956728,
-                29.9341848
+                -90.0954874,
+                29.9322306
               ]
             }
           }
@@ -6387,8 +6665,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6407,7 +6685,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"405.5,7129.5 866.6,-0.0 5158.3,-0.0 5028.4,5331.2 4723.0,7778.3 405.5,7129.5\" /></svg>"
+          "value": "<svg><polygon points=\"4720.6,7780.1 401.6,7131.2 803.2,3675.0 873.4,-0.0 5156.2,-0.0 5060.7,4661.7 4720.6,7780.1\" /></svg>"
         }
       },
       "body": {
@@ -6421,8 +6699,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                887.3,
-                2992.7
+                880.2,
+                2995.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6442,8 +6720,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                884.5,
-                553.1
+                880.2,
+                551.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6480,8 +6758,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6500,7 +6778,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"771.5,827.2 5025.3,811.2 5009.9,7169.9 2161.2,7195.8 757.9,7195.3 771.5,827.2\" /></svg>"
+          "value": "<svg><polygon points=\"735.9,824.5 4988.9,802.9 4981.8,7159.0 2140.3,7188.5 730.6,7189.9 735.9,824.5\" /></svg>"
         }
       },
       "body": {
@@ -6514,8 +6792,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5025.4,
-                2970.3
+                2832.0,
+                5074.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6526,8 +6804,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0989693,
-                29.9307111
+                -90.1000027,
+                29.9296644
               ]
             }
           },
@@ -6535,8 +6813,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5025.4,
-                5081.5
+                2832.0,
+                811.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6547,8 +6825,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0988699,
-                29.9297521
+                -90.1002003,
+                29.9315993
               ]
             }
           }
@@ -6566,15 +6844,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6593,7 +6871,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4165.2,7153.7 648.9,7166.3 600.0,1772.3 4904.6,1730.1 5702.4,6960.8 4165.2,7153.7\" /></svg>"
+          "value": "<svg><polygon points=\"4163.4,7148.9 645.3,7162.1 595.6,1770.3 4902.8,1727.3 5701.3,6955.7 4163.4,7148.9\" /></svg>"
         }
       },
       "body": {
@@ -6607,8 +6885,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2813.6,
-                7170.2
+                2812.5,
+                7166.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6628,8 +6906,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                617.8,
-                2987.1
+                612.1,
+                2983.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6666,8 +6944,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6686,7 +6964,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4956.9,837.1 4987.5,7168.8 -0.0,7220.8 -0.0,862.9 4956.9,837.1\" /></svg>"
+          "value": "<svg><polygon points=\"4984.0,7168.2 -0.0,7214.9 -0.0,855.3 4960.1,834.7 4984.0,7168.2\" /></svg>"
         }
       },
       "body": {
@@ -6700,8 +6978,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2801.9,
-                847.8
+                2804.0,
+                839.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6721,8 +6999,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4986.1,
-                7170.2
+                4984.0,
+                7166.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6752,15 +7030,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6779,7 +7057,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.9,880.7 3977.5,719.9 5021.5,8150.0 699.6,8150.0 704.9,880.7\" /></svg>"
+          "value": "<svg><polygon points=\"704.4,871.2 2545.5,874.1 2808.4,2998.5 4276.7,2827.6 5025.2,8150.0 699.0,8150.0 704.4,871.2\" /></svg>"
         }
       },
       "body": {
@@ -6793,8 +7071,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                698.9,
-                3009.6
+                699.8,
+                3003.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6814,8 +7092,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                701.7,
-                7215.1
+                699.8,
+                7214.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6852,8 +7130,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6872,7 +7150,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4935.2,826.6 4937.8,7163.4 -0.0,7219.7 -0.0,844.4 4935.2,826.6\" /></svg>"
+          "value": "<svg><polygon points=\"666.3,817.2 4948.9,828.0 4930.8,6401.0 648.8,6397.5 666.3,817.2\" /></svg>"
         }
       },
       "body": {
@@ -6886,8 +7164,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                631.8,
-                2942.9
+                2819.5,
+                5048.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6898,8 +7176,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1062774,
-                29.9330655
+                -90.1050285,
+                29.9321958
               ]
             }
           },
@@ -6907,8 +7185,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4936.4,
-                7163.4
+                4935.1,
+                5048.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6919,8 +7197,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.103823,
-                29.931313
+                -90.1039199,
+                29.9322821
               ]
             }
           }
@@ -6945,8 +7223,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6965,7 +7243,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"334.3,863.2 3432.8,847.2 4425.5,850.6 4380.4,7200.6 315.0,7201.1 334.3,863.2\" /></svg>"
+          "value": "<svg><polygon points=\"4784.4,7195.4 5519.0,7195.9 5516.2,8150.0 711.2,8150.0 738.2,855.6 3685.3,841.9 4828.3,846.6 4784.4,7195.4\" /></svg>"
         }
       },
       "body": {
@@ -6979,8 +7257,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2924.8,
-                2975.9
+                2915.0,
+                2967.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6991,8 +7269,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1026515,
-                29.9333421
+                -90.1028671,
+                29.9333256
               ]
             }
           },
@@ -7000,8 +7278,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2924.8,
-                842.2
+                2915.0,
+                839.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7012,8 +7290,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.102752,
-                29.934313
+                -90.1029684,
+                29.9342947
               ]
             }
           }
@@ -7038,8 +7316,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7058,7 +7336,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"645.3,7200.6 641.1,826.7 4957.4,784.7 4951.9,7199.1 645.3,7200.6\" /></svg>"
+          "value": "<svg><polygon points=\"647.8,0.0 4951.6,0.0 4944.2,7184.1 -0.0,7191.9 -0.0,829.3 645.9,828.6 647.8,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7072,8 +7350,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2830.4,
-                5071.4
+                2827.5,
+                5060.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7093,8 +7371,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2830.4,
-                2940.0
+                2827.5,
+                2936.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7131,8 +7409,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7151,7 +7429,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5144.6,861.2 5135.6,7186.4 350.7,7188.4 356.1,864.7 5144.6,861.2\" /></svg>"
+          "value": "<svg><polygon points=\"5134.2,7184.0 347.0,7186.1 351.6,1815.3 5141.8,1808.2 5134.2,7184.0\" /></svg>"
         }
       },
       "body": {
@@ -7165,8 +7443,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2953.6,
-                2987.8
+                2952.5,
+                2984.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7186,8 +7464,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2953.6,
-                7188.6
+                2952.5,
+                7184.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7224,8 +7502,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7244,7 +7522,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4621.7,846.8 4462.4,7239.7 5131.9,7253.7 5112.7,8149.0 158.0,8149.0 1341.6,520.0 3419.9,840.2 4621.7,846.8\" /></svg>"
+          "value": "<svg><polygon points=\"3365.4,839.3 5228.1,833.6 5127.2,7220.8 2948.1,7193.8 367.7,6849.5 1290.5,537.8 3365.4,839.3\" /></svg>"
         }
       },
       "body": {
@@ -7258,29 +7536,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3100.0,
-                2940.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1073783,
-                29.9329715
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1005.3,
-                2619.9
+                971.8,
+                2636.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7293,6 +7550,27 @@
               "coordinates": [
                 -90.1084922,
                 29.9330105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2467.6,
+                7152.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.107465,
+                29.931028
               ]
             }
           }
@@ -7317,8 +7595,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7337,7 +7615,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5586.2,7211.0 2126.2,7208.3 42.9,6890.4 748.0,1903.6 5638.9,1847.0 5586.2,7211.0\" /></svg>"
+          "value": "<svg><polygon points=\"3491.0,921.7 5021.4,939.1 4943.2,7219.2 2110.5,7211.5 19.1,6888.2 923.4,581.7 3491.0,921.7\" /></svg>"
         }
       },
       "body": {
@@ -7351,8 +7629,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2437.1,
-                5099.4
+                3464.0,
+                5096.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7363,8 +7641,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1075479,
-                29.9290752
+                -90.1070003,
+                29.9291221
               ]
             }
           },
@@ -7372,8 +7650,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2125.4,
-                7208.3
+                624.0,
+                2704.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7384,8 +7662,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107601,
-                29.928094
+                -90.1086262,
+                29.9300834
               ]
             }
           }
@@ -7410,8 +7688,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7430,7 +7708,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1072.9,815.7 5703.0,1694.3 5703.0,5863.1 4979.9,5860.1 4963.5,7639.3 708.3,7621.1 718.2,2703.1 1072.9,815.7\" /></svg>"
+          "value": "<svg><polygon points=\"714.4,2700.2 1206.6,59.8 5703.0,914.8 5703.0,7634.7 709.8,7621.1 714.4,2700.2\" /></svg>"
         }
       },
       "body": {
@@ -7444,8 +7722,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2822.0,
-                5863.2
+                2823.5,
+                4048.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7456,8 +7734,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1095671,
-                29.9301171
+                -90.1105267,
+                29.9301512
               ]
             }
           },
@@ -7465,8 +7743,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                707.6,
-                4049.2
+                703.9,
+                4048.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7496,15 +7774,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "13"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7523,7 +7801,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"689.3,5290.4 1419.5,5286.7 1373.6,297.6 5316.7,993.2 4962.0,2940.6 4965.5,7052.3 689.3,7087.6 689.3,5290.4\" /></svg>"
+          "value": "<svg><polygon points=\"5348.4,1012.2 4997.4,3415.1 5003.4,7047.5 1484.8,7079.4 1424.3,323.3 5348.4,1012.2\" /></svg>"
         }
       },
       "body": {
@@ -7537,8 +7815,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                690.7,
-                5290.4
+                2872.0,
+                7080.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7549,8 +7827,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1095246,
-                29.9311073
+                -90.10853,
+                29.932038
               ]
             }
           },
@@ -7558,8 +7836,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                690.7,
-                7087.6
+                4988.0,
+                3480.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7570,8 +7848,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1085825,
-                29.9310677
+                -90.1103699,
+                29.9330837
               ]
             }
           }
@@ -7596,8 +7874,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7616,7 +7894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 4530.1,143.8 4528.1,8149.0 4028.5,8149.0 734.0,7179.6 -0.0,7174.1 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,15.2 4524.1,146.2 4521.9,8149.0 4041.9,8149.0 756.5,7184.3 -0.0,7178.6 -0.0,15.2\" /></svg>"
         }
       },
       "body": {
@@ -7630,8 +7908,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.6,
-                4565.9
+                4521.6,
+                4560.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7651,8 +7929,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4527.6,
-                2412.1
+                4521.6,
+                2412.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7689,8 +7967,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7709,7 +7987,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"956.0,7781.8 953.2,162.9 4961.0,168.9 4958.5,1986.5 5708.0,1844.2 5708.0,6508.4 4715.8,6507.7 4720.9,8149.0 3664.4,8149.0 2830.4,7912.1 2818.7,8149.0 956.0,7781.8\" /></svg>"
+          "value": "<svg><polygon points=\"2814.3,8149.0 954.8,7769.3 952.0,162.0 4953.8,168.1 4938.2,8149.0 3704.9,8149.0 2826.4,7899.5 2814.3,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -7723,8 +8001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                954.6,
-                2285.8
+                952.0,
+                2280.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7744,8 +8022,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                951.8,
-                162.9
+                952.0,
+                160.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7782,8 +8060,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7802,7 +8080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5642.0,7835.7 3568.0,7835.4 2799.7,7975.5 2800.1,7835.1 618.9,7833.9 769.8,0.0 5642.0,0.0 5642.0,7835.7\" /></svg>"
+          "value": "<svg><polygon points=\"747.6,0.0 5642.0,0.0 5642.0,3684.3 4971.2,3684.9 4945.5,7832.7 3591.8,7832.0 2797.7,7986.5 2798.2,7831.6 617.0,7830.5 747.6,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7816,8 +8094,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2778.9,
-                3681.4
+                2777.0,
+                3680.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7837,8 +8115,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                628.8,
-                3681.4
+                628.2,
+                3680.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7868,15 +8146,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "7"
         },
         {
           "label": "intersections",
           "value": "10"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7895,7 +8173,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4838.8,3671.6 5078.6,3672.1 5093.9,7727.3 2976.3,7764.2 1531.3,7763.0 1459.0,75.4 5724.0,0.0 5724.0,301.8 5055.4,314.5 4838.8,3671.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 5724.0,0.0 5724.0,333.1 5058.8,327.0 4827.0,3676.9 5064.6,3678.5 5061.2,7696.2 2962.8,7723.1 2964.3,7483.3 857.0,7491.5 861.2,3684.5 1513.4,3680.8 1496.3,97.3 0.0,104.5 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7909,8 +8187,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2953.2,
-                3675.8
+                2960.0,
+                3672.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7930,8 +8208,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5069.9,
-                5593.7
+                2960.0,
+                5588.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7942,8 +8220,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1119988,
-                29.9363451
+                -90.1122499,
+                29.9354076
               ]
             }
           }
@@ -7961,15 +8239,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7988,7 +8266,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"655.8,1799.7 989.4,0.0 3147.7,0.0 3101.7,244.1 5205.3,643.3 4935.4,2440.0 4957.7,8055.7 2791.0,8042.9 2783.9,5929.6 646.4,5923.2 655.8,1799.7\" /></svg>"
+          "value": "<svg><polygon points=\"656.2,2312.3 1025.8,0.0 1875.6,0.0 3138.1,256.2 3184.9,29.9 5286.7,440.8 4955.1,2286.2 4901.0,8085.6 2734.1,8046.8 2752.3,5934.4 614.5,5902.3 656.2,2312.3\" /></svg>"
         }
       },
       "body": {
@@ -8002,8 +8280,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                656.8,
-                4133.5
+                3829.4,
+                5956.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8014,8 +8292,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1094276,
-                29.933052
+                -90.1084076,
+                29.9344664
               ]
             }
           },
@@ -8023,8 +8301,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4929.0,
-                4133.5
+                656.2,
+                2312.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8035,8 +8313,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1093262,
-                29.9349874
+                -90.1103699,
+                29.9330837
               ]
             }
           }
@@ -8061,8 +8339,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8081,7 +8359,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"779.5,1771.1 1049.1,182.4 5195.2,955.1 4958.7,2214.9 4985.7,7501.7 759.8,7499.6 779.5,1771.1\" /></svg>"
+          "value": "<svg><polygon points=\"769.1,1765.4 1037.5,175.8 5186.7,945.2 4951.1,2205.7 4982.6,7494.8 754.2,7496.2 769.1,1765.4\" /></svg>"
         }
       },
       "body": {
@@ -8095,8 +8373,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2866.2,
-                5425.2
+                2864.0,
+                1968.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8107,8 +8385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1083306,
-                29.9359238
+                -90.1101567,
+                29.935989
               ]
             }
           },
@@ -8116,8 +8394,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4985.7,
-                7503.1
+                2864.0,
+                7504.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8128,8 +8406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.107186,
-                29.936859
+                -90.1072256,
+                29.9358872
               ]
             }
           }
@@ -8154,8 +8432,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8174,7 +8452,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1656.0,879.1 4861.5,835.4 4855.7,7170.7 841.1,7226.6 1656.0,879.1\" /></svg>"
+          "value": "<svg><polygon points=\"820.2,7228.1 1649.4,868.3 4863.9,830.5 4846.1,7179.7 820.2,7228.1\" /></svg>"
         }
       },
       "body": {
@@ -8188,8 +8466,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4844.8,
-                2976.5
+                4841.7,
+                2976.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8209,8 +8487,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1131.2,
-                5093.8
+                1116.4,
+                5092.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8247,8 +8525,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8267,7 +8545,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5724.0,921.1 5724.0,7221.6 554.9,7140.1 686.4,864.2 5724.0,921.1\" /></svg>"
+          "value": "<svg><polygon points=\"5724.0,826.8 5724.0,7225.2 624.6,7231.1 649.6,855.4 5724.0,826.8\" /></svg>"
         }
       },
       "body": {
@@ -8281,8 +8559,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                626.0,
-                2985.0
+                2752.0,
+                2984.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8293,8 +8571,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1054175,
-                29.9360267
+                -90.1043082,
+                29.9361224
               ]
             }
           },
@@ -8302,8 +8580,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2751.1,
-                870.5
+                620.0,
+                5096.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8314,8 +8592,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1044093,
-                29.9370981
+                -90.105326,
+                29.935083
               ]
             }
           }
@@ -8340,8 +8618,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8360,7 +8638,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5066.6,946.8 5041.8,7053.7 1389.3,7039.4 1312.0,918.9 5066.6,946.8\" /></svg>"
+          "value": "<svg><polygon points=\"5041.4,7050.9 1243.7,7036.0 1266.3,1889.6 5062.4,1888.1 5041.4,7050.9\" /></svg>"
         }
       },
       "body": {
@@ -8374,8 +8652,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                508.1,
-                2996.2
+                508.2,
+                2996.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8395,8 +8673,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5058.2,
-                2996.2
+                5057.8,
+                2996.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8426,15 +8704,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "9"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8453,7 +8731,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"968.1,7258.8 922.3,880.1 4079.0,890.9 4983.7,7233.9 968.1,7258.8\" /></svg>"
+          "value": "<svg><polygon points=\"919.8,879.8 4073.9,889.2 4382.8,2995.9 3097.8,2993.3 3685.3,5114.3 4675.4,5123.3 4980.4,7226.2 968.3,7252.8 919.8,879.8\" /></svg>"
         }
       },
       "body": {
@@ -8467,8 +8745,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3122.0,
-                5126.4
+                3119.5,
+                5122.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8488,8 +8766,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                920.9,
-                881.5
+                919.8,
+                879.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8519,15 +8797,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "8"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8546,7 +8824,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4246.7,7228.0 -0.0,6471.1 524.2,2525.7 451.6,699.1 -0.0,674.6 0.0,-0.0 5083.0,-0.0 5074.4,2882.4 4246.7,7228.0\" /></svg>"
+          "value": "<svg><polygon points=\"3916.4,8149.0 1690.1,8047.3 2096.8,6811.6 -0.0,6451.2 427.9,572.6 -0.0,566.8 -0.0,0.0 5056.6,-0.0 5052.4,2879.4 4285.0,7005.5 3916.4,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -8560,8 +8838,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2384.1,
-                5394.3
+                2380.8,
+                5380.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8581,8 +8859,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5012.5,
-                3111.3
+                4989.8,
+                3108.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8616,11 +8894,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "10"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8639,7 +8917,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5136.9,-0.0 5164.5,3052.7 4666.2,6452.8 2516.1,6115.2 2251.0,7560.9 121.7,7219.4 884.0,2878.9 851.2,-0.0 5136.9,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5150.3,3092.4 4340.4,7944.7 89.6,7192.7 890.0,2878.5 884.9,4.6 5152.2,-0.0 5150.3,3092.4\" /></svg>"
         }
       },
       "body": {
@@ -8653,8 +8931,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                825.4,
-                3110.6
+                831.9,
+                3107.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8674,8 +8952,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                370.6,
-                5763.7
+                351.9,
+                5746.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8705,15 +8983,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "12"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8732,7 +9010,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"342.1,0.0 5650.0,0.0 4678.3,282.6 5520.6,7231.3 268.8,7143.2 342.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"318.4,0.0 5650.0,0.0 4668.9,308.1 5551.4,7213.7 2400.8,7168.9 2397.2,8149.0 288.9,8149.0 318.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -8746,8 +9024,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2403.8,
-                2962.5
+                2400.8,
+                2960.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8767,8 +9045,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2403.8,
-                5071.4
+                2400.8,
+                7168.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8779,8 +9057,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.100877,
-                29.938318
+                -90.100784,
+                29.937367
               ]
             }
           }
@@ -8802,11 +9080,11 @@
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "14"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8825,7 +9103,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3527.3,7292.7 84.6,6909.4 952.3,0.0 5719.0,0.0 5719.0,7086.6 3527.3,7292.7\" /></svg>"
+          "value": "<svg><polygon points=\"22.2,6744.8 1137.7,0.0 5719.0,0.0 5719.0,7108.7 3407.4,7255.4 22.2,6744.8\" /></svg>"
         }
       },
       "body": {
@@ -8839,8 +9117,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1757.5,
-                4842.8
+                1403.8,
+                7002.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8851,8 +9129,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0986704,
-                29.9386252
+                -90.0983983,
+                29.9376056
               ]
             }
           },
@@ -8860,8 +9138,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5469.1,
-                4842.8
+                715.9,
+                2591.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8872,8 +9150,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0968228,
-                29.9391971
+                -90.099619,
+                29.939381
               ]
             }
           }
@@ -8898,8 +9176,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8918,7 +9196,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1059.9,0.0 1961.5,163.5 1979.3,0.0 5424.4,46.1 5377.5,5153.4 4989.7,5148.3 4960.9,7194.9 19.8,7203.3 1059.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1063.9,0.0 2220.0,149.7 2018.0,0.0 5664.0,0.0 5432.6,103.3 5373.1,5152.1 4989.4,5146.1 4955.2,7194.0 7.1,7189.5 1063.9,0.0\" /></svg>"
         }
       },
       "body": {
@@ -8932,8 +9210,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5374.8,
-                2976.5
+                1044.0,
+                7200.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1066463,
+                29.9369006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5376.0,
+                2972.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8946,27 +9245,6 @@
               "coordinates": [
                 -90.104614,
                 29.939
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3254.6,
-                7199.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1055029,
-                29.937002
               ]
             }
           }
@@ -8991,8 +9269,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9011,7 +9289,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5103.9,7169.0 -0.0,7184.5 -0.0,5190.2 377.9,5189.8 353.5,213.5 -0.0,219.6 -0.0,-0.0 5719.0,0.0 5719.0,137.8 5073.8,145.5 5103.9,7169.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7180.1 -0.0,5186.3 373.6,5185.9 349.2,210.3 2768.0,195.2 2768.2,0.0 5719.0,0.0 5719.0,134.7 5068.8,142.4 5103.9,8132.3 2952.8,8150.0 2951.0,7171.2 -0.0,7180.1\" /></svg>"
         }
       },
       "body": {
@@ -9025,8 +9303,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2953.6,
-                5160.1
+                2947.5,
+                5154.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9046,8 +9324,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2953.6,
-                909.6
+                2947.5,
+                907.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9084,8 +9362,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9104,7 +9382,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"850.5,491.9 3692.2,1019.5 3727.0,827.1 4520.9,1182.4 4424.4,2321.4 4813.7,3320.9 4794.3,7089.6 625.4,7057.9 610.4,1754.9 850.5,491.9\" /></svg>"
+          "value": "<svg><polygon points=\"3595.8,817.2 4503.8,1190.8 4410.9,2328.0 4802.8,3324.5 4794.8,7086.3 631.3,7067.3 600.2,1774.2 836.1,512.7 3557.1,1008.5 3595.8,817.2\" /></svg>"
         }
       },
       "body": {
@@ -9118,8 +9396,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4800.1,
-                4991.6
+                4792.8,
+                4990.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9139,8 +9417,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                620.4,
-                4991.6
+                4792.8,
+                7086.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9151,8 +9429,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.108278,
-                29.936891
+                -90.1070879,
+                29.9387656
               ]
             }
           }
@@ -9174,11 +9452,11 @@
         },
         {
           "label": "intersections",
-          "value": "20"
+          "value": "25"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9197,7 +9475,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3624.0,8149.0 3690.6,7213.5 553.1,7094.6 673.9,3192.3 297.5,2146.8 427.9,969.8 0.0,874.2 0.0,664.2 1990.2,1096.4 1926.4,1388.3 5750.0,2223.7 5750.0,8149.0 3624.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"5750.0,7365.9 5428.4,7346.1 5482.2,8149.0 3310.1,8149.0 3479.2,7205.1 351.8,6971.3 609.4,3167.1 279.6,2133.3 449.0,989.2 0.0,871.4 0.0,664.7 2084.5,1198.4 2023.6,1452.9 5750.0,2345.0 5750.0,7365.9\" /></svg>"
         }
       },
       "body": {
@@ -9211,8 +9489,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4278.8,
-                3190.0
+                2431.2,
+                4992.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9223,8 +9501,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1090576,
-                29.9404308
+                -90.1081488,
+                29.9396836
               ]
             }
           },
@@ -9232,8 +9510,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                553.1,
-                7093.2
+                2495.1,
+                1416.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9244,8 +9522,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1070879,
-                29.9387656
+                -90.1100178,
+                29.9396709
               ]
             }
           }
@@ -9270,8 +9548,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9290,7 +9568,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"783.1,0.0 5634.0,0.0 5634.0,7351.1 681.6,7310.1 742.8,3311.2 506.4,3306.1 783.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3845.4,0.0 3812.2,3367.7 4553.6,3348.4 4561.9,7235.3 5634.0,7219.7 5634.0,7417.2 694.8,7493.1 660.8,3407.8 419.2,3408.4 623.7,0.0 3845.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9304,8 +9582,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2801.6,
-                5228.6
+                488.2,
+                2000.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9316,8 +9594,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1117469,
-                29.9372936
+                -90.1137188,
+                29.9366287
               ]
             }
           },
@@ -9325,8 +9603,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4553.2,
-                3341.6
+                4553.6,
+                3348.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9363,8 +9641,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9383,7 +9661,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5736.0,0.0 5736.0,1649.9 4973.2,1666.9 4933.5,7185.0 1983.9,7254.6 1747.0,0.0 5736.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 5736.0,0.0 5736.0,1793.3 4968.9,1824.1 4934.9,7183.2 790.8,7284.6 744.0,3383.2 0.0,3409.9 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -9397,8 +9675,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                746.8,
-                3380.2
+                744.0,
+                3383.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9418,8 +9696,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4890.9,
-                5249.9
+                4892.0,
+                5246.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9456,8 +9734,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-06-10T13:56:39Z",
-      "modified": "2026-06-10T13:56:39Z",
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9476,7 +9754,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5634.0,0.0 5634.0,8149.0 5350.3,8149.0 5349.6,7595.0 -0.0,7441.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 5634.0,0.0 5634.0,8149.0 5370.5,8149.0 5377.6,7695.9 4015.6,7671.5 -0.0,7456.5 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9490,8 +9768,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3469.7,
-                5590.9
+                3465.2,
+                5588.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9511,8 +9789,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3469.7,
-                7593.0
+                1556.6,
+                7588.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9523,8 +9801,101 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1110562,
-                29.9398784
+                -90.1120002,
+                29.9400852
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p531",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "15"
+        },
+        {
+          "label": "intersections",
+          "value": "45"
+        }
+      ],
+      "created": "2026-07-17T18:02:16Z",
+      "modified": "2026-07-17T18:02:16Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6070.7 460.5,4533.4 -0.0,4395.4 -0.0,0.0 5660.0,0.0 5660.0,7878.4 2693.6,7897.9 2750.6,6884.2 2346.2,6888.5 2365.2,6727.6 94.8,6599.8 -0.0,6522.4 -0.0,6070.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0531/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3312.0,
+                3908.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1062127,
+                29.9438112
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3312.0,
+                4888.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1061295,
+                29.942932
               ]
             }
           }

--- a/gallery/washington_dc_1916_vol_2.iiif.json
+++ b/gallery/washington_dc_1916_vol_2.iiif.json
@@ -1,31 +1,47 @@
 {
-  "id": "https://www.loc.gov/item/sanborn01227_003/manifest.json/generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn01227_003/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia.",
+  "label": "Mosaic of main content, Washington, D.C. | 1916 | Vol. 2",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 6",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001250 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
           "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5936.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8381.0"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +50,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250/info.json",
           "type": "ImageService2",
-          "height": 8372,
-          "width": 5948
+          "height": 8381,
+          "width": 5936
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3350.0,121.5 2758.8,218.6 4104.7,8372.0 -0.0,8372.0 0.0,-0.0 3329.2,-0.0 3350.0,121.5\" /></svg>"
+          "value": "<svg><polygon points=\"5022.3,8381.0 -0.0,8381.0 0.0,0.0 5936.0,-0.0 5936.0,2537.7 5037.0,2551.6 5022.3,8381.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +89,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01835353048378,
-                38.921125554284565
+                -77.01423854845586,
+                38.92240671553563
               ]
             }
           },
@@ -82,7 +98,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5948.0,
+                5936.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +110,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01857997414172,
-                38.91788392815186
+                -77.01373975131294,
+                38.91928634799142
               ]
             }
           },
@@ -103,8 +119,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5948.0,
-                8372.0
+                5936.0,
+                8381.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +131,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02444372196494,
-                38.91813193537031
+                -77.01940368596354,
+                38.918738164149744
               ]
             }
           },
@@ -125,7 +141,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8372.0
+                8381.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +152,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02421727830699,
-                38.92137356150302
+                -77.01990248310646,
+                38.921858531693964
               ]
             }
           },
@@ -145,8 +161,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4180.0,
-                6340.0
+                1244.0,
+                5989.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -157,8 +173,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0229532,
-                38.9190353
+                -77.018182,
+                38.921361
               ]
             }
           }
@@ -172,19 +188,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 7",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001270",
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -198,12 +214,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/info.json",
           "type": "ImageService2",
-          "height": 8408,
-          "width": 6032
+          "height": 8406,
+          "width": 6029
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 574.3,-0.0 582.6,725.0 5211.7,670.3 5252.8,3758.1 5978.7,4229.5 4337.3,6574.9 3829.3,7620.1 3745.4,8141.7 -0.0,8408.0 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1266.8 586.5,1257.9 581.8,725.0 5209.0,670.2 5250.2,3757.2 5975.7,4228.5 4335.1,6573.3 3827.4,7618.2 3743.5,8139.8 -0.0,8406.0 -0.0,1266.8\" /></svg>"
         }
       },
       "body": {
@@ -217,8 +233,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4428.0,
-                6440.0
+                4425.8,
+                6438.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -238,8 +254,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3792.0,
-                7756.0
+                3790.1,
+                7754.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -265,7 +281,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 8",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001280",
       "metadata": [
         {
           "label": "streets",
@@ -276,8 +292,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -291,12 +307,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/info.json",
           "type": "ImageService2",
-          "height": 8416,
-          "width": 6004
+          "height": 8414,
+          "width": 6002
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6004.0,858.0 6004.0,8416.0 363.4,8416.0 384.8,7870.7 776.1,6736.1 2168.4,4128.0 1365.8,3734.6 941.0,573.7 4300.9,131.7 3926.3,832.0 6004.0,858.0\" /></svg>"
+          "value": "<svg><polygon points=\"5641.3,8414.0 363.3,8414.0 384.7,7868.9 775.8,6734.5 2167.7,4127.0 1365.3,3733.8 1025.9,1208.7 5555.5,1152.0 5641.3,8414.0\" /></svg>"
         }
       },
       "body": {
@@ -310,8 +326,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2168.0,
-                4128.0
+                2167.3,
+                4127.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -331,8 +347,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3928.0,
-                832.0
+                3926.7,
+                831.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -352,25 +368,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 10",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001290",
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -379,21 +395,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/info.json",
           "type": "ImageService2",
-          "height": 8492,
-          "width": 6008
+          "height": 8403,
+          "width": 5961
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"656.7,4779.0 653.1,4443.5 511.4,4453.7 468.1,0.0 5200.1,0.0 5278.4,1087.1 6008.0,1794.5 6008.0,8492.0 5379.4,8492.0 5371.7,7793.2 5191.0,7793.7 5172.1,7617.3 2964.1,7641.8 2828.5,7808.3 690.1,7838.3 512.9,4781.6 656.7,4779.0\" /></svg>"
+          "value": "<svg><polygon points=\"5961.0,8403.0 -0.0,8403.0 477.9,443.2 1627.6,509.8 1781.9,922.4 2024.7,932.9 1867.7,530.1 5679.0,738.0 5659.5,1089.7 5961.0,1102.7 5961.0,8403.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -403,8 +419,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                604.0,
-                6308.0
+                2846.6,
+                3391.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -415,8 +431,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.994977,
-                38.8764944
+                -77.0209829,
+                38.9126598
               ]
             }
           },
@@ -424,8 +440,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                604.0,
-                568.0
+                1747.1,
+                519.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -436,8 +452,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9995209,
-                38.8765331
+                -77.0189352,
+                38.9133729
               ]
             }
           }
@@ -451,7 +467,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 11",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001310",
       "metadata": [
         {
           "label": "streets",
@@ -462,8 +478,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -477,12 +493,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/info.json",
           "type": "ImageService2",
-          "height": 8424,
-          "width": 5968
+          "height": 8423,
+          "width": 5966
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8424.0 -0.0,665.6 5968.0,837.9 5968.0,8424.0 -0.0,8424.0\" /></svg>"
+          "value": "<svg><polygon points=\"5966.0,8423.0 -0.0,8423.0 -0.0,527.6 5763.4,521.0 5764.1,819.4 5966.0,820.9 5966.0,8423.0\" /></svg>"
         }
       },
       "body": {
@@ -496,8 +512,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2824.0,
-                7788.0
+                2823.1,
+                7787.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -517,8 +533,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2824.0,
-                536.0
+                2823.1,
+                535.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -544,19 +560,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 13",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001330",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "5"
         },
         {
           "label": "intersections",
           "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -570,12 +586,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/info.json",
           "type": "ImageService2",
-          "height": 8452,
-          "width": 6036
+          "height": 8450,
+          "width": 6035
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6036.0,8452.0 -0.0,8452.0 -0.0,0.0 6036.0,-0.0 6036.0,8452.0\" /></svg>"
+          "value": "<svg><polygon points=\"6035.0,875.1 6035.0,8450.0 -0.0,8450.0 -0.0,0.0 436.1,-0.0 438.2,576.8 5696.6,572.9 5697.4,876.3 6035.0,875.1\" /></svg>"
         }
       },
       "body": {
@@ -589,8 +605,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2656.0,
-                1980.0
+                711.9,
+                1979.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -601,8 +617,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0199058,
-                38.9014723
+                -77.019907,
+                38.902521
               ]
             }
           },
@@ -610,8 +626,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3292.0,
-                576.0
+                5695.1,
+                1979.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -622,101 +638,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0189285,
-                38.9011315
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 18",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/info.json",
-          "type": "ImageService2",
-          "height": 8444,
-          "width": 5964
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 595.4,0.0 638.2,4462.4 781.8,4452.1 784.7,4672.5 785.3,4791.9 639.7,4794.5 819.2,7889.5 512.1,7886.8 518.2,8444.0 0.0,8444.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb00135s/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                528.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9995209,
-                38.8765331
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                6340.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.994977,
-                38.8764944
+                -77.0199114,
+                38.8998183
               ]
             }
           }
@@ -730,19 +653,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 21",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001370",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -756,42 +679,39 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/info.json",
           "type": "ImageService2",
-          "height": 8488,
-          "width": 6104
+          "height": 8487,
+          "width": 6101
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2796.7,6851.9 1157.6,6954.7 784.0,581.1 1662.3,530.8 1724.4,0.0 6104.0,0.0 6104.0,3993.0 5046.0,4055.0 5171.6,6634.8 4943.5,6732.0 4848.4,6931.3 2796.7,6851.9\" /></svg>"
+          "value": "<svg><polygon points=\"1026.7,594.3 6101.0,622.9 6101.0,4326.0 5030.3,4318.8 4987.7,6887.8 4755.0,6969.5 4647.8,7161.2 3448.5,6973.2 984.3,6945.1 1026.7,594.3\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                2746.6,
+                4307.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "corner"
+              "type": "gcp"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0196671433179,
-                38.91954401976712
+                -77.017557,
+                38.917353
               ]
             }
           },
@@ -799,71 +719,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6104.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01539384273677,
-                38.91975075422094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6104.0,
-                8488.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01502439091952,
-                38.91512694200843
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8488.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01929769150065,
-                38.91492020755461
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                996.0,
-                4308.0
+                995.5,
+                4307.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -889,19 +746,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 22",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001380",
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -915,12 +772,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/info.json",
           "type": "ImageService2",
-          "height": 8396,
+          "height": 8394,
           "width": 5924
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"679.4,8396.0 677.3,7172.3 454.3,7104.3 339.9,6903.8 417.6,6643.8 631.2,6540.7 396.0,4081.8 1403.9,3975.3 1225.5,160.6 -0.0,218.0 -0.0,-0.0 5924.0,0.0 5924.0,7951.6 5521.3,7937.3 5517.4,8396.0 679.4,8396.0\" /></svg>"
+          "value": "<svg><polygon points=\"3462.2,998.7 3366.8,0.0 5924.0,0.0 5924.0,1267.5 5681.3,1260.9 5636.1,3190.9 4990.7,3173.0 4979.9,3812.5 4849.0,3813.8 4808.8,5180.9 5575.8,5202.6 5550.5,6002.7 390.2,5826.7 250.2,4127.4 1308.5,4029.7 1041.4,1229.8 3462.2,998.7\" /></svg>"
         }
       },
       "body": {
@@ -934,29 +791,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                396.0,
-                4080.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.015958,
-                38.917506
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
                 3736.0,
-                1208.0
+                1207.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -971,6 +807,120 @@
                 38.9191751
               ]
             }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                396.0,
+                9605.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0157433,
+                38.91448
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001390",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/info.json",
+          "type": "ImageService2",
+          "height": 8472,
+          "width": 6024
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"976.9,4020.1 201.1,4023.2 197.1,2640.1 329.4,2634.5 319.5,1987.7 972.2,1984.8 955.0,32.5 6024.0,0.0 6024.0,4212.7 5598.5,4377.4 5493.6,8472.0 991.0,8472.0 976.9,4020.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5212.0,
+                4456.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091774,
+                38.9167485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5212.0,
+                7980.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091866,
+                38.9148214
+              ]
+            }
           }
         ]
       }
@@ -982,19 +932,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 24",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001400",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "11"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1009,11 +959,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/info.json",
           "type": "ImageService2",
           "height": 8468,
-          "width": 5980
+          "width": 5978
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5980.0,0.0 5980.0,6208.7 4907.3,6226.4 4934.2,8137.7 3902.4,7572.1 38.5,7645.1 -0.0,490.7 475.6,473.7 462.7,0.0 5980.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3876.8,7645.5 555.9,7641.9 545.8,5825.2 392.2,5741.0 555.0,5742.0 553.0,1352.5 5067.5,1370.5 5062.3,3592.0 4921.4,3591.6 4909.7,8240.0 3876.8,7645.5\" /></svg>"
         }
       },
       "body": {
@@ -1027,8 +977,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5064.0,
-                8204.0
+                5062.3,
+                3592.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1039,8 +989,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0090081,
-                38.9107672
+                -77.0089932,
+                38.9133404
               ]
             }
           },
@@ -1048,8 +998,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5064.0,
-                872.0
+                5062.3,
+                6308.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1060,8 +1010,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089024,
-                38.9148176
+                -77.0089927,
+                38.9118594
               ]
             }
           }
@@ -1075,19 +1025,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 25",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001410",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "14"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1101,12 +1051,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/info.json",
           "type": "ImageService2",
-          "height": 8460,
-          "width": 6020
+          "height": 8459,
+          "width": 6017
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8460.0 -0.0,5171.2 291.5,5174.8 326.3,3120.5 1046.4,3464.3 829.9,1608.2 3111.9,1318.4 4510.7,1358.8 4606.2,1605.6 4872.8,1702.5 4893.7,2981.2 6020.0,2964.8 6020.0,8460.0 -0.0,8460.0\" /></svg>"
+          "value": "<svg><polygon points=\"287.0,5917.2 291.6,4719.7 -0.0,4719.5 -0.0,144.1 642.2,65.9 829.5,1607.9 3406.3,1309.7 4508.4,1358.5 4603.8,1605.2 4870.3,1702.1 5169.5,1387.4 6017.0,1417.7 6017.0,6174.3 5635.7,5981.6 5630.0,8459.0 278.3,8459.0 279.4,6167.7 -0.0,6294.4 -0.0,6042.8 287.0,5917.2\" /></svg>"
         }
       },
       "body": {
@@ -1120,8 +1070,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4224.0,
-                6216.0
+                4221.9,
+                6215.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1141,8 +1091,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                344.0,
-                3076.0
+                343.8,
+                3075.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1168,19 +1118,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 26",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001420",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "5"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1194,12 +1144,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/info.json",
           "type": "ImageService2",
-          "height": 8440,
-          "width": 5996
+          "height": 8439,
+          "width": 5994
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8440.0 -0.0,0.0 5996.0,0.0 5996.0,8440.0 -0.0,8440.0\" /></svg>"
+          "value": "<svg><polygon points=\"377.8,1584.5 41.4,1412.0 80.6,1010.2 312.7,892.1 208.5,0.0 5703.7,0.0 5751.9,8439.0 1612.7,6276.4 1581.1,1278.0 690.2,1251.8 377.8,1584.5\" /></svg>"
         }
       },
       "body": {
@@ -1213,8 +1163,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                352.0,
-                3324.0
+                351.9,
+                4019.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1225,8 +1175,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.002032,
-                38.914822
+                -77.0157433,
+                38.91448
               ]
             }
           },
@@ -1234,8 +1184,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                352.0,
-                6020.0
+                -1247.6,
+                4743.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1246,8 +1196,281 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.002036,
-                38.9133386
+                -77.0168136,
+                38.9141083
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001430",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/info.json",
+          "type": "ImageService2",
+          "height": 8411,
+          "width": 5994
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4921.1 360.4,4925.6 379.3,3273.6 5650.5,3331.1 5597.7,7690.9 118.5,7626.0 101.4,8411.0 -0.0,8411.0 -0.0,4921.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                375.9,
+                3599.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0189371,
+                38.9118725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2947.0,
+                3599.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0171054,
+                38.9118891
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001440",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/info.json",
+          "type": "ImageService2",
+          "height": 8475,
+          "width": 6059
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5050.5,3482.5 4748.4,8162.6 324.1,7881.8 779.9,779.3 5050.5,3482.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01574076335994,
+                38.91379421833687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6059.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01162353641513,
+                38.91399704169709
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6059.0,
+                8475.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01125895762291,
+                38.90951611307794
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8475.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01537618456773,
+                38.90931328971772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                779.9,
+                779.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0158579,
+                38.9136951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                779.9,
+                779.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0151773,
+                38.9134083
               ]
             }
           }
@@ -1261,19 +1484,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 29",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001450",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1288,11 +1511,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/info.json",
           "type": "ImageService2",
           "height": 8400,
-          "width": 5948
+          "width": 5945
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5948.0,10.8 5948.0,4878.6 5648.0,4888.0 5591.0,5902.3 5750.7,6856.4 5615.6,6987.4 5648.0,7800.0 5948.0,7789.6 5948.0,8400.0 -0.0,8400.0 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7887.6 298.9,7885.0 248.9,2108.1 -0.0,2110.0 -0.0,483.2 5637.0,427.2 5656.5,2406.8 4965.5,2413.4 4981.6,3690.3 5628.6,5898.4 5768.1,6857.3 5630.1,6985.6 5645.2,7800.0 4862.1,7829.0 4863.9,8400.0 -0.0,8400.0 -0.0,7887.6\" /></svg>"
         }
       },
       "body": {
@@ -1306,7 +1529,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5648.0,
+                5309.3,
                 4888.0
               ],
               "creator": {
@@ -1318,7 +1541,7 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.015164,
+                -77.015441,
                 38.907236
               ]
             }
@@ -1327,7 +1550,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5648.0,
+                5645.2,
                 7800.0
               ],
               "creator": {
@@ -1354,19 +1577,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 30",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001460",
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "14"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1380,12 +1603,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/info.json",
           "type": "ImageService2",
-          "height": 8428,
-          "width": 6000
+          "height": 8425,
+          "width": 5999
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5076.7,0.0 5075.7,4956.0 977.7,4956.0 1132.6,0.0 5076.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5034.0,6621.6 1215.3,8291.9 1072.1,7859.4 611.2,7860.1 606.5,7046.4 746.0,6920.0 618.8,5960.5 -0.0,3785.2 -0.0,2471.1 690.7,2473.3 696.3,495.7 5051.4,507.4 5034.0,6621.6\" /></svg>"
         }
       },
       "body": {
@@ -1399,8 +1622,29 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2888.0,
-                4956.0
+                707.9,
+                6381.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0151644,
+                38.9064627
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2887.5,
+                4954.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1415,13 +1659,64 @@
                 38.9072357
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001480",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/info.json",
+          "type": "ImageService2",
+          "height": 8439,
+          "width": 6046
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5020.6,222.4 5071.7,7071.1 -0.0,7101.4 -0.0,1486.4 1202.2,1455.8 1344.6,1872.7 5020.6,222.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                672.0,
-                4956.0
+                2303.2,
+                1455.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1432,8 +1727,440 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.015164,
-                38.907236
+                -77.0141188,
+                38.9056618
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1203.6,
+                1455.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0149082,
+                38.9056661
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001490",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/info.json",
+          "type": "ImageService2",
+          "height": 8455,
+          "width": 6063
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8455.0 -0.0,5382.9 310.6,5383.2 326.5,0.0 4926.5,0.0 4923.8,288.5 5057.3,288.8 5505.9,8455.0 -0.0,8455.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01915144313962,
+                38.902668035585464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6063.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01502326253436,
+                38.9026758645979
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6063.0,
+                8455.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0150092322049,
+                38.89819657268264
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8455.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01913741281017,
+                38.898188743670204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4367.3,
+                292.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.016176,
+                38.902519
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001500",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/info.json",
+          "type": "ImageService2",
+          "height": 8442,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5199.1,486.9 4860.6,5875.3 5996.0,5978.3 5996.0,8442.0 -0.0,8442.0 154.9,8369.3 -0.0,8360.8 -0.0,183.3 5199.1,486.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0157146970342,
+                38.90261850085279
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5996.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01163950084357,
+                38.90280046617535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5996.0,
+                8442.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0113101715697,
+                38.898334864134576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8442.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01538536776033,
+                38.898152898812015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2916.0,
+                351.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01372,
+                38.9025208
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001530",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/info.json",
+          "type": "ImageService2",
+          "height": 8420,
+          "width": 5966
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5966.0,6861.1 5966.0,8420.0 -0.0,8420.0 -0.0,-0.0 4742.8,0.0 4730.2,1664.0 5966.0,1667.0 5966.0,6179.3 5617.3,6051.1 5303.9,6607.7 5966.0,6861.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1295.6,
+                4504.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199136,
+                38.8928445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1295.6,
+                -1460.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199158,
+                38.8944258
               ]
             }
           }
@@ -1447,7 +2174,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 39",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001540",
       "metadata": [
         {
           "label": "streets",
@@ -1455,11 +2182,11 @@
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1474,11 +2201,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/info.json",
           "type": "ImageService2",
           "height": 8460,
-          "width": 6088
+          "width": 6085
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8460.0 -0.0,-0.0 6088.0,0.0 6088.0,8460.0 -0.0,8460.0\" /></svg>"
+          "value": "<svg><polygon points=\"6085.0,8460.0 -0.0,8460.0 -0.0,5911.6 583.8,5907.1 578.4,5200.0 277.2,5087.3 417.4,4833.7 475.7,4855.6 576.0,4890.7 560.5,2843.8 -0.0,2846.7 -0.0,-0.0 6085.0,0.0 6085.0,8460.0\" /></svg>"
         }
       },
       "body": {
@@ -1492,7 +2219,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4728.0,
+                4725.7,
                 6332.0
               ],
               "creator": {
@@ -1513,8 +2240,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4728.0,
-                1732.0
+                4725.7,
+                908.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1540,7 +2267,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 41",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001550",
       "metadata": [
         {
           "label": "streets",
@@ -1551,8 +2278,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1566,12 +2293,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/info.json",
           "type": "ImageService2",
-          "height": 8488,
-          "width": 6020
+          "height": 8486,
+          "width": 6017
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.3,3081.4 -0.0,3113.9 -0.0,708.2 4031.6,527.0 5261.3,1156.3 5402.3,4268.2 5532.8,4693.3 6020.0,4673.8 6020.0,5113.7 5580.1,5133.7 5662.4,6901.8 884.8,7026.2 704.3,3081.4\" /></svg>"
+          "value": "<svg><polygon points=\"5121.4,1089.2 5255.7,6892.6 891.1,7111.7 610.6,682.5 4029.6,526.9 5121.4,1089.2\" /></svg>"
         }
       },
       "body": {
@@ -1585,8 +2312,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5244.0,
-                6588.0
+                5241.4,
+                6586.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1606,8 +2333,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5244.0,
-                668.0
+                5241.4,
+                667.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1627,25 +2354,118 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 43",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001560",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
           "value": "7"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/info.json",
+          "type": "ImageService2",
+          "height": 8460,
+          "width": 6022
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"733.8,467.7 4490.6,2428.7 6022.0,3427.4 6022.0,6045.8 677.2,6103.1 733.8,467.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                735.8,
+                468.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090993,
+                38.9108059
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                7153.6,
+                3928.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0046338,
+                38.9088865
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001570",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1659,12 +2479,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/info.json",
           "type": "ImageService2",
-          "height": 8420,
+          "height": 8419,
           "width": 5996
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"636.4,4578.2 546.0,0.0 5201.3,0.0 5212.0,904.0 5088.7,899.4 5081.4,556.0 4821.2,675.5 5080.9,7322.1 5207.3,7317.1 5228.5,8420.0 -0.0,8420.0 -0.0,4571.1 636.4,4578.2\" /></svg>"
+          "value": "<svg><polygon points=\"927.2,0.0 5220.2,0.0 5216.7,698.7 5481.8,584.6 5554.7,938.2 5996.0,938.9 5996.0,7403.3 890.1,7357.0 927.2,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1678,8 +2498,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5212.0,
-                3820.0
+                -1912.0,
+                3819.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1690,8 +2510,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089631,
-                38.9056466
+                -77.0141188,
+                38.9056618
               ]
             }
           },
@@ -1700,7 +2520,7 @@
             "properties": {
               "resourceCoords": [
                 5212.0,
-                904.0
+                903.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1711,8 +2531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089218,
-                38.90723
+                -77.009194,
+                38.9072478
               ]
             }
           }
@@ -1726,7 +2546,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 44",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001580",
       "metadata": [
         {
           "label": "streets",
@@ -1737,8 +2557,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1752,12 +2572,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/info.json",
           "type": "ImageService2",
-          "height": 8496,
-          "width": 5988
+          "height": 8494,
+          "width": 5986
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"350.3,705.4 614.1,590.8 614.4,935.8 738.1,942.9 738.6,737.8 2407.2,0.0 5988.0,0.0 5988.0,3842.7 5288.1,3874.0 5107.0,8496.0 601.7,8496.0 602.8,7384.1 475.8,7386.5 350.3,705.4\" /></svg>"
+          "value": "<svg><polygon points=\"1127.5,941.7 687.8,942.7 613.8,590.6 350.1,705.3 364.8,0.0 5986.0,0.0 5986.0,3841.8 5287.1,3873.1 5107.4,6720.1 1149.7,6719.5 1127.5,941.7\" /></svg>"
         }
       },
       "body": {
@@ -1771,8 +2591,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                740.0,
-                3872.0
+                739.8,
+                3871.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1792,8 +2612,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                740.0,
-                2396.0
+                739.8,
+                2395.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1819,7 +2639,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 45",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001590",
       "metadata": [
         {
           "label": "streets",
@@ -1830,8 +2650,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1845,12 +2665,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/info.json",
           "type": "ImageService2",
-          "height": 8428,
+          "height": 8426,
           "width": 5964
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1807.3 5964.0,1920.4 5964.0,8428.0 -0.0,8428.0 -0.0,1807.3\" /></svg>"
+          "value": "<svg><polygon points=\"582.1,774.3 5137.0,803.8 5132.0,3091.3 5003.0,3091.3 4990.4,8426.0 557.2,8387.9 582.1,774.3\" /></svg>"
         }
       },
       "body": {
@@ -1865,7 +2685,7 @@
             "properties": {
               "resourceCoords": [
                 5132.0,
-                3092.0
+                3091.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1886,7 +2706,7 @@
             "properties": {
               "resourceCoords": [
                 5132.0,
-                7356.0
+                7354.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1906,13 +2726,478 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001600",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/info.json",
+          "type": "ImageService2",
+          "height": 8110,
+          "width": 5610
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"424.7,3003.5 555.8,3003.3 558.6,678.8 428.9,679.0 416.1,0.0 5155.7,0.0 5154.9,4220.1 4786.7,5132.5 5610.0,5189.1 5610.0,7221.0 418.1,7336.6 424.7,3003.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00939612138454,
+                38.90410611768399
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5610.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.005575636863,
+                38.90410570039572
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5610.0,
+                8110.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00557641204121,
+                38.89980861860983
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8110.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00939689656275,
+                38.8998090358981
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                555.8,
+                3003.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091072,
+                38.9025147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                555.8,
+                3003.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091072,
+                38.9025147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                555.8,
+                3003.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090179,
+                38.9025148
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001620",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/info.json",
+          "type": "ImageService2",
+          "height": 8484,
+          "width": 6042
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6042.0,8484.0 -0.0,8484.0 -0.0,1311.3 666.8,1312.1 669.9,218.9 6042.0,113.9 6042.0,8484.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00956862563065,
+                38.90033401772563
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6042.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00545405674683,
+                38.90034055256142
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6042.0,
+                8484.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00544226804489,
+                38.89584642456708
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8484.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00955683692871,
+                38.8958398897313
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.009084,
+                38.8974972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.009084,
+                38.8974972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090723,
+                38.8974629
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.009061,
+                38.8974915
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090723,
+                38.8974629
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                719.8,
+                5420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090723,
+                38.8974629
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 52",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001660",
       "metadata": [
         {
           "label": "streets",
@@ -1923,8 +3208,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1938,12 +3223,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/info.json",
           "type": "ImageService2",
-          "height": 8480,
-          "width": 6032
+          "height": 8479,
+          "width": 6029
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8480.0 -0.0,-0.0 6032.0,-0.0 6032.0,1284.8 3572.5,1286.3 3576.1,6884.4 2470.6,6858.0 2431.8,8480.0 -0.0,8480.0\" /></svg>"
+          "value": "<svg><polygon points=\"4343.0,7773.1 137.1,7652.8 -0.0,7338.8 -0.0,-0.0 6029.0,-0.0 6029.0,1284.6 3570.9,1286.1 3574.1,6529.6 4348.1,6705.0 4343.0,7773.1\" /></svg>"
         }
       },
       "body": {
@@ -1957,8 +3242,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3192.0,
-                8004.0
+                3190.4,
+                8003.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1978,8 +3263,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3192.0,
-                6444.0
+                3190.4,
+                6443.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2005,7 +3290,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 53",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001670",
       "metadata": [
         {
           "label": "streets",
@@ -2016,8 +3301,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2031,12 +3316,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/info.json",
           "type": "ImageService2",
-          "height": 8424,
-          "width": 6004
+          "height": 8421,
+          "width": 6002
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6518.4 -0.0,-0.0 6004.0,-0.0 6004.0,1606.4 4928.0,1367.9 4908.3,6638.7 -0.0,6518.4\" /></svg>"
+          "value": "<svg><polygon points=\"2227.3,7697.3 2228.2,7558.4 894.5,7552.1 901.2,6308.8 -0.0,6104.0 0.0,-0.0 4303.2,-0.0 4222.5,7704.4 2227.3,7697.3\" /></svg>"
         }
       },
       "body": {
@@ -2050,8 +3335,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2228.0,
-                7700.0
+                2227.3,
+                7697.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2071,8 +3356,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4928.0,
-                1368.0
+                4926.4,
+                1367.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2098,19 +3383,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 54",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001680",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "10"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2125,11 +3410,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/info.json",
           "type": "ImageService2",
           "height": 8380,
-          "width": 5972
+          "width": 5969
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5972.0,-0.0 5972.0,7482.3 5565.7,7589.4 2622.4,7604.8 2554.1,7732.0 668.0,7732.0 630.3,1463.3 1696.4,1687.9 1679.8,100.1 -0.0,117.7 0.0,0.0 5972.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"2552.8,7732.0 -0.0,7736.6 0.0,0.0 5969.0,-0.0 5969.0,2606.2 5450.7,2603.8 4474.0,4088.3 2552.8,7732.0\" /></svg>"
         }
       },
       "body": {
@@ -2143,7 +3428,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                668.0,
+                667.7,
                 7732.0
               ],
               "creator": {
@@ -2164,7 +3449,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2556.0,
+                2554.7,
                 7732.0
               ],
               "creator": {
@@ -2191,7 +3476,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 55",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001690",
       "metadata": [
         {
           "label": "streets",
@@ -2202,8 +3487,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2217,12 +3502,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/info.json",
           "type": "ImageService2",
-          "height": 8448,
-          "width": 5992
+          "height": 8446,
+          "width": 5989
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5180.4 137.0,5171.0 -0.0,3180.9 -0.0,510.9 697.1,461.9 665.3,0.0 5827.0,0.0 5836.5,124.7 5344.2,152.5 5923.5,8448.0 -0.0,8448.0 -0.0,5180.4\" /></svg>"
+          "value": "<svg><polygon points=\"5920.5,8446.0 -0.0,8446.0 300.5,7396.9 -0.0,3187.3 -0.0,510.6 696.0,461.7 664.2,0.0 5331.7,0.0 5920.5,8446.0\" /></svg>"
         }
       },
       "body": {
@@ -2236,8 +3521,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5836.0,
-                7180.0
+                5833.1,
+                7178.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2257,8 +3542,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3880.0,
-                264.0
+                3878.1,
+                263.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2284,19 +3569,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 56",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001700",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "5"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2311,11 +3596,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/info.json",
           "type": "ImageService2",
           "height": 8452,
-          "width": 6016
+          "width": 6013
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"373.1,3820.4 2475.7,3835.5 2473.5,322.4 5887.6,319.7 5013.6,8452.0 384.9,8452.0 373.1,3820.4\" /></svg>"
+          "value": "<svg><polygon points=\"5015.9,8452.0 385.9,8452.0 366.1,154.2 -0.0,129.5 0.0,0.0 3984.2,0.0 3982.0,320.0 5493.4,317.7 5495.1,3820.3 6013.0,3816.8 6013.0,7875.7 5500.6,7874.7 5500.3,8086.1 5500.4,8232.8 5016.4,8233.5 5015.9,8452.0\" /></svg>"
         }
       },
       "body": {
@@ -2329,7 +3614,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3984.0,
+                3982.0,
                 6044.0
               ],
               "creator": {
@@ -2350,7 +3635,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5500.0,
+                3982.0,
                 320.0
               ],
               "creator": {
@@ -2362,8 +3647,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.998443,
-                38.9056458
+                -76.999504,
+                38.9056457
               ]
             }
           }
@@ -2377,7 +3662,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 59",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001730",
       "metadata": [
         {
           "label": "streets",
@@ -2385,11 +3670,11 @@
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2403,12 +3688,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/info.json",
           "type": "ImageService2",
-          "height": 8428,
-          "width": 6024
+          "height": 8426,
+          "width": 6022
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5207.3,782.1 5287.7,8428.0 -0.0,8428.0 -0.0,0.0 4800.5,-0.0 4800.9,241.4 5341.0,536.4 5207.3,782.1\" /></svg>"
+          "value": "<svg><polygon points=\"5205.6,781.9 5285.5,8426.0 -0.0,8426.0 -0.0,0.0 4799.0,-0.0 4799.4,241.3 5187.7,453.5 5339.2,536.3 5205.6,781.9\" /></svg>"
         }
       },
       "body": {
@@ -2422,8 +3707,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2564.0,
-                5764.0
+                2563.1,
+                5762.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2443,8 +3728,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4752.0,
-                1636.0
+                4750.4,
+                1635.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2470,7 +3755,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 60",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001740",
       "metadata": [
         {
           "label": "streets",
@@ -2481,8 +3766,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2497,11 +3782,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/info.json",
           "type": "ImageService2",
           "height": 8432,
-          "width": 5984
+          "width": 5983
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5984.0,8432.0 -0.0,8432.0 0.0,0.0 5984.0,0.0 5984.0,8432.0\" /></svg>"
+          "value": "<svg><polygon points=\"5983.0,8432.0 -0.0,8432.0 -0.0,0.0 5983.0,0.0 5983.0,8432.0\" /></svg>"
         }
       },
       "body": {
@@ -2515,7 +3800,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5000.0,
+                4999.2,
                 7892.0
               ],
               "creator": {
@@ -2536,7 +3821,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5000.0,
+                4999.2,
                 1252.0
               ],
               "creator": {
@@ -2563,19 +3848,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 63",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001770",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2589,12 +3874,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/info.json",
           "type": "ImageService2",
-          "height": 8440,
-          "width": 5948
+          "height": 8438,
+          "width": 5946
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5948.0,7723.6 -0.0,7713.7 -0.0,359.9 491.4,359.1 491.5,0.0 5948.0,0.0 5948.0,7723.6\" /></svg>"
+          "value": "<svg><polygon points=\"5509.8,7707.9 -0.0,7708.4 -0.0,362.3 487.9,360.7 487.4,0.0 5490.9,0.0 5509.8,7707.9\" /></svg>"
         }
       },
       "body": {
@@ -2608,8 +3893,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                488.0,
-                6240.0
+                3766.7,
+                2419.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2620,8 +3905,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.998455,
-                38.89814
+                -76.996167,
+                38.9002024
               ]
             }
           },
@@ -2629,8 +3914,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                488.0,
-                2420.0
+                487.8,
+                2419.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2650,13 +3935,106 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001780",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/info.json",
+          "type": "ImageService2",
+          "height": 8476,
+          "width": 5996
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4776.9,0.0 4773.8,400.3 5453.1,401.3 5468.6,8476.0 509.0,8476.0 501.9,53.3 4776.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2240.0,
+                2476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.993757,
+                38.900202
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                504.0,
+                2476.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.994961,
+                38.900203
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 65",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001790",
       "metadata": [
         {
           "label": "streets",
@@ -2667,8 +4045,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2687,7 +4065,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"64.7,416.4 5320.4,421.4 5324.1,7725.7 3218.5,7724.5 2816.2,7544.3 1053.4,8464.0 739.7,8464.0 732.3,7726.6 42.0,7722.0 -0.0,-0.0 64.7,416.4\" /></svg>"
+          "value": "<svg><polygon points=\"4412.8,7724.7 5321.2,7725.3 5321.4,8464.0 737.9,8395.2 736.7,418.4 4472.0,421.1 4412.8,7724.7\" /></svg>"
         }
       },
       "body": {
@@ -2749,7 +4127,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 66",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001800",
       "metadata": [
         {
           "label": "streets",
@@ -2760,8 +4138,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2780,7 +4158,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"848.8,419.7 2954.2,390.5 3190.5,519.6 3475.3,0.0 5976.0,0.0 5976.0,4795.3 4886.5,4805.6 4907.9,8492.0 914.8,8492.0 848.8,419.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7730.9 -0.0,425.9 2954.5,390.5 3190.9,519.5 3475.8,0.0 5976.0,0.0 5976.0,702.6 5823.2,706.5 5327.5,1617.5 4636.6,1296.0 4860.0,1662.8 4908.5,8492.0 914.8,8492.0 908.5,7724.1 -0.0,7730.9\" /></svg>"
         }
       },
       "body": {
@@ -2842,7 +4220,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 67",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001810",
       "metadata": [
         {
           "label": "streets",
@@ -2853,8 +4231,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2869,11 +4247,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/info.json",
           "type": "ImageService2",
           "height": 8472,
-          "width": 5988
+          "width": 5986
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4286.3,6728.8 -0.0,6618.4 -0.0,0.0 5760.9,-0.0 4528.9,4994.1 4309.3,5318.2 4286.3,6728.8\" /></svg>"
+          "value": "<svg><polygon points=\"3436.6,7855.6 975.2,7814.3 585.2,8038.4 940.4,7323.4 -0.0,6779.7 -0.0,-0.0 3644.5,-0.0 3436.6,7855.6\" /></svg>"
         }
       },
       "body": {
@@ -2887,7 +4265,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4424.0,
+                4422.5,
                 5092.0
               ],
               "creator": {
@@ -2908,7 +4286,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1884.0,
+                1883.4,
                 4664.0
               ],
               "creator": {
@@ -2935,19 +4313,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 68",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001820",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2961,12 +4339,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/info.json",
           "type": "ImageService2",
-          "height": 8536,
-          "width": 6020
+          "height": 8535,
+          "width": 6019
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3788.7,5518.8 3860.2,7653.6 1047.7,7751.2 957.6,5381.3 1145.0,5069.6 2106.0,-0.0 4270.8,-0.0 4994.9,353.9 6020.0,312.6 6020.0,2386.7 5840.0,2392.7 5861.7,3011.1 4886.6,3046.2 4952.7,5029.8 3444.1,5091.6 3451.6,5315.1 3788.7,5518.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,69.0 6019.0,69.8 6019.0,8535.0 4663.7,8535.0 4663.2,7848.4 -0.0,7879.0 -0.0,69.0\" /></svg>"
         }
       },
       "body": {
@@ -2980,29 +4358,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                372.0,
-                7776.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9855028,
-                38.899288
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3128.0,
-                5108.0
+                3127.5,
+                5107.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3017,6 +4374,186 @@
                 38.897692
               ]
             }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                907.8,
+                5107.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9836408,
+                38.898855
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001840",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/info.json",
+          "type": "ImageService2",
+          "height": 8481,
+          "width": 5994
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2414.1,7622.1 -0.0,7547.0 -0.0,-0.0 5335.3,0.0 5305.9,667.4 5818.0,689.4 5471.4,8481.0 2381.6,8481.0 2414.1,7622.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00243129206898,
+                38.89758151721692
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5994.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99835277018856,
+                38.897710719056
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5994.0,
+                8481.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99811782701238,
+                38.893220301494196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8481.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00219634889278,
+                38.893091099655116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                351.9,
+                5626.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.002036,
+                38.8946102
+              ]
+            }
           }
         ]
       }
@@ -3028,7 +4565,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 71",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001850",
       "metadata": [
         {
           "label": "streets",
@@ -3039,8 +4576,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3055,11 +4592,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/info.json",
           "type": "ImageService2",
           "height": 8492,
-          "width": 5996
+          "width": 5995
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"428.5,7583.6 462.6,5350.8 2638.0,5370.6 2882.8,5482.8 3773.2,5022.2 3748.0,4171.7 465.6,4150.9 488.3,1720.5 -0.0,1779.0 -0.0,684.7 5923.4,744.9 5996.0,1060.7 5486.0,1121.8 5437.2,7628.0 428.5,7583.6\" /></svg>"
+          "value": "<svg><polygon points=\"5995.0,7631.4 427.9,7582.6 502.0,689.5 5483.7,740.7 5483.3,1417.1 5995.0,1421.2 5995.0,7631.4\" /></svg>"
         }
       },
       "body": {
@@ -3073,7 +4610,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5464.0,
+                5463.1,
                 4216.0
               ],
               "creator": {
@@ -3094,7 +4631,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                488.0,
+                487.9,
                 1828.0
               ],
               "creator": {
@@ -3121,7 +4658,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 73",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001870",
       "metadata": [
         {
           "label": "streets",
@@ -3132,8 +4669,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3148,11 +4685,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/info.json",
           "type": "ImageService2",
           "height": 8444,
-          "width": 6000
+          "width": 5999
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"691.7,459.8 700.3,1361.5 2780.0,280.0 3182.9,461.1 5292.6,465.3 5289.1,1234.7 6000.0,1241.4 6000.0,6616.7 -0.0,6703.9 -0.0,454.2 691.7,459.8\" /></svg>"
+          "value": "<svg><polygon points=\"697.1,1138.5 700.2,1362.1 1010.9,1200.5 5999.0,1242.0 5999.0,6616.1 5278.2,6596.3 5276.3,7363.2 -0.0,7349.0 -0.0,1136.4 697.1,1138.5\" /></svg>"
         }
       },
       "body": {
@@ -3166,7 +4703,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2516.0,
+                2515.6,
                 3944.0
               ],
               "creator": {
@@ -3187,7 +4724,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5280.0,
+                5279.1,
                 3944.0
               ],
               "creator": {
@@ -3214,7 +4751,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 75",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001890",
       "metadata": [
         {
           "label": "streets",
@@ -3225,8 +4762,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3240,12 +4777,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/info.json",
           "type": "ImageService2",
-          "height": 8480,
-          "width": 6024
+          "height": 8478,
+          "width": 6021
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6581.9 -0.0,1138.3 659.6,1141.5 659.8,341.2 2866.7,341.1 3088.7,0.0 3319.8,0.0 3331.5,1559.9 5382.1,1560.3 5384.7,2568.3 6024.0,2567.3 6024.0,6776.4 682.6,6784.9 681.6,6597.6 -0.0,6581.9\" /></svg>"
+          "value": "<svg><polygon points=\"681.3,6595.5 -0.0,6579.8 -0.0,2447.4 6021.0,2481.2 6021.0,7721.2 4194.9,7744.5 2896.0,7262.4 684.8,7264.7 681.3,6595.5\" /></svg>"
         }
       },
       "body": {
@@ -3259,8 +4796,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                668.0,
-                3904.0
+                667.7,
+                3903.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3280,8 +4817,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5392.0,
-                3768.0
+                5389.3,
+                3767.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3307,7 +4844,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 76",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001900",
       "metadata": [
         {
           "label": "streets",
@@ -3315,11 +4852,11 @@
         },
         {
           "label": "intersections",
-          "value": "10"
+          "value": "9"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3333,12 +4870,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/info.json",
           "type": "ImageService2",
-          "height": 8400,
+          "height": 8398,
           "width": 6024
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"564.5,0.0 6024.0,0.0 6024.0,8400.0 1819.0,8400.0 2014.0,482.7 566.2,481.9 564.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6024.0,8398.0 572.3,8398.0 558.4,3808.4 1846.1,3113.4 560.2,3384.5 566.2,483.7 2777.1,485.0 4075.0,968.8 5900.8,948.4 5902.3,0.0 6024.0,0.0 6024.0,8398.0\" /></svg>"
         }
       },
       "body": {
@@ -3353,7 +4890,7 @@
             "properties": {
               "resourceCoords": [
                 572.0,
-                7412.0
+                7410.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3374,7 +4911,7 @@
             "properties": {
               "resourceCoords": [
                 5276.0,
-                7412.0
+                7410.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3400,7 +4937,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 78",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001920",
       "metadata": [
         {
           "label": "streets",
@@ -3408,11 +4945,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3426,12 +4963,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/info.json",
           "type": "ImageService2",
-          "height": 8424,
-          "width": 5972
+          "height": 8422,
+          "width": 5971
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"349.5,3291.7 783.0,3282.0 349.5,3158.1 349.4,2367.1 -0.0,2392.7 -0.0,-0.0 5526.5,0.0 5527.8,6397.0 352.5,6406.2 349.5,3291.7\" /></svg>"
+          "value": "<svg><polygon points=\"81.1,373.3 2455.8,348.4 2460.1,1193.2 5035.3,1086.0 5036.1,7362.4 37.1,7366.0 0.0,-0.0 81.1,373.3\" /></svg>"
         }
       },
       "body": {
@@ -3445,8 +4982,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2472.0,
-                7364.0
+                2471.6,
+                7362.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3466,8 +5003,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5528.0,
-                7364.0
+                5527.1,
+                7362.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3493,7 +5030,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 79",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001930",
       "metadata": [
         {
           "label": "streets",
@@ -3501,11 +5038,11 @@
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "7"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3519,12 +5056,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/info.json",
           "type": "ImageService2",
-          "height": 8400,
+          "height": 8399,
           "width": 5988
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5493.7,6480.1 5496.0,7388.0 488.0,7388.0 458.7,433.3 5988.0,439.0 5988.0,6480.0 5493.7,6480.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7387.2 -0.0,1148.7 456.4,1129.8 458.7,435.2 5988.0,440.7 5988.0,7387.4 -0.0,7387.2\" /></svg>"
         }
       },
       "body": {
@@ -3539,7 +5076,7 @@
             "properties": {
               "resourceCoords": [
                 5496.0,
-                7388.0
+                7387.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3560,7 +5097,7 @@
             "properties": {
               "resourceCoords": [
                 488.0,
-                7388.0
+                7387.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3580,13 +5117,193 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001940",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/info.json",
+          "type": "ImageService2",
+          "height": 8424,
+          "width": 5979
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"943.4,7418.6 983.5,0.0 4761.9,0.0 4763.7,296.8 5452.0,297.1 5492.7,6995.8 5036.4,7407.1 943.4,7418.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99524434272556,
+                38.89374453373918
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5979.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99117336842163,
+                38.893731619179
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5979.0,
+                8424.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99119674881959,
+                38.88926930205803
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8424.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99526772312352,
+                38.88928221661821
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                439.9,
+                7420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949654,
+                38.8898131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                439.9,
+                7420.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949654,
+                38.8898131
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 81",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001950",
       "metadata": [
         {
           "label": "streets",
@@ -3597,8 +5314,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3612,12 +5329,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/info.json",
           "type": "ImageService2",
-          "height": 8436,
+          "height": 8433,
           "width": 5976
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5236.1,2774.9 5013.4,3456.6 5256.3,3459.7 5223.0,5934.1 4366.5,6408.8 713.0,6406.4 712.2,6525.8 -0.0,6525.3 -0.0,-0.0 5215.7,0.0 5236.1,2774.9\" /></svg>"
+          "value": "<svg><polygon points=\"695.5,636.9 5215.0,637.3 5236.0,2774.0 5013.4,3455.4 5256.4,3458.5 5206.6,8433.0 704.1,8422.0 695.5,636.9\" /></svg>"
         }
       },
       "body": {
@@ -3632,7 +5349,7 @@
             "properties": {
               "resourceCoords": [
                 5296.0,
-                3084.0
+                3082.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3653,7 +5370,7 @@
             "properties": {
               "resourceCoords": [
                 3188.0,
-                6408.0
+                6405.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3679,7 +5396,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 82",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001960",
       "metadata": [
         {
           "label": "streets",
@@ -3687,11 +5404,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "9"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3705,12 +5422,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/info.json",
           "type": "ImageService2",
-          "height": 8436,
+          "height": 8434,
           "width": 5988
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"916.0,5894.6 886.7,3482.5 649.9,3485.6 849.8,2815.7 760.7,112.0 4590.8,0.0 4608.8,637.4 5988.0,604.2 5988.0,8436.0 963.5,8436.0 941.8,7695.0 1111.2,7438.8 1467.0,7325.6 1013.5,7153.1 752.3,6409.6 93.2,6378.6 916.0,5894.6\" /></svg>"
+          "value": "<svg><polygon points=\"886.7,3481.7 649.8,3484.7 849.8,2815.0 757.8,0.0 4591.8,0.0 4672.2,3401.4 5891.2,3112.9 4680.5,3805.3 4801.5,8178.3 5988.0,8149.1 5988.0,8434.0 963.5,8434.0 886.7,3481.7\" /></svg>"
         }
       },
       "body": {
@@ -3725,7 +5442,7 @@
             "properties": {
               "resourceCoords": [
                 916.0,
-                5896.0
+                5894.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3746,7 +5463,7 @@
             "properties": {
               "resourceCoords": [
                 916.0,
-                3116.0
+                3115.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3772,7 +5489,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 84",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001980",
       "metadata": [
         {
           "label": "streets",
@@ -3783,8 +5500,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3799,11 +5516,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/info.json",
           "type": "ImageService2",
           "height": 8432,
-          "width": 6012
+          "width": 6009
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4312.5 401.5,4323.8 408.8,0.0 5597.3,0.0 5590.4,7182.7 5315.9,7064.3 2828.2,7129.9 2530.9,6974.4 2530.1,7981.6 1899.1,7983.4 1759.1,8432.0 -0.0,8432.0 -0.0,4312.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6204.4 -0.0,934.7 6009.0,972.0 6009.0,5169.0 5588.7,5166.3 5566.8,8432.0 277.0,8099.5 -0.0,6204.4\" /></svg>"
         }
       },
       "body": {
@@ -3817,7 +5534,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2532.0,
+                4046.0,
                 964.0
               ],
               "creator": {
@@ -3829,8 +5546,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.000571,
-                38.8898167
+                -76.9995165,
+                38.8898131
               ]
             }
           },
@@ -3838,8 +5555,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                408.0,
-                964.0
+                5565.2,
+                8732.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3850,8 +5567,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0020381,
-                38.8898157
+                -76.9984563,
+                38.8857252
               ]
             }
           }
@@ -3865,19 +5582,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 85",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb001990",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3891,12 +5608,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/info.json",
           "type": "ImageService2",
-          "height": 8384,
-          "width": 5964
+          "height": 8381,
+          "width": 5962
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5384.9,7703.4 469.9,7696.6 472.0,868.0 5385.0,871.9 5388.9,4342.3 4894.2,4602.7 4894.1,4868.3 5388.6,4866.1 5384.9,7703.4\" /></svg>"
+          "value": "<svg><polygon points=\"3749.1,7821.3 3719.2,5335.4 3859.0,5260.4 3830.1,4940.6 886.4,4943.3 856.2,867.4 5477.5,864.2 5486.7,4398.8 4983.2,4664.8 4983.4,4935.2 5487.2,4932.3 5487.7,7822.0 3749.1,7821.3\" /></svg>"
         }
       },
       "body": {
@@ -3910,8 +5627,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                472.0,
-                6912.0
+                3742.7,
+                867.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3922,8 +5639,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9984547,
-                38.8864758
+                -76.9961747,
+                38.8898126
               ]
             }
           },
@@ -3931,8 +5648,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                472.0,
-                868.0
+                471.8,
+                867.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3958,7 +5675,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 86",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002000",
       "metadata": [
         {
           "label": "streets",
@@ -3969,8 +5686,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3985,11 +5702,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/info.json",
           "type": "ImageService2",
           "height": 8404,
-          "width": 5996
+          "width": 5995
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"501.9,4958.0 -0.0,4960.4 -0.0,4690.9 501.9,4426.3 493.9,0.0 5416.8,0.0 5413.9,508.7 4968.5,907.3 5242.9,963.7 5421.2,1202.2 5410.6,7823.8 4821.3,7826.4 4887.5,8404.0 3697.6,8404.0 3697.3,7826.9 499.7,7837.7 501.9,4958.0\" /></svg>"
+          "value": "<svg><polygon points=\"4886.9,8404.0 500.7,8404.0 501.8,4956.5 -0.0,4958.9 -0.0,4689.5 501.8,4425.0 495.9,904.0 4967.7,907.3 5412.9,508.9 5407.0,6406.0 4154.6,6407.9 4157.9,7823.3 4876.8,7823.6 4886.9,8404.0\" /></svg>"
         }
       },
       "body": {
@@ -4003,7 +5720,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2216.0,
+                2215.6,
                 904.0
               ],
               "creator": {
@@ -4024,7 +5741,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                496.0,
+                495.9,
                 904.0
               ],
               "creator": {
@@ -4051,19 +5768,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 87",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002010",
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "13"
+          "value": "16"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4077,12 +5794,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/info.json",
           "type": "ImageService2",
-          "height": 8452,
-          "width": 6056
+          "height": 8449,
+          "width": 6055
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"722.3,7890.8 737.9,1297.9 560.5,1060.4 287.3,1004.0 731.0,607.5 735.0,0.0 5077.0,0.0 5226.8,170.2 5383.9,814.2 5851.7,1006.2 5478.0,1114.5 5294.7,1376.9 5297.4,2149.3 6056.0,2168.8 6056.0,8452.0 5854.8,8452.0 5844.9,7859.3 5298.5,8042.6 5247.6,7818.8 722.3,7890.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7753.1 -0.0,6471.7 1134.2,6472.8 1145.6,2426.8 5301.6,2431.7 5302.8,2542.0 6055.0,2562.6 6055.0,8449.0 5803.0,8449.0 5792.3,7733.0 5295.1,7898.8 5294.2,6777.3 2798.0,6814.5 2797.1,7762.4 -0.0,7753.1\" /></svg>"
         }
       },
       "body": {
@@ -4096,8 +5813,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5296.0,
-                6488.0
+                5295.1,
+                6485.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4117,8 +5834,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5296.0,
-                2028.0
+                5295.1,
+                7897.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4129,8 +5846,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9883153,
-                38.8892506
+                -76.9883126,
+                38.8859613
               ]
             }
           }
@@ -4144,7 +5861,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 88",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002020",
       "metadata": [
         {
           "label": "streets",
@@ -4155,8 +5872,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4170,12 +5887,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5680
+          "height": 8158,
+          "width": 5679
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8160.0 -0.0,1003.2 5130.9,1010.2 5128.0,1239.1 5680.0,1064.1 5680.0,8160.0 -0.0,8160.0\" /></svg>"
+          "value": "<svg><polygon points=\"5679.0,8158.0 408.3,8158.0 429.4,6779.6 449.6,5812.9 451.1,5710.1 -0.0,5767.3 -0.0,1003.6 2370.3,1047.1 2386.8,0.0 5144.5,0.0 5127.1,1238.8 5679.0,1063.9 5679.0,8158.0\" /></svg>"
         }
       },
       "body": {
@@ -4189,8 +5906,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2356.0,
-                2148.0
+                2355.6,
+                2147.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4210,8 +5927,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5128.0,
-                1240.0
+                5127.1,
+                1239.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4237,7 +5954,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 89",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002030",
       "metadata": [
         {
           "label": "streets",
@@ -4245,11 +5962,11 @@
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4264,11 +5981,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/info.json",
           "type": "ImageService2",
           "height": 8228,
-          "width": 5704
+          "width": 5702
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1312.5,0.0 5704.0,0.0 5704.0,8228.0 0.0,8228.0 0.0,5676.9 1312.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5702.0,1821.4 5702.0,8228.0 -0.0,8228.0 -0.0,2520.5 561.2,2520.5 564.5,1281.8 4773.9,1294.2 4774.9,1436.8 4777.7,1821.0 5702.0,1821.4\" /></svg>"
         }
       },
       "body": {
@@ -4282,7 +5999,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1624.0,
+                1623.4,
                 1288.0
               ],
               "creator": {
@@ -4294,8 +6011,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9984492,
-                38.8940911
+                -77.0199119,
+                38.886887
               ]
             }
           },
@@ -4303,194 +6020,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3148.0,
-                5664.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949624,
-                38.8954393
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 92",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/info.json",
-          "type": "ImageService2",
-          "height": 8212,
-          "width": 5692
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,5568.5 1082.8,1468.3 2625.1,1468.0 5285.4,5578.5 5292.9,8212.0 0.0,8212.0 0.0,5568.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5288.0,
-                4152.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9961774,
-                38.8860395
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5288.0,
-                6996.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.993761,
-                38.8860394
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 95",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/info.json",
-          "type": "ImageService2",
-          "height": 8204,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5724.0,8204.0 -0.0,8204.0 0.0,0.0 5724.0,-0.0 5724.0,8204.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2372.0,
-                7432.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199088,
-                38.8839411
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                -104.0,
-                7432.0
+                4470.4,
+                1288.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4510,25 +6041,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 99",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002070",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "3"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4537,21 +6068,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/info.json",
           "type": "ImageService2",
-          "height": 8244,
-          "width": 5692
+          "height": 8193,
+          "width": 5699
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5692.0,8244.0 0.0,8244.0 0.0,2454.7 5692.0,2887.7 5692.0,8244.0\" /></svg>"
+          "value": "<svg><polygon points=\"1307.8,7350.3 1314.4,3206.6 -0.0,3203.1 0.0,0.0 5699.0,0.0 5699.0,398.6 4319.3,355.2 4308.8,8193.0 3644.3,8193.0 1307.8,7350.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -4561,8 +6092,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2356.0,
-                2316.0
+                1307.8,
+                4330.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4573,8 +6104,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0030622,
-                38.9056508
+                -77.0199119,
+                38.886887
               ]
             }
           },
@@ -4582,8 +6113,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                592.0,
-                2316.0
+                1307.8,
+                7349.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4594,8 +6125,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0020424,
-                38.9056565
+                -77.0199096,
+                38.8850455
               ]
             }
           }
@@ -4603,13 +6134,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 101",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002080",
       "metadata": [
         {
           "label": "streets",
@@ -4620,8 +6151,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4630,21 +6161,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/info.json",
           "type": "ImageService2",
-          "height": 8208,
-          "width": 5692
+          "height": 8206,
+          "width": 5668
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8208.0 0.0,0.0 4843.9,0.0 4863.7,746.2 5294.7,857.3 4867.2,878.1 5063.8,8208.0 -0.0,8208.0\" /></svg>"
+          "value": "<svg><polygon points=\"4056.7,8043.5 1254.0,8130.6 1005.0,0.0 5668.0,0.0 5668.0,8206.0 4061.8,8206.0 4056.7,8043.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4669,8 +6200,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00543413270151,
-                38.89256352454368
+                -77.01824110537046,
+                38.889327175795046
               ]
             }
           },
@@ -4678,7 +6209,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5692.0,
+                5668.0,
                 0.0
               ],
               "creator": {
@@ -4690,8 +6221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0014430557772,
-                38.892478822302046
+                -77.01438429323684,
+                38.88923559025769
               ]
             }
           },
@@ -4699,8 +6230,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5692.0,
-                8208.0
+                5668.0,
+                8206.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4711,8 +6242,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00160002751292,
-                38.88800057106304
+                -77.01455474029449,
+                38.88488967867406
               ]
             }
           },
@@ -4721,7 +6252,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8208.0
+                8206.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4732,8 +6263,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00559110443722,
-                38.888085273304675
+                -77.0184115524281,
+                38.88498126421142
               ]
             }
           },
@@ -4741,8 +6272,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2756.0,
-                1004.0
+                4528.0,
+                2011.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4753,8 +6284,927 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0035209,
-                38.8919748
+                -77.0152018,
+                38.8881885
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002090",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/info.json",
+          "type": "ImageService2",
+          "height": 8203,
+          "width": 5722
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5722.0,8203.0 345.2,8203.0 339.5,7439.9 -0.0,7433.1 -0.0,7016.0 1046.8,4148.0 1046.5,3334.0 -0.0,3328.5 0.0,0.0 5722.0,-0.0 5722.0,8203.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2371.2,
+                7431.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199088,
+                38.8839411
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                -104.0,
+                7431.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0199096,
+                38.8850455
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002110",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/info.json",
+          "type": "ImageService2",
+          "height": 8209,
+          "width": 5675
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5528.5,821.8 5675.0,8209.0 -0.0,8209.0 -0.0,0.0 719.3,-0.0 655.9,801.2 5528.5,821.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1827.7,
+                7453.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0198965,
+                38.878416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5351.1,
+                7453.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0198854,
+                38.8764806
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002130 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5691.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5763.5"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
+          "type": "ImageService2",
+          "height": 8241,
+          "width": 5691
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5763.5 -0.0,2625.5 1218.5,0.0 2175.6,0.0 2788.1,0.0 5691.0,287.8 5662.2,2087.6 3869.5,5588.6 3667.3,5763.5 -0.0,5763.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.016860331855,
+                38.87917208896764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00913194218262,
+                38.878723185270545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                5763.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00971615000455,
+                38.87263352608267
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                5763.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01744453967693,
+                38.87308242977977
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2355.6,
+                2315.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0138948,
+                38.8765394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2355.6,
+                2315.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0138866,
+                38.8763961
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002170",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/info.json",
+          "type": "ImageService2",
+          "height": 8204,
+          "width": 5683
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,-0.0 5683.0,0.0 5683.0,861.2 4460.4,1055.1 5023.1,7857.0 4973.6,8204.0 -0.0,8204.0 0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01199612145858,
+                38.888225117779484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5683.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00814144644673,
+                38.8879618069395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5683.0,
+                8204.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00862986868043,
+                38.883632640864896
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8204.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01248454369228,
+                38.88389595170488
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5023.1,
+                7856.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002180",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/info.json",
+          "type": "ImageService2",
+          "height": 8188,
+          "width": 5707
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1037.8,8073.8 371.8,8043.6 461.3,7478.5 -0.0,7452.2 -0.0,7094.0 460.3,7167.0 563.9,6830.9 1074.9,0.0 5707.0,0.0 5707.0,8188.0 1031.3,8188.0 1037.8,8073.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                563.9,
+                6832.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090568,
+                38.8838463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4079.3,
+                8128.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0066184,
+                38.8832935
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002200",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/info.json",
+          "type": "ImageService2",
+          "height": 8203,
+          "width": 5691
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 5084.0,0.0 5027.1,567.1 5691.0,559.3 5691.0,7961.6 -0.0,7889.1 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0125570156545,
+                38.8834673683162
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00868238083714,
+                38.88350559228233
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5691.0,
+                8203.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00861157784483,
+                38.879160125519434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8203.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.01248621266218,
+                38.87912190155329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5007.1,
+                2223.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0091288,
+                38.8823232
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5007.1,
+                2223.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090025,
+                38.882288
               ]
             }
           }
@@ -4768,7 +7218,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 107",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002210",
       "metadata": [
         {
           "label": "streets",
@@ -4779,8 +7229,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4794,12 +7244,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/info.json",
           "type": "ImageService2",
-          "height": 8220,
+          "height": 8217,
           "width": 5692
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2322.6,2595.5 -0.0,2590.7 0.0,-0.0 1617.0,-0.0 1617.7,1004.5 2322.6,2595.5\" /></svg>"
+          "value": "<svg><polygon points=\"5184.6,49.0 5312.0,2591.1 2951.0,2703.8 1776.0,2591.1 1881.1,4722.7 5287.4,4551.7 5478.9,8217.0 479.4,8217.0 155.5,1926.7 -0.0,1936.5 71.9,303.9 5184.6,49.0\" /></svg>"
         }
       },
       "body": {
@@ -4813,8 +7263,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                156.0,
-                2592.0
+                1776.0,
+                2591.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4825,8 +7275,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089178,
-                38.908569
+                -77.0091405,
+                38.8784194
               ]
             }
           },
@@ -4835,7 +7285,7 @@
             "properties": {
               "resourceCoords": [
                 5312.0,
-                2592.0
+                2591.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4846,8 +7296,101 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089205,
-                38.9056464
+                -77.0092655,
+                38.8764748
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002220",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/info.json",
+          "type": "ImageService2",
+          "height": 8207,
+          "width": 5702
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5280.5,8130.4 136.3,8025.6 133.2,8207.0 -0.0,8207.0 -0.0,745.0 314.6,753.4 318.9,527.4 319.9,468.2 306.8,321.8 5471.1,427.6 5441.3,1728.0 5284.0,1725.9 5163.3,7914.4 5280.5,8130.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1815.4,
+                4339.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.004846,
+                38.8784148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5330.1,
+                3431.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0041578,
+                38.8764998
               ]
             }
           }
@@ -4861,7 +7404,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 109",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002230",
       "metadata": [
         {
           "label": "streets",
@@ -4872,8 +7415,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4888,11 +7431,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/info.json",
           "type": "ImageService2",
           "height": 8188,
-          "width": 5692
+          "width": 5691
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8188.0 -0.0,-0.0 5293.6,0.0 5296.2,4191.1 4968.0,4188.0 4968.7,8188.0 -0.0,8188.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8188.0 -0.0,7437.6 439.1,7435.9 409.8,792.7 525.6,514.0 4541.8,521.5 4523.2,8188.0 -0.0,8188.0\" /></svg>"
         }
       },
       "body": {
@@ -4906,7 +7449,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2720.0,
+                2719.5,
                 4188.0
               ],
               "creator": {
@@ -4927,7 +7470,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4968.0,
+                4967.1,
                 4188.0
               ],
               "creator": {
@@ -4954,7 +7497,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 110",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002240",
       "metadata": [
         {
           "label": "streets",
@@ -4965,8 +7508,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4980,12 +7523,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/info.json",
           "type": "ImageService2",
-          "height": 8208,
+          "height": 8205,
           "width": 5692
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"429.6,7428.8 428.9,4201.5 743.5,4204.5 743.1,187.8 -0.0,187.4 0.0,-0.0 5692.0,0.0 5692.0,8208.0 -0.0,8208.0 -0.0,8034.9 427.7,8035.1 429.6,7428.8\" /></svg>"
+          "value": "<svg><polygon points=\"5124.9,682.6 5401.7,8205.0 -0.0,8205.0 -0.0,685.1 747.4,813.6 5124.9,682.6\" /></svg>"
         }
       },
       "body": {
@@ -5000,7 +7543,7 @@
             "properties": {
               "resourceCoords": [
                 2868.0,
-                4204.0
+                4202.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5021,7 +7564,7 @@
             "properties": {
               "resourceCoords": [
                 2868.0,
-                808.0
+                807.7
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5047,19 +7590,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 111",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002250",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
           "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5073,12 +7616,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/info.json",
           "type": "ImageService2",
-          "height": 8224,
+          "height": 8221,
           "width": 5684
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5145.3,3.9 5145.3,672.1 5496.0,660.0 5533.8,1609.9 5376.0,1763.1 5578.8,2779.0 5496.0,4064.0 444.8,4221.8 314.5,-0.0 5153.5,-0.0 5145.3,3.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8221.0 51.6,463.5 2546.6,572.0 2227.9,8221.0 -0.0,8221.0\" /></svg>"
         }
       },
       "body": {
@@ -5092,8 +7635,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5496.0,
-                4064.0
+                3104.0,
+                2731.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5104,8 +7647,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.015164,
-                38.907236
+                -77.0037742,
+                38.8754225
               ]
             }
           },
@@ -5113,8 +7656,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5496.0,
-                660.0
+                2624.0,
+                659.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5125,8 +7668,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0152276,
-                38.9056651
+                -77.0041578,
+                38.8764998
               ]
             }
           }
@@ -5140,19 +7683,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 112",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002260",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "1"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "2"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5166,12 +7709,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002260/info.json",
           "type": "ImageService2",
-          "height": 8208,
+          "height": 8205,
           "width": 5684
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"954.7,0.0 5684.0,0.0 5684.0,7732.3 5343.7,7733.1 5344.4,8067.4 541.0,8080.6 504.0,636.0 954.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5684.0,8205.0 -0.0,8205.0 -0.0,616.7 1102.5,618.7 1103.1,716.1 5684.0,687.9 5684.0,8205.0\" /></svg>"
         }
       },
       "body": {
@@ -5185,8 +7728,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                504.0,
-                636.0
+                4128.0,
+                635.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5197,8 +7740,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0020424,
-                38.9056565
+                -76.9995209,
+                38.8765331
               ]
             }
           },
@@ -5207,7 +7750,7 @@
             "properties": {
               "resourceCoords": [
                 5320.0,
-                636.0
+                635.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5218,8 +7761,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.998443,
-                38.9056458
+                -76.9981661,
+                38.8765348
               ]
             }
           }
@@ -5233,19 +7776,19 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 114",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002280",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "7"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5259,12 +7802,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/info.json",
           "type": "ImageService2",
-          "height": 8200,
-          "width": 5692
+          "height": 8199,
+          "width": 5690
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,2495.9 641.8,2293.5 322.6,1267.8 674.6,1331.6 3186.6,474.1 3503.8,507.4 5262.3,6223.3 -0.0,7836.6 -0.0,2495.9\" /></svg>"
+          "value": "<svg><polygon points=\"566.7,8199.0 -0.0,8199.0 -0.0,-0.0 289.5,0.0 552.8,188.6 554.7,1781.9 2542.2,1773.8 2541.9,1225.8 3776.3,1869.6 4149.5,1673.9 5056.7,2149.9 5056.9,2590.9 3969.5,2641.6 3970.3,4835.1 5392.5,4834.2 5394.1,6602.7 562.5,6651.8 566.7,8199.0\" /></svg>"
         }
       },
       "body": {
@@ -5278,8 +7821,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5396.0,
-                6604.0
+                5394.1,
+                6603.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5299,8 +7842,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3864.0,
-                7160.0
+                5394.1,
+                1023.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5311,8 +7854,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.999512,
-                38.8832215
+                -76.9984547,
+                38.8864758
               ]
             }
           }
@@ -5326,7 +7869,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 115",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002290",
       "metadata": [
         {
           "label": "streets",
@@ -5337,8 +7880,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5352,12 +7895,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/info.json",
           "type": "ImageService2",
-          "height": 8208,
-          "width": 5692
+          "height": 8205,
+          "width": 5691
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"365.7,8208.0 353.9,5649.1 368.7,743.4 5535.5,748.8 5534.0,4046.9 3746.3,3113.0 3747.9,3541.3 5528.5,4472.3 5524.4,8208.0 365.7,8208.0\" /></svg>"
+          "value": "<svg><polygon points=\"5525.7,7049.4 364.8,7047.2 367.9,1774.8 -0.0,1634.3 -0.0,1150.8 368.3,1344.1 368.6,743.1 5536.4,748.5 5537.4,1337.7 5691.0,1337.7 5691.0,5723.3 5522.2,5725.3 5525.7,7049.4\" /></svg>"
         }
       },
       "body": {
@@ -5371,8 +7914,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                368.0,
-                6036.0
+                367.9,
+                6033.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5392,8 +7935,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                368.0,
-                1776.0
+                367.9,
+                1775.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5413,13 +7956,193 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002300",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/info.json",
+          "type": "ImageService2",
+          "height": 8199,
+          "width": 5707
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"187.6,7613.2 736.1,1361.9 5707.0,1805.6 5707.0,1865.5 5707.0,7685.8 5707.0,7874.4 1729.0,7750.3 187.6,7613.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00009724894005,
+                38.888287983332695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99622663039541,
+                38.888555335552766
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                8199.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99573303762817,
+                38.884228651763046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8199.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99960365617281,
+                38.883961299542975
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                264.0,
+                4379.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9996538,
+                38.8859892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                264.0,
+                4379.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9993772,
+                38.8861019
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 117",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002310",
       "metadata": [
         {
           "label": "streets",
@@ -5430,8 +8153,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5446,11 +8169,11 @@
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/info.json",
           "type": "ImageService2",
           "height": 8180,
-          "width": 5692
+          "width": 5691
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5408.4,0.0 5433.9,2431.4 5692.0,2429.9 5692.0,6524.4 5416.1,6461.0 4570.2,7365.4 -0.0,7599.3 0.0,0.0 5408.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"401.9,2058.4 388.5,446.2 5423.0,366.8 5429.9,1330.7 5691.0,1329.2 5691.0,7754.3 4570.7,7364.3 427.8,7612.7 426.7,7580.1 -0.0,7599.1 -0.0,2060.6 401.9,2058.4\" /></svg>"
         }
       },
       "body": {
@@ -5464,7 +8187,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                408.0,
+                407.9,
                 5920.0
               ],
               "creator": {
@@ -5485,7 +8208,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5424.0,
+                5423.0,
                 368.0
               ],
               "creator": {
@@ -5506,13 +8229,199 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002320",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/info.json",
+          "type": "ImageService2",
+          "height": 8189,
+          "width": 5692
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2034.0,8189.0 613.5,7692.1 645.8,1297.1 5264.8,1294.4 5271.6,7481.9 3578.1,7482.3 3576.1,8189.0 2034.0,8189.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3576.0,
+                8732.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9961867,
+                38.8785892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5276.0,
+                9356.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949736,
+                38.8782423
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002330",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/info.json",
+          "type": "ImageService2",
+          "height": 8212,
+          "width": 5729
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5729.0,7759.2 360.2,7685.6 447.7,0.0 5428.5,0.0 5398.5,2417.2 5729.0,2415.5 5729.0,7759.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2210.8,
+                -704.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9937623,
+                38.8838111
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                479.7,
+                -1640.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9949671,
+                38.8843038
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 121",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002350",
       "metadata": [
         {
           "label": "streets",
@@ -5523,8 +8432,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5543,7 +8452,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8180.0 -0.0,4621.1 5696.0,4978.6 5696.0,8180.0 -0.0,8180.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7629.4 32.1,3432.7 1095.9,916.8 1153.2,-0.0 5533.9,-0.0 5127.1,7945.5 -0.0,7629.4\" /></svg>"
         }
       },
       "body": {
@@ -5599,13 +8508,106 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002360",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/info.json",
+          "type": "ImageService2",
+          "height": 8157,
+          "width": 5652
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"430.9,327.6 3050.1,492.0 3159.1,321.2 5652.0,449.9 5652.0,6449.5 5478.9,6438.9 5582.3,4486.5 956.2,4478.6 999.7,3801.0 243.4,3750.3 430.9,327.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1584.0,
+                3838.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9961867,
+                38.8785892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5352.0,
+                7053.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.9981661,
+                38.8765348
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 123",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002370",
       "metadata": [
         {
           "label": "streets",
@@ -5616,8 +8618,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5631,12 +8633,12 @@
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/info.json",
           "type": "ImageService2",
-          "height": 8184,
-          "width": 5644
+          "height": 8182,
+          "width": 5642
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5644.0,7996.8 2879.3,7997.2 2723.8,8184.0 223.7,8184.0 204.6,7984.1 -0.0,7982.4 0.0,-0.0 5644.0,-0.0 5644.0,7996.8\" /></svg>"
+          "value": "<svg><polygon points=\"5297.1,7988.0 2877.8,7995.2 2722.4,8182.0 224.4,8182.0 264.5,4407.6 -0.0,4410.6 0.0,-0.0 5642.0,-0.0 5642.0,8182.0 5297.3,8182.0 5297.1,7988.0\" /></svg>"
         }
       },
       "body": {
@@ -5650,8 +8652,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1864.0,
-                2960.0
+                1863.3,
+                2959.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5671,7 +8673,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1864.0,
+                1863.3,
                 196.0
               ],
               "creator": {
@@ -5692,25 +8694,41 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 133",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002440 [3]",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "2"
         },
         {
           "label": "intersections",
-          "value": "2"
+          "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5664.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8224.0"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5719,21 +8737,196 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440/info.json",
           "type": "ImageService2",
-          "height": 8180,
-          "width": 5648
+          "height": 8224,
+          "width": 5664
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5648.0,-0.0 5648.0,8180.0 0.0,8180.0 0.0,0.0 5648.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"653.2,8197.8 -0.0,1975.6 -0.0,-0.0 5664.0,0.0 5664.0,8224.0 4309.0,8224.0 653.2,8197.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002470/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00079768803363,
+                38.90686761271392
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99694471850547,
+                38.9067509675678
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5664.0,
+                8224.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -76.99716238001307,
+                38.90239785069975
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8224.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.00101534954123,
+                38.902514495845864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                428.0,
+                2292.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0005672,
+                38.9056456
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002600 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5551.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8160.0"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5551
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,0.0 5551.0,0.0 5551.0,8160.0 -0.0,8160.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -5743,8 +8936,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                292.0,
-                3176.0
+                3767.3,
+                2288.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5755,8 +8948,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0281054,
-                38.9056616
+                -76.9995279,
+                38.9201209
               ]
             }
           },
@@ -5764,8 +8957,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2880.0,
-                3176.0
+                204.0,
+                204.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5776,8 +8969,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0296282,
-                38.9056671
+                -77.00203,
+                38.921298
               ]
             }
           }
@@ -5785,25 +8978,41 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 135",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002610 [4]",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "15"
+          "value": "7"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3399.2"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "5302.0"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5812,7 +9021,7 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/selector",
         "type": "SpecificResource",
         "source": {
           "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/info.json",
@@ -5822,16 +9031,146 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5302.0 -0.0,0.0 3399.2,-0.0 3399.2,3806.3 2763.3,3373.1 1546.3,5159.2 1756.2,5302.0 -0.0,5302.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
         },
         "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1939.5,
+                5601.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090875,
+                38.9251261
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                911.8,
+                4898.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0090823,
+                38.9258397
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002610 [4]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5536.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8160.0"
+        }
+      ],
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/info.json",
+          "type": "ImageService2",
+          "height": 8160,
+          "width": 5536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,0.0 3116.1,0.0 3267.0,458.2 3266.8,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3264.0,
+                5668.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -77.0089892,
+                38.922372
+              ]
+            }
+          },
           {
             "type": "Feature",
             "properties": {
@@ -5852,27 +9191,6 @@
                 38.9245149
               ]
             }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3264.0,
-                7636.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0089922,
-                38.9213036
-              ]
-            }
           }
         ]
       }
@@ -5884,7 +9202,7 @@
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Sanborn Fire Insurance Map from Washington, District of Columbia, District of Columbia. | Page 136",
+      "label": "Washington, D.C. | 1916 | Vol. 2 psb002620",
       "metadata": [
         {
           "label": "streets",
@@ -5892,11 +9210,11 @@
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "13"
         }
       ],
-      "created": "2026-06-12T14:50:49Z",
-      "modified": "2026-06-12T14:50:49Z",
+      "created": "2026-07-17T18:38:07Z",
+      "modified": "2026-07-17T18:38:07Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5915,7 +9233,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6414.0 389.6,5717.3 405.7,5647.3 497.3,3373.6 105.1,3284.0 58.9,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,6414.0\" /></svg>"
+          "value": "<svg><polygon points=\"104.3,3283.9 58.3,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,3259.7 104.3,3283.9\" /></svg>"
         }
       },
       "body": {

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -17,6 +17,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.fit",
         "Georeference, build IIIF, and optionally compare (fast pipeline)",
     ),
+    "rerun": (
+        "mapsnap.pipeline_rerun",
+        "Re-run split/keymap/ocr/adjacency/fit on downloaded volumes, reusing CRAFT boxes",
+    ),
     "experiments": (
         "mapsnap.experiments",
         "Compare archived fit runs (experiments diff <id-a> <id-b>)",

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -571,8 +571,9 @@ def detect_text(
 
     reuse_boxes loads CRAFT bounding boxes from the existing <stem>.boxes.json
     file instead of re-running CRAFT. Useful for iterating on recognition
-    parameters without redoing the (slower) detection step. The caller is
-    responsible for ensuring the file exists before calling with reuse_boxes=True.
+    parameters without redoing the (slower) detection step. An image with no
+    .boxes.json falls back to running CRAFT (and writes the file); the CLI
+    gates that fallback behind --allow-missing-boxes.
 
     Writes <stem>.boxes.json alongside the image whenever CRAFT is run (i.e.
     when reuse_boxes=False). The file records the image dimensions, a timestamp,
@@ -606,7 +607,7 @@ def detect_text(
     img = Image.open(image_path).convert("RGB")
     orig_width, orig_height = img.size
 
-    if reuse_boxes:
+    if reuse_boxes and Path(_boxes_path(image_path)).exists():
         with open(_boxes_path(image_path)) as f:
             angle_boxes: list[dict] = json.load(f)["boxes"]
     else:
@@ -904,7 +905,16 @@ def main() -> None:
             "Reuse CRAFT bounding boxes from existing <stem>.boxes.json files instead "
             "of re-running CRAFT detection. Useful for iterating on recognition "
             "parameters without redoing detection. All images must already have a "
-            ".boxes.json file; this flag aborts with an error if any are missing."
+            ".boxes.json file; this flag aborts with an error if any are missing "
+            "(see --allow-missing-boxes)."
+        ),
+    )
+    parser.add_argument(
+        "--allow-missing-boxes",
+        action="store_true",
+        help=(
+            "With --reuse-boxes: images that have no .boxes.json (e.g. freshly split "
+            "panels) run full CRAFT detection instead of aborting the run."
         ),
     )
     args = parser.parse_args()
@@ -997,11 +1007,18 @@ def main() -> None:
 
     if args.reuse_boxes:
         missing = [p for p in images if not Path(_boxes_path(p)).exists()]
-        if missing:
+        if missing and not args.allow_missing_boxes:
             for p in missing:
                 print(f"Missing boxes file: {_boxes_path(p)}", file=sys.stderr)
             sys.exit(
-                f"--reuse-boxes: {len(missing)} image(s) have no .boxes.json file."
+                f"--reuse-boxes: {len(missing)} image(s) have no .boxes.json file "
+                "(pass --allow-missing-boxes to run CRAFT for them)."
+            )
+        if missing:
+            print(
+                f"--reuse-boxes: {len(missing)}/{len(images)} image(s) have no "
+                ".boxes.json; running full CRAFT detection for those.",
+                file=sys.stderr,
             )
 
     gpu = not args.no_gpu

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -119,6 +119,14 @@ def main() -> None:
         action="store_true",
         help="Skip the key-map OCR pass for images that already have a .streets.json output.",
     )
+    parser.add_argument(
+        "--reuse-boxes",
+        action="store_true",
+        help=(
+            "Pass --reuse-boxes --allow-missing-boxes to the key-map OCR pass: reuse existing "
+            "<stem>.boxes.json CRAFT boxes and run detection only for key maps without one."
+        ),
+    )
     args = parser.parse_args()
 
     images = [Path(image) for image in args.images]
@@ -177,6 +185,8 @@ def main() -> None:
     ]
     if args.resume:
         ocr_cmd.append("--resume")
+    if args.reuse_boxes:
+        ocr_cmd.extend(["--reuse-boxes", "--allow-missing-boxes"])
     run_cmd([*ocr_cmd, *image_args])
     run_cmd(
         [

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -142,13 +142,41 @@ def box_center(bbox: list[list[float]]) -> tuple[float, float]:
     return (sum(p[0] for p in bbox) / 4, sum(p[1] for p in bbox) / 4)
 
 
-def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[dict]:
+def cached_craft_boxes(image_path: Path) -> tuple[list, list] | None:
+    """The angle-0 CRAFT boxes from ``<stem>.boxes.json`` (written by ``mapsnap ocr``), or None.
+
+    Returns (horizontal_list, free_list) in the same shape ``reader.detect`` yields, so
+    recognition can skip the CRAFT pass entirely. Returns None when the file is absent, records
+    different image dimensions (boxes from another resolution would misplace every read), or has
+    no angle-0 entry.
+    """
+    boxes_path = image_path.parent / f"{image_stem(str(image_path))}.boxes.json"
+    if not boxes_path.exists():
+        return None
+    doc = json.loads(boxes_path.read_text())
+    with Image.open(image_path) as image:
+        if (doc.get("width"), doc.get("height")) != image.size:
+            return None
+    for entry in doc.get("boxes", []):
+        if entry.get("angle") == 0:
+            return entry.get("horizontal_list", []), entry.get("free_list", [])
+    return None
+
+
+def digit_detections(
+    image_path: Path,
+    reader,
+    valid_numbers: set[int],
+    craft_boxes: tuple[list, list] | None = None,
+) -> list[dict]:
     """All digit reads on one page that parse to a valid volume page number.
 
     Two recognition passes over the same image: the digits-only pass supplies the
     transcription (immune to look-alike substitutions like 0 -> O), and a letters-allowed
     pass over the same boxes vetoes the ones that are actually street names or other text
-    (see is_text_veto).
+    (see is_text_veto). ``craft_boxes`` (from cached_craft_boxes) skips the CRAFT
+    detection pass — by far the most expensive step — reusing the boxes ``mapsnap ocr``
+    already computed for the same image.
 
     Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
     confidence, the glyph ``height`` in pixels, position as width/height fractions, the
@@ -165,7 +193,10 @@ def digit_detections(image_path: Path, reader, valid_numbers: set[int]) -> list[
     # allowlist-independent, so the two passes share its boxes (readtext = detect +
     # recognize with these same defaults).
     img, img_grey = reformat_input(image)
-    horizontal_lists, free_lists = reader.detect(img)
+    if craft_boxes is not None:
+        horizontal_lists, free_lists = [craft_boxes[0]], [craft_boxes[1]]
+    else:
+        horizontal_lists, free_lists = reader.detect(img)
     results = reader.recognize(
         img_grey, horizontal_lists[0], free_lists[0], allowlist="0123456789"
     )
@@ -360,6 +391,15 @@ def main() -> None:
     parser.add_argument(
         "--no-gpu", action="store_true", help="Disable GPU acceleration for EasyOCR."
     )
+    parser.add_argument(
+        "--reuse-boxes",
+        action="store_true",
+        help=(
+            "Reuse CRAFT boxes from each page's <stem>.boxes.json (written by mapsnap ocr) "
+            "instead of re-running detection; pages without one (or whose boxes were computed "
+            "at different image dimensions) still run CRAFT."
+        ),
+    )
     args = parser.parse_args()
 
     import easyocr
@@ -379,17 +419,22 @@ def main() -> None:
     reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
 
     pages: dict[str, dict] = {}
+    reused = 0
     for image in tqdm(images, smoothing=0):
         stem = image_stem(str(image))
         # Record the scanned image's dimensions so a viewer can rescale detection
         # polygons when it loads the page at a different resolution.
         width, height = Image.open(image).size
+        craft_boxes = cached_craft_boxes(image) if args.reuse_boxes else None
+        reused += craft_boxes is not None
         pages[stem] = {
             "number": page_number(stem),
             "width": width,
             "height": height,
-            "detections": digit_detections(image, reader, valid_numbers),
+            "detections": digit_detections(image, reader, valid_numbers, craft_boxes),
         }
+    if args.reuse_boxes:
+        print(f"Reused CRAFT boxes for {reused}/{len(images)} pages.", file=sys.stderr)
 
     def compute_claims(
         height_band: tuple[float, float] | None,

--- a/mapsnap/pipeline_rerun.py
+++ b/mapsnap/pipeline_rerun.py
@@ -1,0 +1,135 @@
+"""Re-run the full pipeline on already-downloaded volume(s), reusing cached CRAFT boxes.
+
+For regenerating a release's results tables: every step recomputes its outputs, but nothing
+is re-downloaded (images, OSM data, truth JSON are reused as-is) and CRAFT detection — the
+most expensive stage — is skipped wherever a ``<stem>.boxes.json`` from a previous run
+exists. Freshly split panels and never-OCR'd key maps have no boxes file, so those run full
+detection.
+
+Per volume:
+
+  1. verify the volume was set up by a pipeline run (``mapsnap.json`` exists) and has
+     ``centerlines.geojson`` — this pipeline never downloads;
+  2. ``mapsnap split`` regenerates the split panels (pN__i.jpg + pN.panels.json);
+  3. ``mapsnap keymap-detect`` identifies the key map(s); ``mapsnap keymap --reuse-boxes``
+     rebuilds their sidecars from the full-resolution ``raw/`` scans (a detected key map
+     with no raw scan is skipped with a warning — downloading is out of scope here);
+  4. ``mapsnap ocr --reuse-boxes --allow-missing-boxes`` re-recognizes every page (panels
+     supersede their parent), auto-discovering the georeferenced key maps;
+  5. ``mapsnap adjacency --reuse-boxes`` rebuilds the printed-neighbor adjacency graph;
+  6. ``mapsnap fit --tag <tag>`` georeferences, builds the IIIF AnnotationPage, and
+     compares against truth.
+
+Steps are resumable per volume via ``.pipeline/rerun-<tag>-<step>.done`` stamps (the tag
+prefix keeps them distinct from the original pipeline's stamps); ``--force`` redoes them.
+A volume that fails is reported and the remaining volumes still run.
+
+    uv run mapsnap rerun data/champaign_ill_1915 --tag 2026-07-17-v1.2
+    uv run mapsnap rerun data/*/ --tag 2026-07-17-v1.2   # every dir with a mapsnap.json
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from mapsnap.utils import Step, list_pages, run_cmd
+
+
+def rerun_volume(volume: Path, tag: str, force: bool) -> None:
+    """Run the six re-run steps for one volume (raises SystemExit on step failure)."""
+    if not (volume / "mapsnap.json").exists():
+        sys.exit(
+            f"{volume} has no mapsnap.json — it was never set up by a pipeline run; "
+            "this command re-runs existing volumes and never downloads."
+        )
+    centerlines = volume / "centerlines.geojson"
+    if not centerlines.exists():
+        sys.exit(f"{volume} has no centerlines.geojson (re-run does not download OSM).")
+
+    step = Step(volume, force=force)
+
+    with step(f"rerun-{tag}-split"):
+        pages = [str(p) for p in sorted(volume.glob("p*.jpg")) if "__" not in p.stem]
+        run_cmd(["mapsnap", "split", *pages])
+
+    with step(f"rerun-{tag}-keymap"):
+        from mapsnap.keymap.identify import identify_keymaps
+
+        keymap_keys = identify_keymaps(volume)
+        raw_keymaps = []
+        for key in keymap_keys:
+            raw = volume / "raw" / f"{key}.jpg"
+            if raw.exists():
+                raw_keymaps.append(str(raw))
+            else:
+                print(
+                    f"WARNING: key map {key} has no full-resolution scan at {raw}; "
+                    "skipping its sidecars (fetch it and re-run with --force to use it).",
+                    file=sys.stderr,
+                )
+        if raw_keymaps:
+            run_cmd(["mapsnap", "keymap", "--reuse-boxes", *raw_keymaps])
+        else:
+            print(f"No usable key map for {volume.name}.", flush=True)
+
+    with step(f"rerun-{tag}-ocr"):
+        images = [str(p) for p in list_pages(volume)]
+        run_cmd(
+            [
+                "mapsnap",
+                "ocr",
+                "--resume",
+                "--reuse-boxes",
+                "--allow-missing-boxes",
+                "--centerlines",
+                str(centerlines),
+                *images,
+            ]
+        )
+
+    with step(f"rerun-{tag}-adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(volume), "--reuse-boxes"])
+
+    # fit resumes itself (an already-archived run id is skipped), so no stamp.
+    run_cmd(["mapsnap", "fit", str(volume), "--tag", tag])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Re-run split/keymap/ocr/adjacency/fit on downloaded volumes, reusing CRAFT boxes."
+    )
+    parser.add_argument(
+        "volumes", nargs="+", type=Path, metavar="DIR", help="Volume directories."
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        metavar="TAG",
+        help="Run tag passed to `mapsnap fit` (e.g. 2026-07-17-v1.2).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Redo steps whose rerun stamps say they already completed.",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    for volume in args.volumes:
+        print(f"\n=== {volume} ===", flush=True)
+        try:
+            rerun_volume(volume, args.tag, args.force)
+        except SystemExit as exit_info:
+            print(
+                f"FAILED {volume}: {exit_info.code}",
+                file=sys.stderr,
+                flush=True,
+            )
+            failures.append(str(volume))
+    if failures:
+        sys.exit(f"{len(failures)} volume(s) failed: {', '.join(failures)}")
+    print(f"\nAll {len(args.volumes)} volume(s) completed.", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #120 

This also expands the "Performance" table to more closely match the numbers I pay attention to now.

Unclear if `mapsnap rerun` will be useful again, but it's there if I need it.