### PR TITLE
Read `mapsnap compare` output in volume viewer

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -16,6 +16,7 @@ import type {
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from './iiifAnnotations.ts';
+import type { CompareResponse } from './compareTxt.ts';
 import type { ImageInfo, LabelsJson } from '../src/keymap/types.ts';
 
 /** Query naming a georeference AnnotationPage, repo-root-relative. */
@@ -88,6 +89,9 @@ export interface API {
   };
   '/iiif-api/failed-georefs': {
     get: GetEndpoint<FailedGeorefsResponse, VolumeQuery>;
+  };
+  '/iiif-api/compare': {
+    get: GetEndpoint<CompareResponse, AnnotationQuery>;
   };
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;

--- a/app/server/compareTxt.test.ts
+++ b/app/server/compareTxt.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { parseCompareTxt } from './compareTxt.ts';
+
+const HEADER =
+  'Page          n_t n_g  str  int  t.px/ft  g.px/ft   rmse_ft    max_ft   trans_ft   rot_err  scale_%   skew°   aniso';
+const RULE = '-'.repeat(HEADER.length);
+
+// A compare table built from real 2026-07-21.txt rows: a plain pair, a split whose numbering
+// disagrees (gen key in trailing parens), and a truth-only "(no fit)" row.
+const TABLE = [
+  HEADER,
+  RULE,
+  'p1404__2        5   2    5    6     6.02     5.85      18.2      22.7       15.4     +0.34    +2.88   +0.73   1.030',
+  'p1499N__2       5   2    5    5     6.03     6.13      12.8      17.6        7.9     +0.31    -1.68   +0.66   1.024',
+  'p1499L__3 (t)  10   2    9    6     2.97     3.00      10.5      16.3        8.6     -0.01    -1.12   -0.26   1.015  (p1499L)',
+  'p1401__2        3   —    —    —        —        —         —         —          —         —        —   -2.31   1.009  (no fit)',
+  RULE,
+  '',
+  '111/129 = 86.05% pages georeferenced (18 total losses)',
+  'RMSE:  mean=31 ft  median=12 ft  max=403 ft',
+].join('\n');
+
+describe('parseCompareTxt', () => {
+  it('parses paired rows keyed by the generated page stem', () => {
+    const pages = parseCompareTxt(TABLE);
+    expect(pages.map((p) => p.genPageKey)).toEqual([
+      'p1404__2',
+      'p1499n__2', // uppercase suffix lowercased to match the file stem
+      'p1499l', // split numbers disagree: generated key comes from the trailing parens
+    ]);
+  });
+
+  it('reads the error metrics of a plain paired row', () => {
+    const p1404 = parseCompareTxt(TABLE).find(
+      (p) => p.genPageKey === 'p1404__2',
+    )!;
+    expect(p1404).toMatchObject({
+      rmseFt: 18.2,
+      maxFt: 22.7,
+      translationFt: 15.4,
+      rotationErrorDegrees: 0.34,
+      scaleErrorPercent: 2.88,
+    });
+  });
+
+  it('takes the generated key from the trailing parens when numbering disagrees', () => {
+    const p1499l = parseCompareTxt(TABLE).find(
+      (p) => p.genPageKey === 'p1499l',
+    )!;
+    expect(p1499l.rmseFt).toBe(10.5);
+  });
+
+  it('drops "(no fit)" truth-only rows', () => {
+    expect(
+      parseCompareTxt(TABLE).some((p) => p.genPageKey === 'p1401__2'),
+    ).toBe(false);
+  });
+
+  it('returns [] for a non-compare text file', () => {
+    expect(parseCompareTxt('LOS ANGELES\nsome ocr text\n')).toEqual([]);
+  });
+});

--- a/app/server/compareTxt.ts
+++ b/app/server/compareTxt.ts
@@ -1,0 +1,100 @@
+/**
+ * Parser for `mapsnap compare` sidecar tables (`<annotation>.txt`).
+ *
+ * Rather than recomputing per-page truth error in the browser, the volume viewer reads the
+ * comparison the pipeline already produced. Each generated annotation `<name>.iiif.json` has a
+ * `<name>.txt` next to it holding the fixed-width table printed by `mapsnap compare`; this
+ * turns its paired rows into structured stats keyed by the generated page's file stem.
+ *
+ * The table (see compare_iiif_georef.print_table) has a header, a `---` rule, one row per truth
+ * page — paired rows carry error metrics, `(no fit)` rows are truth-only — a closing `---`, then
+ * summary lines. A paired row's Page column is the truth page key; when our split numbering
+ * differs it is marked `(t)` and the generated key follows in trailing parens.
+ */
+
+/** One paired page's truth-comparison error, keyed by the generated page's file stem. */
+export interface ComparePageStats {
+  /** Generated page key (lowercased file stem), e.g. "p1499l" or "p1499n__2". */
+  genPageKey: string;
+  rmseFt: number;
+  maxFt: number;
+  translationFt: number;
+  rotationErrorDegrees: number;
+  scaleErrorPercent: number;
+}
+
+/** Response of GET /iiif-api/compare — paired-page stats from the sidecar table. */
+export interface CompareResponse {
+  pages: ComparePageStats[];
+}
+
+// Whether a line is a header/rule row of the compare table (not a data row).
+function isSeparator(line: string): boolean {
+  return /^-{3,}$/.test(line.trim());
+}
+
+// Parse one data row; returns null for `(no fit)` (truth-only) rows and unparseable lines.
+function parseRow(line: string): ComparePageStats | null {
+  let body = line;
+  let genKeyOverride: string | null = null;
+  // A trailing "(…)" is either "(no fit)" or, when split numbers disagree, the generated key.
+  const trailing = body.match(/\s+\(([^)]*)\)\s*$/);
+  if (trailing) {
+    if (trailing[1] === 'no fit') return null;
+    genKeyOverride = trailing[1] ?? null;
+    body = body.slice(0, trailing.index);
+  }
+  const tokens = body.trim().split(/\s+/);
+  if (tokens.length < 2) return null;
+  const disagree = tokens[1] === '(t)';
+  const numeric = tokens.slice(disagree ? 2 : 1);
+  // n_t n_g str int t.px g.px rmse max trans rot scale skew aniso
+  const rmseFt = Number(numeric[6]);
+  const maxFt = Number(numeric[7]);
+  const translationFt = Number(numeric[8]);
+  const rotationErrorDegrees = Number(numeric[9]);
+  const scaleErrorPercent = Number(numeric[10]);
+  if (
+    !Number.isFinite(rmseFt) ||
+    !Number.isFinite(maxFt) ||
+    !Number.isFinite(translationFt) ||
+    !Number.isFinite(rotationErrorDegrees) ||
+    !Number.isFinite(scaleErrorPercent)
+  ) {
+    return null;
+  }
+  const genPageKey =
+    (disagree ? (genKeyOverride ?? tokens[0]) : tokens[0]) ?? '';
+  return {
+    genPageKey: genPageKey.toLowerCase(),
+    rmseFt,
+    maxFt,
+    translationFt,
+    rotationErrorDegrees,
+    scaleErrorPercent,
+  };
+}
+
+/**
+ * Parse a `mapsnap compare` table, returning the paired pages' error stats.
+ *
+ * Returns [] when the text is not a compare table (e.g. an unrelated `.txt`). Only rows with a
+ * fit are returned; `(no fit)` truth-only rows are dropped (the viewer sources missing pages
+ * from the truth annotation instead).
+ */
+export function parseCompareTxt(text: string): ComparePageStats[] {
+  const lines = text.split('\n');
+  const header = lines.find((line) => line.trim() !== '');
+  if (!header || !header.includes('rmse_ft')) return [];
+  const start = lines.findIndex(isSeparator);
+  if (start < 0) return [];
+  const pages: ComparePageStats[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (isSeparator(line)) break; // end of the data section
+    if (line.trim() === '') continue;
+    const row = parseRow(line);
+    if (row) pages.push(row);
+  }
+  return pages;
+}

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -21,6 +21,7 @@ import {
 } from './iiifAnnotations.ts';
 import { normalizeIiifImageUrl } from './iiifSizeWorkaround.ts';
 import { jpegDimensions } from './jpegDimensions.ts';
+import { parseCompareTxt } from './compareTxt.ts';
 
 const require = createRequire(import.meta.url);
 const iiif = require('express-iiif').default;
