### PR TITLE
Add `mapsnap score`: the land-weighted success metric

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -51,6 +51,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.compare_iiif_georef",
         "Compare human vs computer IIIF georeferencing",
     ),
+    "score": (
+        "mapsnap.score",
+        "Land-weighted success score vs truth (good share minus disaster share)",
+    ),
     "download-osm": ("mapsnap.download_osm", "Download street data from OSM"),
     "osm-to-geojson": ("mapsnap.osm_to_centerlines", "Convert OSM data to GeoJSON."),
     "scale": ("mapsnap.scale_images", "Shrink images by a uniform amount."),

--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -25,7 +25,8 @@ import sys
 from pathlib import Path
 
 from mapsnap.compare_iiif_georef import compare_pages
-from mapsnap.utils import list_pages
+from mapsnap.score import summarize, volume_page_scores
+from mapsnap.utils import default_centerlines, list_pages
 
 ARTIFACTS_DIRNAME = "artifacts"
 
@@ -176,7 +177,8 @@ def truth_metrics(truth_path: Path, iiif_path: Path) -> dict:
     """Compute aggregate and per-page error of a generated IIIF against truth.
 
     Error is each page's RMSE in feet (the headline metric of ``mapsnap compare``). Returns
-    ``compared``/``missing`` counts, mean/median RMSE, and a ``per_page`` map.
+    ``compared``/``missing`` counts, mean/median RMSE, a ``per_page`` map, and — when the
+    volume has centerlines for land weighting — the project success ``score``.
     """
     rows, missing = compare_pages(truth_path, iiif_path)
     rmses = sorted(r["rmse_ft"] for r in rows)
@@ -188,13 +190,26 @@ def truth_metrics(truth_path: Path, iiif_path: Path) -> dict:
         )
     else:
         mean_rmse = median_rmse = 0.0
-    return {
+    metrics = {
         "compared": n,
         "missing": len(missing),
         "mean_rmse_ft": round(mean_rmse, 1),
         "median_rmse_ft": round(median_rmse, 1),
         "per_page": {r["page_key"]: r["rmse_ft"] for r in rows},
     }
+    # The project success metric (see mapsnap.score): land-weighted good share
+    # minus disaster share. Needs centerlines for the land weights, which a
+    # truth-bearing volume normally has.
+    if default_centerlines(iiif_path.parent) is not None:
+        score = summarize(volume_page_scores(iiif_path))
+        metrics["score"] = {
+            "net": round(score.net_score, 4),
+            "good_share": round(score.good_share, 4),
+            "disaster_share": round(score.disaster_share, 4),
+            "n_pages": score.n_pages,
+            "n_placed": score.n_placed,
+        }
+    return metrics
 
 
 def build_manifest(

--- a/mapsnap/experiments_test.py
+++ b/mapsnap/experiments_test.py
@@ -265,3 +265,81 @@ def test_page_status_missing_when_absent_from_truth():
     man = _manifest_with_truth({"p1": 10.0})
     assert page_status(man, "p1") == "ok"
     assert page_status(man, "p9") == "missing"
+
+
+def _georef_item(label: str, source_id: str) -> dict:
+    # Pixel (0..100)^2 mapped to a ~110m lon/lat box; selector = the full rect.
+    gcps = [
+        ((0, 0), (0.0, 0.0)),
+        ((100, 0), (0.001, 0.0)),
+        ((100, 100), (0.001, -0.001)),
+        ((0, 100), (0.0, -0.001)),
+    ]
+    return {
+        "label": label,
+        "target": {
+            "source": {"id": source_id, "width": 100, "height": 100},
+            "selector": {
+                "type": "SvgSelector",
+                "value": '<svg><polygon points="0,0 100,0 100,100 0,100" /></svg>',
+            },
+        },
+        "body": {
+            "features": [
+                {
+                    "properties": {"resourceCoords": list(px)},
+                    "geometry": {"coordinates": list(geo)},
+                }
+                for px, geo in gcps
+            ],
+        },
+    }
+
+
+def test_truth_metrics_includes_score(tmp_path):
+    from mapsnap.experiments import truth_metrics
+
+    item = _georef_item("p1", "https://example.com/x-1950-0001/info.json")
+    truth = tmp_path / "main.iiif.json"
+    truth.write_text(json.dumps({"items": [item]}))
+    generated = tmp_path / "run.iiif.json"
+    generated.write_text(json.dumps({"items": [item]}))
+    # One street through the page footprint: the whole box is "land".
+    (tmp_path / "centerlines.geojson").write_text(
+        json.dumps(
+            {
+                "features": [
+                    {
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[-0.001, -0.0005], [0.002, -0.0005]],
+                        },
+                        "properties": {"street_name": "Main"},
+                    }
+                ]
+            }
+        )
+    )
+    metrics = truth_metrics(truth, generated)
+    assert metrics["compared"] == 1 and metrics["missing"] == 0
+    score = metrics["score"]
+    # Identical transforms: RMSE 0 -> the whole (all-land) footprint is good.
+    assert score == {
+        "net": 1.0,
+        "good_share": 1.0,
+        "disaster_share": 0.0,
+        "n_pages": 1,
+        "n_placed": 1,
+    }
+
+
+def test_truth_metrics_score_absent_without_centerlines(tmp_path):
+    from mapsnap.experiments import truth_metrics
+
+    item = _georef_item("p1", "https://example.com/x-1950-0001/info.json")
+    truth = tmp_path / "main.iiif.json"
+    truth.write_text(json.dumps({"items": [item]}))
+    generated = tmp_path / "run.iiif.json"
+    generated.write_text(json.dumps({"items": [item]}))
+    metrics = truth_metrics(truth, generated)
+    assert "score" not in metrics

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -2,6 +2,7 @@
 
 import argparse
 import glob
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -158,6 +159,14 @@ def main() -> None:
         compare_txt,
         args.label,
     )
