### PR TITLE
Split key maps: mirror splits onto raw scans and pick the right panel

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -786,6 +786,7 @@ def main() -> None:
     if args.csv:
         fields = [
             "page_key",
+            "gen_page_key",
             "n_truth",
             "n_gen",
             "n_streets",

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3144,7 +3144,7 @@ def main() -> None:
         metavar="KM",
         help=(
             "Rename georefs whose center is more than this many km from every other "
-            "georeferenced page to .georef-outlier.json (default: 1.0). Set to 0 to disable."
+            "georeferenced page to .georef-outlier.json (default: %(default)s). Set to 0 to disable."
         ),
     )
     parser.add_argument(
@@ -3526,7 +3526,12 @@ def main() -> None:
             print(f"Dropped {n_dropped} scale outlier(s).", file=sys.stderr)
 
     # Drop georef files whose center is far from every other georeferenced page.
-    if args.min_distance_for_outlier_km > 0 and len(location_records) >= 2:
+    # Only meaningful with a real sample: with a handful of pages every page is
+    # "far from the rest" of nothing — a 2-image key-map run (Brooklyn's p0+p0b
+    # halves, centroids 2.1 km apart but each sheet 4 km across) dropped both
+    # perfectly-fit halves. Five georeferenced pages is the floor for calling
+    # anything an outlier.
+    if args.min_distance_for_outlier_km > 0 and len(location_records) >= 5:
         # Only pages whose .georef.json still exists (not already renamed by scale check).
         active = [
             (p, c) for p, c in location_records if os.path.exists(derive_paths(p)[1])

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -84,8 +84,22 @@ def main() -> None:
         keymap_keys = identify_keymaps(dir_path)
         if keymap_keys:
             print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
-            scaled_keymaps = [str(dir_path / f"{key}.jpg") for key in keymap_keys]
-            run_cmd(["mapsnap", "download-raw", *scaled_keymaps])
+            # A key confirmed as a split panel (p0__1) has no LOC image of its
+            # own: download the parent sheet's raw scan, then re-run split so
+            # the raw copy gains the matching panel files (the splitter mirrors
+            # a page's split onto raw/ when the raw scan is present).
+            parents = sorted({key.split("__")[0] for key in keymap_keys})
+            run_cmd(
+                ["mapsnap", "download-raw"]
+                + [str(dir_path / f"{parent}.jpg") for parent in parents]
+            )
+            split_parents = [
+                str(dir_path / f"{parent}.jpg")
+                for parent in parents
+                if any(key.startswith(f"{parent}__") for key in keymap_keys)
+            ]
+            if split_parents:
+                run_cmd(["mapsnap", "split", *split_parents])
             raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
             run_cmd(["mapsnap", "keymap", *raw_keymaps])
         else:

--- a/mapsnap/split.py
+++ b/mapsnap/split.py
@@ -21,11 +21,12 @@ from typing import TypedDict
 import cv2
 import numpy as np
 from PIL import Image, ImageDraw
+import shapely.affinity
 from shapely.geometry import LineString, Point, Polygon, box
 from shapely.ops import polygonize, unary_union
 from skimage.morphology import medial_axis
 
-from mapsnap.utils import image_stem
+from mapsnap.utils import image_stem, jpeg_dimensions
 
 
 class PanelsJson(TypedDict):
@@ -963,17 +964,28 @@ def compute_panels(image_path: Path, border: int = BORDER_PX) -> list:
     return panels
 
 
+def order_panels(panels: list) -> list:
+    """Panels in reading order (top to bottom, then left to right).
+
+    Ordering happens once, at the scale the panels were detected at, so a
+    raw-resolution copy written from scaled polygons keeps identical numbering
+    (the row-bucketing would bucket differently at 4x coordinates).
+    """
+    return sorted(panels, key=lambda p: (round(p.bounds[1] / 50), p.bounds[0]))
+
+
 def write_panels(image_path: Path, panels: list, base: str) -> list[Path]:
     """Write each panel to <base>__N.jpg next to image_path; return the written paths.
 
     A panel is cropped to its bounding box, with any pixels outside its (possibly
-    non-rectangular) polygon set to white. Panels are numbered in reading order: top to
-    bottom, then left to right. Also writes <base>.panels.json recording the panel
-    polygons in image_path's pixel frame, in the same order as the numbering.
+    non-rectangular) polygon set to white. ``panels`` must already be in reading
+    order (see order_panels); numbering follows the given order. Also writes
+    <base>.panels.json recording the panel polygons in image_path's pixel frame,
+    in the same order as the numbering.
     """
     rgb = load_rgb(image_path)
     h, w = rgb.shape[:2]
-    ordered = sorted(panels, key=lambda p: (round(p.bounds[1] / 50), p.bounds[0]))
+    ordered = panels
     out_paths = []
     for i, panel in enumerate(ordered, start=1):
         mask = np.zeros((h, w), dtype=np.uint8)
@@ -1047,15 +1059,38 @@ def process_image(image_path: Path, debug: bool = False) -> None:
             out_dir / f"{base}.panels.png"
         )
 
+    raw_path = image_path.parent / "raw" / image_path.name
+    if raw_path.exists():
+        remove_split_outputs(raw_path)
+
     # A single panel covering the whole page means no split was found.
     is_single_full = len(panels) == 1 and panels[0].area >= 0.99 * full_h * full_w
     if is_single_full:
         print(f"{image_path.name}: single panel — not split")
         return
-    out_paths = write_panels(image_path, panels, base)
+    ordered = order_panels(panels)
+    out_paths = write_panels(image_path, ordered, base)
     print(
         f"{image_path.name}: {len(panels)} panels → {', '.join(p.name for p in out_paths)}"
     )
+
+    # Mirror the split onto the full-resolution copy, if one exists: the key-map
+    # pipeline needs raw/<panel>.jpg when the key map shares its sheet with
+    # another panel (a multi-volume index map, a legend). The splitter itself
+    # can only run on the 25% images, so the raw panels are cut from the same
+    # polygons scaled up to the raw frame, keeping identical numbering.
+    if raw_path.exists():
+        raw_width, raw_height = jpeg_dimensions(raw_path)
+        scaled = [
+            shapely.affinity.scale(
+                panel, xfact=raw_width / w, yfact=raw_height / h, origin=(0, 0)
+            )
+            for panel in ordered
+        ]
+        raw_paths = write_panels(raw_path, scaled, base)
+        print(
+            f"  raw copy: {len(raw_paths)} panels → {', '.join(p.name for p in raw_paths)}"
+        )
 
 
 def main() -> None:


### PR DESCRIPTION
Three of the eleven test volumes (Detroit 1929, Kansas City 1951, New Orleans 1951) have key-map sheets that are genuinely split into two panels — and in KC and New Orleans, one panel is a "multi-volume index" map that must be ignored. The v1.2 release silently ran all three volumes **without a key map**: the splitter only runs on 25%-scale images, so `raw/` never contained the panel files that `mapsnap keymap` needs, and the keymap step failed with "No usable key map". Separately, Brooklyn 1939 also ran keymap-less for a different reason: its two key-map halves (p0 + p0b) were each dropped as "location outliers" of the other.

## Changes

1. **`mapsnap split` mirrors a page's split onto its `raw/` copy.** Panel polygons are detected and ordered **once, at 25% scale** (the reading-order sort buckets rows differently at 4×, so re-sorting in the raw frame could renumber panels), then scaled up and cut from the raw scan. Stale raw split outputs are removed first.
2. **`pipeline_loc` handles panel key-map keys.** A key confirmed as a split panel (`p0__1`) has no LOC image of its own, so the pipeline now downloads the **parent** sheet's raw scan, re-runs `mapsnap split` on split parents (the raw panels now come into existence), and then runs `mapsnap keymap` on the panel raws. `pipeline_oim` and `mapsnap rerun` need no changes — they have `raw/` before splitting.
3. **The location-outlier filter requires ≥5 georeferenced pages.** With a 2-image key-map run (Brooklyn's p0 + p0b halves, centroids 2.1 km apart but each sheet ~4 km across), every page is "far from the rest of nothing" — both perfectly-fit halves were dropped. Five pages is the floor for calling anything an outlier.
4. `mapsnap compare --csv` fix: `gen_page_key` was added to the row dicts by the split-page matching work but not to the CSV fieldnames, so `--csv` crashed.

## Key-map detection on the split panels

With raw panels in place, the page-number-coverage check picks the right panel on all three volumes and rejects the index panels outright:

| Volume | Confirmed panel | Rejected panel |
|---|---|---|
| Kansas City | p0__1 (coverage 0.94) | p0__2 — multi-volume index (0.00) |
| New Orleans 1951 | p0__2 (0.98) | p0__1 — "Graphic Map of Volumes" (0.00) |
| Detroit | p0__1 (0.94) | p0__2 (0.00) |

## Performance (v1.2 → this PR, keymap-restricted OCR + fit)

| Volume | Fit / Total | Median | Mean | Max |
|---|---|---|---|---|
| Brooklyn 1939 v1 | 54/62 → **55/62** | 10ft | 103 → **80ft** | 2645 → **1706ft** |
| New Orleans 1951 | 103/109 | 12ft | 47 → **41ft** | 878 → 891ft |
| Detroit 1929 | 81/103 → **83/103** | 15ft | 25 → 41ft ⚠ | 166 → 429ft ⚠ |
| Kansas City 1951 | 107/142 → **108/142** | 19ft | 39 → 43ft | 830ft |

Pages that moved:

- **Brooklyn p14** is newly placed, and **p44** improved 2645 → 1173ft (keymap-restricted vocabulary; still a bad relaxed-floor fit at ~0.43× true scale).
- **New Orleans p436**: 698 → **98ft** — the keymap-restricted vocabulary rescued a page whose unrestricted OCR matched the wrong streets.
- **Detroit p59** newly placed at 32ft; KC p551 newly placed (poorly, 454ft).

⚠ **The Detroit regression is not caused by the keymap itself.** Restricting Detroit's vocabulary dropped a handful of junk far-away street matches that were RANSAC *outliers* anyway — but their removal changed the population of fitted scales, which flipped `consensus_scale`'s reference anchor onto a wrong-scale fit and poisoned every deferred 1-GCP page (ten pages inherited a scale ~18% off). That failure mode — the third one observed for `consensus_scale` — is fixed in the follow-up PR, which brings Detroit to mean 25ft / max 246ft *with* the keymap.

## Reproducing

```sh
mapsnap split data/detroit_mich_1929_vol_11/p0.jpg   # now also writes raw/p0__1.jpg, raw/p0__2.jpg
mapsnap keymap-detect data/detroit_mich_1929_vol_11  # prints p0__1
mapsnap keymap --reuse-boxes data/detroit_mich_1929_vol_11/raw/p0__1.jpg
mapsnap ocr --reuse-boxes --allow-missing-boxes --centerlines data/detroit_mich_1929_vol_11/centerlines.geojson data/detroit_mich_1929_vol_11/p*.jpg
mapsnap fit data/detroit_mich_1929_vol_11 --tag my-run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
