### PR TITLE
Visualize volume-wide adjacency data

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -18,6 +18,12 @@ import type {
 } from './iiifAnnotations.ts';
 import type { CompareResponse } from './compareTxt.ts';
 import type { ImageInfo, LabelsJson } from '../src/keymap/types.ts';
+import type { AdjacencyData } from '../src/types.ts';
+
+/** Response of GET /iiif-api/adjacency — the volume's adjacency.json, or null when absent. */
+export interface AdjacencyResponse {
+  adjacency: AdjacencyData | null;
+}
 
 /** Query naming a georeference AnnotationPage, repo-root-relative. */
 export interface AnnotationQuery {
@@ -92,6 +98,9 @@ export interface API {
   };
   '/iiif-api/compare': {
     get: GetEndpoint<CompareResponse, AnnotationQuery>;
+  };
+  '/iiif-api/adjacency': {
+    get: GetEndpoint<AdjacencyResponse, VolumeQuery>;
   };
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -181,6 +181,24 @@ export function registerIiifApi(
     }
   });
 
+  // A volume's adjacency.json (per-page sheet-number claims + the mutual-edge graph),
+  // for the viewer's adjacency overlay. Null when the volume has no adjacency data.
+  router.get('/iiif-api/adjacency', async (_params, request) => {
+    const { volume } = request.query;
+    if (!isSafeName(volume)) {
+      throw new HTTPError(400, `invalid volume: ${volume}`);
+    }
+    try {
+      const text = await readFile(
+        join(dataDir, volume, 'adjacency.json'),
+        'utf8',
+      );
+      return { adjacency: JSON.parse(text) };
+    } catch {
+      return { adjacency: null };
+    }
+  });
+
   // Page stems with a failed-georef sidecar in a volume, and each one's kind, so
   // the viewer can link an un-georeferenced page to its georef-<kind>.json file.
   // ?volume=<dir> → { failed: { "p1452": "nofit", "p1427": "misscale" } }.

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -23,6 +23,8 @@ interface InfoPanelProps {
   selectedStats: PageCompareStats | null;
   /** The selected page's note text, or null when it has none. */
   selectedNote: string | null;
+  /** Whether the volume has adjacency data (adds an adjacency-view link). */
+  hasAdjacency: boolean;
   /** Volume directory name, e.g. "brooklyn_ny_1906_vol_6". */
   volume: string;
   onClose: () => void;
@@ -71,6 +73,7 @@ export function InfoPanel(props: InfoPanelProps) {
     selectedFailedGeorefType,
     selectedStats,
     selectedNote,
+    hasAdjacency,
     volume,
     onClose,
   } = props;
@@ -149,6 +152,11 @@ export function InfoPanel(props: InfoPanelProps) {
             )
           ) : (
             <a href={`?files=${base}.jpg,${base}.georef.json`}>georef view</a>
+          )}
+          {hasAdjacency && (
+            <a href={`?files=${base}.jpg,data/${volume}/adjacency.json`}>
+              adjacency view
+            </a>
           )}
         </div>
       </div>

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -5,6 +5,7 @@ import { WarpedMapLayer } from '@allmaps/maplibre';
 import type { FeatureCollection } from 'geojson';
 import { pointInPolygon } from '../geometry';
 import type { PageGeo } from '../iiif/pages';
