### PR TITLE
Accept any letter in page keys (for Los Angeles)

### DIFF
--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -51,9 +51,15 @@ def georef_path_to_page_key(path: str) -> str | None:
     Accepts filenames ending in '_p16s.georef.json', '_p16.georef.json',
     '_p16s.gcps.georef.json' (the '.gcps' infix is optional), or the
     neighbor-fit variant '_p16.georef-neighbor.json'.
+
+    Any letter page suffix is kept (Sanborn sheets run 'a', 'b', … past the
+    directional 's'/'n'/'e'/'w'/'l'/'r' letters), not just a known few — a
+    dropped suffix silently loses that page from the manifest. Compound suffixes
+    that are ambiguous with a skeleton sheet (a letter then 's', e.g. 'p6ns')
+    still parse here; drop_redundant_skeletons raises on them rather than guess.
     """
     m = re.search(
-        r"(?:\b|_)(p\d+)([snewlr]?)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor)?\.json$",
+        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor)?\.json$",
         path,
         re.IGNORECASE,
     )
@@ -69,13 +75,26 @@ def expand_georef_globs(pattern: str) -> list[str]:
     'v/p*.georef.json,v/p*.georef-neighbor.json' renders the hybrid volume:
     the RANSAC georef when a page has one, the neighbor/pose-graph placement
     otherwise.
+
+    A file whose page key cannot be parsed is skipped with a warning rather than
+    silently: it would otherwise vanish from the output with no trace (as an
+    unrecognized page suffix once did). A later glob repeating an already-chosen
+    page key is skipped quietly, since that is the intended first-glob-wins
+    behaviour of the hybrid pattern above.
     """
     chosen: dict[str, str] = {}
     ordered: list[str] = []
     for sub_pattern in pattern.split(","):
         for path in sorted(glob.glob(sub_pattern.strip())):
             page_key = georef_path_to_page_key(path)
-            if page_key is None or page_key in chosen:
+            if page_key is None:
+                print(
+                    f"Warning: could not parse a page key from '{path}'; "
+                    "omitting it from the output.",
+                    file=sys.stderr,
+                )
+                continue
+            if page_key in chosen:
                 continue
             chosen[page_key] = path
             ordered.append(path)

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -273,6 +273,24 @@ def test_georef_path_with_gcps_infix():
     assert georef_path_to_page_key("data/vol/p16s.gcps.georef.json") == "p16s"
 
 
+def test_georef_path_with_sequence_letter_suffix():
+    # Sanborn sheets run past the directional letters into a/b/c/…; every letter
+    # suffix must be kept, not just s/n/e/w/l/r.
+    assert georef_path_to_page_key("data/vol/p1499o.georef.json") == "p1499o"
+    assert georef_path_to_page_key("data/vol/p1499a.georef.json") == "p1499a"
+    assert georef_path_to_page_key("data/vol/p1499q.georef.json") == "p1499q"
+
+
+def test_georef_path_sequence_letter_split():
+    assert georef_path_to_page_key("data/vol/p1499q__2.georef.json") == "p1499q__2"
+
+
+def test_georef_path_multi_letter_suffix_parses():
+    # A compound suffix parses (rather than silently dropping the page);
+    # drop_redundant_skeletons is what raises on the ambiguous trailing 's'.
+    assert georef_path_to_page_key("data/vol/p6ns.georef.json") == "p6ns"
+
+
 def test_georef_path_split_page():
     assert georef_path_to_page_key("data/vol/p20__2.georef.json") == "p20__2"
 
@@ -301,6 +319,19 @@ def test_expand_georef_globs_first_glob_wins(tmp_path):
     pattern = f"{tmp_path}/p*.georef.json,{tmp_path}/p*.georef-neighbor.json"
     paths = [Path(p).name for p in expand_georef_globs(pattern)]
     assert paths == ["p1.georef.json", "p2.georef-neighbor.json"]
+
+
+def test_expand_georef_globs_warns_on_unparsable_key(tmp_path, capsys):
+    # A file whose name encodes no page key must not vanish silently: it is
+    # skipped, but with a warning naming the file (regression guard for the
+    # suffix bug that once dropped pages with no trace).
+    (tmp_path / "p16.georef.json").write_text("{}")
+    (tmp_path / "key.georef.json").write_text("{}")
+    paths = [Path(p).name for p in expand_georef_globs(f"{tmp_path}/*.georef.json")]
+    assert paths == ["p16.georef.json"]
+    err = capsys.readouterr().err
+    assert "could not parse" in err
+    assert "key.georef.json" in err
 
 
 def test_georef_path_no_match():


### PR DESCRIPTION
`mapsnap iiif` was silently dropping georeferenced pages whose page-key letter suffix wasn't one of `s`, `n`, `e`, `w`, `l`, or `r`.

## Motivation

Sanborn sheets can carry any letter suffix — e.g. Los Angeles 1949 vol. 14 splits page 1499 into panels `p1499a` … `p1499r`. The page-key parser (`georef_path_to_page_key`) only recognized the suffix class `[snewlr]`, so of those panels only `p1499e/l/n/r` survived; `p1499a, b, c, d, f, g, h, i, j, k, m, o, p, q` were dropped from the generated IIIF annotation — even though each had a perfectly good `georef.json`.

Worse, the drop was **silent**. `expand_georef_globs` skips any file whose key doesn't parse, and it runs *before* the "no canvas / missing image" warnings in the load loops, so nothing was logged. The run summary printed something like `Generated 95 annotations from 111 georef files`, but that mismatch was easy to overlook and gave no hint as to which files or why. It surfaced only because the volume viewer's new "missing pages" overlay flagged `p1499o`/`p1499p` as missing despite them having `georef.json` files.

Regenerating LA county after this fix goes from 95 → 111 items — all 16 dropped `p1499` panels restored.

## What changed

- **Broaden the suffix class** in `georef_path_to_page_key` from `[snewlr]?` to `[a-z]*`, so any letter (or letter run) suffix is kept. Using `*` rather than `?` is deliberate: a compound suffix like `p6ns` still *parses*, so it reaches `drop_redundant_skeletons`'s existing assertion that fails loudly on the ambiguous trailing `s` — instead of being silently dropped, which is the exact failure mode this PR fixes.
- **Warn on unparseable keys** in `expand_georef_globs`, naming the offending file, so this failure mode is obvious in the future instead of silent. The cross-glob first-wins dedup (used by hybrid `*.georef.json,*.georef-neighbor.json` patterns) stays quiet, since dropping the later duplicate there is intended.
- **Tests** for sequence-letter suffixes (`p1499o/a/q`, split `p1499q__2`), the compound-suffix parse (`p6ns`), and the new warning.

No behavior change for existing suffixes — the single directional letters (`s`, `L`/`R`), the `.gcps` infix, `__N` splits, and the `-neighbor` variant are all still covered by existing and new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