@@ -154,6 +155,30 @@ export function registerIiifApi(
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
     return rewriteAnnotationPage(page, localPages, serviceBaseUrl);
+  });
+
+  // Per-page truth comparison from the annotation's `mapsnap compare` sidecar table
+  // (`<name>.txt` next to `<name>.iiif.json`). Empty when there is no sidecar.
+  router.get('/iiif-api/compare', async (_params, request) => {
+    const rawPath = request.query.path;
+    const relativePath = rawPath.replace(/^data\//, '');
+    const parts = relativePath.split('/');
+    if (
+      !relativePath.endsWith('.iiif.json') ||
+      parts.length < 2 ||
+      !parts.every(isSafeName)
+    ) {
+      throw new HTTPError(400, `invalid path: ${rawPath}`);
+    }
+    const txtPath = join(
+      dataDir,
+      relativePath.replace(/\.iiif\.json$/, '.txt'),
+    );
+    try {
+      return { pages: parseCompareTxt(await readFile(txtPath, 'utf8')) };
+    } catch {
+      return { pages: [] };
+    }
   });
 
   // Page stems with a failed-georef sidecar in a volume, and each one's kind, so

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -76,11 +76,11 @@ export function InfoPanel(props: InfoPanelProps) {
   } = props;
 
   if (selectedPage) {
-    const base = `data/${volume}/${selectedPage.pageKey}`;
+    const base = `data/${volume}/${selectedPage.stem}`;
     return (
       <div className="page-info-panel">
         <div className="page-info-header">
-          <strong>{selectedPage.pageKey}</strong>
+          <strong>{selectedPage.stem}</strong>
           <button type="button" onClick={onClose} title="Deselect page">
             ×
           </button>

--- a/app/src/components/PageList.tsx
+++ b/app/src/components/PageList.tsx
@@ -76,7 +76,7 @@ export function PageList(props: PageListProps) {
   // truth stats, so they blank out the RMSE/Δ columns and sink under those sorts.
   const missingKeys = new Set(missingPages.map((page) => page.itemIndex));
   const sorted = [...pages, ...missingPages].sort((a, b) => {
-    const naturalOrder = comparePageKeys(a.pageKey, b.pageKey);
+    const naturalOrder = comparePageKeys(a.stem, b.stem);
     if (effectiveSort.key === 'page') {
       return effectiveSort.descending ? -naturalOrder : naturalOrder;
     }
@@ -155,11 +155,11 @@ export function PageList(props: PageListProps) {
                 }
               >
                 <td>
-                  {page.pageKey}
-                  {notes.has(page.pageKey) && (
+                  {page.stem}
+                  {notes.has(page.stem) && (
                     <span
                       className="page-note-marker"
-                      title={notes.get(page.pageKey)}
+                      title={notes.get(page.stem)}
                     >
                       {' '}
                       📓

--- a/app/src/components/PageList.tsx
+++ b/app/src/components/PageList.tsx
@@ -7,8 +7,8 @@ interface PageListProps {
   pages: PageGeo[];
   /** Truth pages the run never fitted; shown with blank RMSE/Δ columns. */
   missingPages: PageGeo[];
-  /** Per-itemIndex truth stats; null entry = truth exists but is incomparable (split). */
-  stats: Map<number, PageCompareStats | null> | null;
+  /** Per-itemIndex compare stats; a page absent here has no truth counterpart. Null: no truth. */
+  stats: Map<number, PageCompareStats> | null;
   /** Page key → note text for the volume; keys present here get a marker. */
   notes: Map<string, string>;
   selectedItemIndex: number | null;
@@ -34,7 +34,7 @@ function rmseClass(rmseFt: number): string {
 function sortValue(
   key: SortKey,
   page: PageGeo,
-  stats: PageCompareStats | null | undefined,
+  stats: PageCompareStats | undefined,
 ): number | undefined {
   switch (key) {
     case 'page':
@@ -176,12 +176,8 @@ export function PageList(props: PageListProps) {
                       <span className={rmseClass(pageStats.rmseFt)}>
                         {pageStats.rmseFt.toFixed(0)}ft
                       </span>
-                    ) : stats.has(page.itemIndex) ? (
-                      <span title="split page: truth is in the parent canvas frame">
-                        split
-                      </span>
                     ) : (
-                      <span title="no truth annotation for this page">—</span>
+                      <span title="no truth counterpart for this page">—</span>
                     )}
                   </td>
                 )}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -311,9 +311,7 @@ export function VolumeViewer() {
           selectedPage={selectedPage}
           selectedMissing={selectedIsMissing}
           selectedFailedGeorefType={
-            selectedPage
-              ? (failedGeorefs.get(selectedPage.pageKey) ?? null)
-              : null
+            selectedPage ? (failedGeorefs.get(selectedPage.stem) ?? null) : null
           }
           selectedStats={
             selectedItemIndex === null
@@ -321,7 +319,7 @@ export function VolumeViewer() {
               : (truthStats?.get(selectedItemIndex) ?? null)
           }
           selectedNote={
-            selectedPage ? (notes.get(selectedPage.pageKey) ?? null) : null
+            selectedPage ? (notes.get(selectedPage.stem) ?? null) : null
           }
           volume={selection?.volume ?? ''}
           onClose={() => setSelectedItemIndex(null)}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -6,11 +6,13 @@ import type {
 } from '../../server/iiifAnnotations';
 import {
   RMSE_BUCKET_COLORS,
-  compareToTruth,
   rmseBucket,
+  statsByItemIndex,
   type PageCompareStats,
 } from '../iiif/compare';
+import type { ComparePageStats } from '../../server/compareTxt';
 import {
+  fetchCompare,
   fetchFailedGeorefs,
   fetchRewrittenAnnotation,
   fetchVolumes,
@@ -55,6 +57,11 @@ export function VolumeViewer() {
     null,
   );
   const [truthAnnotation, setTruthAnnotation] = useState<unknown>(null);
+  // Paired-page error stats from the annotation's `mapsnap compare` sidecar, or null when
+  // there is no sidecar (no truth comparison for this annotation).
+  const [compareRows, setCompareRows] = useState<ComparePageStats[] | null>(
+    null,
+  );
   // Page key → note text for the selected volume (markers + tooltip).
   const [notes, setNotes] = useState<Map<string, string>>(new Map());
   // Page stem → failed-georef kind ("nofit"/"1gcp"/…) for the selected volume.
@@ -89,8 +96,18 @@ export function VolumeViewer() {
     params.set('iiif', selectedPath);
     history.replaceState(null, '', `?${params}`);
 
-    // Truth for the compare column: the volume's main.iiif.json, rewritten
-    // into the same local pixel frame. Skipped when viewing the truth itself.
+    // Per-page truth error from this annotation's `mapsnap compare` sidecar table.
+    setCompareRows(null);
+    fetchCompare(selectedPath)
+      .then((pages) => {
+        if (!cancelled) setCompareRows(pages);
+      })
+      .catch(() => {
+        if (!cancelled) setCompareRows([]);
+      });
+
+    // Truth annotation, rewritten into the same local pixel frame, for the missing-page
+    // footprints. Skipped when viewing the truth itself.
     setTruthAnnotation(null);
     const parsed = parseAnnotationPath(selectedPath);
     if (parsed && parsed.file !== 'main.iiif.json') {
@@ -165,9 +182,14 @@ export function VolumeViewer() {
         : null,
     [truthAnnotation],
   );
-  const truthStats: Map<number, PageCompareStats | null> | null = useMemo(
-    () => (truthPages ? compareToTruth(pages, truthPages) : null),
-    [pages, truthPages],
+  // Per-page compare stats keyed by itemIndex, from the sidecar rows. Null when the annotation
+  // has no compare sidecar; empty rows also read as "no comparison".
+  const truthStats: Map<number, PageCompareStats> | null = useMemo(
+    () =>
+      compareRows && compareRows.length > 0
+        ? statsByItemIndex(compareRows, pages)
+        : null,
+    [compareRows, pages],
   );
   // Truth pages the run never georeferenced, shown as "missing" rows/footprints.
   const missingPages = useMemo(
@@ -179,9 +201,7 @@ export function VolumeViewer() {
     if (!colorByRmse || !truthStats) return null;
     const colors = new Map<number, string>();
     for (const [itemIndex, stats] of truthStats) {
-      if (stats) {
-        colors.set(itemIndex, RMSE_BUCKET_COLORS[rmseBucket(stats.rmseFt)]);
-      }
+      colors.set(itemIndex, RMSE_BUCKET_COLORS[rmseBucket(stats.rmseFt)]);
     }
     return colors;
   }, [colorByRmse, truthStats]);

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -1,6 +1,7 @@
 import { typedApi } from 'crosswalk';
 import { jsonFetch } from '../apiFetch';
 import type { API } from '../../server/api';
+import type { ComparePageStats } from '../../server/compareTxt';
 import type {
   RewrittenAnnotationResponse,
   VolumeListResponse,
@@ -35,4 +36,13 @@ export async function fetchFailedGeorefs(
     volume,
   });
   return new Map(Object.entries(failed));
+}
+
+/**
+ * Fetch the per-page truth comparison from an annotation's `mapsnap compare` sidecar table,
+ * as paired-page stats keyed by generated page stem. Empty when there is no sidecar.
+ */
+export async function fetchCompare(path: string): Promise<ComparePageStats[]> {
+  const { pages } = await api.get('/iiif-api/compare')(null, { path });
+  return pages;
 }

--- a/app/src/iiif/compare.test.ts
+++ b/app/src/iiif/compare.test.ts
@@ -15,6 +15,8 @@ function page(
   const lon0 = overrides.corners?.[0]?.[0] ?? -74.0;
   const lat0 = overrides.corners?.[0]?.[1] ?? 40.7;
   return {
+    splitIndex: null,
+    stem: overrides.pageKey,
     width: 1000,
     height: 1000,
     corners: [
@@ -25,12 +27,38 @@ function page(
     ],
     rectRing: [],
     clipRing: [],
+    clipPolygon: [
+      [0, 0],
+      [1000, 0],
+      [1000, 1000],
+      [0, 1000],
+    ],
     scalePixelsPerFoot: 1,
     rotationDegrees: 0,
     gcps: [],
     transformationType: 'polynomial',
     ...overrides,
   };
+}
+
+// Corner quad placing (0,0)..(1000,1000) on a 0.01°×0.01° box at (lon0, lat0).
+function cornersAt(lon0: number, lat0: number): PageGeo['corners'] {
+  return [
+    [lon0, lat0],
+    [lon0 + 0.01, lat0],
+    [lon0 + 0.01, lat0 - 0.01],
+    [lon0, lat0 - 0.01],
+  ];
+}
+
+// A left/right half [x0,x1] clip polygon over the 1000×1000 frame.
+function halfClip(x0: number, x1: number): [number, number][] {
+  return [
+    [x0, 0],
+    [x1, 0],
+    [x1, 1000],
+    [x0, 1000],
+  ];
 }
 
 describe('haversineFeet', () => {
@@ -90,28 +118,76 @@ describe('comparePage', () => {
 });
 
 describe('compareToTruth', () => {
-  it('pairs by page key and nulls split panels', () => {
+  it('pairs whole pages by page key and skips pages with no truth', () => {
     const pages = [
       page({ pageKey: 'p1', itemIndex: 0 }),
-      page({ pageKey: 'p2__1', itemIndex: 1 }),
       page({ pageKey: 'p9', itemIndex: 2 }), // no truth
     ];
-    const truth = [
-      page({ pageKey: 'p1', itemIndex: 0 }),
-      page({ pageKey: 'p2', itemIndex: 1 }),
-    ];
+    const truth = [page({ pageKey: 'p1', itemIndex: 0 })];
     const stats = compareToTruth(pages, truth);
     expect(stats.get(0)?.rmseFt).toBeCloseTo(0, 5);
-    expect(stats.get(1)).toBeNull(); // split: parent-frame truth
     expect(stats.has(2)).toBe(false);
   });
 
-  it('nulls pages whose truth key is ambiguous', () => {
-    const pages = [page({ pageKey: 'p3', itemIndex: 0 })];
+  it('compares a page we kept whole against the truth largest split', () => {
+    // We kept p5 whole; truth split it into a large left panel and a small right one.
+    // The whole page should pair with the largest split — the left one, which here
+    // carries our exact fit — not the small right one (a different, far-off fit).
+    const pages = [page({ pageKey: 'p5', itemIndex: 0 })];
     const truth = [
-      page({ pageKey: 'p3', itemIndex: 0 }),
-      page({ pageKey: 'p3', itemIndex: 1 }),
+      page({
+        pageKey: 'p5',
+        itemIndex: 0,
+        clipPolygon: halfClip(0, 800), // large left panel, same fit as ours
+      }),
+      page({
+        pageKey: 'p5',
+        itemIndex: 1,
+        clipPolygon: halfClip(800, 1000), // small right panel, far-off fit
+        corners: cornersAt(-70.0, 40.7),
+      }),
     ];
-    expect(compareToTruth(pages, truth).get(0)).toBeNull();
+    const stats = compareToTruth(pages, truth);
+    expect(stats.get(0)).not.toBeNull();
+    expect(stats.get(0)!.rmseFt).toBeCloseTo(0, 3);
+  });
+
+  it('matches split panels by overlap even when the numbering differs', () => {
+    // We split p6 into left (__1) and right (__2); truth numbered them the other way.
+    // Overlap must pair each of our panels with the truth panel it covers, so both
+    // read ~0 error (each panel carries the matching truth fit).
+    const pages = [
+      page({
+        pageKey: 'p6',
+        itemIndex: 0,
+        splitIndex: 1,
+        clipPolygon: halfClip(0, 500), // our left panel
+        corners: cornersAt(-74.0, 40.7),
+      }),
+      page({
+        pageKey: 'p6',
+        itemIndex: 1,
+        splitIndex: 2,
+        clipPolygon: halfClip(500, 1000), // our right panel
+        corners: cornersAt(-73.0, 40.7),
+      }),
+    ];
+    const truth = [
+      page({
+        pageKey: 'p6',
+        itemIndex: 0,
+        clipPolygon: halfClip(500, 1000), // truth right panel
+        corners: cornersAt(-73.0, 40.7),
+      }),
+      page({
+        pageKey: 'p6',
+        itemIndex: 1,
+        clipPolygon: halfClip(0, 500), // truth left panel
+        corners: cornersAt(-74.0, 40.7),
+      }),
+    ];
+    const stats = compareToTruth(pages, truth);
+    expect(stats.get(0)!.rmseFt).toBeCloseTo(0, 3);
+    expect(stats.get(1)!.rmseFt).toBeCloseTo(0, 3);
   });
 });

--- a/app/src/iiif/compare.test.ts
+++ b/app/src/iiif/compare.test.ts
@@ -1,193 +1,53 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  comparePage,
-  compareToTruth,
-  haversineFeet,
-  sampleGrid,
-} from './compare';
+import { rmseBucket, statsByItemIndex } from './compare';
+import type { ComparePageStats } from '../../server/compareTxt';
 import type { PageGeo } from './pages';
 
-// A page whose corner quad places (0,0)..(w,h) on a small lon/lat rectangle.
-function page(
-  overrides: Partial<PageGeo> & { pageKey: string; itemIndex: number },
-): PageGeo {
-  const lon0 = overrides.corners?.[0]?.[0] ?? -74.0;
-  const lat0 = overrides.corners?.[0]?.[1] ?? 40.7;
+// A compare-sidecar row with the given generated key and RMSE.
+function row(genPageKey: string, rmseFt: number): ComparePageStats {
   return {
-    splitIndex: null,
-    stem: overrides.pageKey,
-    width: 1000,
-    height: 1000,
-    corners: [
-      [lon0, lat0],
-      [lon0 + 0.01, lat0],
-      [lon0 + 0.01, lat0 - 0.01],
-      [lon0, lat0 - 0.01],
-    ],
-    rectRing: [],
-    clipRing: [],
-    clipPolygon: [
-      [0, 0],
-      [1000, 0],
-      [1000, 1000],
-      [0, 1000],
-    ],
-    scalePixelsPerFoot: 1,
-    rotationDegrees: 0,
-    gcps: [],
-    transformationType: 'polynomial',
-    ...overrides,
+    genPageKey,
+    rmseFt,
+    maxFt: rmseFt * 1.5,
+    translationFt: rmseFt * 0.8,
+    rotationErrorDegrees: 0.5,
+    scaleErrorPercent: 1.2,
   };
 }
 
-// Corner quad placing (0,0)..(1000,1000) on a 0.01°×0.01° box at (lon0, lat0).
-function cornersAt(lon0: number, lat0: number): PageGeo['corners'] {
-  return [
-    [lon0, lat0],
-    [lon0 + 0.01, lat0],
-    [lon0 + 0.01, lat0 - 0.01],
-    [lon0, lat0 - 0.01],
-  ];
+// A page with only the fields statsByItemIndex reads.
+function page(stem: string, itemIndex: number): PageGeo {
+  return { stem, itemIndex } as PageGeo;
 }
 
-// A left/right half [x0,x1] clip polygon over the 1000×1000 frame.
-function halfClip(x0: number, x1: number): [number, number][] {
-  return [
-    [x0, 0],
-    [x1, 0],
-    [x1, 1000],
-    [x0, 1000],
-  ];
-}
-
-describe('haversineFeet', () => {
-  it('measures a degree of latitude as ~364,000 ft', () => {
-    const feet = haversineFeet([-74, 40], [-74, 41]);
-    expect(feet).toBeGreaterThan(360_000);
-    expect(feet).toBeLessThan(368_000);
+describe('rmseBucket', () => {
+  it('buckets RMSE by its boundaries', () => {
+    expect(rmseBucket(25)).toBe('good');
+    expect(rmseBucket(80)).toBe('ok');
+    expect(rmseBucket(150)).toBe('poor');
+    expect(rmseBucket(400)).toBe('disaster');
   });
 });
 
-describe('sampleGrid', () => {
-  it('is the 7x7 grid over the full image', () => {
-    const grid = sampleGrid(600, 1200);
-    expect(grid).toHaveLength(49);
-    expect(grid[0]).toEqual([0, 0]);
-    expect(grid.at(-1)).toEqual([600, 1200]);
-  });
-});
-
-describe('comparePage', () => {
-  it('reports zero error for identical transforms', () => {
-    const a = page({ pageKey: 'p1', itemIndex: 0 });
-    const b = page({ pageKey: 'p1', itemIndex: 0 });
-    const stats = comparePage(a, b);
-    expect(stats.rmseFt).toBeCloseTo(0, 5);
-    expect(stats.maxFt).toBeCloseTo(0, 5);
-    expect(stats.translationFt).toBeCloseTo(0, 5);
+describe('statsByItemIndex', () => {
+  it('keys sidecar rows to pages by file stem, skipping unpaired pages', () => {
+    const rows = [row('p1499l', 10.5), row('p1499n__2', 12.8)];
+    const pages = [page('p1499l', 0), page('p1499n__2', 1), page('p1407', 2)];
+    const stats = statsByItemIndex(rows, pages);
+    expect(stats.get(0)?.rmseFt).toBe(10.5);
+    expect(stats.get(1)?.rmseFt).toBe(12.8);
+    expect(stats.has(2)).toBe(false); // no row for p1407
   });
 
-  it('reports a pure shift as equal rmse/max/translation', () => {
-    const a = page({ pageKey: 'p1', itemIndex: 0 });
-    // Shift ~one ten-thousandth of a degree of latitude south: ~36.4 ft.
-    const shifted = page({
-      pageKey: 'p1',
-      itemIndex: 0,
-      corners: a.corners.map(([lon, lat]) => [lon, lat - 0.0001]) as never,
+  it('stores just the compare metrics (drops the generated key)', () => {
+    const stats = statsByItemIndex([row('p1', 5)], [page('p1', 0)]);
+    expect(stats.get(0)).toEqual({
+      rmseFt: 5,
+      maxFt: 7.5,
+      translationFt: 4,
+      rotationErrorDegrees: 0.5,
+      scaleErrorPercent: 1.2,
     });
-    const stats = comparePage(a, shifted);
-    expect(stats.rmseFt).toBeGreaterThan(30);
-    expect(stats.rmseFt).toBeLessThan(40);
-    expect(stats.maxFt).toBeCloseTo(stats.rmseFt, 1);
-    expect(stats.translationFt).toBeCloseTo(stats.rmseFt, 1);
-  });
-
-  it('reports scale and rotation differences', () => {
-    const a = page({ pageKey: 'p1', itemIndex: 0, scalePixelsPerFoot: 1.0 });
-    const b = page({
-      pageKey: 'p1',
-      itemIndex: 0,
-      scalePixelsPerFoot: 1.05,
-      rotationDegrees: 2,
-    });
-    const stats = comparePage(a, b);
-    expect(stats.scaleErrorPercent).toBeCloseTo(5, 5);
-    expect(stats.rotationErrorDegrees).toBeCloseTo(-2, 5);
-  });
-});
-
-describe('compareToTruth', () => {
-  it('pairs whole pages by page key and skips pages with no truth', () => {
-    const pages = [
-      page({ pageKey: 'p1', itemIndex: 0 }),
-      page({ pageKey: 'p9', itemIndex: 2 }), // no truth
-    ];
-    const truth = [page({ pageKey: 'p1', itemIndex: 0 })];
-    const stats = compareToTruth(pages, truth);
-    expect(stats.get(0)?.rmseFt).toBeCloseTo(0, 5);
-    expect(stats.has(2)).toBe(false);
-  });
-
-  it('compares a page we kept whole against the truth largest split', () => {
-    // We kept p5 whole; truth split it into a large left panel and a small right one.
-    // The whole page should pair with the largest split — the left one, which here
-    // carries our exact fit — not the small right one (a different, far-off fit).
-    const pages = [page({ pageKey: 'p5', itemIndex: 0 })];
-    const truth = [
-      page({
-        pageKey: 'p5',
-        itemIndex: 0,
-        clipPolygon: halfClip(0, 800), // large left panel, same fit as ours
-      }),
-      page({
-        pageKey: 'p5',
-        itemIndex: 1,
-        clipPolygon: halfClip(800, 1000), // small right panel, far-off fit
-        corners: cornersAt(-70.0, 40.7),
-      }),
-    ];
-    const stats = compareToTruth(pages, truth);
-    expect(stats.get(0)).not.toBeNull();
-    expect(stats.get(0)!.rmseFt).toBeCloseTo(0, 3);
-  });
-
-  it('matches split panels by overlap even when the numbering differs', () => {
-    // We split p6 into left (__1) and right (__2); truth numbered them the other way.
-    // Overlap must pair each of our panels with the truth panel it covers, so both
-    // read ~0 error (each panel carries the matching truth fit).
-    const pages = [
-      page({
-        pageKey: 'p6',
-        itemIndex: 0,
-        splitIndex: 1,
-        clipPolygon: halfClip(0, 500), // our left panel
-        corners: cornersAt(-74.0, 40.7),
-      }),
-      page({
-        pageKey: 'p6',
-        itemIndex: 1,
-        splitIndex: 2,
-        clipPolygon: halfClip(500, 1000), // our right panel
-        corners: cornersAt(-73.0, 40.7),
-      }),
-    ];
-    const truth = [
-      page({
-        pageKey: 'p6',
-        itemIndex: 0,
-        clipPolygon: halfClip(500, 1000), // truth right panel
-        corners: cornersAt(-73.0, 40.7),
-      }),
-      page({
-        pageKey: 'p6',
-        itemIndex: 1,
-        clipPolygon: halfClip(0, 500), // truth left panel
-        corners: cornersAt(-74.0, 40.7),
-      }),
-    ];
-    const stats = compareToTruth(pages, truth);
-    expect(stats.get(0)!.rmseFt).toBeCloseTo(0, 3);
-    expect(stats.get(1)!.rmseFt).toBeCloseTo(0, 3);
   });
 });

--- a/app/src/iiif/compare.ts
+++ b/app/src/iiif/compare.ts
@@ -1,30 +1,14 @@
 /**
- * Per-page truth comparison for the volume viewer, mirroring `mapsnap compare`.
+ * Truth-comparison types and display buckets for the volume viewer.
  *
- * Both the loaded annotation and the volume's truth (main.iiif.json) are
- * rewritten into the same local-image pixel frame by the server, and each
- * page's corner quad reproduces its fitted transform exactly (an affine maps
- * the corner rectangle to a parallelogram, and bilinear interpolation through
- * a parallelogram is that affine). So the compare metrics reduce to mapping a
- * 7×7 pixel grid through both corner quads and measuring the separation —
- * the same measurement `mapsnap compare` reports.
- *
- * Split panels are the exception: truth expresses a split in the parent
- * page's canvas while our panels are their own images, and relating the two
- * frames needs pN.panels.json. Those pages get `null` stats rather than a
- * wrong number.
+ * The per-page error metrics come from the pipeline's `mapsnap compare` sidecar table (parsed
+ * by server/compareTxt, fetched via fetchCompare) rather than being recomputed in the browser,
+ * so split-panel associations and RMSEs match exactly what `mapsnap compare` reports. This
+ * module only shapes those rows for display and buckets RMSE into colours.
  */
 
-import { pointInPolygon, projectThroughCorners } from '../geometry';
+import type { ComparePageStats } from '../../server/compareTxt';
 import type { PageGeo } from './pages';
-
-const EARTH_RADIUS_FT = 20_925_524.0;
-
-/** Minimum panel overlap (IoU) to treat a truth and generated split as the same region. */
-const MIN_SPLIT_IOU = 0.1;
-
-/** Grid resolution for the sampled polygon-IoU used to match split panels. */
-const IOU_GRID = 40;
 
 /** Compare metrics for one page, matching `mapsnap compare`'s columns. */
 export interface PageCompareStats {
@@ -57,227 +41,30 @@ export const RMSE_BUCKET_COLORS: Record<RmseBucket, string> = {
   disaster: '#cf222e',
 };
 
-/** Great-circle distance in feet between two [lon, lat] points. */
-export function haversineFeet(
-  a: [number, number],
-  b: [number, number],
-): number {
-  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
-  const [lon1, lat1] = a.map(toRadians) as [number, number];
-  const [lon2, lat2] = b.map(toRadians) as [number, number];
-  const sinLat = Math.sin((lat2 - lat1) / 2);
-  const sinLon = Math.sin((lon2 - lon1) / 2);
-  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon;
-  return 2 * EARTH_RADIUS_FT * Math.asin(Math.sqrt(h));
-}
-
-/** A pixel-frame rectangle to sample over: [minX, minY, maxX, maxY]. */
-export type SampleRegion = [number, number, number, number];
-
-/** A 7×7 grid of pixel sample points spanning the given region. */
-export function sampleGridRegion(region: SampleRegion): [number, number][] {
-  const [minX, minY, maxX, maxY] = region;
-  const points: [number, number][] = [];
-  for (let i = 0; i < 7; i++) {
-    for (let j = 0; j < 7; j++) {
-      points.push([
-        minX + ((maxX - minX) * i) / 6,
-        minY + ((maxY - minY) * j) / 6,
-      ]);
-    }
-  }
-  return points;
-}
-
-/** The 7×7 grid of pixel sample points `mapsnap compare` measures over. */
-export function sampleGrid(width: number, height: number): [number, number][] {
-  return sampleGridRegion([0, 0, width, height]);
-}
-
-/** Fold a degree difference into (-180, 180]. */
-function wrapDegrees(value: number): number {
-  return ((value + 540) % 360) - 180;
-}
-
 /**
- * Compare one generated page against its truth counterpart.
+ * Per-page compare stats keyed by itemIndex, pairing each sidecar row to the generated page
+ * whose file stem matches its generated key.
  *
- * `region` restricts the error grid to a sub-rectangle of the image (both pages share the
- * same local pixel frame), so a split panel is measured only over its own pixels rather than
- * the whole sheet — mirroring `mapsnap compare`'s split-canvas sampling. Defaults to the
- * whole image.
+ * The sidecar already resolved split-panel associations, so pages that were split on either
+ * side are keyed correctly here. A page with no paired row (no truth counterpart) is simply
+ * absent, so the map and table leave it uncoloured.
  */
-export function comparePage(
-  generated: PageGeo,
-  truth: PageGeo,
-  region?: SampleRegion,
-): PageCompareStats {
-  const { width, height } = generated;
-  const distances = sampleGridRegion(region ?? [0, 0, width, height]).map(
-    ([x, y]) =>
-      haversineFeet(
-        projectThroughCorners(generated.corners, width, height, x, y),
-        projectThroughCorners(truth.corners, truth.width, truth.height, x, y),
-      ),
-  );
-  const rmseFt = Math.sqrt(
-    distances.reduce((sum, d) => sum + d * d, 0) / distances.length,
-  );
-  const translationFt = haversineFeet(
-    projectThroughCorners(
-      generated.corners,
-      width,
-      height,
-      width / 2,
-      height / 2,
-    ),
-    projectThroughCorners(
-      truth.corners,
-      truth.width,
-      truth.height,
-      width / 2,
-      height / 2,
-    ),
-  );
-  return {
-    rmseFt,
-    maxFt: Math.max(...distances),
-    translationFt,
-    rotationErrorDegrees: wrapDegrees(
-      generated.rotationDegrees - truth.rotationDegrees,
-    ),
-    scaleErrorPercent:
-      (truth.scalePixelsPerFoot / generated.scalePixelsPerFoot - 1) * 100,
-  };
-}
-
-// Bounding box [minX, minY, maxX, maxY] of a pixel-frame polygon.
-function polygonBounds(polygon: [number, number][]): SampleRegion {
-  const xs = polygon.map(([x]) => x);
-  const ys = polygon.map(([, y]) => y);
-  return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
-}
-
-// A boolean IOU_GRID×IOU_GRID rasterization of a local-frame polygon over [0,w]×[0,h].
-function polygonMask(
-  polygon: [number, number][],
-  width: number,
-  height: number,
-): boolean[] {
-  const mask: boolean[] = new Array(IOU_GRID * IOU_GRID);
-  for (let i = 0; i < IOU_GRID; i++) {
-    const x = ((i + 0.5) / IOU_GRID) * width;
-    for (let j = 0; j < IOU_GRID; j++) {
-      const y = ((j + 0.5) / IOU_GRID) * height;
-      mask[i * IOU_GRID + j] = pointInPolygon(x, y, polygon);
-    }
-  }
-  return mask;
-}
-
-// Intersection-over-union of two rasterized masks.
-function maskIou(a: boolean[], b: boolean[]): number {
-  let inter = 0;
-  let union = 0;
-  for (let k = 0; k < a.length; k++) {
-    if (a[k] && b[k]) inter++;
-    if (a[k] || b[k]) union++;
-  }
-  return union > 0 ? inter / union : 0;
-}
-
-/**
- * Pair generated and truth split panels by greatest panel overlap, returning generated
- * itemIndex → matched truth page. Mirrors `match_split_pairs` in compare_iiif_georef.py:
- * every pair with IoU ≥ MIN_SPLIT_IOU is considered and the highest-overlap pairs are
- * assigned first, each panel used once. A generated page we kept whole (no split index)
- * stands in with the full page rectangle, so it pairs with the truth split it most overlaps
- * — the largest one. All polygons are in the shared local pixel frame.
- */
-function matchSplitPairs(
-  genPages: PageGeo[],
-  truthPages: PageGeo[],
-): Map<number, PageGeo> {
-  const { width, height } = truthPages[0]!;
-  const fullRect: [number, number][] = [
-    [0, 0],
-    [width, 0],
-    [width, height],
-    [0, height],
-  ];
-  const genMasks = genPages.map((g) =>
-    polygonMask(g.splitIndex != null ? g.clipPolygon : fullRect, width, height),
-  );
-  const truthMasks = truthPages.map((t) =>
-    polygonMask(t.clipPolygon, width, height),
-  );
-  const candidates: { iou: number; gi: number; ti: number }[] = [];
-  for (let gi = 0; gi < genPages.length; gi++) {
-    for (let ti = 0; ti < truthPages.length; ti++) {
-      const iou = maskIou(genMasks[gi]!, truthMasks[ti]!);
-      if (iou >= MIN_SPLIT_IOU) candidates.push({ iou, gi, ti });
-    }
-  }
-  candidates.sort((a, b) => b.iou - a.iou);
-  const usedGen = new Set<number>();
-  const usedTruth = new Set<number>();
-  const pairs = new Map<number, PageGeo>();
-  for (const { gi, ti } of candidates) {
-    if (usedGen.has(gi) || usedTruth.has(ti)) continue;
-    usedGen.add(gi);
-    usedTruth.add(ti);
-    pairs.set(genPages[gi]!.itemIndex, truthPages[ti]!);
-  }
-  return pairs;
-}
-
-// Group pages by their (parent) page key.
-function groupByPageKey(pages: PageGeo[]): Map<string, PageGeo[]> {
-  const groups = new Map<string, PageGeo[]>();
-  for (const page of pages) {
-    const list = groups.get(page.pageKey) ?? [];
-    list.push(page);
-    groups.set(page.pageKey, list);
-  }
-  return groups;
-}
-
-/**
- * Stats for every page of the loaded annotation, keyed by itemIndex.
- *
- * Pages with no truth counterpart are absent from the map. When a page is split on either
- * side — including the common case where we kept a page whole but the truth split it — the
- * panels are matched by overlap ({@link matchSplitPairs}) and each pair compared over the
- * generated panel's own region (the whole sheet for a page we kept whole). A generated
- * panel that no truth split overlaps maps to null.
- */
-export function compareToTruth(
+export function statsByItemIndex(
+  rows: ComparePageStats[],
   pages: PageGeo[],
-  truthPages: PageGeo[],
-): Map<number, PageCompareStats | null> {
-  const truthByKey = groupByPageKey(truthPages);
-  const stats = new Map<number, PageCompareStats | null>();
-  for (const [pageKey, genGroup] of groupByPageKey(pages)) {
-    const truthGroup = truthByKey.get(pageKey);
-    if (!truthGroup || truthGroup.length === 0) continue; // no truth for this page
-    if (genGroup.length === 1 && truthGroup.length === 1) {
-      stats.set(
-        genGroup[0]!.itemIndex,
-        comparePage(genGroup[0]!, truthGroup[0]!),
-      );
-      continue;
-    }
-    const pairs = matchSplitPairs(genGroup, truthGroup);
-    for (const gen of genGroup) {
-      const truth = pairs.get(gen.itemIndex);
-      if (!truth) {
-        stats.set(gen.itemIndex, null); // no overlapping truth panel
-        continue;
-      }
-      const region =
-        gen.splitIndex != null ? polygonBounds(gen.clipPolygon) : undefined;
-      stats.set(gen.itemIndex, comparePage(gen, truth, region));
-    }
+): Map<number, PageCompareStats> {
+  const byKey = new Map(rows.map((row) => [row.genPageKey, row]));
+  const stats = new Map<number, PageCompareStats>();
+  for (const page of pages) {
+    const row = byKey.get(page.stem);
+    if (!row) continue;
+    stats.set(page.itemIndex, {
+      rmseFt: row.rmseFt,
+      maxFt: row.maxFt,
+      translationFt: row.translationFt,
+      rotationErrorDegrees: row.rotationErrorDegrees,
+      scaleErrorPercent: row.scaleErrorPercent,
+    });
   }
   return stats;
 }

--- a/app/src/iiif/compare.ts
+++ b/app/src/iiif/compare.ts
@@ -15,10 +15,16 @@
  * wrong number.
  */
 
-import { projectThroughCorners } from '../geometry';
+import { pointInPolygon, projectThroughCorners } from '../geometry';
 import type { PageGeo } from './pages';
 
 const EARTH_RADIUS_FT = 20_925_524.0;
+
+/** Minimum panel overlap (IoU) to treat a truth and generated split as the same region. */
+const MIN_SPLIT_IOU = 0.1;
+
+/** Grid resolution for the sampled polygon-IoU used to match split panels. */
+const IOU_GRID = 40;
 
 /** Compare metrics for one page, matching `mapsnap compare`'s columns. */
 export interface PageCompareStats {
@@ -65,15 +71,27 @@ export function haversineFeet(
   return 2 * EARTH_RADIUS_FT * Math.asin(Math.sqrt(h));
 }
 
-/** The 7×7 grid of pixel sample points `mapsnap compare` measures over. */
-export function sampleGrid(width: number, height: number): [number, number][] {
+/** A pixel-frame rectangle to sample over: [minX, minY, maxX, maxY]. */
+export type SampleRegion = [number, number, number, number];
+
+/** A 7×7 grid of pixel sample points spanning the given region. */
+export function sampleGridRegion(region: SampleRegion): [number, number][] {
+  const [minX, minY, maxX, maxY] = region;
   const points: [number, number][] = [];
   for (let i = 0; i < 7; i++) {
     for (let j = 0; j < 7; j++) {
-      points.push([(width * i) / 6, (height * j) / 6]);
+      points.push([
+        minX + ((maxX - minX) * i) / 6,
+        minY + ((maxY - minY) * j) / 6,
+      ]);
     }
   }
   return points;
+}
+
+/** The 7×7 grid of pixel sample points `mapsnap compare` measures over. */
+export function sampleGrid(width: number, height: number): [number, number][] {
+  return sampleGridRegion([0, 0, width, height]);
 }
 
 /** Fold a degree difference into (-180, 180]. */
@@ -81,17 +99,26 @@ function wrapDegrees(value: number): number {
   return ((value + 540) % 360) - 180;
 }
 
-/** Compare one generated page against its truth counterpart. */
+/**
+ * Compare one generated page against its truth counterpart.
+ *
+ * `region` restricts the error grid to a sub-rectangle of the image (both pages share the
+ * same local pixel frame), so a split panel is measured only over its own pixels rather than
+ * the whole sheet — mirroring `mapsnap compare`'s split-canvas sampling. Defaults to the
+ * whole image.
+ */
 export function comparePage(
   generated: PageGeo,
   truth: PageGeo,
+  region?: SampleRegion,
 ): PageCompareStats {
   const { width, height } = generated;
-  const distances = sampleGrid(width, height).map(([x, y]) =>
-    haversineFeet(
-      projectThroughCorners(generated.corners, width, height, x, y),
-      projectThroughCorners(truth.corners, truth.width, truth.height, x, y),
-    ),
+  const distances = sampleGridRegion(region ?? [0, 0, width, height]).map(
+    ([x, y]) =>
+      haversineFeet(
+        projectThroughCorners(generated.corners, width, height, x, y),
+        projectThroughCorners(truth.corners, truth.width, truth.height, x, y),
+      ),
   );
   const rmseFt = Math.sqrt(
     distances.reduce((sum, d) => sum + d * d, 0) / distances.length,
@@ -124,37 +151,133 @@ export function comparePage(
   };
 }
 
+// Bounding box [minX, minY, maxX, maxY] of a pixel-frame polygon.
+function polygonBounds(polygon: [number, number][]): SampleRegion {
+  const xs = polygon.map(([x]) => x);
+  const ys = polygon.map(([, y]) => y);
+  return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
+}
+
+// A boolean IOU_GRID×IOU_GRID rasterization of a local-frame polygon over [0,w]×[0,h].
+function polygonMask(
+  polygon: [number, number][],
+  width: number,
+  height: number,
+): boolean[] {
+  const mask: boolean[] = new Array(IOU_GRID * IOU_GRID);
+  for (let i = 0; i < IOU_GRID; i++) {
+    const x = ((i + 0.5) / IOU_GRID) * width;
+    for (let j = 0; j < IOU_GRID; j++) {
+      const y = ((j + 0.5) / IOU_GRID) * height;
+      mask[i * IOU_GRID + j] = pointInPolygon(x, y, polygon);
+    }
+  }
+  return mask;
+}
+
+// Intersection-over-union of two rasterized masks.
+function maskIou(a: boolean[], b: boolean[]): number {
+  let inter = 0;
+  let union = 0;
+  for (let k = 0; k < a.length; k++) {
+    if (a[k] && b[k]) inter++;
+    if (a[k] || b[k]) union++;
+  }
+  return union > 0 ? inter / union : 0;
+}
+
+/**
+ * Pair generated and truth split panels by greatest panel overlap, returning generated
+ * itemIndex → matched truth page. Mirrors `match_split_pairs` in compare_iiif_georef.py:
+ * every pair with IoU ≥ MIN_SPLIT_IOU is considered and the highest-overlap pairs are
+ * assigned first, each panel used once. A generated page we kept whole (no split index)
+ * stands in with the full page rectangle, so it pairs with the truth split it most overlaps
+ * — the largest one. All polygons are in the shared local pixel frame.
+ */
+function matchSplitPairs(
+  genPages: PageGeo[],
+  truthPages: PageGeo[],
+): Map<number, PageGeo> {
+  const { width, height } = truthPages[0]!;
+  const fullRect: [number, number][] = [
+    [0, 0],
+    [width, 0],
+    [width, height],
+    [0, height],
+  ];
+  const genMasks = genPages.map((g) =>
+    polygonMask(g.splitIndex != null ? g.clipPolygon : fullRect, width, height),
+  );
+  const truthMasks = truthPages.map((t) =>
+    polygonMask(t.clipPolygon, width, height),
+  );
+  const candidates: { iou: number; gi: number; ti: number }[] = [];
+  for (let gi = 0; gi < genPages.length; gi++) {
+    for (let ti = 0; ti < truthPages.length; ti++) {
+      const iou = maskIou(genMasks[gi]!, truthMasks[ti]!);
+      if (iou >= MIN_SPLIT_IOU) candidates.push({ iou, gi, ti });
+    }
+  }
+  candidates.sort((a, b) => b.iou - a.iou);
+  const usedGen = new Set<number>();
+  const usedTruth = new Set<number>();
+  const pairs = new Map<number, PageGeo>();
+  for (const { gi, ti } of candidates) {
+    if (usedGen.has(gi) || usedTruth.has(ti)) continue;
+    usedGen.add(gi);
+    usedTruth.add(ti);
+    pairs.set(genPages[gi]!.itemIndex, truthPages[ti]!);
+  }
+  return pairs;
+}
+
+// Group pages by their (parent) page key.
+function groupByPageKey(pages: PageGeo[]): Map<string, PageGeo[]> {
+  const groups = new Map<string, PageGeo[]>();
+  for (const page of pages) {
+    const list = groups.get(page.pageKey) ?? [];
+    list.push(page);
+    groups.set(page.pageKey, list);
+  }
+  return groups;
+}
+
 /**
  * Stats for every page of the loaded annotation, keyed by itemIndex.
  *
- * A page pairs with the truth item sharing its page key. Pages with no truth
- * counterpart are absent from the map; split panels (whose truth lives in the
- * parent canvas frame) map to null.
+ * Pages with no truth counterpart are absent from the map. When a page is split on either
+ * side — including the common case where we kept a page whole but the truth split it — the
+ * panels are matched by overlap ({@link matchSplitPairs}) and each pair compared over the
+ * generated panel's own region (the whole sheet for a page we kept whole). A generated
+ * panel that no truth split overlaps maps to null.
  */
 export function compareToTruth(
   pages: PageGeo[],
   truthPages: PageGeo[],
 ): Map<number, PageCompareStats | null> {
-  const truthByKey = new Map<string, PageGeo[]>();
-  for (const truthPage of truthPages) {
-    const list = truthByKey.get(truthPage.pageKey) ?? [];
-    list.push(truthPage);
-    truthByKey.set(truthPage.pageKey, list);
-  }
+  const truthByKey = groupByPageKey(truthPages);
   const stats = new Map<number, PageCompareStats | null>();
-  for (const page of pages) {
-    const isSplit = page.pageKey.includes('__');
-    const parentKey = page.pageKey.split('__')[0] ?? page.pageKey;
-    const candidates =
-      truthByKey.get(page.pageKey) ?? truthByKey.get(parentKey);
-    if (!candidates || candidates.length === 0) continue;
-    if (isSplit || candidates.length > 1) {
-      // Truth for a split is in the parent-canvas pixel frame; comparing
-      // would need the panel offset from pN.panels.json.
-      stats.set(page.itemIndex, null);
+  for (const [pageKey, genGroup] of groupByPageKey(pages)) {
+    const truthGroup = truthByKey.get(pageKey);
+    if (!truthGroup || truthGroup.length === 0) continue; // no truth for this page
+    if (genGroup.length === 1 && truthGroup.length === 1) {
+      stats.set(
+        genGroup[0]!.itemIndex,
+        comparePage(genGroup[0]!, truthGroup[0]!),
+      );
       continue;
     }
-    stats.set(page.itemIndex, comparePage(page, candidates[0]!));
+    const pairs = matchSplitPairs(genGroup, truthGroup);
+    for (const gen of genGroup) {
+      const truth = pairs.get(gen.itemIndex);
+      if (!truth) {
+        stats.set(gen.itemIndex, null); // no overlapping truth panel
+        continue;
+      }
+      const region =
+        gen.splitIndex != null ? polygonBounds(gen.clipPolygon) : undefined;
+      stats.set(gen.itemIndex, comparePage(gen, truth, region));
+    }
   }
   return stats;
 }

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -177,9 +177,26 @@ describe('pagesFromAnnotation', () => {
       gcpFeature(1000, 0, offset(2000, 0)),
     ]);
     annotation.items[0]!.id = 'https://oim/…656_14_1949-1499L/georef';
+    // A generated whole page can carry a stray "[3]" label copied from the truth; ignore it.
+    annotation.items[0]!.label = 'Los Angeles p1499L [3]';
     const page = pagesFromAnnotation(annotation)[0]!;
     expect(page.splitIndex).toBeNull();
     expect(page.stem).toBe('p7');
+  });
+
+  it('reads a truth split index from a trailing "[N]" label', () => {
+    const annotation = annotationWith([
+      gcpFeature(0, 0, offset(0, 0)),
+      gcpFeature(1000, 0, offset(2000, 0)),
+    ]);
+    // Truth items have a plain resource id (no "/georef") and the split number in the label.
+    annotation.items[0]!.id =
+      'https://oldinsurancemaps.net/iiif/resource/57213/';
+    annotation.items[0]!.label =
+      'Los Angeles, Calif. | 1949 | Vol. 14 p1404 [2]';
+    const page = pagesFromAnnotation(annotation)[0]!;
+    expect(page.splitIndex).toBe(2);
+    expect(page.stem).toBe('p7__2');
   });
 
   it('skips items without page metadata or enough GCPs', () => {

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -160,6 +160,28 @@ describe('pagesFromAnnotation', () => {
     expect(page.clipRing[0]![1]).toBeCloseTo(LAT0, 5);
   });
 
+  it('reads the split index and file stem from a generated annotation id', () => {
+    const annotation = annotationWith([
+      gcpFeature(0, 0, offset(0, 0)),
+      gcpFeature(1000, 0, offset(2000, 0)),
+    ]);
+    annotation.items[0]!.id = 'https://oim/…656_14_1949-1499M__2/georef';
+    const page = pagesFromAnnotation(annotation)[0]!;
+    expect(page.splitIndex).toBe(2);
+    expect(page.stem).toBe('p7__2');
+  });
+
+  it('leaves a whole page with no split index (stem === pageKey)', () => {
+    const annotation = annotationWith([
+      gcpFeature(0, 0, offset(0, 0)),
+      gcpFeature(1000, 0, offset(2000, 0)),
+    ]);
+    annotation.items[0]!.id = 'https://oim/…656_14_1949-1499L/georef';
+    const page = pagesFromAnnotation(annotation)[0]!;
+    expect(page.splitIndex).toBeNull();
+    expect(page.stem).toBe('p7');
+  });
+
   it('skips items without page metadata or enough GCPs', () => {
     const noMetadata = annotationWith([
       gcpFeature(0, 0, offset(0, 0)),

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -61,10 +61,22 @@ export interface PageGeo {
   transformationType: string;
 }
 
-/** Split panel number from a generated annotation id like "…-1499M__2/georef", or null. */
-function idSplitIndex(id: string | undefined): number | null {
-  const match = id?.match(/__(\d+)\//);
-  return match ? Number(match[1]) : null;
+/**
+ * Split panel number for an item, or null for a whole page.
+ *
+ * A generated split carries it in its id (`…-1499M__2/georef`); a truth split carries it in
+ * a trailing `[N]` on its label. A generated whole page's id ends in `/georef` and its label
+ * may still carry a stray `[N]` copied from the truth — which is ignored.
+ */
+function splitIndexFor(
+  id: string | undefined,
+  label: string | undefined,
+): number | null {
+  const idMatch = id?.match(/__(\d+)\//);
+  if (idMatch) return Number(idMatch[1]);
+  if (id?.includes('/georef')) return null; // generated whole page
+  const labelMatch = label?.match(/\[(\d+)\]\s*$/);
+  return labelMatch ? Number(labelMatch[1]) : null;
 }
 
 /** Parse the vertex list out of an SvgSelector's polygon value. */
@@ -193,7 +205,14 @@ export function missingTruthPages(
   for (const truthPage of truthPages) {
     if (fitKeys.has(truthPage.pageKey) || seen.has(truthPage.pageKey)) continue;
     seen.add(truthPage.pageKey);
-    missing.push({ ...truthPage, itemIndex: -(missing.length + 1) });
+    // The whole page is missing (no panel was fitted), so label it by the parent
+    // key rather than the first truth panel's split stem.
+    missing.push({
+      ...truthPage,
+      itemIndex: -(missing.length + 1),
+      splitIndex: null,
+      stem: truthPage.pageKey,
+    });
   }
   return missing;
 }
@@ -259,7 +278,7 @@ export function pagesFromAnnotation(
           [0, height],
         ];
 
-    const splitIndex = idSplitIndex(item.id);
+    const splitIndex = splitIndexFor(item.id, item.label);
     const stem = splitIndex != null ? `${pageKey}__${splitIndex}` : pageKey;
 
     const [nw, ne, , sw] = corners;

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -51,8 +51,6 @@ export interface PageGeo {
   rectRing: [number, number][];
   /** Closed [lon, lat] ring of the clipping polygon. */
   clipRing: [number, number][];
-  /** The clipping polygon in the local image's pixel frame, for split panel overlap (IoU). */
-  clipPolygon: [number, number][];
   scalePixelsPerFoot: number;
   /** Rotation from north-up in degrees, positive clockwise. */
   rotationDegrees: number;
@@ -259,24 +257,14 @@ export function pagesFromAnnotation(
 
     const rectRing = closedRing([...corners]);
     const clipPoints = svgPolygonPoints(item.target?.selector?.value ?? '');
-    const hasClip = clipPoints.length >= 3;
-    const clipRing = hasClip
-      ? closedRing(
-          clipPoints.map(([x, y]) =>
-            projectThroughCorners(corners, width, height, x, y),
-          ),
-        )
-      : rectRing;
-    // The clip polygon in the local pixel frame (for split-panel overlap); a page
-    // with no clip covers its whole rectangle.
-    const clipPolygon: [number, number][] = hasClip
-      ? clipPoints
-      : [
-          [0, 0],
-          [width, 0],
-          [width, height],
-          [0, height],
-        ];
+    const clipRing =
+      clipPoints.length >= 3
+        ? closedRing(
+            clipPoints.map(([x, y]) =>
+              projectThroughCorners(corners, width, height, x, y),
+            ),
+          )
+        : rectRing;
 
     const splitIndex = splitIndexFor(item.id, item.label);
     const stem = splitIndex != null ? `${pageKey}__${splitIndex}` : pageKey;
@@ -302,7 +290,6 @@ export function pagesFromAnnotation(
       corners,
       rectRing,
       clipRing,
-      clipPolygon,
       scalePixelsPerFoot,
       rotationDegrees,
       gcps: points,

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -33,7 +33,16 @@ export interface PageGcp {
 export interface PageGeo {
   /** Index of this page's item in the annotation's items array; selection id. */
   itemIndex: number;
+  /** Parent page key (splits share it), e.g. "p1499m" for both p1499m panels. */
   pageKey: string;
+  /**
+   * Split panel number from the annotation id (`…__2/georef`), or null for a whole
+   * page. Present only on our generated splits; a truth split carries it in its
+   * label instead and is matched by panel overlap rather than by number.
+   */
+  splitIndex: number | null;
+  /** Page key including any split index, matching the on-disk file stem (e.g. "p1499m__2"). */
+  stem: string;
   width: number;
   height: number;
   /** Geo images of the image corners (0,0), (w,0), (w,h), (0,h) as [lon, lat]. */
@@ -42,12 +51,20 @@ export interface PageGeo {
   rectRing: [number, number][];
   /** Closed [lon, lat] ring of the clipping polygon. */
   clipRing: [number, number][];
+  /** The clipping polygon in the local image's pixel frame, for split panel overlap (IoU). */
+  clipPolygon: [number, number][];
   scalePixelsPerFoot: number;
   /** Rotation from north-up in degrees, positive clockwise. */
   rotationDegrees: number;
   gcps: PageGcp[];
   /** The annotation's transformation type, e.g. "polynomial" or "helmert". */
   transformationType: string;
+}
+
+/** Split panel number from a generated annotation id like "…-1499M__2/georef", or null. */
+function idSplitIndex(id: string | undefined): number | null {
+  const match = id?.match(/__(\d+)\//);
+  return match ? Number(match[1]) : null;
 }
 
 /** Parse the vertex list out of an SvgSelector's polygon value. */
@@ -223,14 +240,27 @@ export function pagesFromAnnotation(
 
     const rectRing = closedRing([...corners]);
     const clipPoints = svgPolygonPoints(item.target?.selector?.value ?? '');
-    const clipRing =
-      clipPoints.length >= 3
-        ? closedRing(
-            clipPoints.map(([x, y]) =>
-              projectThroughCorners(corners, width, height, x, y),
-            ),
-          )
-        : rectRing;
+    const hasClip = clipPoints.length >= 3;
+    const clipRing = hasClip
+      ? closedRing(
+          clipPoints.map(([x, y]) =>
+            projectThroughCorners(corners, width, height, x, y),
+          ),
+        )
+      : rectRing;
+    // The clip polygon in the local pixel frame (for split-panel overlap); a page
+    // with no clip covers its whole rectangle.
+    const clipPolygon: [number, number][] = hasClip
+      ? clipPoints
+      : [
+          [0, 0],
+          [width, 0],
+          [width, height],
+          [0, height],
+        ];
+
+    const splitIndex = idSplitIndex(item.id);
+    const stem = splitIndex != null ? `${pageKey}__${splitIndex}` : pageKey;
 
     const [nw, ne, , sw] = corners;
     const feetAcross = Math.hypot(...deltaMeters(nw, ne)) * FEET_PER_METER;
@@ -246,11 +276,14 @@ export function pagesFromAnnotation(
     pages.push({
       itemIndex,
       pageKey,
+      splitIndex,
+      stem,
       width,
       height,
       corners,
       rectRing,
       clipRing,
+      clipPolygon,
       scalePixelsPerFoot,
       rotationDegrees,
       gcps: points,


### PR DESCRIPTION
The volume viewer now sources its per-page truth error from the pipeline's `mapsnap compare` output instead of recomputing it in the browser, and labels split panels by their file stem.

## Motivation

The viewer's "Color by RMSE" left **gaps wherever a page was split** on either side — those pages got a null comparison and rendered uncoloured. Fixing that properly means replicating `mapsnap compare`'s split-panel matching (associate our panels to the truth panels by overlap, using `panels.json`) and its RMSE sampling.

I first ported that machinery to TypeScript (see the first commit), but it was a lot of geometry to keep in sync with Python — and it came out subtly wrong on real data: it worked off the annotation clip polygons, which are occasionally broken (e.g. LA p1404, [OldInsuranceMaps#402](https://github.com/ohmg-dev/OldInsuranceMaps/issues/402)), whereas `mapsnap compare` uses `panels.json`. The pipeline already computes exactly what we want, so this PR reads its sidecar instead.

## What changed

- **Server** — parse the sidecar the pipeline already writes. `mapsnap compare` prints a `<name>.txt` next to each `<name>.iiif.json`; [`parseCompareTxt`](app/server/compareTxt.ts) turns its table into paired-page error stats keyed by the generated page's file stem (handling the `(t)` split-numbering-disagrees rows and `(no fit)` rows). New `GET /iiif-api/compare` reads `<name>.txt` for the loaded annotation.
- **Frontend** — consume, don't recompute. `fetchCompare` + `statsByItemIndex` key each row to a page by file stem. This **removes** the whole in-browser comparison path: `compareToTruth`, `matchSplitPairs`, the sampled polygon-IoU, `comparePage`, `sampleGrid`/`haversineFeet`, and `clipPolygon` on `PageGeo`.
- **Split labels** — split pages now show and link by file stem (`p1404__1`, `p1499n__2`) rather than a duplicated parent key. A generated split reads its number from the `__N` in its annotation id, a truth split from the trailing `[N]` in its label.

Page geometry (footprints, the Rot/Scale columns) and missing-page footprints still come from the annotations; only the error metrics moved to the sidecar.

## Result

RMSE and the Δ columns now match `mapsnap compare` to the decimal, and every fitted page is coloured — the split-page gaps are gone. On LA 1949 vol 14 (`2026-07-21.iiif.json`):

- former "split" gaps now correct: `p1404__2` = 18 ft, `p1499n__3` = 393 ft
- whole-vs-largest-split `p1499l` = 11 ft (was ~8 ft under the TS approximation; the sidecar says 10.5)
- disagree-numbering pairs resolve: `p1499q__1` = 58 ft, `p1499q__2` = 140 ft (generated key taken from the trailing parens)

One caveat inherent to reading a sidecar: the numbers reflect whatever `<name>.txt` holds, so regenerate the annotation and its compare output together to keep them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
