### PR TITLE
Support letter-only page ids (pa/pb) as key-map candidates

### DIFF
--- a/mapsnap/keymap/fit_keymap.py
+++ b/mapsnap/keymap/fit_keymap.py
@@ -272,10 +272,14 @@ def ransac(
 
 
 def volume_page_numbers(volume: Path) -> set[int]:
-    """All page numbers present in the volume (from its page images)."""
+    """All page numbers present in the volume (from its page images).
+
+    Split panels contribute their base page's number: parsing ``pa__1`` whole
+    would read the panel index as a page number (a letter page has none).
+    """
     numbers: set[int] = set()
     for image in volume.glob("p*.jpg"):
-        number = page_number(image.name.split(".")[0])
+        number = page_number(image.name.split(".")[0].split("__")[0])
         if number is not None:
             numbers.add(number)
     return numbers

--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -28,6 +28,7 @@ to decide which pages to fetch and process as key maps.
 """
 
 import argparse
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -63,6 +64,16 @@ MIN_DISTINCT = 6
 CANDIDATE_PAGE_NUMBERS = (0, 1)
 
 
+def is_letter_page(stem: str) -> bool:
+    """True for a letter-only page id like ``pa`` or ``pb`` (no digits).
+
+    Some volumes bind un-numbered index sheets in front of the numbered pages
+    (Los Angeles 1949 vol 14's key maps are its ``pa`` and ``pb`` sheets), so
+    letter pages are key-map candidates alongside the page-0/page-1 families.
+    """
+    return re.fullmatch(r"p[a-z]{1,2}", stem) is not None
+
+
 def volume_valid_pages(volume: Path) -> list[str]:
     """The volume's real page numbers as strings (positive, from its ``p*.jpg`` images)."""
     return [
@@ -71,23 +82,28 @@ def volume_valid_pages(volume: Path) -> list[str]:
 
 
 def candidate_keys(volume: Path) -> list[str]:
-    """Page keys to test as key maps: every page numbered 0 or 1 (CANDIDATE_PAGE_NUMBERS).
+    """Page keys to test as key maps: letter pages plus every page numbered 0 or 1.
 
-    The key map is always page 0 or page 1, and shares its number with any lettered/split siblings
-    (p0/p0b/p0L/p0R, p1a-d); nominating both families covers a page-0 cover sitting in front of a
-    page-1 key map while staying a handful of pages. Numbering by absolute value (not rank) avoids
-    dragging in the first real map page when it starts high, e.g. p125. Split panels (stems with
+    The key map is an un-numbered letter sheet (pa/pb) or page 0 or page 1, and shares
+    its number with any lettered/split siblings (p0/p0b/p0L/p0R, p1a-d); nominating all
+    these families covers a page-0 cover sitting in front of a page-1 key map while
+    staying a handful of pages. Numbering by absolute value (not rank) avoids dragging
+    in the first real map page when it starts high, e.g. p125. Split panels (stems with
     ``__``) are never key maps and are skipped.
     """
+    letters: list[str] = []
     by_number: dict[int, list[str]] = defaultdict(list)
     for image in sorted(volume.glob("p*.jpg")):
         stem = image_stem(str(image))
         if "__" in stem:
             continue
+        if is_letter_page(stem):
+            letters.append(stem)
+            continue
         number = page_number(stem)
         if number is not None and number in CANDIDATE_PAGE_NUMBERS:
             by_number[number].append(stem)
-    keys: list[str] = []
+    keys = letters
     for number in sorted(by_number):
         keys.extend(by_number[number])
     return keys
@@ -124,9 +140,15 @@ def detection_plan(volume: Path) -> tuple[list[str], list[str]]:
     page_zero, page_zero_splits = page_zero_stems(volume)
     if page_zero and not page_zero_splits:
         return page_zero, []
-    keys = candidate_keys(volume)
-    if page_zero_splits:
-        keys = page_zero_splits + [key for key in keys if page_number(key) != 0]
+    # A candidate sheet that has been split into panels is tested panel-by-panel
+    # (the composite may mix the key map with an index map or legend) and the
+    # unsplit parent is dropped.
+    keys: list[str] = []
+    for key in candidate_keys(volume):
+        panels = sorted(
+            image_stem(str(image)) for image in volume.glob(f"{key}__*.jpg")
+        )
+        keys.extend(panels or [key])
     return [], keys
 
 

--- a/mapsnap/keymap/identify_test.py
+++ b/mapsnap/keymap/identify_test.py
@@ -105,3 +105,26 @@ def test_detection_plan_no_page_zero_uses_candidates(tmp_path: Path):
     assumed, to_test = detection_plan(volume)
     assert assumed == []
     assert to_test == ["p1a", "p1b"]
+
+
+def test_candidate_keys_letter_pages(tmp_path: Path):
+    # Los Angeles-style: un-numbered index sheets pa/pb are the key maps.
+    volume = make_volume(tmp_path, ["pa.jpg", "pb.jpg", "p1401.jpg", "p1402.jpg"])
+    assert candidate_keys(volume) == ["pa", "pb"]
+
+
+def test_detection_plan_letter_page_splits_tested_as_panels(tmp_path: Path):
+    # A split letter-page candidate is tested panel-by-panel; the parent is dropped.
+    volume = make_volume(
+        tmp_path,
+        ["pa.jpg", "pa__1.jpg", "pa__2.jpg", "pb.jpg", "p1401.jpg"],
+    )
+    assumed, confirm = detection_plan(volume)
+    assert assumed == []
+    assert confirm == ["pa__1", "pa__2", "pb"]
+
+
+def test_letter_page_panels_do_not_pollute_valid_pages(tmp_path: Path):
+    # pa__1's panel index must not be read as a volume page number.
+    volume = make_volume(tmp_path, ["pa.jpg", "pa__1.jpg", "p1401.jpg", "p1402.jpg"])
+    assert volume_valid_pages(volume) == ["1401", "1402"]

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -200,10 +200,14 @@ def label_to_page_key(label: str) -> str | None:
     to lowercase with bracket variants collapsed to double-underscores:
       "New Orleans, La. | 1951 | Vol. 5 p428 [2]" → "p428__2"
       "New Orleans, La. | 1896 | Vol. 2 p156"     → "p156"
+    Un-numbered index sheets (key maps) carry letter-only page ids:
+      "Los Angeles, Calif. | 1949 | Vol. 14 pa [2]" → "pa__2"
     Returns None if no page identifier is found.
     """
     last_part = label.rsplit("|", 1)[-1].strip()
-    m = re.search(r"\b(p\d+[a-z]?)(?:\s*\[(\d+)\])?$", last_part, re.IGNORECASE)
+    m = re.search(
+        r"\b(p\d+[a-z]?|p[a-z]{1,2})(?:\s*\[(\d+)\])?$", last_part, re.IGNORECASE
+    )
     if m is None:
         return None
     page = m.group(1).lower()

--- a/mapsnap/utils_test.py
+++ b/mapsnap/utils_test.py
@@ -8,6 +8,7 @@ from mapsnap.utils import (
     Step,
     default_centerlines,
     image_stem,
+    label_to_page_key,
     list_pages,
     mark_step_done,
     source_id_to_page_key,
@@ -207,3 +208,11 @@ def test_step_leaves_no_stamp_when_body_raises(tmp_path: Path):
         with step("osm"):
             raise ValueError("boom")
     assert not step_done(tmp_path, "osm")  # interrupted step re-runs next time
+
+
+def test_label_letter_page_key():
+    # Un-numbered index sheets (key maps) have letter-only page ids.
+    assert label_to_page_key("Los Angeles, Calif. | 1949 | Vol. 14 pa [2]") == "pa__2"
+    assert label_to_page_key("Los Angeles, Calif. | 1949 | Vol. 14 pb") == "pb"
+    # A trailing non-page word must not become a page key.
+    assert label_to_page_key("Los Angeles, Calif. | 1949 | key map") is None


### PR DESCRIPTION
Los Angeles 1949 vol 14 binds its key maps as un-numbered letter sheets: OIM labels them "... Vol. 14 pa [2]" / "pb [2]". label_to_page_key required digits after 'p', so download-oim skipped every key.iiif.json item and the volume ran keymap-less. Letter pages now parse (pa__2), are nominated as key-map candidates confirmed by page-number coverage, and a split candidate is tested panel-by-panel with the unsplit parent dropped (generalizing the page-0 panel logic). volume_page_numbers no longer reads a panel index as a page number (pa__1 has none).