### PR TITLE
Boxes view

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import './styles.css';
 import type {
   AdjacencyData,
+  Box,
   Corners,
   GcpPairResult,
   GeorefData,
@@ -29,6 +30,7 @@ import { GcpControls, type GcpFitStats } from './components/GcpControls';
 import { AdjacencyTable } from './components/AdjacencyTable';
 import { DetectionsTable } from './components/DetectionsTable';
 import { PanelsTable } from './components/PanelsTable';
+import { BoxControls } from './components/BoxControls';
 import { VolumeViewer } from './components/VolumeViewer';
 import { NoteButton } from './components/NoteButton';
 import { noteContextFromFiles, type NoteContext } from './notes/api';
@@ -101,8 +103,9 @@ declare global {
 }
 
 /**
- * Top-level debugger app with three modes: georef (map + overlays), streets
- * (text detections), and panels (page-split polygons).
+ * Top-level debugger app with several modes: georef (map + overlays), streets
+ * (text detections), panels (page-split polygons), and boxes (raw CRAFT
+ * detection boxes per rotation).
  */
 export function App() {
   const [mode, setMode] = useState<Mode>(() =>
@@ -131,6 +134,9 @@ export function App() {
   const [panelLabels, setPanelLabels] = useState<string[] | undefined>(
     undefined,
   );
+  const [boxes, setBoxes] = useState<Box[]>([]);
+  // Detection rotations currently shown in boxes mode (0/90/270°).
+  const [enabledAngles, setEnabledAngles] = useState<Set<number>>(new Set());
   const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
     null,
   );
@@ -332,6 +338,7 @@ export function App() {
       setDetections(result.detections);
       setPanels([]);
       setPanelLabels(undefined);
+      setBoxes([]);
       setJsonWidth(result.width);
       setJsonHeight(result.height);
     } else if (result.kind === 'panels') {
@@ -340,6 +347,17 @@ export function App() {
       setPanels(result.panels);
       setPanelLabels(result.labels);
       setDetections([]);
+      setBoxes([]);
+      setJsonWidth(result.width);
+      setJsonHeight(result.height);
+    } else if (result.kind === 'boxes') {
+      setMode('boxes');
+      setSelectedIndices(new Set());
+      setBoxes(result.boxes);
+      setEnabledAngles(new Set(result.boxes.map((box) => box.angle)));
+      setDetections([]);
+      setPanels([]);
+      setPanelLabels(undefined);
       setJsonWidth(result.width);
       setJsonHeight(result.height);
     } else if (result.kind === 'adjacency') {
@@ -349,14 +367,26 @@ export function App() {
       setDetections([]);
       setPanels([]);
       setPanelLabels(undefined);
+      setBoxes([]);
     } else {
       setMode('georef');
       setSelectedIndices(new Set());
       setDetections([]);
       setPanels([]);
       setPanelLabels(undefined);
+      setBoxes([]);
       applyGeorefJson(result.text);
     }
+  }
+
+  // Toggle whether a detection rotation's boxes are shown (boxes mode).
+  function toggleAngle(angle: number): void {
+    setEnabledAngles((prev) => {
+      const next = new Set(prev);
+      if (next.has(angle)) next.delete(angle);
+      else next.add(angle);
+      return next;
+    });
   }
 
   // Point the viewer at a decoded image, updating its source and JSON dimensions.
@@ -497,6 +527,8 @@ export function App() {
         }
         panels={panels}
         panelLabels={panelLabels}
+        boxes={boxes}
+        enabledAngles={enabledAngles}
         selectedIndices={selectedIndices}
         onSelectIndices={setSelectedIndices}
         showStreetsOnImage={showStreetsOnImage}
@@ -598,6 +630,13 @@ export function App() {
             onSelect={(index) => setSelectedIndices(new Set([index]))}
             jsonWidth={jsonWidth}
             jsonHeight={jsonHeight}
+          />
+        )}
+        {mode === 'boxes' && (
+          <BoxControls
+            boxes={boxes}
+            enabledAngles={enabledAngles}
+            onToggleAngle={toggleAngle}
           />
         )}
         {mode === 'adjacency' && adjacencyData && (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,6 +23,7 @@ import {
   type DetectionFilters,
   type IndexedDetection,
 } from './detections';
+import { filterBoxes } from './boxes';
 import { pageStem, parseDroppedJson } from './fileLoading';
 import { ImageColumn, type Mode } from './components/ImageColumn';
 import { MapView } from './components/MapView';
@@ -30,7 +31,7 @@ import { GcpControls, type GcpFitStats } from './components/GcpControls';
 import { AdjacencyTable } from './components/AdjacencyTable';
 import { DetectionsTable } from './components/DetectionsTable';
 import { PanelsTable } from './components/PanelsTable';
-import { BoxControls } from './components/BoxControls';
+import { BoxesTable } from './components/BoxesTable';
 import { VolumeViewer } from './components/VolumeViewer';
 import { NoteButton } from './components/NoteButton';
 import { noteContextFromFiles, type NoteContext } from './notes/api';
@@ -264,6 +265,27 @@ export function App() {
   const filteredDetections = useMemo(
     () => filterDetections(detections, filters),
     [detections, filters],
+  );
+
+  // Boxes mode: apply the short/long-side sliders, then hide the toggled-off rotations.
+  // The angle checkboxes count from the side-filtered set so the numbers track the sliders,
+  // while the overlay/table show only the enabled rotations.
+  const sideFilteredBoxes = useMemo(
+    () => filterBoxes(boxes, filters),
+    [boxes, filters],
+  );
+  const boxAngleGroups = useMemo<[number, number][]>(() => {
+    const angles = [...new Set(boxes.map((box) => box.angle))].sort(
+      (a, b) => a - b,
+    );
+    return angles.map((angle) => [
+      angle,
+      sideFilteredBoxes.filter(({ box }) => box.angle === angle).length,
+    ]);
+  }, [boxes, sideFilteredBoxes]);
+  const visibleBoxes = useMemo(
+    () => sideFilteredBoxes.filter(({ box }) => enabledAngles.has(box.angle)),
+    [sideFilteredBoxes, enabledAngles],
   );
 
   // Adjacency mode: the loaded image's page entry (identified by filename stem)
@@ -527,8 +549,10 @@ export function App() {
         }
         panels={panels}
         panelLabels={panelLabels}
-        boxes={boxes}
+        boxes={visibleBoxes}
         enabledAngles={enabledAngles}
+        boxAngleGroups={boxAngleGroups}
+        onToggleAngle={toggleAngle}
         selectedIndices={selectedIndices}
         onSelectIndices={setSelectedIndices}
         showStreetsOnImage={showStreetsOnImage}
@@ -633,10 +657,13 @@ export function App() {
           />
         )}
         {mode === 'boxes' && (
-          <BoxControls
-            boxes={boxes}
-            enabledAngles={enabledAngles}
-            onToggleAngle={toggleAngle}
+          <BoxesTable
+            boxes={visibleBoxes}
+            selectedIndices={selectedIndices}
+            onSelect={(index) => setSelectedIndices(new Set([index]))}
+            image={imageEl}
+            jsonWidth={jsonWidth}
+            jsonHeight={jsonHeight}
           />
         )}
         {mode === 'adjacency' && adjacencyData && (

--- a/app/src/boxes.test.ts
+++ b/app/src/boxes.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { boxAngleColor, boxesFromJson, unrotatePoint } from './boxes';
-import type { BoxesJsonData } from './types';
+import {
+  boxArea,
+  boxAngleColor,
+  boxesFromJson,
+  boxSideLengths,
+  filterBoxes,
+  unrotatePoint,
+} from './boxes';
+import type { Box, BoxesJsonData } from './types';
 
 describe('unrotatePoint', () => {
   it('is the identity at angle 0', () => {
@@ -66,6 +73,13 @@ describe('boxesFromJson', () => {
     ]);
   });
 
+  it('records each box long/short side lengths', () => {
+    const [box] = boxesFromJson(data);
+    // 30px wide, 18px tall.
+    expect(box.long_side).toBe(30);
+    expect(box.short_side).toBe(18);
+  });
+
   it('leaves free-list polygons untouched at angle 0', () => {
     expect(boxesFromJson(data)[1].polygon).toEqual([
       [867, 44],
@@ -89,6 +103,44 @@ describe('boxesFromJson', () => {
       [19, 769],
       [19, 801],
     ]);
+  });
+});
+
+describe('boxSideLengths', () => {
+  it('averages opposite edges of a skewed quad', () => {
+    const { long, short } = boxSideLengths([
+      [0, 0],
+      [10, 0],
+      [10, 4],
+      [0, 4],
+    ]);
+    expect(long).toBe(10);
+    expect(short).toBe(4);
+  });
+});
+
+function makeBox(long: number, short: number, angle = 0): Box {
+  return { polygon: [], angle, long_side: long, short_side: short };
+}
+
+describe('filterBoxes', () => {
+  const boxes = [makeBox(30, 18), makeBox(200, 40), makeBox(10, 8)];
+
+  it('keeps boxes meeting both side minimums, with original indices', () => {
+    const kept = filterBoxes(boxes, { minShortSide: 15, minLongSide: 20 });
+    expect(kept.map((b) => b.i)).toEqual([0, 1]);
+  });
+
+  it('drops a box failing either minimum', () => {
+    expect(
+      filterBoxes(boxes, { minShortSide: 20, minLongSide: 0 }),
+    ).toHaveLength(1);
+  });
+});
+
+describe('boxArea', () => {
+  it('multiplies the two side lengths', () => {
+    expect(boxArea(makeBox(30, 18))).toBe(540);
   });
 });
 

--- a/app/src/boxes.test.ts
+++ b/app/src/boxes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { boxAngleColor, boxesFromJson, unrotatePoint } from './boxes';
+import type { BoxesJsonData } from './types';
+
+describe('unrotatePoint', () => {
+  it('is the identity at angle 0', () => {
+    expect(unrotatePoint(63, 31, 0, 1409, 2037)).toEqual([63, 31]);
+  });
+
+  it('inverts the 90° (CCW) rotation', () => {
+    expect(unrotatePoint(1071, -1, 90, 1409, 2037)).toEqual([1409, 1071]);
+    expect(unrotatePoint(1107, 15, 90, 1409, 2037)).toEqual([1393, 1107]);
+  });
+
+  it('inverts the 270° (CW) rotation', () => {
+    expect(unrotatePoint(1235, 5, 270, 1409, 2037)).toEqual([5, 801]);
+    expect(unrotatePoint(1267, 19, 270, 1409, 2037)).toEqual([19, 769]);
+  });
+});
+
+describe('boxesFromJson', () => {
+  const data: BoxesJsonData = {
+    width: 1409,
+    height: 2037,
+    timestamp: 'now',
+    command: [],
+    boxes: [
+      {
+        angle: 0,
+        horizontal_list: [[63, 93, 31, 49]],
+        free_list: [
+          [
+            [867, 44],
+            [900, 35],
+            [904, 53],
+            [871, 62],
+          ],
+        ],
+      },
+      {
+        angle: 90,
+        horizontal_list: [[1071, 1107, -1, 15]],
+        free_list: [],
+      },
+      {
+        angle: 270,
+        horizontal_list: [[1235, 1267, 5, 19]],
+        free_list: [],
+      },
+    ],
+  };
+
+  it('maps every box into the original image frame, tagged by angle', () => {
+    const boxes = boxesFromJson(data);
+    // Two angle-0 boxes (one horizontal, one free) plus one each at 90 and 270.
+    expect(boxes.map((b) => b.angle)).toEqual([0, 0, 90, 270]);
+  });
+
+  it('turns an axis-aligned box into its four corners at angle 0', () => {
+    const [box] = boxesFromJson(data);
+    expect(box.polygon).toEqual([
+      [63, 31],
+      [93, 31],
+      [93, 49],
+      [63, 49],
+    ]);
+  });
+
+  it('leaves free-list polygons untouched at angle 0', () => {
+    expect(boxesFromJson(data)[1].polygon).toEqual([
+      [867, 44],
+      [900, 35],
+      [904, 53],
+      [871, 62],
+    ]);
+  });
+
+  it('unrotates 90° and 270° boxes back onto the image', () => {
+    const boxes = boxesFromJson(data);
+    expect(boxes[2].polygon).toEqual([
+      [1409, 1071],
+      [1409, 1107],
+      [1393, 1107],
+      [1393, 1071],
+    ]);
+    expect(boxes[3].polygon).toEqual([
+      [5, 801],
+      [5, 769],
+      [19, 769],
+      [19, 801],
+    ]);
+  });
+});
+
+describe('boxAngleColor', () => {
+  it('gives each standard rotation a distinct color', () => {
+    const colors = [0, 90, 270].map(boxAngleColor);
+    expect(new Set(colors).size).toBe(3);
+  });
+});

--- a/app/src/boxes.ts
+++ b/app/src/boxes.ts
@@ -1,0 +1,75 @@
+import type { Box, BoxesJsonData } from './types';
+
+/**
+ * Map a point from a rotated detection frame back to the original image frame.
+ *
+ * CRAFT runs on the image rotated by `angle` (PIL `rotate(expand=True)`), so a box's
+ * coordinates are in that rotated frame. This inverts the rotation, mirroring the polygon
+ * mapping in mapsnap/detect_text.py. `width`/`height` are the original image's dimensions.
+ */
+export function unrotatePoint(
+  x: number,
+  y: number,
+  angle: number,
+  width: number,
+  height: number,
+): [number, number] {
+  // PIL rotate(90) is CCW; inverse: (rx, ry) -> (W-1-ry, rx).
+  if (angle === 90) return [width - 1 - y, x];
+  // PIL rotate(270) is CW; inverse: (rx, ry) -> (ry, H-1-rx).
+  if (angle === 270) return [y, height - 1 - x];
+  return [x, y];
+}
+
+// The four corners of an axis-aligned [x_min, x_max, y_min, y_max] box, clockwise.
+function horizontalBoxCorners(
+  box: [number, number, number, number],
+): [number, number][] {
+  const [xMin, xMax, yMin, yMax] = box;
+  return [
+    [xMin, yMin],
+    [xMax, yMin],
+    [xMax, yMax],
+    [xMin, yMax],
+  ];
+}
+
+/**
+ * Flatten boxes.json's per-rotation groups into one list of boxes, each polygon mapped
+ * into the original image frame and tagged with the rotation that found it.
+ *
+ * Both the axis-aligned (`horizontal_list`) and free-quadrilateral (`free_list`) boxes are
+ * included, since together they are all of a rotation pass's detections.
+ */
+export function boxesFromJson(data: BoxesJsonData): Box[] {
+  const boxes: Box[] = [];
+  for (const group of data.boxes) {
+    const angle = group.angle;
+    const unrotate = (x: number, y: number): [number, number] =>
+      unrotatePoint(x, y, angle, data.width, data.height);
+    for (const box of group.horizontal_list) {
+      boxes.push({
+        polygon: horizontalBoxCorners(box).map(([x, y]) => unrotate(x, y)),
+        angle,
+      });
+    }
+    for (const polygon of group.free_list) {
+      boxes.push({ polygon: polygon.map(([x, y]) => unrotate(x, y)), angle });
+    }
+  }
+  return boxes;
+}
+
+/** Distinct outline color for a detection rotation (0/90/270°). */
+export function boxAngleColor(angle: number): string {
+  switch (angle) {
+    case 0:
+      return '#2563eb'; // blue
+    case 90:
+      return '#059669'; // green
+    case 270:
+      return '#d97706'; // amber
+    default:
+      return `hsl(${(angle * 2) % 360}, 70%, 45%)`;
+  }
+}

--- a/app/src/boxes.ts
+++ b/app/src/boxes.ts
@@ -35,6 +35,24 @@ function horizontalBoxCorners(
 }
 
 /**
+ * The longer and shorter side lengths (rounded pixels) of a 4-corner box, each taken as the
+ * mean of its two opposite edges so a slightly skewed free-list quad still gets sane numbers.
+ */
+export function boxSideLengths(polygon: [number, number][]): {
+  long: number;
+  short: number;
+} {
+  const edge = (a: number, b: number): number =>
+    Math.hypot(polygon[b][0] - polygon[a][0], polygon[b][1] - polygon[a][1]);
+  const sideA = (edge(0, 1) + edge(2, 3)) / 2;
+  const sideB = (edge(1, 2) + edge(3, 0)) / 2;
+  return {
+    long: Math.round(Math.max(sideA, sideB)),
+    short: Math.round(Math.min(sideA, sideB)),
+  };
+}
+
+/**
  * Flatten boxes.json's per-rotation groups into one list of boxes, each polygon mapped
  * into the original image frame and tagged with the rotation that found it.
  *
@@ -47,17 +65,46 @@ export function boxesFromJson(data: BoxesJsonData): Box[] {
     const angle = group.angle;
     const unrotate = (x: number, y: number): [number, number] =>
       unrotatePoint(x, y, angle, data.width, data.height);
+    const add = (polygon: [number, number][]): void => {
+      const { long, short } = boxSideLengths(polygon);
+      boxes.push({ polygon, angle, long_side: long, short_side: short });
+    };
     for (const box of group.horizontal_list) {
-      boxes.push({
-        polygon: horizontalBoxCorners(box).map(([x, y]) => unrotate(x, y)),
-        angle,
-      });
+      add(horizontalBoxCorners(box).map(([x, y]) => unrotate(x, y)));
     }
     for (const polygon of group.free_list) {
-      boxes.push({ polygon: polygon.map(([x, y]) => unrotate(x, y)), angle });
+      add(polygon.map(([x, y]) => unrotate(x, y)));
     }
   }
   return boxes;
+}
+
+/** A box paired with its index in the original, unfiltered list. */
+export interface IndexedBox {
+  box: Box;
+  i: number;
+}
+
+/** A box's area in square pixels, used to order the detection list. */
+export function boxArea(box: Box): number {
+  return box.long_side * box.short_side;
+}
+
+/**
+ * Return boxes passing the short/long-side minimums, paired with their original indices.
+ * (Confidence, the streets view's other filter, does not exist before recognition.)
+ */
+export function filterBoxes(
+  boxes: Box[],
+  filters: { minShortSide: number; minLongSide: number },
+): IndexedBox[] {
+  return boxes
+    .map((box, i) => ({ box, i }))
+    .filter(
+      ({ box }) =>
+        box.short_side >= filters.minShortSide &&
+        box.long_side >= filters.minLongSide,
+    );
 }
 
 /** Distinct outline color for a detection rotation (0/90/270°). */

--- a/app/src/components/BoxControls.tsx
+++ b/app/src/components/BoxControls.tsx
@@ -1,51 +1,86 @@
-import { useMemo } from 'react';
 import { boxAngleColor } from '../boxes';
-import type { Box } from '../types';
+import type { DetectionFilters } from '../detections';
 
 interface BoxControlsProps {
-  boxes: Box[];
-  /** Rotations currently shown on the image. */
+  /** Present rotations paired with their (side-filtered) box counts, ordered by angle. */
+  angleGroups: [number, number][];
   enabledAngles: Set<number>;
   onToggleAngle: (angle: number) => void;
+  filters: DetectionFilters;
+  setFilters: (filters: DetectionFilters) => void;
 }
 
 /**
- * Right-column panel for boxes mode: one checkbox per detection rotation (0/90/270°),
- * each with the group's outline color and box count, toggling that rotation's overlay.
+ * Image-column controls for boxes mode: one checkbox per detection rotation (0/90/270°),
+ * each with the group's overlay color and current box count, plus the short/long-side
+ * minimum sliders carried over from streets mode (confidence does not apply to raw boxes).
  */
 export function BoxControls(props: BoxControlsProps) {
-  const { boxes, enabledAngles, onToggleAngle } = props;
-
-  // Box count per rotation, ordered by angle for a stable checkbox list.
-  const groups = useMemo(() => {
-    const counts = new Map<number, number>();
-    for (const box of boxes) {
-      counts.set(box.angle, (counts.get(box.angle) ?? 0) + 1);
-    }
-    return [...counts.entries()].sort((a, b) => a[0] - b[0]);
-  }, [boxes]);
+  const { angleGroups, enabledAngles, onToggleAngle, filters, setFilters } =
+    props;
 
   return (
-    <div id="box-controls">
-      <h3>Detection boxes</h3>
+    <>
       <p className="box-controls-note">
         Raw CRAFT boxes from each rotation pass, before text recognition.
       </p>
-      {groups.map(([angle, count]) => (
-        <label key={angle} className="box-angle-row">
+      <div id="box-angle-toggles">
+        {angleGroups.map(([angle, count]) => (
+          <label key={angle} className="box-angle-row">
+            <input
+              type="checkbox"
+              checked={enabledAngles.has(angle)}
+              onChange={() => onToggleAngle(angle)}
+            />
+            <span
+              className="box-swatch"
+              style={{ backgroundColor: boxAngleColor(angle) }}
+            />
+            <span className="box-angle-label">{angle}°</span>
+            <span className="box-angle-count">{count}</span>
+          </label>
+        ))}
+      </div>
+      <div id="detection-filters">
+        <div className="filter-row">
+          <label htmlFor="box-filter-short">
+            Min short side: <span>{filters.minShortSide.toFixed(0)}</span>
+          </label>
           <input
-            type="checkbox"
-            checked={enabledAngles.has(angle)}
-            onChange={() => onToggleAngle(angle)}
+            type="range"
+            id="box-filter-short"
+            min={0}
+            max={200}
+            step={1}
+            value={filters.minShortSide}
+            onChange={(e) =>
+              setFilters({
+                ...filters,
+                minShortSide: parseFloat(e.target.value),
+              })
+            }
           />
-          <span
-            className="box-swatch"
-            style={{ backgroundColor: boxAngleColor(angle) }}
+        </div>
+        <div className="filter-row">
+          <label htmlFor="box-filter-long">
+            Min long side: <span>{filters.minLongSide.toFixed(0)}</span>
+          </label>
+          <input
+            type="range"
+            id="box-filter-long"
+            min={0}
+            max={200}
+            step={1}
+            value={filters.minLongSide}
+            onChange={(e) =>
+              setFilters({
+                ...filters,
+                minLongSide: parseFloat(e.target.value),
+              })
+            }
           />
-          <span className="box-angle-label">{angle}°</span>
-          <span className="box-angle-count">{count}</span>
-        </label>
-      ))}
-    </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/app/src/components/BoxControls.tsx
+++ b/app/src/components/BoxControls.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { boxAngleColor } from '../boxes';
+import type { Box } from '../types';
+
+interface BoxControlsProps {
+  boxes: Box[];
+  /** Rotations currently shown on the image. */
+  enabledAngles: Set<number>;
+  onToggleAngle: (angle: number) => void;
+}
+
+/**
+ * Right-column panel for boxes mode: one checkbox per detection rotation (0/90/270°),
+ * each with the group's outline color and box count, toggling that rotation's overlay.
+ */
+export function BoxControls(props: BoxControlsProps) {
+  const { boxes, enabledAngles, onToggleAngle } = props;
+
+  // Box count per rotation, ordered by angle for a stable checkbox list.
+  const groups = useMemo(() => {
+    const counts = new Map<number, number>();
+    for (const box of boxes) {
+      counts.set(box.angle, (counts.get(box.angle) ?? 0) + 1);
+    }
+    return [...counts.entries()].sort((a, b) => a[0] - b[0]);
+  }, [boxes]);
+
+  return (
+    <div id="box-controls">
+      <h3>Detection boxes</h3>
+      <p className="box-controls-note">
+        Raw CRAFT boxes from each rotation pass, before text recognition.
+      </p>
+      {groups.map(([angle, count]) => (
+        <label key={angle} className="box-angle-row">
+          <input
+            type="checkbox"
+            checked={enabledAngles.has(angle)}
+            onChange={() => onToggleAngle(angle)}
+          />
+          <span
+            className="box-swatch"
+            style={{ backgroundColor: boxAngleColor(angle) }}
+          />
+          <span className="box-angle-label">{angle}°</span>
+          <span className="box-angle-count">{count}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/BoxesOverlay.tsx
+++ b/app/src/components/BoxesOverlay.tsx
@@ -1,0 +1,66 @@
+import { boxAngleColor } from '../boxes';
+import type { Box } from '../types';
+
+interface BoxesOverlayProps {
+  boxes: Box[];
+  /** Rotations whose boxes are shown; boxes at other angles are hidden. */
+  enabledAngles: Set<number>;
+  /** Rendered image size in CSS pixels. */
+  displayWidth: number;
+  displayHeight: number;
+  /** Image size in JSON coordinate space. */
+  jsonWidth: number;
+  jsonHeight: number;
+}
+
+/**
+ * SVG overlay for boxes mode: the raw CRAFT detection boxes over the displayed image,
+ * outlined by the rotation pass that found them and filtered to the enabled rotations.
+ */
+export function BoxesOverlay(props: BoxesOverlayProps) {
+  const {
+    boxes,
+    enabledAngles,
+    displayWidth,
+    displayHeight,
+    jsonWidth,
+    jsonHeight,
+  } = props;
+
+  const toDisplay = (nx: number, ny: number): [number, number] => [
+    (nx * displayWidth) / jsonWidth,
+    (ny * displayHeight) / jsonHeight,
+  ];
+
+  return (
+    <svg
+      width={displayWidth}
+      height={displayHeight}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      {boxes.map((box, i) => {
+        if (!enabledAngles.has(box.angle)) return null;
+        const color = boxAngleColor(box.angle);
+        const points = box.polygon
+          .map(([x, y]) => toDisplay(x, y))
+          .map(([dx, dy]) => `${dx},${dy}`)
+          .join(' ');
+        return (
+          <polygon
+            key={i}
+            points={points}
+            fill={color}
+            fillOpacity={0.05}
+            stroke={color}
+            strokeWidth={1.2}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/src/components/BoxesOverlay.tsx
+++ b/app/src/components/BoxesOverlay.tsx
@@ -1,10 +1,9 @@
-import { boxAngleColor } from '../boxes';
-import type { Box } from '../types';
+import { boxAngleColor, type IndexedBox } from '../boxes';
 
 interface BoxesOverlayProps {
-  boxes: Box[];
-  /** Rotations whose boxes are shown; boxes at other angles are hidden. */
-  enabledAngles: Set<number>;
+  /** Boxes already filtered to the visible rotations and side minimums. */
+  boxes: IndexedBox[];
+  selectedIndices: Set<number>;
   /** Rendered image size in CSS pixels. */
   displayWidth: number;
   displayHeight: number;
@@ -15,12 +14,12 @@ interface BoxesOverlayProps {
 
 /**
  * SVG overlay for boxes mode: the raw CRAFT detection boxes over the displayed image,
- * outlined by the rotation pass that found them and filtered to the enabled rotations.
+ * outlined by the rotation pass that found them. The selected box is highlighted.
  */
 export function BoxesOverlay(props: BoxesOverlayProps) {
   const {
     boxes,
-    enabledAngles,
+    selectedIndices,
     displayWidth,
     displayHeight,
     jsonWidth,
@@ -43,9 +42,9 @@ export function BoxesOverlay(props: BoxesOverlayProps) {
         pointerEvents: 'none',
       }}
     >
-      {boxes.map((box, i) => {
-        if (!enabledAngles.has(box.angle)) return null;
-        const color = boxAngleColor(box.angle);
+      {boxes.map(({ box, i }) => {
+        const isSelected = selectedIndices.has(i);
+        const color = isSelected ? '#ff6600' : boxAngleColor(box.angle);
         const points = box.polygon
           .map(([x, y]) => toDisplay(x, y))
           .map(([dx, dy]) => `${dx},${dy}`)
@@ -55,9 +54,9 @@ export function BoxesOverlay(props: BoxesOverlayProps) {
             key={i}
             points={points}
             fill={color}
-            fillOpacity={0.05}
+            fillOpacity={isSelected ? 0.25 : 0.05}
             stroke={color}
-            strokeWidth={1.2}
+            strokeWidth={isSelected ? 2.5 : 1.2}
           />
         );
       })}

--- a/app/src/components/BoxesTable.tsx
+++ b/app/src/components/BoxesTable.tsx
@@ -1,0 +1,77 @@
+import { boxAngleColor, boxArea, type IndexedBox } from '../boxes';
+import { DetectionCanvas } from './DetectionCanvas';
+
+interface BoxesTableProps {
+  boxes: IndexedBox[];
+  selectedIndices: Set<number>;
+  onSelect: (index: number) => void;
+  image: HTMLImageElement | null;
+  jsonWidth: number;
+  jsonHeight: number;
+}
+
+const NUM_PREVIEW_IMAGES = 100;
+
+/**
+ * Table of detection boxes sorted by area (largest first). Shows all visible boxes, or only
+ * the selected one when a selection is active. The first rows render a deskewed image patch,
+ * and each row's angle is tagged with the overlay color. Clicking a row selects that box.
+ */
+export function BoxesTable(props: BoxesTableProps) {
+  const { boxes, selectedIndices, onSelect, image, jsonWidth, jsonHeight } =
+    props;
+
+  const visible = boxes
+    .filter(({ i }) => selectedIndices.size === 0 || selectedIndices.has(i))
+    .sort((a, b) => boxArea(b.box) - boxArea(a.box));
+
+  return (
+    <div id="detections-panel">
+      <table id="detections-table">
+        <thead>
+          <tr>
+            <th>Angle</th>
+            <th>Long</th>
+            <th>Short</th>
+            <th>Area</th>
+            <th>Image</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map(({ box, i }, rowIdx) => (
+            <tr
+              key={i}
+              className={selectedIndices.has(i) ? 'selected' : undefined}
+              onClick={() => onSelect(i)}
+            >
+              <td>
+                <span
+                  className="box-swatch"
+                  style={{
+                    backgroundColor: boxAngleColor(box.angle),
+                    marginRight: 6,
+                    verticalAlign: 'middle',
+                  }}
+                />
+                {box.angle}°
+              </td>
+              <td>{box.long_side}</td>
+              <td>{box.short_side}</td>
+              <td>{boxArea(box).toLocaleString()}</td>
+              <td>
+                {rowIdx < NUM_PREVIEW_IMAGES && (
+                  <DetectionCanvas
+                    det={box}
+                    image={image}
+                    jsonWidth={jsonWidth}
+                    jsonHeight={jsonHeight}
+                  />
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/components/DetectionCanvas.tsx
+++ b/app/src/components/DetectionCanvas.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useRef } from 'react';
-import { drawDetectionCanvas } from '../detections';
-import type { Detection } from '../types';
+import { drawDetectionCanvas, type OrientedBox } from '../detections';
 
 interface DetectionCanvasProps {
-  det: Detection;
+  det: OrientedBox;
   image: HTMLImageElement | null;
   jsonWidth: number;
   jsonHeight: number;
 }
 
-/** A small canvas showing the rotated, deskewed image patch for one detection. */
+/** A small canvas showing the rotated, deskewed image patch for one detection or box. */
 export function DetectionCanvas(props: DetectionCanvasProps) {
   const { det, image, jsonWidth, jsonHeight } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -1,13 +1,20 @@
 import { useState } from 'react';
 import type { DetectionFilters, IndexedDetection } from '../detections';
 import { pointInPolygon } from '../geometry';
-import type { IntersectionPoint, PanelPolygon, Street } from '../types';
+import type { Box, IntersectionPoint, PanelPolygon, Street } from '../types';
 import { useElementSize } from '../hooks/useElementSize';
+import { BoxesOverlay } from './BoxesOverlay';
 import { DetectionsOverlay } from './DetectionsOverlay';
 import { GeorefOverlay } from './GeorefOverlay';
 import { PanelsOverlay } from './PanelsOverlay';
 
-export type Mode = 'georef' | 'streets' | 'panels' | 'adjacency' | 'iiif';
+export type Mode =
+  | 'georef'
+  | 'streets'
+  | 'panels'
+  | 'boxes'
+  | 'adjacency'
+  | 'iiif';
 
 interface ImageColumnProps {
   mode: Mode;
@@ -19,6 +26,8 @@ interface ImageColumnProps {
   filteredDetections: IndexedDetection[];
   panels: PanelPolygon[];
   panelLabels?: string[];
+  boxes: Box[];
+  enabledAngles: Set<number>;
   selectedIndices: Set<number>;
   onSelectIndices: (indices: Set<number>) => void;
   showStreetsOnImage: boolean;
@@ -49,6 +58,8 @@ export function ImageColumn(props: ImageColumnProps) {
     filteredDetections,
     panels,
     panelLabels,
+    boxes,
+    enabledAngles,
     selectedIndices,
     onSelectIndices,
     showStreetsOnImage,
@@ -67,13 +78,16 @@ export function ImageColumn(props: ImageColumnProps) {
   const streetsMode = mode === 'streets';
   const panelsMode = mode === 'panels';
   const georefMode = mode === 'georef';
+  const boxesMode = mode === 'boxes';
   // Adjacency mode renders detections just like streets mode (overlay + click select).
   const detectionsMode = streetsMode || mode === 'adjacency';
+  // Modes with no per-shape selection: clicking does nothing and the cursor stays default.
+  const nonSelectableMode = georefMode || boxesMode;
 
   // In streets/panels mode, select the shapes under the click point. The wrapper
   // (currentTarget) tightly wraps the image, so its rect matches the image's.
   function handleClick(e: React.MouseEvent): void {
-    if (georefMode || !imgSize.width || !imgSize.height) return;
+    if (nonSelectableMode || !imgSize.width || !imgSize.height) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const imgX = ((e.clientX - rect.left) * jsonWidth) / imgSize.width;
     const imgY = ((e.clientY - rect.top) * jsonHeight) / imgSize.height;
@@ -114,7 +128,7 @@ export function ImageColumn(props: ImageColumnProps) {
       {imageSrc ? (
         <div
           className="image-wrapper"
-          style={{ cursor: georefMode ? undefined : 'crosshair' }}
+          style={{ cursor: nonSelectableMode ? undefined : 'crosshair' }}
           onClick={handleClick}
         >
           <img
@@ -137,6 +151,16 @@ export function ImageColumn(props: ImageColumnProps) {
               panels={panels}
               labels={panelLabels}
               selectedIndices={selectedIndices}
+              displayWidth={imgSize.width}
+              displayHeight={imgSize.height}
+              jsonWidth={jsonWidth}
+              jsonHeight={jsonHeight}
+            />
+          )}
+          {boxesMode && (
+            <BoxesOverlay
+              boxes={boxes}
+              enabledAngles={enabledAngles}
               displayWidth={imgSize.width}
               displayHeight={imgSize.height}
               jsonWidth={jsonWidth}

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import type { IndexedBox } from '../boxes';
 import type { DetectionFilters, IndexedDetection } from '../detections';
 import { pointInPolygon } from '../geometry';
-import type { Box, IntersectionPoint, PanelPolygon, Street } from '../types';
+import type { IntersectionPoint, PanelPolygon, Street } from '../types';
 import { useElementSize } from '../hooks/useElementSize';
+import { BoxControls } from './BoxControls';
 import { BoxesOverlay } from './BoxesOverlay';
 import { DetectionsOverlay } from './DetectionsOverlay';
 import { GeorefOverlay } from './GeorefOverlay';
@@ -26,8 +28,10 @@ interface ImageColumnProps {
   filteredDetections: IndexedDetection[];
   panels: PanelPolygon[];
   panelLabels?: string[];
-  boxes: Box[];
+  boxes: IndexedBox[];
   enabledAngles: Set<number>;
+  boxAngleGroups: [number, number][];
+  onToggleAngle: (angle: number) => void;
   selectedIndices: Set<number>;
   onSelectIndices: (indices: Set<number>) => void;
   showStreetsOnImage: boolean;
@@ -60,6 +64,8 @@ export function ImageColumn(props: ImageColumnProps) {
     panelLabels,
     boxes,
     enabledAngles,
+    boxAngleGroups,
+    onToggleAngle,
     selectedIndices,
     onSelectIndices,
     showStreetsOnImage,
@@ -81,13 +87,11 @@ export function ImageColumn(props: ImageColumnProps) {
   const boxesMode = mode === 'boxes';
   // Adjacency mode renders detections just like streets mode (overlay + click select).
   const detectionsMode = streetsMode || mode === 'adjacency';
-  // Modes with no per-shape selection: clicking does nothing and the cursor stays default.
-  const nonSelectableMode = georefMode || boxesMode;
 
-  // In streets/panels mode, select the shapes under the click point. The wrapper
+  // In streets/panels/boxes mode, select the shapes under the click point. The wrapper
   // (currentTarget) tightly wraps the image, so its rect matches the image's.
   function handleClick(e: React.MouseEvent): void {
-    if (nonSelectableMode || !imgSize.width || !imgSize.height) return;
+    if (georefMode || !imgSize.width || !imgSize.height) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const imgX = ((e.clientX - rect.left) * jsonWidth) / imgSize.width;
     const imgY = ((e.clientY - rect.top) * jsonHeight) / imgSize.height;
@@ -95,9 +99,13 @@ export function ImageColumn(props: ImageColumnProps) {
       ? panels.flatMap((polygon, i) =>
           pointInPolygon(imgX, imgY, polygon) ? [i] : [],
         )
-      : filteredDetections
-          .filter(({ det }) => pointInPolygon(imgX, imgY, det.polygon))
-          .map(({ i }) => i);
+      : boxesMode
+        ? boxes.flatMap(({ box, i }) =>
+            pointInPolygon(imgX, imgY, box.polygon) ? [i] : [],
+          )
+        : filteredDetections
+            .filter(({ det }) => pointInPolygon(imgX, imgY, det.polygon))
+            .map(({ i }) => i);
     onSelectIndices(new Set(hit));
   }
 
@@ -128,7 +136,7 @@ export function ImageColumn(props: ImageColumnProps) {
       {imageSrc ? (
         <div
           className="image-wrapper"
-          style={{ cursor: nonSelectableMode ? undefined : 'crosshair' }}
+          style={{ cursor: georefMode ? undefined : 'crosshair' }}
           onClick={handleClick}
         >
           <img
@@ -160,7 +168,7 @@ export function ImageColumn(props: ImageColumnProps) {
           {boxesMode && (
             <BoxesOverlay
               boxes={boxes}
-              enabledAngles={enabledAngles}
+              selectedIndices={selectedIndices}
               displayWidth={imgSize.width}
               displayHeight={imgSize.height}
               jsonWidth={jsonWidth}
@@ -294,6 +302,16 @@ export function ImageColumn(props: ImageColumnProps) {
             <label htmlFor="show-ignored">Show ignored detections</label>
           </div>
         </div>
+      )}
+
+      {boxesMode && (
+        <BoxControls
+          angleGroups={boxAngleGroups}
+          enabledAngles={enabledAngles}
+          onToggleAngle={onToggleAngle}
+          filters={filters}
+          setFilters={setFilters}
+        />
       )}
     </div>
   );

--- a/app/src/detections.ts
+++ b/app/src/detections.ts
@@ -136,10 +136,21 @@ export function previewOrientation(
   };
 }
 
+/**
+ * The oriented-box geometry {@link drawDetectionCanvas} needs to crop and deskew a patch.
+ * Satisfied by both a {@link Detection} and a boxes.json `Box`.
+ */
+export interface OrientedBox {
+  polygon: [number, number][];
+  angle: number;
+  long_side: number;
+  short_side: number;
+}
+
 /** Options for {@link drawDetectionCanvas}. */
 export interface DrawDetectionOptions {
   canvas: HTMLCanvasElement;
-  det: Detection;
+  det: OrientedBox;
   image: HTMLImageElement;
   jsonWidth: number;
   jsonHeight: number;

--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -136,6 +136,28 @@ describe('parseDroppedJson', () => {
     }
   });
 
+  it('recognizes boxes.json and maps boxes into the image frame', () => {
+    const text = JSON.stringify({
+      width: 1409,
+      height: 2037,
+      timestamp: 'now',
+      command: [],
+      boxes: [
+        { angle: 0, horizontal_list: [[63, 93, 31, 49]], free_list: [] },
+        { angle: 90, horizontal_list: [[1071, 1107, -1, 15]], free_list: [] },
+      ],
+    });
+    const result = parseDroppedJson(text, fallback);
+    expect(result.kind).toBe('boxes');
+    if (result.kind === 'boxes') {
+      expect(result.width).toBe(1409);
+      expect(result.height).toBe(2037);
+      expect(result.boxes.map((b) => b.angle)).toEqual([0, 90]);
+      // The 90° box is unrotated back onto the original image frame.
+      expect(result.boxes[1].polygon[0]).toEqual([1409, 1071]);
+    }
+  });
+
   it('treats georef objects as georef', () => {
     const text = JSON.stringify({
       width: 100,

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -1,5 +1,8 @@
+import { boxesFromJson } from './boxes';
 import type {
   AdjacencyData,
+  Box,
+  BoxesJsonData,
   Detection,
   PanelPolygon,
   PanelsJsonData,
@@ -22,6 +25,13 @@ export type ParsedJson =
       text: string;
       panels: PanelPolygon[];
       labels?: string[];
+      width: number;
+      height: number;
+    }
+  | {
+      kind: 'boxes';
+      text: string;
+      boxes: Box[];
       width: number;
       height: number;
     }
@@ -66,6 +76,18 @@ function isPanelsFormat(parsed: unknown): parsed is PanelsJsonData {
   );
 }
 
+// Whether a parsed object is a boxes.json sidecar (raw CRAFT boxes grouped by rotation).
+function isBoxesFormat(parsed: unknown): parsed is BoxesJsonData {
+  if (typeof parsed !== 'object' || parsed === null || !('boxes' in parsed)) {
+    return false;
+  }
+  const boxes = (parsed as BoxesJsonData).boxes;
+  return (
+    Array.isArray(boxes) &&
+    (boxes.length === 0 || 'horizontal_list' in boxes[0])
+  );
+}
+
 // Whether a parsed object is a volume adjacency.json (per-page detections + edge list).
 function isAdjacencyFormat(parsed: unknown): parsed is AdjacencyData {
   return (
@@ -85,6 +107,7 @@ function isAdjacencyFormat(parsed: unknown): parsed is AdjacencyData {
  * streets.json comes either as a bare array of detections (old format) or as an
  * object with a `streets` array plus image metadata (new format). panels.json is
  * an object with a `panels` array of polygon rings plus image metadata.
+ * boxes.json is an object with a `boxes` array of per-rotation CRAFT box groups.
  * adjacency.json is an object with `pages` and `adjacency` keys. Anything else
  * is treated as georef data. Returns `{ kind: 'invalid' }` if the text is not
  * JSON.
@@ -110,6 +133,16 @@ export function parseDroppedJson(
       text,
       panels: parsed.panels,
       labels: parsed.labels,
+      width: parsed.width || fallback.width || 1,
+      height: parsed.height || fallback.height || 1,
+    };
+  }
+
+  if (!Array.isArray(parsed) && isBoxesFormat(parsed)) {
+    return {
+      kind: 'boxes',
+      text,
+      boxes: boxesFromJson(parsed),
       width: parsed.width || fallback.width || 1,
       height: parsed.height || fallback.height || 1,
     };

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -606,3 +606,47 @@ tr.on-fill td {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* Boxes mode: right-column panel toggling each detection rotation's overlay. */
+#box-controls {
+  font-family: sans-serif;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#box-controls h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.box-controls-note {
+  margin: 0 0 4px;
+  font-size: 12px;
+  color: #777;
+}
+
+.box-angle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.box-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.box-angle-label {
+  width: 3em;
+}
+
+.box-angle-count {
+  color: #777;
+  font-variant-numeric: tabular-nums;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -607,24 +607,20 @@ tr.on-fill td {
   word-break: break-word;
 }
 
-/* Boxes mode: right-column panel toggling each detection rotation's overlay. */
-#box-controls {
-  font-family: sans-serif;
-  font-size: 14px;
+/* Boxes mode: image-column checkboxes toggling each detection rotation's overlay. */
+#box-angle-toggles {
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-
-#box-controls h3 {
-  margin: 0;
-  font-size: 15px;
+  font-family: sans-serif;
+  font-size: 14px;
 }
 
 .box-controls-note {
-  margin: 0 0 4px;
+  margin: 0;
   font-size: 12px;
   color: #777;
+  max-width: 320px;
 }
 
 .box-angle-row {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -171,6 +171,10 @@ export interface Box {
   polygon: [number, number][];
   /** Rotation pass that produced the box, in degrees: 0, 90, or 270. */
   angle: number;
+  /** Length of the box's longer side, in image pixels. */
+  long_side: number;
+  /** Length of the box's shorter side, in image pixels. */
+  short_side: number;
 }
 
 /**

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -163,6 +163,40 @@ export interface AdjacencyData {
   adjacency: [string, string][];
 }
 
+/**
+ * A single CRAFT detection box, mapped into the original image's pixel space and
+ * tagged with the rotation pass that found it (before any text recognition).
+ */
+export interface Box {
+  polygon: [number, number][];
+  /** Rotation pass that produced the box, in degrees: 0, 90, or 270. */
+  angle: number;
+}
+
+/**
+ * One rotation pass's raw boxes in boxes.json, in the rotated image's coordinate
+ * frame (CRAFT is run on the image rotated by `angle`).
+ */
+export interface BoxAngleGroup {
+  angle: number;
+  /** Axis-aligned boxes as [x_min, x_max, y_min, y_max] in the rotated frame. */
+  horizontal_list: [number, number, number, number][];
+  /** Free (quadrilateral) boxes as [x, y] corner lists in the rotated frame. */
+  free_list: [number, number][][];
+}
+
+/**
+ * boxes.json sidecar: the raw CRAFT detection boxes from `mapsnap ocr`, grouped by
+ * rotation pass, before recognition assigns any text.
+ */
+export interface BoxesJsonData {
+  width: number;
+  height: number;
+  timestamp: string;
+  command: string[];
+  boxes: BoxAngleGroup[];
+}
+
 /** A single panel polygon ring (one [x, y] vertex per point, in pixel space). */
 export type PanelPolygon = [number, number][];
 


### PR DESCRIPTION
Closes #62 

This is similar to the streets view, but without the text or confidence. Since there are three CRAFT runs (0°, 90°, 270°), it includes three checkboxes to toggle between them.

It's notable that the best box for any given detection isn't necessarily the one at the correct angle. In this Brooklyn image, for example, CLARK and TILLARY are broken up at 90° and 270°, but intact at 0°. (#144)

<img width="1183" height="436" alt="image" src="https://github.com/user-attachments/assets/beec819b-1b93-4277-ba54-641cd79db7bc" />

<img width="1076" height="253" alt="image" src="https://github.com/user-attachments/assets/ffff1ed5-e4cd-46b2-aee0-d58cdef4afb9" />

<img width="1151" height="549" alt="image" src="https://github.com/user-attachments/assets/2035787d-c3f5-4565-abde-869132cf242f" />