+    manifest = json.loads((archived / "manifest.json").read_text())
+    score = manifest.get("metrics", {}).get("score")
+    if score:
+        print(
+            f"\nScore: {score['net']:.1%} "
+            f"(<=25ft {score['good_share']:.1%}, >=200ft {score['disaster_share']:.1%}, "
+            f"{score['n_placed']}/{score['n_pages']} pages placed)"
+        )
     print(f"\nArchived run {run_id} to {archived}")
 
 

--- a/mapsnap/score.py
+++ b/mapsnap/score.py
@@ -1,0 +1,345 @@
+"""Land-weighted success score for georeferenced volumes.
+
+The project's success metric: **the share of truth land area on pages
+georeferenced to within a good-fit threshold (default 25ft RMSE), minus the
+share placed disastrously (default >=200ft)** — placing a page 2000ft off is
+worse than not placing it at all, so a disaster subtracts what a success adds.
+Unplaced truth pages stay in the denominator and earn nothing.
+
+Weighting by *land* area (rather than counting pages) downweights small split
+panels and waterfront sheets that are mostly water. Land is approximated by
+street proximity: the fraction of a page's footprint within STREET_NEAR_M of an
+OSM street centerline. Streets only exist on usable land, so this needs no
+separate water dataset and also discounts rail yards and other unmapped ground.
+
+Each GENERATED_IIIF argument is scored against the ``main.iiif.json`` truth and
+``centerlines.geojson`` in its own directory; pages are matched and RMSE
+computed exactly as ``mapsnap compare`` does. With several volumes an aggregate
+row is printed — the project scoreboard.
+
+    uv run mapsnap score data/*/2026-07-19-familyscale.iiif.json
+"""
+
+import argparse
+import csv
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import shapely
+from shapely.geometry import Polygon
+from shapely.strtree import STRtree
+
+from mapsnap.compare_iiif_georef import (
+    annotation_transform_type,
+    compare_pages,
+    extract_gcps,
+    fit_transform,
+    truth_polygon_world,
+)
+from mapsnap.utils import default_centerlines, source_id_to_page_key
+
+GOOD_FT = 25.0
+DISASTER_FT = 200.0
+STREET_NEAR_M = 120.0
+GRID_N = 15  # land sampling grid per footprint (GRID_N x GRID_N candidate points)
+
+METERS_PER_DEGREE_LAT = 110_540.0
+METERS_PER_DEGREE_LON_EQUATOR = 111_320.0
+
+
+@dataclass
+class LocalFrame:
+    """Equirectangular lon/lat -> local metres about a reference point."""
+
+    lon0: float
+    lat0: float
+
+    def to_xy(self, lon: float, lat: float) -> tuple[float, float]:
+        kx = METERS_PER_DEGREE_LON_EQUATOR * math.cos(math.radians(self.lat0))
+        return ((lon - self.lon0) * kx, (lat - self.lat0) * METERS_PER_DEGREE_LAT)
+
+
+@dataclass
+class PageScore:
+    """One truth page's contribution to the score."""
+
+    page_key: str
+    area_m2: float
+    land_m2: float
+    rmse_ft: float | None  # None = truth page with no generated fit
+
+
+@dataclass
+class ScoreSummary:
+    """Land-weighted totals for a set of pages (one volume or the aggregate)."""
+
+    n_pages: int
+    n_placed: int
+    land_m2: float
+    good_m2: float  # rmse <= good threshold
+    disaster_m2: float  # placed at rmse >= disaster threshold
+
+    @property
+    def good_share(self) -> float:
+        return self.good_m2 / self.land_m2 if self.land_m2 else 0.0
+
+    @property
+    def disaster_share(self) -> float:
+        return self.disaster_m2 / self.land_m2 if self.land_m2 else 0.0
+
+    @property
+    def net_score(self) -> float:
+        """The success metric: good land share minus disaster land share."""
+        return self.good_share - self.disaster_share
+
+
+def truth_footprint_ring(item: dict) -> list[list[float]] | None:
+    """World [lon, lat] ring of a truth item's footprint, or None.
+
+    Prefers the clip-selector polygon (via ``truth_polygon_world``); truth
+    annotations without a selector (e.g. Grand Rapids) fall back to the full
+    source rectangle mapped through the item's own GCP transform.
+    """
+    ring = truth_polygon_world(item)
+    if ring:
+        return ring
+    gcps = extract_gcps(item)
+    source = item.get("target", {}).get("source", {})
+    width, height = source.get("width"), source.get("height")
+    if len(gcps) < 2 or not width or not height:
+        return None
+    transform = fit_transform(gcps, annotation_transform_type(item))
+    corners = [(0, 0), (width, 0), (width, height), (0, height)]
+    return [list(transform @ np.array([x, y, 1.0])) for x, y in corners]
+
+
+def street_tree(centerlines_path: Path, frame: LocalFrame) -> STRtree:
+    """STRtree of the volume's street centerlines in local metres."""
+    lines = []
+    for feature in json.loads(centerlines_path.read_text())["features"]:
+        geometry = feature.get("geometry", {})
+        kind = geometry.get("type")
+        parts = (
+            [geometry["coordinates"]]
+            if kind == "LineString"
+            else geometry.get("coordinates", [])
+            if kind == "MultiLineString"
+            else []
+        )
+        for part in parts:
+            if len(part) < 2:
+                continue
+            lines.append(
+                shapely.LineString([frame.to_xy(lon, lat) for lon, lat in part])
+            )
+    return STRtree(lines)
+
+
+def land_fraction(
+    footprint: Polygon, streets: STRtree, *, near_m: float = STREET_NEAR_M
+) -> float:
+    """Fraction of a footprint that lies near a street ("on usable land").
+
+    Samples a GRID_N x GRID_N grid over the footprint's bounds, keeps the points
+    inside the polygon, and counts the share within ``near_m`` of any street.
+    Returns 0.0 when the tree is empty or no grid point lands inside.
+    """
+    if len(streets.geometries) == 0:
+        return 0.0
+    min_x, min_y, max_x, max_y = footprint.bounds
+    xs = np.linspace(min_x, max_x, GRID_N)
+    ys = np.linspace(min_y, max_y, GRID_N)
+    grid = shapely.points([[x, y] for x in xs for y in ys])
+    inside = grid[shapely.contains(footprint, grid)]
+    if len(inside) == 0:
+        return 0.0
+    hits, _ = streets.query(inside, predicate="dwithin", distance=near_m)
+    return float(len(np.unique(hits)) / len(inside))
+
+
+def volume_page_scores(
+    generated_iiif: Path, *, street_near_m: float = STREET_NEAR_M
+) -> list[PageScore]:
+    """Per-truth-page scores for one volume's generated annotation file.
+
+    Matching and RMSE come from ``compare_pages`` (identical to ``mapsnap
+    compare``, including the skeleton rule); footprints and land fractions are
+    computed here from the truth items and the volume's centerlines.
+    """
+    volume = generated_iiif.parent
+    truth_path = volume / "main.iiif.json"
+    if not truth_path.exists():
+        sys.exit(f"{volume} has no main.iiif.json truth data.")
+    centerlines = default_centerlines(volume)
+    if centerlines is None:
+        sys.exit(f"{volume} has no centerlines.geojson (needed for land weights).")
+
+    rows, missing = compare_pages(truth_path, generated_iiif)
+    rmse_by_key: dict[str, float | None] = {}
+    for row in missing:
+        rmse_by_key.setdefault(row["page_key"], None)
+    for row in rows:
+        if row["page_key"] in rmse_by_key and rmse_by_key[row["page_key"]] is not None:
+            print(
+                f"  duplicate page key {row['page_key']}; keeping first",
+                file=sys.stderr,
+            )
+            continue
+        rmse_by_key[row["page_key"]] = row["rmse_ft"]
+
+    rings: dict[str, list[list[float]]] = {}
+    for item in json.loads(truth_path.read_text()).get("items", []):
+        key = source_id_to_page_key(
+            item["target"]["source"].get("id"), item.get("label") or ""
+        )
+        if key not in rmse_by_key or key in rings:
+            continue
+        ring = truth_footprint_ring(item)
+        if ring:
+            rings[key] = ring
+
+    dropped = set(rmse_by_key) - set(rings)
+    if dropped:
+        print(
+            f"  {len(dropped)} truth page(s) lack a usable footprint; "
+            "excluded: " + ", ".join(sorted(dropped)),
+            file=sys.stderr,
+        )
+
+    points = [p for ring in rings.values() for p in ring]
+    frame = LocalFrame(
+        lon0=sum(p[0] for p in points) / len(points),
+        lat0=sum(p[1] for p in points) / len(points),
+    )
+    streets = street_tree(centerlines, frame)
+
+    scores = []
+    for key, ring in sorted(rings.items()):
+        footprint = Polygon([frame.to_xy(lon, lat) for lon, lat in ring]).buffer(0)
+        if footprint.is_empty:
+            continue
+        fraction = land_fraction(footprint, streets, near_m=street_near_m)
+        scores.append(
+            PageScore(
+                page_key=key,
+                area_m2=footprint.area,
+                land_m2=footprint.area * fraction,
+                rmse_ft=rmse_by_key[key],
+            )
+        )
+    return scores
+
+
+def summarize(
+    pages: list[PageScore],
+    *,
+    good_ft: float = GOOD_FT,
+    disaster_ft: float = DISASTER_FT,
+) -> ScoreSummary:
+    """Land-weighted totals over a set of page scores."""
+    return ScoreSummary(
+        n_pages=len(pages),
+        n_placed=sum(1 for p in pages if p.rmse_ft is not None),
+        land_m2=sum(p.land_m2 for p in pages),
+        good_m2=sum(
+            p.land_m2 for p in pages if p.rmse_ft is not None and p.rmse_ft <= good_ft
+        ),
+        disaster_m2=sum(
+            p.land_m2
+            for p in pages
+            if p.rmse_ft is not None and p.rmse_ft >= disaster_ft
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Land-weighted success score: share of truth land area georeferenced "
+            "to <=GOOD ft RMSE, minus the share placed at >=DISASTER ft."
+        )
+    )
+    parser.add_argument(
+        "generated",
+        nargs="+",
+        metavar="GEN_IIIF",
+        help=(
+            "Generated IIIF AnnotationPage file(s); each is scored against the "
+            "main.iiif.json and centerlines.geojson in its own directory."
+        ),
+    )
+    parser.add_argument(
+        "--good-ft",
+        type=float,
+        default=GOOD_FT,
+        help="RMSE at or below this earns full credit (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--disaster-ft",
+        type=float,
+        default=DISASTER_FT,
+        help="Placed pages at or above this subtract credit (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--street-near-m",
+        type=float,
+        default=STREET_NEAR_M,
+        help="Footprint counts as land within this range of a street (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--csv", metavar="FILE", help="Also write per-page scores to a CSV file"
+    )
+    args = parser.parse_args()
+
+    header = (
+        f"{'volume':<30} {'pages':>5} {'placed':>6} "
+        f"{'<=' + format(args.good_ft, 'g') + 'ft':>8} "
+        f"{'>=' + format(args.disaster_ft, 'g') + 'ft':>8} {'score':>6}"
+    )
+    print(header)
+    print("-" * len(header))
+    all_pages: list[tuple[str, PageScore]] = []
+    for path in args.generated:
+        generated = Path(path)
+        pages = volume_page_scores(generated, street_near_m=args.street_near_m)
+        all_pages.extend((generated.parent.name, p) for p in pages)
+        s = summarize(pages, good_ft=args.good_ft, disaster_ft=args.disaster_ft)
+        print(
+            f"{generated.parent.name:<30} {s.n_pages:>5} {s.n_placed:>6} "
+            f"{s.good_share:>7.1%} {s.disaster_share:>7.1%} {s.net_score:>6.1%}"
+        )
+    if len(args.generated) > 1:
+        s = summarize(
+            [p for _, p in all_pages],
+            good_ft=args.good_ft,
+            disaster_ft=args.disaster_ft,
+        )
+        print("-" * len(header))
+        print(
+            f"{'AGGREGATE':<30} {s.n_pages:>5} {s.n_placed:>6} "
+            f"{s.good_share:>7.1%} {s.disaster_share:>7.1%} {s.net_score:>6.1%}"
+        )
+
+    if args.csv:
+        with open(args.csv, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["volume", "page_key", "area_m2", "land_m2", "rmse_ft"])
+            for volume_name, p in all_pages:
+                writer.writerow(
+                    [
+                        volume_name,
+                        p.page_key,
+                        round(p.area_m2, 1),
+                        round(p.land_m2, 1),
+                        "" if p.rmse_ft is None else round(p.rmse_ft, 1),
+                    ]
+                )
+        print(f"\nCSV written to {args.csv}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/score_test.py
+++ b/mapsnap/score_test.py
@@ -1,0 +1,134 @@
+"""Tests for mapsnap.score."""
+
+import shapely
+from shapely.geometry import Polygon
+from shapely.strtree import STRtree
+
+from mapsnap.score import (
+    LocalFrame,
+    PageScore,
+    land_fraction,
+    summarize,
+    truth_footprint_ring,
+)
+
+
+def _identity_georef_item(polygon: list[tuple[float, float]] | None) -> dict:
+    """An annotation whose GCPs make pixel == world; optionally with a selector."""
+    item: dict = {
+        "target": {"source": {"width": 100, "height": 100}},
+        "body": {
+            "features": [
+                {
+                    "properties": {"resourceCoords": [px, py]},
+                    "geometry": {"coordinates": [px, py]},
+                }
+                for px, py in [(0, 0), (100, 0), (100, 100), (0, 100)]
+            ],
+        },
+    }
+    if polygon is not None:
+        points = " ".join(f"{x},{y}" for x, y in polygon)
+        item["target"]["selector"] = {
+            "type": "SvgSelector",
+            "value": f'<svg><polygon points="{points}" /></svg>',
+        }
+    return item
+
+
+# truth_footprint_ring
+
+
+def test_footprint_uses_selector_when_present():
+    poly = [(10.0, 20.0), (30.0, 20.0), (30.0, 40.0), (10.0, 40.0)]
+    assert truth_footprint_ring(_identity_georef_item(poly)) == [
+        [10.0, 20.0],
+        [30.0, 20.0],
+        [30.0, 40.0],
+        [10.0, 40.0],
+    ]
+
+
+def test_footprint_falls_back_to_gcp_rectangle():
+    # No selector (Grand Rapids-style truth): the full source rect through the
+    # identity GCP transform is the footprint.
+    ring = truth_footprint_ring(_identity_georef_item(None))
+    assert ring is not None
+    assert [[round(x), round(y)] for x, y in ring] == [
+        [0, 0],
+        [100, 0],
+        [100, 100],
+        [0, 100],
+    ]
+
+
+def test_footprint_none_without_gcps_or_selector():
+    item = _identity_georef_item(None)
+    item["body"]["features"] = []
+    assert truth_footprint_ring(item) is None
+
+
+# land_fraction
+
+
+def test_land_fraction_near_street_band():
+    footprint = Polygon([(0, 0), (1000, 0), (1000, 1000), (0, 1000)])
+    one_street = STRtree([shapely.LineString([(100, -10), (100, 1010)])])
+    fraction = land_fraction(footprint, one_street, near_m=120.0)
+    # Only the ~220m-wide band around x=100 is "land".
+    assert 0.1 < fraction < 0.4
+
+
+def test_land_fraction_dense_streets_is_all_land():
+    footprint = Polygon([(0, 0), (1000, 0), (1000, 1000), (0, 1000)])
+    grid_streets = STRtree(
+        [shapely.LineString([(x, -10), (x, 1010)]) for x in range(0, 1100, 100)]
+    )
+    assert land_fraction(footprint, grid_streets, near_m=120.0) == 1.0
+
+
+def test_land_fraction_far_streets_and_empty_tree_are_zero():
+    footprint = Polygon([(0, 0), (1000, 0), (1000, 1000), (0, 1000)])
+    far = STRtree([shapely.LineString([(9000, 0), (9000, 1000)])])
+    assert land_fraction(footprint, far, near_m=120.0) == 0.0
+    assert land_fraction(footprint, STRtree([]), near_m=120.0) == 0.0
+
+
+# summarize
+
+
+def test_summarize_net_score_subtracts_disasters():
+    pages = [
+        PageScore("p1", area_m2=100.0, land_m2=100.0, rmse_ft=10.0),  # good
+        PageScore("p2", area_m2=100.0, land_m2=100.0, rmse_ft=100.0),  # mid: no credit
+        PageScore("p3", area_m2=100.0, land_m2=100.0, rmse_ft=500.0),  # disaster
+        PageScore("p4", area_m2=100.0, land_m2=100.0, rmse_ft=None),  # unplaced
+    ]
+    s = summarize(pages, good_ft=25.0, disaster_ft=200.0)
+    assert s.n_pages == 4 and s.n_placed == 3
+    assert s.good_share == 0.25
+    assert s.disaster_share == 0.25
+    assert s.net_score == 0.0  # the disaster cancels the success
+
+
+def test_summarize_weights_by_land_not_pages():
+    pages = [
+        PageScore("big", area_m2=400.0, land_m2=400.0, rmse_ft=10.0),
+        PageScore("small", area_m2=100.0, land_m2=100.0, rmse_ft=None),
+    ]
+    s = summarize(pages)
+    assert s.net_score == 0.8  # 400 of 500 land, not 1 of 2 pages
+
+
+def test_summarize_empty_is_zero():
+    s = summarize([])
+    assert s.net_score == 0.0 and s.land_m2 == 0.0
+
+
+# LocalFrame sanity
+
+
+def test_local_frame_metres_scale():
+    frame = LocalFrame(lon0=-118.0, lat0=34.0)
+    x, y = frame.to_xy(-118.0, 34.01)
+    assert abs(x) < 1e-6 and 1000 < y < 1200  # ~1.1km per 0.01 deg lat


### PR DESCRIPTION
Score = share of truth land area georeferenced to <=25ft RMSE minus the share placed at >=200ft — a disaster subtracts what a success adds, so placing a page 2000ft off is worse than not placing it. Unplaced truth pages stay in the denominator. Land is approximated by street proximity (footprint within 120m of an OSM centerline): streets only exist on usable land, so waterfront, rivers, and rail yards discount themselves without needing a water dataset.

Pages are matched and RMSE computed via `compare_pages` (identical to `mapsnap compare`, including the skeleton rule); truth footprints come from the clip selector with a full-rect GCP fallback for annotations without one (Grand Rapids). Thresholds and the street radius are flags (`--good-ft`, `--disaster-ft`, `--street-near-m`), and `--csv` writes per-page rows.

Every `mapsnap fit` run now records its score too: `truth_metrics` adds a `score` block to the archived manifest whenever the volume has centerlines, and `fit` prints the score after archiving.

## Current standing (12 truth volumes, best run each)

| volume | pages | placed | ≤25ft | ≥200ft | score |
|---|---:|---:|---:|---:|---:|
| champaign_ill_1915 | 33 | 26 | 90.5% | 0.0% | **90.5%** |
| new_orleans_la_1951_vol_5 | 109 | 103 | 84.4% | 0.0% | **84.4%** |
| brooklyn_ny_1939_vol_1 | 62 | 55 | 76.9% | 5.2% | **71.6%** |
| chicago_il_1950_vol_1 | 111 | 99 | 70.3% | 0.9% | **69.4%** |
| grand_rapids_mi_1953_vol7 | 83 | 62 | 65.4% | 3.7% | **61.6%** |
| detroit_mich_1929_vol_11 | 103 | 82 | 62.8% | 3.9% | **58.9%** |
| los_angeles_ca_1949_vol_14 | 129 | 95 | 59.9% | 3.1% | **56.8%** |
| kansas_city_mo_1951_vol_4 | 142 | 108 | 55.5% | 5.3% | **50.2%** |
| nashville_tn_1957_vol1a | 71 | 55 | 45.6% | 4.2% | **41.4%** |
| new_orleans_la_1896_vol_2 | 91 | 81 | 42.1% | 3.1% | **39.0%** |
| hudson_co_nj_1950_vol_9 | 95 | 60 | 34.5% | 1.0% | **33.5%** |
| washington_dc_1916_vol_2 | 134 | 84 | 33.5% | 4.1% | **29.3%** |
| **AGGREGATE** | **1163** | **910** | **56.5%** | **3.2%** | **53.2%** |

Target: **>=90%**. One volume (Champaign) is already there; the aggregate gap splits into ~19% of land on unplaced pages and ~24% on placed-but->25ft pages (about 13 points of which sit in the 25–50ft band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
