### PR TITLE
Lower aspect-ratio filter and add keymap location outlier check

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -30,7 +30,7 @@ import numpy as np
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import box
 
-from mapsnap.utils import source_id_to_page_key
+from mapsnap.utils import FEET_PER_METER, haversine_m, source_id_to_page_key
 
 GCP = tuple[tuple[float, float], tuple[float, float]]  # ((px, py), (lon, lat))
 EARTH_RADIUS_FT = 20_925_524.0
@@ -238,18 +238,6 @@ def px_per_ft(A: np.ndarray) -> float:
     return 1.0 / (scale_deg_per_px(A) * _FT_PER_DEG_LAT)
 
 
-def haversine_ft(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Return Haversine distance in feet between two (lat, lon) points."""
-    phi1, phi2 = math.radians(lat1), math.radians(lat2)
-    dphi = math.radians(lat2 - lat1)
-    dlam = math.radians(lon2 - lon1)
-    a = (
-        math.sin(dphi / 2) ** 2
-        + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
-    )
-    return 2.0 * EARTH_RADIUS_FT * math.asin(math.sqrt(a))
-
-
 def sample_grid(width: float, height: float, n: int = 7) -> list[tuple[float, float]]:
     """Return an n×n grid of pixel points at uniform fractional positions.
 
@@ -348,7 +336,7 @@ def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
         v = np.array([px, py, 1.0])
         lon_t, lat_t = A_truth @ v
         lon_g, lat_g = A_gen @ v
-        errors.append(haversine_ft(lat_t, lon_t, lat_g, lon_g))
+        errors.append(haversine_m(lat_t, lon_t, lat_g, lon_g) * FEET_PER_METER)
 
     rmse_ft = math.sqrt(sum(e**2 for e in errors) / len(errors))
     max_ft = max(errors)
@@ -358,7 +346,7 @@ def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
     v_center = np.array([cx, cy, 1.0])
     lon_t, lat_t = A_truth @ v_center
     lon_g, lat_g = A_gen @ v_center
-    trans_ft = haversine_ft(lat_t, lon_t, lat_g, lon_g)
+    trans_ft = haversine_m(lat_t, lon_t, lat_g, lon_g) * FEET_PER_METER
 
     # Rotation and scale from affine linear parts.
     rot_err = angle_diff(north_angle(A_gen), north_angle(A_truth))

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -41,7 +41,6 @@ from mapsnap.compare_iiif_georef import (
     annotation_transform_type,
     extract_gcps,
     fit_transform,
-    haversine_ft,
     north_angle,
     redundant_skeleton_keys,
     sample_grid,
@@ -53,7 +52,12 @@ from mapsnap.keymap.align_page_region import (
 )
 from mapsnap.keymap.fit_keymap import page_number, project
 from mapsnap.score_adjacency import truth_adjacent_pairs
-from mapsnap.utils import jpeg_dimensions, source_id_to_page_key
+from mapsnap.utils import (
+    FEET_PER_METER,
+    haversine_m,
+    jpeg_dimensions,
+    source_id_to_page_key,
+)
 
 GEOREF_VARIANTS = [
     "georef",
@@ -128,7 +132,7 @@ def grid_rmse_ft_between(
     for x, y in sample_grid(width, height):
         lon_a, lat_a = apply_affine(affine_a, x, y)
         lon_b, lat_b = apply_affine(affine_b, x, y)
-        errors.append(haversine_ft(lat_a, lon_a, lat_b, lon_b) ** 2)
+        errors.append((haversine_m(lat_a, lon_a, lat_b, lon_b) * FEET_PER_METER) ** 2)
     return math.sqrt(sum(errors) / len(errors))
 
 

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3210,7 +3210,7 @@ def main() -> None:
     parser.add_argument(
         "--min-aspect-ratio",
         type=float,
-        default=1.75,
+        default=1.00,
         metavar="RATIO",
         help="Minimum long/short side ratio for a text polygon (default: %(default)s)",
     )

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -2441,6 +2441,47 @@ def drop_collinear_dominated(
     return kept, dominated
 
 
+def passes_admission_gate(
+    det: dict,
+    normalized_streets: set[str],
+    *,
+    min_confidence: float,
+    min_short_side: float,
+    min_long_side: float,
+    min_aspect_ratio: float,
+    high_confidence_size_fraction: float,
+) -> bool:
+    """Whether an unpromoted detection clears the confidence, size, aspect, and word gates.
+
+    This is the admission test applied in :func:`prepare_label_features` to a non-promoted
+    detection: the confidence floor, the confidence-relaxed size floor, the aspect-ratio floor,
+    and the number-only/bare-letter/direction-word rejections. Promoted detections bypass these
+    (confidence only) and are not covered here.
+    """
+    required_short_side = confidence_relaxed_threshold(
+        det["confidence"],
+        min_confidence,
+        min_short_side,
+        min_short_side * high_confidence_size_fraction,
+    )
+    required_long_side = min_long_side * (required_short_side / min_short_side)
+    return (
+        det["confidence"] >= min_confidence
+        and det.get("long_side", float("inf")) >= required_long_side
+        and det.get("short_side", float("inf")) >= required_short_side
+        and det.get("long_side", float("inf"))
+        >= min_aspect_ratio * det.get("short_side", 1.0)
+        and not is_number_only(det["text"])
+        # Bare single letters are accepted only via promotion; an unpromoted "M"/"W" is almost
+        # always a rotated misread of a quadrant/type box, so reject it here.
+        and not is_bare_letter(det["text"])
+        and (
+            normalize_street(det["text"]) not in DIRECTION_WORDS
+            or det["text"].upper().strip() in normalized_streets
+        )
+    )
+
+
 def prepare_label_features(
     labels_path: str,
     block_index: dict[str, list[Block]],
@@ -2539,12 +2580,27 @@ def prepare_label_features(
             min_long_side=min_long_side,
             perp_tolerance_px=collinear_perp_tolerance_px,
         )
-        if dominated:
+        # Only surface drops that would otherwise have been admitted; a detection the
+        # size/confidence gate would reject anyway is not informative, just log noise.
+        loggable = [
+            d
+            for d in dominated
+            if passes_admission_gate(
+                d,
+                normalized_streets,
+                min_confidence=min_confidence,
+                min_short_side=min_short_side,
+                min_long_side=min_long_side,
+                min_aspect_ratio=min_aspect_ratio,
+                high_confidence_size_fraction=high_confidence_size_fraction,
+            )
+        ]
+        if loggable:
             print(
-                f"Dropped {len(dominated)} collinear-dominated detection(s): "
+                f"Dropped {len(loggable)} collinear-dominated detection(s): "
                 + ", ".join(
                     f"{d['text']}({d.get('short_side', 0):.0f}px,{d.get('confidence', 0):.2f})"
-                    for d in dominated
+                    for d in loggable
                 ),
                 file=sys.stderr,
             )
@@ -2556,28 +2612,14 @@ def prepare_label_features(
             if det["confidence"] < min_confidence or is_number_only(det["text"]):
                 continue
         else:
-            required_short_side = confidence_relaxed_threshold(
-                det["confidence"],
-                min_confidence,
-                min_short_side,
-                min_short_side * high_confidence_size_fraction,
-            )
-            required_long_side = min_long_side * (required_short_side / min_short_side)
-            if not (
-                det["confidence"] >= min_confidence
-                and det.get("long_side", float("inf")) >= required_long_side
-                and det.get("short_side", float("inf")) >= required_short_side
-                and det.get("long_side", float("inf"))
-                >= min_aspect_ratio * det.get("short_side", 1.0)
-                and not is_number_only(det["text"])
-                # Bare single letters are accepted only via promotion (the is_promoted
-                # branch above); an unpromoted "M"/"W" is almost always a rotated misread of
-                # a quadrant/type box, so reject it here.
-                and not is_bare_letter(det["text"])
-                and (
-                    normalize_street(det["text"]) not in DIRECTION_WORDS
-                    or det["text"].upper().strip() in normalized_streets
-                )
+            if not passes_admission_gate(
+                det,
+                normalized_streets,
+                min_confidence=min_confidence,
+                min_short_side=min_short_side,
+                min_long_side=min_long_side,
+                min_aspect_ratio=min_aspect_ratio,
+                high_confidence_size_fraction=high_confidence_size_fraction,
             ):
                 continue
         if edge_margin > 0 and not is_promoted:

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -329,6 +329,17 @@ WEAK_PARTNER_CONFIDENCE = 0.05
 # keeping genuinely parallel streets (a block apart) separate.
 COLLINEAR_PERP_TOLERANCE_PX = 20.0
 
+# Confidence a detection must clear to count as evidence that a page belongs at its key-map
+# location (see has_confident_street_in_radius / the key-map-outlier rejection).
+KEYMAP_OUTLIER_MIN_CONFIDENCE = 0.5
+
+# The key-map-outlier rejection trusts a page's key-map location only when its key-map regions
+# cluster within this many radii of each other. A multi-panel page (e.g. an index sheet split
+# across the map) has its number detected in far-apart regions, so its single (lat, lon) is not a
+# reliable anchor — LA's p1499 series spans 6 km at a 472 m radius, and its correct fits land far
+# from that point. Above this ratio the check is skipped rather than reject a good fit.
+KEYMAP_OUTLIER_MAX_REGION_SPREAD_RATIO = 3.0
+
 
 def is_split_page(stem: str) -> bool:
     """Whether an image stem names one panel of a split sheet (p21__1-style suffix)."""
@@ -2145,6 +2156,75 @@ def _init_worker(
     )
 
 
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two (lat, lon) points."""
+    radius_m = 6_371_000.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    )
+    return 2 * radius_m * math.asin(math.sqrt(a))
+
+
+def keymap_center_distance_m(
+    center: tuple[float, float], keymap: dict | None
+) -> float | None:
+    """Distance (m) from a fitted (lon, lat) page center to the page's key-map location.
+
+    Returns None when there is no key-map location to measure against.
+    """
+    if not keymap or keymap.get("lat") is None or keymap.get("lon") is None:
+        return None
+    lon, lat = center
+    return haversine_m(lat, lon, keymap["lat"], keymap["lon"])
+
+
+def keymap_location_is_anchored(keymap: dict | None) -> bool:
+    """Whether a page's key-map regions are tight enough for its location to anchor a check.
+
+    True when the page has at most one key-map region, or when all its regions cluster within
+    ``KEYMAP_OUTLIER_MAX_REGION_SPREAD_RATIO`` radii of each other. A multi-panel page detected in
+    far-apart regions (LA's p1499 spans 6 km) fails this, so the key-map-outlier rejection is
+    skipped for it rather than reject a correct fit against an unreliable single location.
+    """
+    if not keymap or keymap.get("radius_m") is None:
+        return False
+    centroids = [
+        (sum(p[0] for p in ring) / len(ring), sum(p[1] for p in ring) / len(ring))
+        for ring in (keymap.get("regions") or [])
+        if ring
+    ]
+    if len(centroids) <= 1:
+        return True
+    spread_m = max(
+        haversine_m(a[1], a[0], b[1], b[0]) for a in centroids for b in centroids
+    )
+    return spread_m <= KEYMAP_OUTLIER_MAX_REGION_SPREAD_RATIO * keymap["radius_m"]
+
+
+def has_confident_street_in_radius(
+    labels_path: str, in_radius_streets: set[str], min_confidence: float
+) -> bool:
+    """Whether any confident detection names a street inside the key-map radius.
+
+    This is the evidence that a page truly belongs at its key-map location: an OCR read that
+    both clears ``min_confidence`` and canonically matches a street within the radius. It gates
+    the key-map-outlier rejection, so a page with no such local evidence — whose key-map location
+    may itself be unreliable — is never rejected merely for landing elsewhere.
+    """
+    for detection in load_detections(labels_path):
+        if (
+            detection.get("confidence", 0.0) >= min_confidence
+            and canonical_street_match(detection.get("text", ""), in_radius_streets)
+            is not None
+        ):
+            return True
+    return False
+
+
 def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     """Georeference one image using _worker_state, capturing its log to a <stem>.txt sidecar.
 
@@ -2160,6 +2240,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
         ".georef-outlier.json",
         ".georef-1gcp.json",
         ".georef-nofit.json",
+        ".georef-keymap-outlier.json",
     ):
         stale_path = output_path.replace(".georef.json", stale_suffix)
         if os.path.exists(stale_path):
@@ -2266,17 +2347,34 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                     broadened = run(*rectangle_index)
                     # The rectangle vocabulary reintroduces same-name streets from across
                     # the volume, which fallback-vocab labels can assemble into a spurious
-                    # multi-GCP fit (p61W: 16 GCPs at 0.04x the true scale). The page's
-                    # key-map region gives an independent per-page scale check.
-                    if broadened.success and broadened.scale_deg_per_px is not None:
-                        prior = region_prior_px_per_ft(
-                            keymap,
-                            *image_size(image_path),
-                            split_page=is_split_page(image_stem(image_path)),
+                    # multi-GCP fit (p61W: 16 GCPs at 0.04x the true scale). Two independent
+                    # key-map checks reject those: the page's region gives a per-page scale
+                    # check, and its location gives a per-page position check.
+                    if broadened.success:
+                        prior = (
+                            region_prior_px_per_ft(
+                                keymap,
+                                *image_size(image_path),
+                                split_page=is_split_page(image_stem(image_path)),
+                            )
+                            if broadened.scale_deg_per_px is not None
+                            else None
                         )
-                        fitted = deg_per_px_to_px_per_ft(broadened.scale_deg_per_px)
-                        if prior is not None and not broadened_scale_plausible(
-                            fitted, prior
+                        fitted = (
+                            deg_per_px_to_px_per_ft(broadened.scale_deg_per_px)
+                            if broadened.scale_deg_per_px is not None
+                            else None
+                        )
+                        distance_m = (
+                            keymap_center_distance_m(broadened.center, keymap)
+                            if broadened.center is not None
+                            else None
+                        )
+                        radius_m = (keymap or {}).get("radius_m")
+                        if (
+                            fitted is not None
+                            and prior is not None
+                            and not broadened_scale_plausible(fitted, prior)
                         ):
                             print(
                                 f"  rejecting broadened fit: {fitted:.3f} px/ft is "
@@ -2287,10 +2385,35 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                             # rejection isn't a no-op on disk.
                             if os.path.exists(output_path):
                                 os.remove(output_path)
+                        elif (
+                            distance_m is not None
+                            and radius_m is not None
+                            and distance_m > radius_m
+                            and keymap_location_is_anchored(keymap)
+                            and has_confident_street_in_radius(
+                                labels_path,
+                                set(near.keys()),
+                                KEYMAP_OUTLIER_MIN_CONFIDENCE,
+                            )
+                        ):
+                            print(
+                                f"  rejecting broadened fit: placed {distance_m:.0f} m from "
+                                f"the key-map location ({distance_m / radius_m:.1f}x the "
+                                f"{radius_m:.0f} m radius) despite confident in-radius streets"
+                            )
+                            # Keep the fit as a key-map-outlier sidecar (it records where the
+                            # page was wrongly placed) instead of a plain georef.json.
+                            os.replace(
+                                output_path,
+                                output_path.replace(
+                                    ".georef.json", ".georef-keymap-outlier.json"
+                                ),
+                            )
+                            # Failure with nofit_written set: the page stays unplaced and the
+                            # redundant nofit sidecar is suppressed (the outlier one stands in).
+                            result = ProcessResult(success=False, nofit_written=True)
                         else:
                             result = broadened
-                    elif broadened.success:
-                        result = broadened
             elif rectangle_index is not None:
                 # Unplaced page: the key-map rectangle is the tightest vocabulary available.
                 result = run(*rectangle_index)

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -50,7 +50,7 @@ from mapsnap.streets import (
     is_number_only,
     normalize_street,
 )
-from mapsnap.utils import default_centerlines, image_stem
+from mapsnap.utils import default_centerlines, haversine_m, image_stem
 
 
 @dataclass
@@ -2154,19 +2154,6 @@ def _init_worker(
         rectangle_index=rectangle_index,
         truth_by_page=truth_by_page or None,
     )
-
-
-def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Great-circle distance in metres between two (lat, lon) points."""
-    radius_m = 6_371_000.0
-    phi1, phi2 = math.radians(lat1), math.radians(lat2)
-    d_phi = math.radians(lat2 - lat1)
-    d_lambda = math.radians(lon2 - lon1)
-    a = (
-        math.sin(d_phi / 2) ** 2
-        + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
-    )
-    return 2 * radius_m * math.asin(math.sqrt(a))
 
 
 def keymap_center_distance_m(

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1762,9 +1762,11 @@ def test_keymap_center_distance_m():
 
     keymap = {"lat": 38.8734, "lon": -77.0173}
     # center is (lon, lat): ~0 m at the key-map point.
-    assert keymap_center_distance_m((-77.0173, 38.8734), keymap) < 1.0
+    near = keymap_center_distance_m((-77.0173, 38.8734), keymap)
+    assert near is not None and near < 1.0
     # p214's NW mismatch: ~0.034 deg north is a few km, far outside the 570 m radius.
-    assert keymap_center_distance_m((-77.0166, 38.9070), keymap) > 3000
+    far = keymap_center_distance_m((-77.0166, 38.9070), keymap)
+    assert far is not None and far > 3000
     # No key-map location to measure against -> None.
     assert keymap_center_distance_m((-77.0, 38.9), None) is None
     assert keymap_center_distance_m((-77.0, 38.9), {}) is None

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1750,10 +1750,10 @@ def test_needs_size_relaxation_tracks_the_base_gate():
 
 
 def test_haversine_m_one_degree_latitude():
-    from mapsnap.georef_from_labels import haversine_m
+    from mapsnap.utils import haversine_m
 
     # One degree of latitude is ~111 km anywhere on the globe.
-    assert abs(haversine_m(0.0, 0.0, 1.0, 0.0) - 111_195) < 1000
+    assert abs(haversine_m(0.0, 0.0, 1.0, 0.0) - 111_320) < 500
     assert haversine_m(38.9, -77.0, 38.9, -77.0) == 0.0
 
 

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1579,6 +1579,42 @@ def test_drop_collinear_dominated_keeps_when_not_strictly_worse():
     assert len(kept) == 2
 
 
+# p1477's derived gate: min_confidence 0.15, auto min_short_side ~17, min_long_side ~34.
+_ADMISSION_GATE = {
+    "min_confidence": 0.15,
+    "min_short_side": 17.0,
+    "min_long_side": 34.0,
+    "min_aspect_ratio": 1.75,
+    "high_confidence_size_fraction": 0.7,
+}
+
+
+def _sized_label(text: str, short: float, long: float, conf: float) -> dict:
+    """A detection with explicit short/long side and confidence (geometry irrelevant here)."""
+    return {"text": text, "confidence": conf, "short_side": short, "long_side": long}
+
+
+def test_passes_admission_gate_rejects_low_confidence_small_label():
+    from mapsnap.georef_from_labels import passes_admission_gate
+
+    # The junk "1ST" copy that rides a better street's line (conf 0.001, 12px) fails the
+    # confidence/size gate on its own, so its collinear drop is not worth logging.
+    junk = _sized_label("1ST", short=12.0, long=26.0, conf=0.001)
+    assert not passes_admission_gate(junk, set(), **_ADMISSION_GATE)
+
+
+def test_passes_admission_gate_aspect_floor_gates_short_names():
+    from mapsnap.georef_from_labels import passes_admission_gate
+
+    # p1477's real "1ST": clears confidence and both size floors but is nearly square
+    # (38/24 = 1.58). A 1.75 aspect floor rejects it; dropping the floor to 1.0 admits it.
+    first = _sized_label("1ST", short=24.0, long=38.0, conf=0.237)
+    assert not passes_admission_gate(first, set(), **_ADMISSION_GATE)
+    assert passes_admission_gate(
+        first, set(), **{**_ADMISSION_GATE, "min_aspect_ratio": 1.0}
+    )
+
+
 def _on(text: str, hue: float, chroma: float = 12.0) -> dict:
     """A detection OCR marked as sitting on a fill of the given hue."""
     return {

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1747,3 +1747,76 @@ def test_needs_size_relaxation_tracks_the_base_gate():
     assert not needs_size_relaxation(
         {"short_side": 4.0, "long_side": 4.0, "promoted": True}, 18.0, 36.0
     )
+
+
+def test_haversine_m_one_degree_latitude():
+    from mapsnap.georef_from_labels import haversine_m
+
+    # One degree of latitude is ~111 km anywhere on the globe.
+    assert abs(haversine_m(0.0, 0.0, 1.0, 0.0) - 111_195) < 1000
+    assert haversine_m(38.9, -77.0, 38.9, -77.0) == 0.0
+
+
+def test_keymap_center_distance_m():
+    from mapsnap.georef_from_labels import keymap_center_distance_m
+
+    keymap = {"lat": 38.8734, "lon": -77.0173}
+    # center is (lon, lat): ~0 m at the key-map point.
+    assert keymap_center_distance_m((-77.0173, 38.8734), keymap) < 1.0
+    # p214's NW mismatch: ~0.034 deg north is a few km, far outside the 570 m radius.
+    assert keymap_center_distance_m((-77.0166, 38.9070), keymap) > 3000
+    # No key-map location to measure against -> None.
+    assert keymap_center_distance_m((-77.0, 38.9), None) is None
+    assert keymap_center_distance_m((-77.0, 38.9), {}) is None
+
+
+def test_has_confident_street_in_radius(tmp_path):
+    from mapsnap.georef_from_labels import has_confident_street_in_radius
+
+    in_radius = {"DELAWARE AVENUE SOUTHWEST", "NORTH STREET SOUTHWEST"}
+
+    def labels(detections: list[dict]) -> str:
+        path = tmp_path / "p.streets.json"
+        _write_streets_json(path, detections)
+        return str(path)
+
+    # A confident in-radius street name is evidence the page belongs at the key-map location.
+    assert has_confident_street_in_radius(
+        labels([{"text": "DELAWARE", "confidence": 0.99}]), in_radius, 0.5
+    )
+    # The same name below the confidence bar is not trusted.
+    assert not has_confident_street_in_radius(
+        labels([{"text": "DELAWARE", "confidence": 0.1}]), in_radius, 0.5
+    )
+    # A confident detection that names no in-radius street is not evidence.
+    assert not has_confident_street_in_radius(
+        labels([{"text": "BROADWAY", "confidence": 0.99}]), in_radius, 0.5
+    )
+
+
+def test_keymap_location_is_anchored():
+    from mapsnap.georef_from_labels import keymap_location_is_anchored
+
+    # A tight single-region key map (DC p214): the location anchors the check.
+    tight = {
+        "lat": 38.8734,
+        "lon": -77.0173,
+        "radius_m": 570.0,
+        "regions": [[[-77.018, 38.873], [-77.016, 38.873], [-77.017, 38.874]]],
+    }
+    assert keymap_location_is_anchored(tight)
+    # No regions -> just the point; treated as anchored.
+    assert keymap_location_is_anchored({"lat": 38.8, "lon": -77.0, "radius_m": 570.0})
+    # A multi-panel page whose regions span kilometres (LA p1499) is not a reliable anchor.
+    spread = {
+        "lat": 34.03,
+        "lon": -118.19,
+        "radius_m": 472.0,
+        "regions": [
+            [[-118.19, 34.03], [-118.191, 34.031]],
+            [[-118.14, 34.06], [-118.141, 34.061]],
+        ],
+    }
+    assert not keymap_location_is_anchored(spread)
+    # No key map at all -> not anchored.
+    assert not keymap_location_is_anchored(None)

--- a/mapsnap/keymap/align_page_region.py
+++ b/mapsnap/keymap/align_page_region.py
@@ -61,12 +61,12 @@ from mapsnap.compare_iiif_georef import (
     annotation_transform_type,
     extract_gcps,
     fit_transform,
-    haversine_ft,
     sample_grid,
     truth_page_number,
     truth_polygons_by_page,
 )
 from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
+from mapsnap.utils import FEET_PER_METER, haversine_m
 from mapsnap.keymap.fit_keymap import (
     project,
     similarity_apply,
@@ -911,7 +911,7 @@ def grid_rmse_ft(
         lon_g, lat_g = bilinear_pixel_to_world(
             corner_points, 1, 1, (px / truth_width, py / truth_height)
         )
-        errors.append(haversine_ft(lat_t, lon_t, lat_g, lon_g))
+        errors.append(haversine_m(lat_t, lon_t, lat_g, lon_g) * FEET_PER_METER)
     rmse = math.sqrt(sum(error**2 for error in errors) / len(errors))
     return rmse, max(errors)
 
@@ -1183,13 +1183,8 @@ def volume_median_scale_px_per_m(volume: Path) -> float | None:
         if not corners or not width or not height or len(corners) != 4:
             continue
         top_left, top_right, _bottom_right, bottom_left = corners
-        width_m = (
-            haversine_ft(top_left[1], top_left[0], top_right[1], top_right[0]) / 3.28084
-        )
-        height_m = (
-            haversine_ft(top_left[1], top_left[0], bottom_left[1], bottom_left[0])
-            / 3.28084
-        )
+        width_m = haversine_m(top_left[1], top_left[0], top_right[1], top_right[0])
+        height_m = haversine_m(top_left[1], top_left[0], bottom_left[1], bottom_left[0])
         if width_m > 0 and height_m > 0:
             scales.append((width / width_m + height / height_m) / 2)
     if not scales:

--- a/mapsnap/utils.py
+++ b/mapsnap/utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for mapsnap scripts."""
 
 import json
+import math
 import re
 import struct
 import subprocess
@@ -8,6 +9,24 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import FrameType
+
+FEET_PER_METER = 3.280839895
+# Earth radius shared across mapsnap. Kept equal to the 20,925,524 ft radius that compare's
+# degree-per-foot scale uses, so distances and pixel/foot scales assume one sphere and
+# haversine_m(...) * FEET_PER_METER reproduces the historical foot distances exactly.
+EARTH_RADIUS_M = 20_925_524.0 / FEET_PER_METER
+
+
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two (lat, lon) points."""
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    )
+    return 2 * EARTH_RADIUS_M * math.asin(math.sqrt(a))
 
 
 def run_cmd(cmd: list[str]) -> None:


### PR DESCRIPTION
## What & why

`--min-aspect-ratio` (the long/short bounding-box ratio a street-name detection must clear) was 1.75, which systematically rejects short street names — `1ST`, `2ND`, `ASH` — whose boxes are naturally near-square. On LA vol 14 **p1477** the only cross-street (`1ST` → EAST FIRST STREET) was dropped on aspect alone (38 px long vs 42 px required), leaving the page with only parallel N–S avenues, **0 intersection GCPs**, and no fit.

Lowering the filter to 1.0 recovers those pages, but it also lets short, name-ambiguous detections feed the key-map **rectangle fallback**, which can place a page in the wrong part of the volume. DC vol 2 **p214** is the worst case: its 1916 SW streets are gone from modern OSM, so the neighborhood (in-radius) fit starves with 0 GCPs, and the fallback matches the surviving `…STREET NORTHWEST` namesakes instead — placing the page **~3.6 km north of where the key map puts it**. The existing fallback guard only checks *scale*, which a same-scale wrong-quadrant fit sails through.

## Changes

1. **Default `--min-aspect-ratio` 1.75 → 1.0.** Short street names are admitted; a vocabulary match already vouches that a detection is text.
2. **Key-map location outlier check.** A broadened/rectangle-tier fit is rejected when it lands **outside the page's key-map radius**, the page has **confident detections of streets inside that radius**, and the key-map location is a **reliable anchor**. The fit is kept as `<stem>.georef-keymap-outlier.json` (for debugging) rather than a live `.georef.json`.
   - **Reliability gate:** skipped when the page's key-map regions span more than 3× the radius. A multi-panel page — LA's `p1499` index sheet (`p1499`, `p1499A`, `p1499B`, … detected in 18 regions over 6 km because the key-map CRNN doesn't read letter suffixes) — has no meaningful single location, so its correct fits, which legitimately land far from the mis-assigned key-map point, are spared.
3. **Targeted "dropping collinear" logging:** only log a collinear-dominated drop that would otherwise have cleared the size/confidence gate (the old log listed junk that the gate rejected anyway).
4. **Dedup `haversine`** into `utils.haversine_m` (previously `haversine_ft` in `compare_iiif_georef` plus a copy in `georef_from_labels`); the foot distances are unchanged.

## Score impact

`mapsnap score` (land-weighted share ≤25 ft RMSE minus share ≥200 ft), across all 10 truth volumes with good key maps (Nashville and Grand Rapids excluded). Baseline is aspect 1.75; "this PR" is aspect 1.0 with the key-map-outlier check.

| volume | baseline | this PR | Δ | outliers |
|---|---|---|---|---|
| washington_dc_1916_vol_2 | 29.3% | 36.6% | **+7.3** | 3 |
| brooklyn_ny_1939_vol_1 | 71.6% | 75.6% | **+4.0** | 0 |
| los_angeles_ca_1949_vol_14 | 64.9% | 66.5% | **+1.6** | 0 |
| chicago_il_1950_vol_1 | 69.4% | 69.4% | — | 0 |
| champaign_ill_1915 | 90.5% | 90.5% | — | 0 |
| detroit_mich_1929_vol_11 | 58.9% | 58.9% | — | 0 |
| hudson_co_nj_1950_vol_9 | 33.5% | 33.5% | — | 0 |
| kansas_city_mo_1951_vol_4 | 50.2% | 50.2% | — | 0 |
| new_orleans_la_1896_vol_2 | 39.0% | 39.0% | — | 0 |
| new_orleans_la_1951_vol_5 | 84.4% | 84.4% | — | 0 |
| **aggregate** | **53.9%** | **55.6%** | **+1.7** | 3 |

**+1.7 pts aggregate, no regression on any volume.** Gains concentrate in **DC (+7.3)** — quadrant catastrophes removed and short cross-streets admitted, **Brooklyn (+4.0)** — disaster share drops 5.2% → 3.3% as aspect 1.0 fixes previously-disastrous fits, and **LA (+1.6)** — p1477 and similar cross-streets recovered. The other six volumes are unchanged: lowering the aspect floor shifts some georeferences but not across the score thresholds.

The **key-map-outlier check fired on DC only** (p210/p212/p214); the other nine volumes had **zero rejections**, so it's a safe no-op where it isn't needed. Its isolated effect on DC (holding aspect at 1.0): good-land share unchanged, disaster share **4.9% → 3.5%** — it removes wrong-quadrant placements without dropping a single good page, and the region-spread gate keeps LA's mis-keymapped `p1499` panels from being wrongly rejected.

## Known limitation

DC **p260__2** (6,639 ft) is still placed wrong: the key map can't locate it at all (no anchor), so the outlier check doesn't apply. A natural follow-up is to have pages with no key-map location decline the rectangle fallback rather than place blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
