### PR TITLE
Show missing pages + misc debugger improvements

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -41,6 +41,17 @@ export interface VolumeQuery {
   volume: string;
 }
 
+/**
+ * Response of GET /iiif-api/failed-georefs — page stem → failure kind.
+ *
+ * Maps each page that has a failed-georef sidecar (`<stem>.georef-<kind>.json`,
+ * e.g. `p1452.georef-nofit.json`) to its kind ("nofit", "1gcp", "misscale", …),
+ * so the volume viewer can link a not-georeferenced page to that debug file.
+ */
+export interface FailedGeorefsResponse {
+  failed: Record<string, string>;
+}
+
 /** Query naming one page of one volume. */
 export interface NoteTarget {
   volume: string;
@@ -74,6 +85,9 @@ export interface API {
   };
   '/iiif-api/annotation': {
     get: GetEndpoint<RewrittenAnnotationResponse, AnnotationQuery>;
+  };
+  '/iiif-api/failed-georefs': {
+    get: GetEndpoint<FailedGeorefsResponse, VolumeQuery>;
   };
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -27,6 +27,10 @@ const iiif = require('express-iiif').default;
 
 const PAGE_IMAGE_PATTERN = /^p\d+[a-z]?\.jpg$/i;
 
+// A failed-georef sidecar name -> [full, stem, kind], e.g.
+// "p1452.georef-nofit.json" -> ["…", "p1452", "nofit"].
+const FAILED_GEOREF_PATTERN = /^(.+)\.georef-([a-z0-9]+)\.json$/i;
+
 // Reject a path segment that could escape the data directory.
 function isSafeName(name: string): boolean {
   return (
@@ -150,5 +154,30 @@ export function registerIiifApi(
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
     return rewriteAnnotationPage(page, localPages, serviceBaseUrl);
+  });
+
+  // Page stems with a failed-georef sidecar in a volume, and each one's kind, so
+  // the viewer can link an un-georeferenced page to its georef-<kind>.json file.
+  // ?volume=<dir> → { failed: { "p1452": "nofit", "p1427": "misscale" } }.
+  router.get('/iiif-api/failed-georefs', async (_params, request) => {
+    const { volume } = request.query;
+    if (!isSafeName(volume)) {
+      throw new HTTPError(400, `invalid volume: ${volume}`);
+    }
+    let files: string[];
+    try {
+      files = await readdir(join(dataDir, volume));
+    } catch {
+      throw new HTTPError(404, `no such volume: ${volume}`);
+    }
+    const failed: Record<string, string> = {};
+    for (const file of files) {
+      const match = file.match(FAILED_GEOREF_PATTERN);
+      // First kind wins if a page somehow has more than one failed sidecar.
+      if (match && match[1] && match[2] && !(match[1] in failed)) {
+        failed[match[1]] = match[2].toLowerCase();
+      }
+    }
+    return { failed };
   });
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -150,6 +150,12 @@ export function App() {
   // The (volume, page) this view is on, when opened via a `?files=data/...`
   // deep link — the anchor for per-page notes. Null for dropped files.
   const [noteContext, setNoteContext] = useState<NoteContext | null>(null);
+  // True until the initial `?files=` deep link finishes loading, so the georef
+  // map can stay hidden until it knows where to look instead of flashing the
+  // default location. Only a deep link waits; a fresh app has nothing pending.
+  const [initialViewPending, setInitialViewPending] = useState(() =>
+    new URLSearchParams(window.location.search).has('files'),
+  );
 
   // Display toggles.
   const [opacity, setOpacity] = useState(85); // 0..100
@@ -500,7 +506,7 @@ export function App() {
       .map((s) => s.trim())
       .filter(Boolean);
     setNoteContext(noteContextFromFiles(files));
-    void loadFromUrls(files);
+    void loadFromUrls(files).finally(() => setInitialViewPending(false));
     // Runs once on mount; loadFromUrls closes over the initial (empty) state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -579,6 +585,7 @@ export function App() {
               showLabels={showLabels}
               showIntersections={showIntersections}
               colorByInlier={colorByInlier}
+              awaitingView={initialViewPending}
             />
             {gcpPairs && selectedPair && intersections.length >= 2 && (
               <GcpControls

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -5,11 +5,20 @@ import type { PageGeo } from '../iiif/pages';
 interface InfoPanelProps {
   /** All pages in the loaded annotation, or [] before one is loaded. */
   pages: PageGeo[];
+  /** How many truth pages the run never georeferenced, for the volume summary. */
+  missingCount: number;
   /** Items the server dropped while rewriting the annotation. */
   skipped: SkippedItem[];
   /** The loaded annotation file's name, for the summary header. */
   annotationName: string | null;
   selectedPage: PageGeo | null;
+  /** Whether the selected page is a missing (un-fitted) truth page. */
+  selectedMissing: boolean;
+  /**
+   * Failure kind of the selected page's failed-georef sidecar ("nofit"/"1gcp"/…),
+   * or null when it has none; drives the georef-view link for a missing page.
+   */
+  selectedFailedGeorefType: string | null;
   /** Truth-compare stats for the selected page, when the volume has truth. */
   selectedStats: PageCompareStats | null;
   /** The selected page's note text, or null when it has none. */
@@ -54,9 +63,12 @@ function fitSummary(pages: PageGeo[]): string {
 export function InfoPanel(props: InfoPanelProps) {
   const {
     pages,
+    missingCount,
     skipped,
     annotationName,
     selectedPage,
+    selectedMissing,
+    selectedFailedGeorefType,
     selectedStats,
     selectedNote,
     volume,
@@ -74,33 +86,50 @@ export function InfoPanel(props: InfoPanelProps) {
           </button>
         </div>
         <dl>
-          {selectedStats && (
+          {selectedMissing ? (
             <>
-              <dt>RMSE</dt>
+              <dt>Status</dt>
+              <dd>not georeferenced</dd>
+              <dt>Truth scale</dt>
+              <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
+              <dt>Truth rotation</dt>
+              <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
+              <dt>Size</dt>
               <dd>
-                {selectedStats.rmseFt.toFixed(1)} ft (max{' '}
-                {selectedStats.maxFt.toFixed(1)} ft)
+                {selectedPage.width} × {selectedPage.height} px
               </dd>
-              <dt>Translation</dt>
-              <dd>{selectedStats.translationFt.toFixed(1)} ft</dd>
-              <dt>Rotation Δ</dt>
-              <dd>{selectedStats.rotationErrorDegrees.toFixed(2)}°</dd>
-              <dt>Scale Δ</dt>
-              <dd>{selectedStats.scaleErrorPercent.toFixed(2)}%</dd>
+            </>
+          ) : (
+            <>
+              {selectedStats && (
+                <>
+                  <dt>RMSE</dt>
+                  <dd>
+                    {selectedStats.rmseFt.toFixed(1)} ft (max{' '}
+                    {selectedStats.maxFt.toFixed(1)} ft)
+                  </dd>
+                  <dt>Translation</dt>
+                  <dd>{selectedStats.translationFt.toFixed(1)} ft</dd>
+                  <dt>Rotation Δ</dt>
+                  <dd>{selectedStats.rotationErrorDegrees.toFixed(2)}°</dd>
+                  <dt>Scale Δ</dt>
+                  <dd>{selectedStats.scaleErrorPercent.toFixed(2)}%</dd>
+                </>
+              )}
+              <dt>Scale</dt>
+              <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
+              <dt>Rotation</dt>
+              <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
+              <dt>Size</dt>
+              <dd>
+                {selectedPage.width} × {selectedPage.height} px
+              </dd>
+              <dt>GCPs</dt>
+              <dd>{selectedPage.gcps.length}</dd>
+              <dt>Fit</dt>
+              <dd>{selectedPage.transformationType}</dd>
             </>
           )}
-          <dt>Scale</dt>
-          <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
-          <dt>Rotation</dt>
-          <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
-          <dt>Size</dt>
-          <dd>
-            {selectedPage.width} × {selectedPage.height} px
-          </dd>
-          <dt>GCPs</dt>
-          <dd>{selectedPage.gcps.length}</dd>
-          <dt>Fit</dt>
-          <dd>{selectedPage.transformationType}</dd>
         </dl>
         {selectedNote && (
           <div className="page-info-note">
@@ -110,7 +139,17 @@ export function InfoPanel(props: InfoPanelProps) {
         )}
         <div className="page-info-links">
           <a href={`?files=${base}.jpg,${base}.streets.json`}>streets view</a>
-          <a href={`?files=${base}.jpg,${base}.georef.json`}>georef view</a>
+          {selectedMissing ? (
+            selectedFailedGeorefType && (
+              <a
+                href={`?files=${base}.jpg,${base}.georef-${selectedFailedGeorefType}.json`}
+              >
+                georef view ({selectedFailedGeorefType})
+              </a>
+            )
+          ) : (
+            <a href={`?files=${base}.jpg,${base}.georef.json`}>georef view</a>
+          )}
         </div>
       </div>
     );
@@ -137,6 +176,12 @@ export function InfoPanel(props: InfoPanelProps) {
       <dl>
         <dt>Pages</dt>
         <dd>{pages.length}</dd>
+        {missingCount > 0 && (
+          <>
+            <dt>Missing</dt>
+            <dd>{missingCount}</dd>
+          </>
+        )}
         {skipped.length > 0 && (
           <>
             <dt>Skipped</dt>

--- a/app/src/components/MapView.tsx
+++ b/app/src/components/MapView.tsx
@@ -23,6 +23,12 @@ interface MapViewProps {
   showLabels: boolean;
   showIntersections: boolean;
   colorByInlier: boolean;
+  /**
+   * True while a deep link is still loading the page whose view isn't known yet.
+   * The map stays hidden until it has been positioned, so it never flashes at the
+   * default location before the real one arrives.
+   */
+  awaitingView: boolean;
 }
 
 // Teal for streets read by the key-map rectangle fallback vocabulary (matching the neighborhood
@@ -85,12 +91,28 @@ export function MapView(props: MapViewProps) {
     showLabels,
     showIntersections,
     colorByInlier,
+    awaitingView,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const lastFittedCornersRef = useRef('');
   const [mapReady, setMapReady] = useState(false);
+  // Whether the map has been framed on real data (corners or a key-map location).
+  const [positioned, setPositioned] = useState(false);
+  // Whether the map is shown. Latched true once there is something to show, so it
+  // never reverts to hidden on a later data change.
+  const [revealed, setRevealed] = useState(false);
+
+  // Reveal once the map is framed on its data, or — when nothing is loading and
+  // there is nothing to frame (the empty debugger) — right away at the default view.
+  const hasView = Boolean(corners) || Boolean(keymap);
+  useEffect(() => {
+    if (revealed) return;
+    if (mapReady && (positioned || (!hasView && !awaitingView))) {
+      setRevealed(true);
+    }
+  }, [revealed, mapReady, positioned, hasView, awaitingView]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -180,6 +202,7 @@ export function MapView(props: MapViewProps) {
           animate: shouldAnimateTo(map, newCenterLon, newCenterLat),
         },
       );
+      setPositioned(true);
     }
   }, [mapReady, corners, imageSrc, opacity]);
 
@@ -506,6 +529,7 @@ export function MapView(props: MapViewProps) {
           animate: shouldAnimateTo(map, targetLon, targetLat),
         },
       );
+      setPositioned(true);
     }
   }, [mapReady, keymap, corners]);
 
@@ -547,5 +571,11 @@ export function MapView(props: MapViewProps) {
     }
   }, [mapReady, truth]);
 
-  return <div id="map" ref={containerRef} />;
+  return (
+    <div
+      id="map"
+      ref={containerRef}
+      style={{ visibility: revealed ? undefined : 'hidden' }}
+    />
+  );
 }

--- a/app/src/components/PageList.tsx
+++ b/app/src/components/PageList.tsx
@@ -5,6 +5,8 @@ import type { PageGeo } from '../iiif/pages';
 
 interface PageListProps {
   pages: PageGeo[];
+  /** Truth pages the run never fitted; shown with blank RMSE/Δ columns. */
+  missingPages: PageGeo[];
   /** Per-itemIndex truth stats; null entry = truth exists but is incomparable (split). */
   stats: Map<number, PageCompareStats | null> | null;
   /** Page key → note text for the volume; keys present here get a marker. */
@@ -57,7 +59,8 @@ function sortValue(
  * the worst fits are on top — and a row to select the page on the map.
  */
 export function PageList(props: PageListProps) {
-  const { pages, stats, notes, selectedItemIndex, onSelectPage } = props;
+  const { pages, missingPages, stats, notes, selectedItemIndex, onSelectPage } =
+    props;
   const [sort, setSort] = useState<{ key: SortKey; descending: boolean }>({
     key: 'rmse',
     descending: true,
@@ -69,14 +72,24 @@ export function PageList(props: PageListProps) {
       ? { key: 'page' as SortKey, descending: false }
       : sort;
 
-  const sorted = [...pages].sort((a, b) => {
+  // Missing (un-fitted) pages carry a negative synthetic itemIndex and have no
+  // truth stats, so they blank out the RMSE/Δ columns and sink under those sorts.
+  const missingKeys = new Set(missingPages.map((page) => page.itemIndex));
+  const sorted = [...pages, ...missingPages].sort((a, b) => {
     const naturalOrder = comparePageKeys(a.pageKey, b.pageKey);
     if (effectiveSort.key === 'page') {
       return effectiveSort.descending ? -naturalOrder : naturalOrder;
     }
     const aValue = sortValue(effectiveSort.key, a, stats?.get(a.itemIndex));
     const bValue = sortValue(effectiveSort.key, b, stats?.get(b.itemIndex));
-    if (aValue === undefined && bValue === undefined) return naturalOrder;
+    if (aValue === undefined && bValue === undefined) {
+      // Both rows lack a value under this sort. Cluster them so the fitted-but-
+      // incomparable (split) pages sit above the un-fitted missing pages, keeping
+      // all missing pages grouped at the very bottom; alphabetical within a group.
+      const aMissing = missingKeys.has(a.itemIndex) ? 1 : 0;
+      const bMissing = missingKeys.has(b.itemIndex) ? 1 : 0;
+      return aMissing - bMissing || naturalOrder;
+    }
     if (aValue === undefined) return 1; // valueless rows always sink
     if (bValue === undefined) return -1;
     const order = aValue - bValue;
@@ -123,12 +136,16 @@ export function PageList(props: PageListProps) {
         <tbody>
           {sorted.map((page) => {
             const pageStats = stats?.get(page.itemIndex);
+            const missing = missingKeys.has(page.itemIndex);
             return (
               <tr
                 key={page.itemIndex}
-                className={
-                  page.itemIndex === selectedItemIndex ? 'selected' : ''
-                }
+                className={[
+                  page.itemIndex === selectedItemIndex ? 'selected' : '',
+                  missing ? 'missing' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
                 onClick={() =>
                   onSelectPage(
                     page.itemIndex === selectedItemIndex
@@ -151,7 +168,11 @@ export function PageList(props: PageListProps) {
                 </td>
                 {hasTruth && (
                   <td className="numeric">
-                    {pageStats ? (
+                    {missing ? (
+                      <span title="not georeferenced; shown at its truth location">
+                        —
+                      </span>
+                    ) : pageStats ? (
                       <span className={rmseClass(pageStats.rmseFt)}>
                         {pageStats.rmseFt.toFixed(0)}ft
                       </span>

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -32,6 +32,10 @@ const EMPTY_FEATURES: FeatureCollection = {
   features: [],
 };
 
+// The RMSE color-coding fill opacity at full slider opacity; scaled down in
+// proportion as the opacity slider is reduced, so the fills fade with the maps.
+const RMSE_FILL_OPACITY = 0.45;
+
 // Overlay features for a selected page: the full image rectangle (solid), the
 // clipping polygon (dashed), and its GCPs (circles), distinguished by `kind`.
 function selectionFeatures(page: PageGeo): FeatureCollection {
@@ -157,7 +161,10 @@ export function VolumeMap(props: VolumeMapProps) {
         source: 'rmse-fills',
         paint: {
           'fill-color': ['get', 'color'],
-          'fill-opacity': 0.45,
+          'fill-opacity': RMSE_FILL_OPACITY,
+          // No transition so the fill tracks the opacity slider instantly,
+          // matching the warped maps (which animate: false below).
+          'fill-opacity-transition': { duration: 0 },
           'fill-outline-color': ['get', 'color'],
         },
       });
@@ -348,9 +355,18 @@ export function VolumeMap(props: VolumeMapProps) {
   // disabled so scrubbing the slider tracks instantly instead of queueing
   // 300ms transitions.
   useEffect(() => {
+    const map = mapRef.current;
     const layer = layerRef.current;
-    if (!layer || !mapReady) return;
+    if (!map || !layer || !mapReady) return;
     layer.setLayerOptions({ opacity }, { animate: false });
+    // Fade the RMSE color fills along with the maps, proportional to their base.
+    if (map.getLayer('rmse-fill')) {
+      map.setPaintProperty(
+        'rmse-fill',
+        'fill-opacity',
+        RMSE_FILL_OPACITY * opacity,
+      );
+    }
   }, [opacity, annotation, mapReady]);
 
   // RMSE color-coding: one translucent fill per page footprint when enabled.

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -11,6 +11,10 @@ interface VolumeMapProps {
   annotation: unknown;
   /** Derived page geometry for hit-testing and outlines. */
   pages: PageGeo[];
+  /** Truth pages never fitted; drawn as dashed truth-location footprints. */
+  missingPages: PageGeo[];
+  /** Whether the missing-page footprints are drawn and clickable. */
+  showMissing: boolean;
   /** itemIndex of the selected page, or null for no selection. */
   selectedItemIndex: number | null;
   /** Called with the clicked page's itemIndex, or null for empty space. */
@@ -63,6 +67,8 @@ export function VolumeMap(props: VolumeMapProps) {
   const {
     annotation,
     pages,
+    missingPages,
+    showMissing,
     selectedItemIndex,
     onSelectPage,
     opacity,
@@ -76,13 +82,17 @@ export function VolumeMap(props: VolumeMapProps) {
 
   // Latest props for the click/hover handlers, which are installed once.
   const pagesRef = useRef(pages);
+  const missingPagesRef = useRef(missingPages);
+  const showMissingRef = useRef(showMissing);
   const onSelectPageRef = useRef(onSelectPage);
   const selectedRef = useRef(selectedItemIndex);
   useEffect(() => {
     pagesRef.current = pages;
+    missingPagesRef.current = missingPages;
+    showMissingRef.current = showMissing;
     onSelectPageRef.current = onSelectPage;
     selectedRef.current = selectedItemIndex;
-  }, [pages, onSelectPage, selectedItemIndex]);
+  }, [pages, missingPages, showMissing, onSelectPage, selectedItemIndex]);
 
   // Allmaps map IDs indexed by annotation itemIndex, and the itemIndexes
   // brought to front so far (most recent last) so hit-testing can pick the
@@ -151,6 +161,28 @@ export function VolumeMap(props: VolumeMapProps) {
           'fill-outline-color': ['get', 'color'],
         },
       });
+      // Missing (un-fitted) pages, drawn at their truth footprint as translucent
+      // white polygons with a dashed border to read as distinct from fit pages.
+      map.addSource('missing-pages', {
+        type: 'geojson',
+        data: EMPTY_FEATURES,
+      });
+      map.addLayer({
+        id: 'missing-pages-fill',
+        type: 'fill',
+        source: 'missing-pages',
+        paint: { 'fill-color': '#ffffff', 'fill-opacity': 0.35 },
+      });
+      map.addLayer({
+        id: 'missing-pages-outline',
+        type: 'line',
+        source: 'missing-pages',
+        paint: {
+          'line-color': '#333333',
+          'line-width': 1.5,
+          'line-dasharray': [3, 2],
+        },
+      });
       map.addSource('selected-page', {
         type: 'geojson',
         data: EMPTY_FEATURES,
@@ -200,11 +232,13 @@ export function VolumeMap(props: VolumeMapProps) {
     // The selected page renders unclipped, so its full rectangle counts as a
     // hit while it is selected. Otherwise the most-recently-selected page wins
     // an overlap, then the later-added page (Allmaps renders later additions
-    // on top).
+    // on top). Missing-page footprints are considered last (and only when
+    // shown), so a fitted page always wins where the two overlap.
     function pageAtPoint(lng: number, lat: number): number | null {
-      const selected = pagesRef.current.find(
-        (p) => p.itemIndex === selectedRef.current,
-      );
+      const selectedId = selectedRef.current;
+      const selected =
+        pagesRef.current.find((p) => p.itemIndex === selectedId) ??
+        missingPagesRef.current.find((p) => p.itemIndex === selectedId);
       if (selected && pointInPolygon(lng, lat, selected.rectRing)) {
         return selected.itemIndex;
       }
@@ -219,7 +253,13 @@ export function VolumeMap(props: VolumeMapProps) {
           best = page.itemIndex;
         }
       }
-      return best;
+      if (best !== null) return best;
+      if (showMissingRef.current) {
+        for (const page of missingPagesRef.current) {
+          if (pointInPolygon(lng, lat, page.clipRing)) return page.itemIndex;
+        }
+      }
+      return null;
     }
 
     map.on('click', (e) => {
@@ -282,10 +322,13 @@ export function VolumeMap(props: VolumeMapProps) {
       unmaskedMapIdRef.current = null;
     }
     const source = map.getSource<maplibregl.GeoJSONSource>('selected-page');
+    // A missing page has no warped map to bring forward; its footprint is still
+    // outlined here so selecting one (from the list or the map) shows where it is.
     const page =
       selectedItemIndex === null
         ? undefined
-        : pages.find((p) => p.itemIndex === selectedItemIndex);
+        : (pages.find((p) => p.itemIndex === selectedItemIndex) ??
+          missingPages.find((p) => p.itemIndex === selectedItemIndex));
     if (!page) {
       source?.setData(EMPTY_FEATURES);
       return;
@@ -298,7 +341,7 @@ export function VolumeMap(props: VolumeMapProps) {
       unmaskedMapIdRef.current = mapId;
       frontOrderRef.current.push(page.itemIndex);
     }
-  }, [selectedItemIndex, pages, mapReady]);
+  }, [selectedItemIndex, pages, missingPages, mapReady]);
 
   // Also depends on `annotation`: newly added maps start at full opacity, so
   // the current value must be reapplied after each volume load. Animation is
@@ -329,6 +372,27 @@ export function VolumeMap(props: VolumeMapProps) {
       }));
     source.setData({ type: 'FeatureCollection', features });
   }, [props.pageColors, props.pages, mapReady]);
+
+  // Missing-page footprints: one translucent white polygon per un-fitted page
+  // at its truth clip ring, shown only when the toggle is on.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+    const source = map.getSource<maplibregl.GeoJSONSource>('missing-pages');
+    if (!source) return;
+    if (!showMissing) {
+      source.setData(EMPTY_FEATURES);
+      return;
+    }
+    source.setData({
+      type: 'FeatureCollection',
+      features: missingPages.map((page): FeatureCollection['features'][0] => ({
+        type: 'Feature',
+        properties: { itemIndex: page.itemIndex },
+        geometry: { type: 'Polygon', coordinates: [page.clipRing] },
+      })),
+    });
+  }, [missingPages, showMissing, mapReady]);
 
   return <div id="map" ref={containerRef} />;
 }

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -21,6 +21,12 @@ interface VolumeMapProps {
   onSelectPage: (itemIndex: number | null) => void;
   /** Warped-image opacity in [0, 1]. */
   opacity: number;
+  /**
+   * True while a selected annotation is still loading. The map stays hidden
+   * until it has been fit to that annotation, so it never flashes the default
+   * location before the volume's real one arrives.
+   */
+  awaitingView: boolean;
   /** Per-itemIndex fill color for RMSE color-coding, or null when off. */
   pageColors: Map<number, string> | null;
   /** Called with per-page add results whenever a new annotation is shown. */
@@ -76,6 +82,7 @@ export function VolumeMap(props: VolumeMapProps) {
     selectedItemIndex,
     onSelectPage,
     opacity,
+    awaitingView,
     onLoadResult,
   } = props;
 
@@ -83,6 +90,20 @@ export function VolumeMap(props: VolumeMapProps) {
   const mapRef = useRef<maplibregl.Map | null>(null);
   const layerRef = useRef<WarpedMapLayer | null>(null);
   const [mapReady, setMapReady] = useState(false);
+  // Whether the map has been fit to a loaded annotation.
+  const [positioned, setPositioned] = useState(false);
+  // Whether the map is shown. Latched true once there is something to show, so
+  // it never reverts to hidden on a later volume/selection change.
+  const [revealed, setRevealed] = useState(false);
+
+  // Reveal once the map is fit to its annotation, or — when nothing is loading
+  // and no annotation is present (the volume picker) — right away at the default view.
+  useEffect(() => {
+    if (revealed) return;
+    if (mapReady && (positioned || (!annotation && !awaitingView))) {
+      setRevealed(true);
+    }
+  }, [revealed, mapReady, positioned, annotation, awaitingView]);
 
   // Latest props for the click/hover handlers, which are installed once.
   const pagesRef = useRef(pages);
@@ -313,6 +334,7 @@ export function VolumeMap(props: VolumeMapProps) {
     onLoadResultRef.current?.({ loaded: results.length - failed, failed });
     const bounds = layer.getBounds();
     if (bounds) map.fitBounds(bounds, { padding: 40, animate: false });
+    setPositioned(true);
   }, [annotation, mapReady]);
 
   // Outline the selected page, bring it to the front of the stack, and remove
@@ -410,5 +432,11 @@ export function VolumeMap(props: VolumeMapProps) {
     });
   }, [missingPages, showMissing, mapReady]);
 
-  return <div id="map" ref={containerRef} />;
+  return (
+    <div
+      id="map"
+      ref={containerRef}
+      style={{ visibility: revealed ? undefined : 'hidden' }}
+    />
+  );
 }

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -10,10 +10,14 @@ import {
   rmseBucket,
   type PageCompareStats,
 } from '../iiif/compare';
-import { fetchRewrittenAnnotation, fetchVolumes } from '../iiif/api';
+import {
+  fetchFailedGeorefs,
+  fetchRewrittenAnnotation,
+  fetchVolumes,
+} from '../iiif/api';
 import { isTypingTarget } from '../keyboard';
 import { fetchVolumeNotes } from '../notes/api';
-import { pagesFromAnnotation } from '../iiif/pages';
+import { missingTruthPages, pagesFromAnnotation } from '../iiif/pages';
 import { InfoPanel } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
@@ -45,6 +49,7 @@ export function VolumeViewer() {
   } | null>(null);
   const [opacity, setOpacity] = useState(100);
   const [colorByRmse, setColorByRmse] = useState(false);
+  const [showMissing, setShowMissing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedItemIndex, setSelectedItemIndex] = useState<number | null>(
     null,
@@ -52,6 +57,10 @@ export function VolumeViewer() {
   const [truthAnnotation, setTruthAnnotation] = useState<unknown>(null);
   // Page key → note text for the selected volume (markers + tooltip).
   const [notes, setNotes] = useState<Map<string, string>>(new Map());
+  // Page stem → failed-georef kind ("nofit"/"1gcp"/…) for the selected volume.
+  const [failedGeorefs, setFailedGeorefs] = useState<Map<string, string>>(
+    new Map(),
+  );
 
   useEffect(() => {
     fetchVolumes()
@@ -101,11 +110,13 @@ export function VolumeViewer() {
   const selection = parseAnnotationPath(selectedPath);
   const selectedVolume = volumes?.find((v) => v.name === selection?.volume);
 
-  // Load the selected volume's page notes for the list markers and tooltip.
+  // Load the selected volume's page notes and failed-georef sidecars: the notes
+  // drive the list markers/tooltip, the failed-georefs the missing-page links.
   const volumeName = selection?.volume;
   useEffect(() => {
     if (!volumeName) {
       setNotes(new Map());
+      setFailedGeorefs(new Map());
       return;
     }
     let cancelled = false;
@@ -115,6 +126,13 @@ export function VolumeViewer() {
       })
       .catch(() => {
         if (!cancelled) setNotes(new Map());
+      });
+    fetchFailedGeorefs(volumeName)
+      .then((map) => {
+        if (!cancelled) setFailedGeorefs(map);
+      })
+      .catch(() => {
+        if (!cancelled) setFailedGeorefs(new Map());
       });
     return () => {
       cancelled = true;
@@ -140,14 +158,22 @@ export function VolumeViewer() {
       annotation ? pagesFromAnnotation(annotation as GeorefAnnotationPage) : [],
     [annotation],
   );
-  const truthStats: Map<number, PageCompareStats | null> | null =
-    useMemo(() => {
-      if (!truthAnnotation) return null;
-      const truthPages = pagesFromAnnotation(
-        truthAnnotation as GeorefAnnotationPage,
-      );
-      return compareToTruth(pages, truthPages);
-    }, [pages, truthAnnotation]);
+  const truthPages = useMemo(
+    () =>
+      truthAnnotation
+        ? pagesFromAnnotation(truthAnnotation as GeorefAnnotationPage)
+        : null,
+    [truthAnnotation],
+  );
+  const truthStats: Map<number, PageCompareStats | null> | null = useMemo(
+    () => (truthPages ? compareToTruth(pages, truthPages) : null),
+    [pages, truthPages],
+  );
+  // Truth pages the run never georeferenced, shown as "missing" rows/footprints.
+  const missingPages = useMemo(
+    () => (truthPages ? missingTruthPages(pages, truthPages) : []),
+    [pages, truthPages],
+  );
 
   const pageColors: Map<number, string> | null = useMemo(() => {
     if (!colorByRmse || !truthStats) return null;
@@ -160,10 +186,18 @@ export function VolumeViewer() {
     return colors;
   }, [colorByRmse, truthStats]);
 
+  // A missing page carries a negative synthetic id, so it is found in
+  // missingPages, not the fitted pages; the info panel renders it differently.
   const selectedPage =
     selectedItemIndex === null
       ? null
-      : (pages.find((p) => p.itemIndex === selectedItemIndex) ?? null);
+      : (pages.find((p) => p.itemIndex === selectedItemIndex) ??
+        missingPages.find((p) => p.itemIndex === selectedItemIndex) ??
+        null);
+  const selectedIsMissing =
+    selectedPage !== null &&
+    selectedItemIndex !== null &&
+    selectedItemIndex < 0;
 
   function selectVolume(name: string): void {
     const volume = volumes?.find((v) => v.name === name);
@@ -225,6 +259,16 @@ export function VolumeViewer() {
             Color by RMSE
           </label>
         )}
+        {missingPages.length > 0 && (
+          <label className="rmse-color-control">
+            <input
+              type="checkbox"
+              checked={showMissing}
+              onChange={(e) => setShowMissing(e.target.checked)}
+            />
+            Show missing pages
+          </label>
+        )}
         <div className="opacity-control">
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
@@ -241,6 +285,7 @@ export function VolumeViewer() {
       <div className="volume-viewer-body">
         <PageList
           pages={pages}
+          missingPages={missingPages}
           stats={truthStats}
           notes={notes}
           selectedItemIndex={selectedItemIndex}
@@ -249,6 +294,8 @@ export function VolumeViewer() {
         <VolumeMap
           annotation={annotation}
           pages={pages}
+          missingPages={missingPages}
+          showMissing={showMissing}
           selectedItemIndex={selectedItemIndex}
           onSelectPage={setSelectedItemIndex}
           opacity={opacity / 100}
@@ -257,9 +304,16 @@ export function VolumeViewer() {
         />
         <InfoPanel
           pages={pages}
+          missingCount={missingPages.length}
           skipped={skipped}
           annotationName={selection?.file ?? null}
           selectedPage={selectedPage}
+          selectedMissing={selectedIsMissing}
+          selectedFailedGeorefType={
+            selectedPage
+              ? (failedGeorefs.get(selectedPage.pageKey) ?? null)
+              : null
+          }
           selectedStats={
             selectedItemIndex === null
               ? null

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -299,6 +299,7 @@ export function VolumeViewer() {
           selectedItemIndex={selectedItemIndex}
           onSelectPage={setSelectedItemIndex}
           opacity={opacity / 100}
+          awaitingView={!!selectedPath && !error}
           pageColors={pageColors}
           onLoadResult={setLoadResult}
         />

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -23,3 +23,16 @@ export function fetchRewrittenAnnotation(
 ): Promise<RewrittenAnnotationResponse> {
   return api.get('/iiif-api/annotation')(null, { path });
 }
+
+/**
+ * Fetch a volume's failed-georef sidecars as a page-stem → failure-kind map
+ * (e.g. "p1452" → "nofit"), for linking un-georeferenced pages to the georef view.
+ */
+export async function fetchFailedGeorefs(
+  volume: string,
+): Promise<Map<string, string>> {
+  const { failed } = await api.get('/iiif-api/failed-georefs')(null, {
+    volume,
+  });
+  return new Map(Object.entries(failed));
+}

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { GeorefAnnotationPage } from '../../server/iiifAnnotations';
-import { bearingDegrees, pagesFromAnnotation, svgPolygonPoints } from './pages';
+import {
+  bearingDegrees,
+  missingTruthPages,
+  pagesFromAnnotation,
+  svgPolygonPoints,
+  type PageGeo,
+} from './pages';
 
 const METERS_PER_DEGREE_LAT = 110574;
 const METERS_PER_DEGREE_LON_AT_EQUATOR = 111320;
@@ -164,5 +170,34 @@ describe('pagesFromAnnotation', () => {
 
     const oneGcp = annotationWith([gcpFeature(0, 0, offset(0, 0))]);
     expect(pagesFromAnnotation(oneGcp)).toHaveLength(0);
+  });
+});
+
+// A stand-in PageGeo carrying only the fields missingTruthPages reads.
+function pageGeo(pageKey: string, itemIndex: number): PageGeo {
+  return { pageKey, itemIndex } as PageGeo;
+}
+
+describe('missingTruthPages', () => {
+  it('returns truth pages absent from the fit, with negative ids', () => {
+    const fit = [pageGeo('p1', 0), pageGeo('p2', 1)];
+    const truth = [pageGeo('p1', 0), pageGeo('p2', 1), pageGeo('p3', 2)];
+    const missing = missingTruthPages(fit, truth);
+    expect(missing.map((p) => p.pageKey)).toEqual(['p3']);
+    // Negative id keeps it out of the fit pages' itemIndex space.
+    expect(missing[0]!.itemIndex).toBe(-1);
+  });
+
+  it('dedupes a split parent that appears once per truth panel', () => {
+    const fit = [pageGeo('p1', 0)];
+    const truth = [pageGeo('p9', 5), pageGeo('p9', 6), pageGeo('p10', 7)];
+    const missing = missingTruthPages(fit, truth);
+    expect(missing.map((p) => p.pageKey)).toEqual(['p9', 'p10']);
+    expect(missing.map((p) => p.itemIndex)).toEqual([-1, -2]);
+  });
+
+  it('returns nothing when every truth page was fitted', () => {
+    const fit = [pageGeo('p1', 0), pageGeo('p2', 1)];
+    expect(missingTruthPages(fit, [pageGeo('p1', 0)])).toEqual([]);
   });
 });

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -157,6 +157,30 @@ function gcpPoints(features: GcpFeature[]): PageGcp[] {
   return points;
 }
 
+/**
+ * Truth pages that the loaded run never georeferenced, ready to show as
+ * "missing" rows and footprints.
+ *
+ * A truth page is missing when its page key is absent from the fitted pages.
+ * Results are deduped by page key (a split parent has one truth item per panel;
+ * we keep the first) and given negative `itemIndex` selection ids so they never
+ * collide with the fitted pages' array indices.
+ */
+export function missingTruthPages(
+  fitPages: PageGeo[],
+  truthPages: PageGeo[],
+): PageGeo[] {
+  const fitKeys = new Set(fitPages.map((page) => page.pageKey));
+  const seen = new Set<string>();
+  const missing: PageGeo[] = [];
+  for (const truthPage of truthPages) {
+    if (fitKeys.has(truthPage.pageKey) || seen.has(truthPage.pageKey)) continue;
+    seen.add(truthPage.pageKey);
+    missing.push({ ...truthPage, itemIndex: -(missing.length + 1) });
+  }
+  return missing;
+}
+
 // Close a ring in place if its last point differs from its first.
 function closedRing(ring: [number, number][]): [number, number][] {
   if (ring.length === 0) return ring;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -462,6 +462,14 @@ tr.on-fill td {
   background: #dde5ff;
   font-weight: bold;
 }
+/* Missing (un-fitted) pages, shown at their truth location. */
+.page-list tbody tr.missing {
+  color: #888;
+  font-style: italic;
+}
+.page-list tbody tr.missing.selected {
+  color: inherit;
+}
 .page-list .rmse-good {
   color: #1a7f37;
 }


### PR DESCRIPTION
Three improvements to the debugger's volume viewer and georef view.

<img width="1526" height="848" alt="image" src="https://github.com/user-attachments/assets/c5d44991-aa88-4615-8f2e-4a785d07e7b2" />

## 1. Show missing pages in the volume viewer

The viewer lists the pages a run georeferenced but silently omits the ones it didn't. When a volume has truth data (`main.iiif.json`), we know exactly which pages are missing and where they belong — so now it shows them.

- **Page list**: truth pages absent from the loaded annotation appear as muted/italic rows with a `—` in the RMSE column and blank Δ columns. The RMSE sort groups them last: fitted pages (by RMSE), then split pages, then missing pages, alphabetical within each group.
- **Map**: a **"Show missing pages"** checkbox (next to "Color by RMSE") renders each missing page at its truth footprint as a translucent white polygon with a dashed border, so it's clearly distinct from the fitted pages.
- **Info panel**: clicking a missing page (in the list or on the map) shows its details like a fitted page — "not georeferenced", truth scale/rotation/size, a **streets view** link, and, when a failed-georef sidecar exists, a **"georef view (misscale)"**-style link naming the failure kind and pointing at the `pN.georef-<kind>.json` file. Pages with notes still show the 📓 marker.
- **Server**: new `GET /iiif-api/failed-georefs?volume=…` reports which page stems have a failed-georef sidecar (`georef-nofit`/`-1gcp`/`-misscale`/…) and its kind, so the panel can link to it.
- Volumes without truth data are unaffected — no checkbox, no missing rows, no extra columns.

(This is also what surfaced the page-key drop bug fixed in #145: the overlay flagged `p1499o`/`p1499p` as missing even though they had georef files.)

## 2. Color-by-RMSE fills fade with the opacity slider

With "Color by RMSE" on, reducing the opacity slider faded the warped maps but left the colored rectangles at full opacity. The RMSE fill opacity now scales with the slider (`0.45 × opacity`), with the paint transition disabled so it tracks the slider instantly instead of lagging behind by maplibre's default 300 ms.

## 3. No flash of the default location on load

Loading a page with a data file (`&iiif=` or `&files=`) rendered the MapLibre map at its hardcoded default center (Brooklyn), then jumped to the correct location once the data arrived — a needless flash. Both maps (volume viewer and georef view) now stay hidden until they've been fit to their data, revealing only once positioned. Empty/no-selection states (the volume picker, the blank debugger) still show the default map immediately.

## Testing

Added unit tests for the missing-page derivation (`missingTruthPages`) and verified all three changes in the browser: the missing-page list/map/links against LA county, the RMSE fills fading proportionally with the slider, and — by recording every animation frame from load — that the map is never *visible* at the default location before it reaches the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