+import type { AdjacencyClaim } from '../iiif/adjacency';
 
 interface VolumeMapProps {
   /** Rewritten Georeference AnnotationPage to display, or null before load. */
@@ -34,6 +35,13 @@ interface VolumeMapProps {
   awaitingView: boolean;
   /** Per-itemIndex fill color for RMSE color-coding, or null when off. */
   pageColors: Map<number, string> | null;
+  /** Adjacency claim boxes to draw (blue mutual / amber one-sided); empty to hide the overlay. */
+  adjacencyClaims: AdjacencyClaim[];
+  /**
+   * File stem of the selected page, or null when nothing is selected. Claims on this page draw
+   * filled; claims on other pages draw as a dashed outline, as if underneath it.
+   */
+  selectedStem: string | null;
   /** Called with per-page add results whenever a new annotation is shown. */
   onLoadResult?: (result: { loaded: number; failed: number }) => void;
 }
@@ -224,6 +232,41 @@ export function VolumeMap(props: VolumeMapProps) {
           'line-color': '#333333',
           'line-width': 1.5,
           'line-dasharray': [3, 2],
+        },
+      });
+      // Adjacency claim boxes: blue where the claimed neighbor claims back (mutual), red for
+      // a one-sided claim. Drawn where each read sits on its page.
+      map.addSource('adjacency-claims', {
+        type: 'geojson',
+        data: EMPTY_FEATURES,
+      });
+      // Claims on the selected page (or all of them when nothing is selected) draw filled with a
+      // solid outline; `onSelectedPage` is set per feature in the source-populating effect.
+      map.addLayer({
+        id: 'adjacency-claims-fill',
+        type: 'fill',
+        source: 'adjacency-claims',
+        paint: {
+          'fill-color': ['case', ['get', 'mutual'], '#2563eb', '#d97706'],
+          'fill-opacity': ['case', ['get', 'onSelectedPage'], 0.5, 0],
+          'fill-outline-color': [
+            'case',
+            ['get', 'mutual'],
+            '#1e3a8a',
+            '#92400e',
+          ],
+        },
+      });
+      // Claims on other pages draw as a dashed outline only, reading as "underneath" the selection.
+      map.addLayer({
+        id: 'adjacency-claims-dashed',
+        type: 'line',
+        source: 'adjacency-claims',
+        filter: ['!', ['get', 'onSelectedPage']],
+        paint: {
+          'line-color': ['case', ['get', 'mutual'], '#2563eb', '#d97706'],
+          'line-width': 1.5,
+          'line-dasharray': [2, 2],
         },
       });
       map.addSource('selected-page', {
@@ -442,6 +485,30 @@ export function VolumeMap(props: VolumeMapProps) {
       }));
     source.setData({ type: 'FeatureCollection', features });
   }, [props.pageColors, props.pages, mapReady]);
+
+  // Adjacency claim boxes, one polygon per claim. `mutual` drives the colour; `onSelectedPage`
+  // (true for every claim when nothing is selected) drives filled-vs-dashed in the layer paint.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+    const source = map.getSource<maplibregl.GeoJSONSource>('adjacency-claims');
+    if (!source) return;
+    const { selectedStem } = props;
+    source.setData({
+      type: 'FeatureCollection',
+      features: props.adjacencyClaims.map(
+        (claim): FeatureCollection['features'][0] => ({
+          type: 'Feature',
+          properties: {
+            mutual: claim.mutual,
+            onSelectedPage:
+              selectedStem === null || claim.stem === selectedStem,
+          },
+          geometry: { type: 'Polygon', coordinates: [claim.ring] },
+        }),
+      ),
+    });
+  }, [props.adjacencyClaims, props.selectedStem, mapReady]);
 
   // Missing-page footprints: one translucent white polygon per un-fitted page
   // at its truth clip ring, shown only when the toggle is on.

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -11,7 +11,9 @@ import {
   type PageCompareStats,
 } from '../iiif/compare';
 import type { ComparePageStats } from '../../server/compareTxt';
+import type { AdjacencyData } from '../types';
 import {
+  fetchAdjacency,
   fetchCompare,
   fetchFailedGeorefs,
   fetchRewrittenAnnotation,
@@ -19,6 +21,7 @@ import {
 } from '../iiif/api';
 import { isTypingTarget } from '../keyboard';
 import { fetchVolumeNotes } from '../notes/api';
+import { adjacencyClaimFeatures } from '../iiif/adjacency';
 import { missingTruthPages, pagesFromAnnotation } from '../iiif/pages';
 import { InfoPanel } from './InfoPanel';
 import { PageList } from './PageList';
@@ -52,6 +55,7 @@ export function VolumeViewer() {
   const [opacity, setOpacity] = useState(100);
   const [colorByRmse, setColorByRmse] = useState(false);
   const [showMissing, setShowMissing] = useState(false);
+  const [showAdjacency, setShowAdjacency] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedItemIndex, setSelectedItemIndex] = useState<number | null>(
     null,
@@ -60,6 +64,10 @@ export function VolumeViewer() {
   // Paired-page error stats from the annotation's `mapsnap compare` sidecar, or null when
   // there is no sidecar (no truth comparison for this annotation).
   const [compareRows, setCompareRows] = useState<ComparePageStats[] | null>(
+    null,
+  );
+  // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
+  const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
     null,
   );
   // Page key → note text for the selected volume (markers + tooltip).
@@ -127,13 +135,15 @@ export function VolumeViewer() {
   const selection = parseAnnotationPath(selectedPath);
   const selectedVolume = volumes?.find((v) => v.name === selection?.volume);
 
-  // Load the selected volume's page notes and failed-georef sidecars: the notes
-  // drive the list markers/tooltip, the failed-georefs the missing-page links.
+  // Load the selected volume's page notes, failed-georef sidecars, and adjacency data: the
+  // notes drive the list markers/tooltip, the failed-georefs the missing-page links, the
+  // adjacency the claim overlay.
   const volumeName = selection?.volume;
   useEffect(() => {
     if (!volumeName) {
       setNotes(new Map());
       setFailedGeorefs(new Map());
+      setAdjacencyData(null);
       return;
     }
     let cancelled = false;
@@ -150,6 +160,14 @@ export function VolumeViewer() {
       })
       .catch(() => {
         if (!cancelled) setFailedGeorefs(new Map());
+      });
+    setAdjacencyData(null);
+    fetchAdjacency(volumeName)
+      .then((data) => {
+        if (!cancelled) setAdjacencyData(data);
+      })
+      .catch(() => {
+        if (!cancelled) setAdjacencyData(null);
       });
     return () => {
       cancelled = true;
@@ -196,6 +214,14 @@ export function VolumeViewer() {
     () => (truthPages ? missingTruthPages(pages, truthPages) : []),
     [pages, truthPages],
   );
+
+  // Adjacency claim boxes, mapped into geo through each page's georeference: the fitted pages,
+  // plus the missing pages (via their truth georef) when those are being shown.
+  const adjacencyClaims = useMemo(() => {
+    if (!adjacencyData) return [];
+    const withGeoref = showMissing ? [...pages, ...missingPages] : pages;
+    return adjacencyClaimFeatures(adjacencyData, withGeoref);
+  }, [adjacencyData, pages, missingPages, showMissing]);
 
   const pageColors: Map<number, string> | null = useMemo(() => {
     if (!colorByRmse || !truthStats) return null;
@@ -289,6 +315,16 @@ export function VolumeViewer() {
             Show missing pages
           </label>
         )}
+        {adjacencyData && (
+          <label className="rmse-color-control">
+            <input
+              type="checkbox"
+              checked={showAdjacency}
+              onChange={(e) => setShowAdjacency(e.target.checked)}
+            />
+            Show adjacency
+          </label>
+        )}
         <div className="opacity-control">
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
@@ -322,6 +358,8 @@ export function VolumeViewer() {
           opacity={opacity / 100}
           awaitingView={!!selectedPath && !error}
           pageColors={pageColors}
+          adjacencyClaims={showAdjacency ? adjacencyClaims : []}
+          selectedStem={selectedPage?.stem ?? null}
           onLoadResult={setLoadResult}
         />
         <InfoPanel
@@ -342,6 +380,7 @@ export function VolumeViewer() {
           selectedNote={
             selectedPage ? (notes.get(selectedPage.stem) ?? null) : null
           }
+          hasAdjacency={adjacencyData !== null}
           volume={selection?.volume ?? ''}
           onClose={() => setSelectedItemIndex(null)}
         />

--- a/app/src/iiif/adjacency.test.ts
+++ b/app/src/iiif/adjacency.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { adjacencyClaimFeatures, mutualNumbersByStem } from './adjacency';
+import type { AdjacencyData, AdjacencyDetection } from '../types';
+import type { PageGeo } from './pages';
+
+// A 1000×1000 page on a 0.01°×0.01° geo box at (-74, 40.7).
+function page(stem: string): PageGeo {
+  return {
+    stem,
+    itemIndex: 0,
+    pageKey: stem,
+    splitIndex: null,
+    width: 1000,
+    height: 1000,
+    corners: [
+      [-74, 40.7],
+      [-73.99, 40.7],
+      [-73.99, 40.69],
+      [-74, 40.69],
+    ],
+    rectRing: [],
+    clipRing: [],
+    scalePixelsPerFoot: 1,
+    rotationDegrees: 0,
+    gcps: [],
+    transformationType: 'polynomial',
+  };
+}
+
+function detection(
+  number: number,
+  polygon: [number, number][],
+  claim: boolean,
+): AdjacencyDetection {
+  return {
+    number,
+    text: String(number),
+    confidence: 1,
+    polygon,
+    height: 30,
+    x_frac: 0,
+    y_frac: 0,
+    edge: 'center',
+    claim,
+  };
+}
+
+describe('mutualNumbersByStem', () => {
+  it("collects each page's reciprocated-neighbour numbers", () => {
+    const adjacency: AdjacencyData = {
+      pages: {
+        p1: { number: 1, detections: [] },
+        p2: { number: 2, detections: [] },
+        p3: { number: 3, detections: [] },
+      },
+      adjacency: [['p1', 'p2']],
+    };
+    const mutual = mutualNumbersByStem(adjacency);
+    expect([...(mutual.get('p1') ?? [])]).toEqual([2]);
+    expect([...(mutual.get('p2') ?? [])]).toEqual([1]);
+    expect(mutual.has('p3')).toBe(false); // no reciprocated edge
+  });
+});
+
+describe('adjacencyClaimFeatures', () => {
+  const adjacency: AdjacencyData = {
+    pages: {
+      p1: {
+        number: 1,
+        width: 1000,
+        height: 1000,
+        detections: [
+          detection(
+            2,
+            [
+              [0, 0],
+              [100, 0],
+              [100, 100],
+              [0, 100],
+            ],
+            true,
+          ), // claims p2 (mutual)
+          detection(
+            3,
+            [
+              [500, 500],
+              [600, 500],
+              [600, 600],
+              [500, 600],
+            ],
+            true,
+          ), // claims p3 (one-sided)
+          detection(9, [[0, 0]], false), // not a claim
+        ],
+      },
+      p2: { number: 2, detections: [] },
+      p3: { number: 3, detections: [] },
+    },
+    adjacency: [['p1', 'p2']],
+  };
+
+  it('returns a closed geo ring per claim, flagging mutual vs one-sided', () => {
+    const claims = adjacencyClaimFeatures(adjacency, [page('p1')]);
+    expect(claims).toHaveLength(2); // the two claims; the non-claim detection is skipped
+    expect(claims.map((c) => c.mutual)).toEqual([true, false]);
+    expect(claims.map((c) => c.stem)).toEqual(['p1', 'p1']); // both drawn on p1
+    // First box's top-left pixel (0,0) maps to the page's NW corner; the ring is closed.
+    expect(claims[0]!.ring[0]).toEqual([-74, 40.7]);
+    expect(claims[0]!.ring).toHaveLength(5);
+    expect(claims[0]!.ring[4]).toEqual(claims[0]!.ring[0]);
+  });
+
+  it('skips pages absent from the adjacency data', () => {
+    expect(adjacencyClaimFeatures(adjacency, [page('p99')])).toEqual([]);
+  });
+});

--- a/app/src/iiif/adjacency.ts
+++ b/app/src/iiif/adjacency.ts
@@ -1,0 +1,78 @@
+/**
+ * Adjacency-claim geometry for the volume viewer's overlay.
+ *
+ * `mapsnap adjacency` records, per page, the sheet numbers it read near its edges (a "claim"
+ * points at a neighbouring page) plus the graph of reciprocated (mutual) claims. This maps each
+ * claim's pixel box into geo through its page's georeference so the viewer can draw it where it
+ * sits on the map, blue when the claimed neighbour claims back and amber when the claim is
+ * one-sided.
+ */
+
+import { projectThroughCorners } from '../geometry';
+import type { AdjacencyData } from '../types';
+import type { PageGeo } from './pages';
+
+/** A claim box to draw on the map: a closed [lon, lat] ring, mutual when its neighbour reciprocates. */
+export interface AdjacencyClaim {
+  ring: [number, number][];
+  /** True when the claimed page number belongs to a reciprocated (mutual) neighbour. */
+  mutual: boolean;
+  /** File stem of the page the claim is drawn on, so the viewer can dim other pages' claims. */
+  stem: string;
+}
+
+/**
+ * Each page's reciprocated-neighbour page numbers, keyed by page stem.
+ *
+ * The adjacency graph's edges are exactly the mutual pairs, so a page's claim is mutual when the
+ * number it claims is one of its neighbours' numbers here.
+ */
+export function mutualNumbersByStem(
+  adjacency: AdjacencyData,
+): Map<string, Set<number>> {
+  const result = new Map<string, Set<number>>();
+  const add = (stem: string, number: number | null | undefined): void => {
+    if (number == null) return;
+    const set = result.get(stem) ?? new Set<number>();
+    set.add(number);
+    result.set(stem, set);
+  };
+  for (const [a, b] of adjacency.adjacency) {
+    add(a, adjacency.pages[b]?.number);
+    add(b, adjacency.pages[a]?.number);
+  }
+  return result;
+}
+
+/**
+ * Claim boxes for the given pages, each polygon mapped from its page's pixel frame into geo
+ * through the page's georeference corners. Only `claim` detections are returned; a page absent
+ * from the adjacency data contributes none.
+ */
+export function adjacencyClaimFeatures(
+  adjacency: AdjacencyData,
+  pages: PageGeo[],
+): AdjacencyClaim[] {
+  const mutualByStem = mutualNumbersByStem(adjacency);
+  const claims: AdjacencyClaim[] = [];
+  for (const page of pages) {
+    const adjacencyPage = adjacency.pages[page.stem];
+    if (!adjacencyPage) continue;
+    const width = adjacencyPage.width ?? page.width;
+    const height = adjacencyPage.height ?? page.height;
+    const mutualNumbers = mutualByStem.get(page.stem) ?? new Set<number>();
+    for (const detection of adjacencyPage.detections) {
+      if (!detection.claim || detection.polygon.length === 0) continue;
+      const ring = detection.polygon.map(([x, y]) =>
+        projectThroughCorners(page.corners, width, height, x, y),
+      );
+      ring.push(ring[0]!); // close the polygon
+      claims.push({
+        ring,
+        mutual: mutualNumbers.has(detection.number),
+        stem: page.stem,
+      });
+    }
+  }
+  return claims;
+}

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -6,6 +6,7 @@ import type {
   RewrittenAnnotationResponse,
   VolumeListResponse,
 } from '../../server/iiifAnnotations';
+import type { AdjacencyData } from '../types';
 
 const api = typedApi<API>({ fetch: jsonFetch });
 
@@ -45,4 +46,12 @@ export async function fetchFailedGeorefs(
 export async function fetchCompare(path: string): Promise<ComparePageStats[]> {
   const { pages } = await api.get('/iiif-api/compare')(null, { path });
   return pages;
+}
+
+/** Fetch a volume's adjacency.json (per-page sheet-number claims + mutual graph), or null. */
+export async function fetchAdjacency(
+  volume: string,
+): Promise<AdjacencyData | null> {
+  const { adjacency } = await api.get('/iiif-api/adjacency')(null, { volume });
+  return adjacency;
 }


### PR DESCRIPTION
When `adjacency.json` exists, there's a "Show adjacency" checkbox. This is the base display:

<img width="883" height="789" alt="image" src="https://github.com/user-attachments/assets/0d312abe-d0f6-4dfc-b6de-8ef3c08c6dbf" />

This is the selected page display. Claims from other pages are de-emphasized by showing them as dashed outlines:

<img width="970" height="887" alt="image" src="https://github.com/user-attachments/assets/3b58124d-af21-431c-b6ca-c3af6fbe7533" />

This also adds a link to the per-page adjacency view.