### PR TITLE
Geometry-first georeferencing (osm-snap): rescue, arbitration, refinement — score 55.5 → 69.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,10 +325,11 @@ The four arguments here are:
 - `mapsnap ocr`: runs OCR over the downscaled images, saving candidate detections to `boxes.json` and `streets.json` files.
 - `mapsnap fit`: another pipeline that runs:
   - `mapsnap georef`: georeferences images based on street detections, writing out `georef.json` files where it can find a good fit.
+  - `mapsnap snap`: the geometry-first channel — matches each page's road-UNet mask directly against OSM street geometry to rescue pages the street-name georeferencer couldn't place, replace fits that OSM actively contradicts, and refine mid-tier fits to street-grid precision. Writes `georef-osm.json` sidecars that take priority in the next step. Skip with `--no-snap`.
   - `mapsnap iiif`: produces a IIIF Georeference Extension with clipping masks. You can find examples of these in the `gallery` directory. View them on Allmaps.
   - `mapsnap compare`: compares the generated IIIF file with the human-generated one from OIM, producing a report on the accuracy of the fit.
 
-`mapsnap ocr` is typically the slowest step. The steps under `mapsnap fit` run relatively quickly. You can run `mapsnap fit` yourself to experiment.
+`mapsnap ocr` is typically the slowest step. The first `mapsnap snap` run on a volume also takes a while (road-UNet inference plus grid matching, roughly 10–30 minutes); its candidates are cached and later runs take seconds. The other steps under `mapsnap fit` run relatively quickly. You can run `mapsnap fit` yourself to experiment.
 
 The end result is a IIIF file pointing at Library of Congress imagery that you can view in Allmaps, along with a text file comparing Mapsnap's results against OIM's.
 

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -43,6 +43,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.page_adjacency",
         "Detect printed adjacent-sheet numbers and build a volume adjacency graph",
     ),
+    "snap": (
+        "mapsnap.snap",
+        "Geometry-first OSM snap: rescue unplaced pages, arbitrate and refine fits",
+    ),
     "iiif": (
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -713,6 +713,20 @@ def compare_pages(
         source = truth_items[0]["target"]["source"]
         source_dims = (float(source["width"]), float(source["height"]))
         truth_polygons = load_split_polygons(oim_dir / f"{page_key}.panels.json")
+        if not truth_polygons:
+            # Without OIM's panel polygons NO placement of this page can ever
+            # be matched to its truth splits — every one scores as unplaced,
+            # silently understating the volume (KC sat ~4 net points low this
+            # way). Loud warning rather than assertion: the fix is a data run
+            # (`mapsnap oim-split-truth`), and comparison of the other pages
+            # is still meaningful in the meantime.
+            print(
+                f"Warning: {page_key} has {len(truth_splits)} truth split(s) but "
+                f"{oim_dir / f'{page_key}.panels.json'} is missing; its placements "
+                "will score as unplaced. Run `mapsnap oim-split-truth` (see its "
+                "docstring for the required raw/ and oim/ images).",
+                file=sys.stderr,
+            )
         gen_polygons = load_split_polygons(
             gen_dir / f"{page_key}.panels.json", source_dims
         )

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -342,3 +342,46 @@ def test_compare_pages_ignores_skeletons_with_full_color_counterparts(tmp_path):
     # it must not count as a missing page.
     assert [r["page_key"] for r in rows] == ["p153"]
     assert missing == []
+
+
+def test_compare_pages_warns_on_truth_splits_without_oim_panels(tmp_path, capsys):
+    from mapsnap.compare_iiif_georef import compare_pages
+
+    def item(page_id: str, label: str) -> dict:
+        return {
+            "label": label,
+            "target": {
+                "source": {
+                    "id": f"https://loc.gov/x/g123-{page_id}/info.json",
+                    "width": 1000,
+                    "height": 1000,
+                },
+            },
+            "body": {
+                "transformation": {"type": "polynomial", "options": {"order": 1}},
+                "features": [
+                    {
+                        "properties": {"resourceCoords": [x, y]},
+                        "geometry": {
+                            "coordinates": [-74.0 + x * 1e-6, 40.0 + y * 1e-6]
+                        },
+                    }
+                    for x, y in [(0, 0), (900, 0), (0, 900)]
+                ],
+            },
+        }
+
+    # Truth split items but no oim/p52.panels.json: the generated placement can
+    # never be matched — that silent gap once understated KC by ~4 net points,
+    # so compare (and through it `mapsnap score`) must say so out loud.
+    truth = {"items": [item("0052", "x p52 [1]"), item("0052", "x p52 [2]")]}
+    generated = {"items": [item("0052", "x p52")]}
+    truth_path = tmp_path / "main.iiif.json"
+    gen_path = tmp_path / "gen.iiif.json"
+    truth_path.write_text(json.dumps(truth))
+    gen_path.write_text(json.dumps(generated))
+    rows, missing = compare_pages(truth_path, gen_path)
+    assert rows == []
+    assert len(missing) == 2
+    err = capsys.readouterr().err
+    assert "p52" in err and "oim-split-truth" in err

--- a/mapsnap/edge_join.py
+++ b/mapsnap/edge_join.py
@@ -71,6 +71,60 @@ def compose(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     return a @ np.vstack([b, [0.0, 0.0, 1.0]])
 
 
+@dataclass
+class FrameSpec:
+    """A pair-local raster frame: equirectangular metres, north-up rows.
+
+    col = (x - x_min) / res, row = (y_max - y) / res, where (x, y) are metres
+    east/north of `origin`. Page images map into the raster without reflection.
+    """
+
+    origin: tuple[float, float]  # lon, lat
+    x_min: float
+    y_max: float
+    res_m: float
+    shape: tuple[int, int]  # rows, cols
+
+    def metre_scales(self) -> tuple[float, float]:
+        kx = 111_320.0 * math.cos(math.radians(self.origin[1]))
+        return kx, 110_540.0
+
+    def lonlat_to_raster(self, lon: float, lat: float) -> tuple[float, float]:
+        kx, ky = self.metre_scales()
+        x = (lon - self.origin[0]) * kx
+        y = (lat - self.origin[1]) * ky
+        return (x - self.x_min) / self.res_m, (self.y_max - y) / self.res_m
+
+    def page_to_raster_affine(self, affine_local: np.ndarray) -> np.ndarray:
+        """2x3 mapping page px -> raster px given a page px -> lon/lat affine."""
+        kx, ky = self.metre_scales()
+        a = affine_local
+        metres = np.array(
+            [
+                [a[0, 0] * kx, a[0, 1] * kx, (a[0, 2] - self.origin[0]) * kx],
+                [a[1, 0] * ky, a[1, 1] * ky, (a[1, 2] - self.origin[1]) * ky],
+            ]
+        )
+        to_frame = np.array(
+            [
+                [1 / self.res_m, 0, -self.x_min / self.res_m],
+                [0, -1 / self.res_m, self.y_max / self.res_m],
+            ]
+        )
+        return compose(to_frame, metres)
+
+    def raster_pose_to_world_affine(self, pose: np.ndarray) -> np.ndarray:
+        """2x3 mapping page px -> (lon, lat) given a page px -> raster px pose."""
+        kx, ky = self.metre_scales()
+        from_raster = np.array(
+            [
+                [self.res_m / kx, 0, self.origin[0] + self.x_min / kx],
+                [0, -self.res_m / ky, self.origin[1] + self.y_max / ky],
+            ]
+        )
+        return compose(from_raster, pose)
+
+
 def dominant_orientation_deg(
     prob: np.ndarray, valid: np.ndarray | None = None, border_px: int = 12
 ) -> float:

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -623,12 +623,12 @@ def cmd_infer(volume: Path) -> None:
     import torch  # noqa: F401  (import check before loading model)
 
     from mapsnap.keymap.number_model import select_device
-    from mapsnap.road_model import load_model, predict_page
+    from mapsnap.road_model import ROAD_MODEL_PATH, load_model, predict_page
 
     out_dir = volume / "artifacts" / "edge_join" / "roadprob"
     out_dir.mkdir(parents=True, exist_ok=True)
     device = select_device()
-    model = load_model(Path("models/road_unet.pt"), device)
+    model = load_model(ROAD_MODEL_PATH, device)
     jpgs = [p for p in sorted(volume.glob("p*.jpg")) if "__" not in p.stem]
     done = 0
     for jpg in jpgs:

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -795,58 +795,9 @@ def cmd_sanity(volume: Path, limit: int | None) -> None:
     print(f"contact sheets in {out_dir}")
 
 
-@dataclass
-class FrameSpec:
-    """A pair-local raster frame: equirectangular metres, north-up rows.
-
-    col = (x - x_min) / res, row = (y_max - y) / res, where (x, y) are metres
-    east/north of `origin`. Page images map into the raster without reflection.
-    """
-
-    origin: tuple[float, float]  # lon, lat
-    x_min: float
-    y_max: float
-    res_m: float
-    shape: tuple[int, int]  # rows, cols
-
-    def metre_scales(self) -> tuple[float, float]:
-        kx = 111_320.0 * math.cos(math.radians(self.origin[1]))
-        return kx, 110_540.0
-
-    def lonlat_to_raster(self, lon: float, lat: float) -> tuple[float, float]:
-        kx, ky = self.metre_scales()
-        x = (lon - self.origin[0]) * kx
-        y = (lat - self.origin[1]) * ky
-        return (x - self.x_min) / self.res_m, (self.y_max - y) / self.res_m
-
-    def page_to_raster_affine(self, affine_local: np.ndarray) -> np.ndarray:
-        """2x3 mapping page px -> raster px given a page px -> lon/lat affine."""
-        kx, ky = self.metre_scales()
-        a = affine_local
-        metres = np.array(
-            [
-                [a[0, 0] * kx, a[0, 1] * kx, (a[0, 2] - self.origin[0]) * kx],
-                [a[1, 0] * ky, a[1, 1] * ky, (a[1, 2] - self.origin[1]) * ky],
-            ]
-        )
-        to_frame = np.array(
-            [
-                [1 / self.res_m, 0, -self.x_min / self.res_m],
-                [0, -1 / self.res_m, self.y_max / self.res_m],
-            ]
-        )
-        return edge_join.compose(to_frame, metres)
-
-    def raster_pose_to_world_affine(self, pose: np.ndarray) -> np.ndarray:
-        """2x3 mapping page px -> (lon, lat) given a page px -> raster px pose."""
-        kx, ky = self.metre_scales()
-        from_raster = np.array(
-            [
-                [self.res_m / kx, 0, self.origin[0] + self.x_min / kx],
-                [0, -self.res_m / ky, self.origin[1] + self.y_max / ky],
-            ]
-        )
-        return edge_join.compose(from_raster, pose)
+# The frame class moved to the truth-free matcher library; re-exported here
+# because the harness's artifacts and callers refer to it by this module.
+FrameSpec = edge_join.FrameSpec
 
 
 def build_frame(

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -2032,30 +2032,6 @@ def effective_gcp_count(volume: Path, stem: str) -> int:
     return count_from_georef(json.loads((volume / f"{stem}.georef.json").read_text()))
 
 
-DIRECTIONAL_SUFFIXES = {
-    "NORTH",
-    "SOUTH",
-    "EAST",
-    "WEST",
-    "NORTHEAST",
-    "NORTHWEST",
-    "SOUTHEAST",
-    "SOUTHWEST",
-}
-
-
-def street_base_name(name: str) -> str:
-    """A street name with any trailing directional word removed.
-
-    "K STREET SOUTHEAST" and "K STREET NORTHWEST" are quadrant segments of
-    one physical street, not two candidate matches.
-    """
-    words = name.split()
-    if len(words) > 1 and words[-1] in DIRECTIONAL_SUFFIXES:
-        return " ".join(words[:-1])
-    return name
-
-
 def build_line_factors(
     volume: Path,
     vframe,
@@ -2088,7 +2064,7 @@ def build_line_factors(
         geometry_segments,
         segment_point_distance_m,
     )
-    from mapsnap.streets import build_block_index
+    from mapsnap.streets import build_block_index, street_base_name
     from mapsnap.utils import default_centerlines
 
     centerlines_path = default_centerlines(volume)

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -297,6 +297,90 @@ def detected_pairs(volume: Path) -> set[frozenset[int]]:
     return pairs
 
 
+def keymap_region_adjacency(
+    volume: Path, gap_m: float = 40.0
+) -> tuple[set[frozenset[int]], dict[int, tuple[float, float]]]:
+    """Candidate adjacency pairs from key-map region proximity, and region centroids.
+
+    A key map draws one colored block per page; two pages whose blocks nearly
+    touch (segmented-region polygon distance <= ``gap_m``) are candidate
+    neighbors. Unlike printed-number adjacency this needs no OCR and covers
+    every page the key map places, so it is far denser (LA: ~58% of truth pairs
+    at 40m vs the printed graph's ~21%). Returns the pair set and each page
+    number's region centroid (world lon/lat), used to derive the anchor-side
+    direction the printed number would otherwise supply.
+    """
+    from shapely.geometry import Polygon
+    from shapely.geometry.base import BaseGeometry
+    from shapely.ops import unary_union
+
+    from mapsnap.keymap.locate import KeymapLocator
+
+    keymaps = sorted((volume / "raw").glob("*.keymap.json"))
+    if not keymaps:
+        return set(), {}
+    regions = KeymapLocator.from_keymaps(keymaps).regions
+    if not regions:
+        return set(), {}
+    all_pts = [pt for rings in regions.values() for ring in rings for pt in ring]
+    lon0 = sum(p[0] for p in all_pts) / len(all_pts)
+    lat0 = sum(p[1] for p in all_pts) / len(all_pts)
+    kx = 111_320.0 * math.cos(math.radians(lat0))
+    ky = 110_540.0
+    shapes: dict[int, BaseGeometry] = {}
+    centroids: dict[int, tuple[float, float]] = {}
+    for number, rings in regions.items():
+        polys = [
+            Polygon(
+                [((lon - lon0) * kx, (lat - lat0) * ky) for lon, lat in ring]
+            ).buffer(0)
+            for ring in rings
+            if len(ring) >= 3
+        ]
+        polys = [p for p in polys if not p.is_empty]
+        if not polys:
+            continue
+        shape = unary_union(polys)
+        shapes[number] = shape
+        centroids[number] = (lon0 + shape.centroid.x / kx, lat0 + shape.centroid.y / ky)
+    numbers = sorted(shapes)
+    pairs: set[frozenset[int]] = set()
+    for i, a in enumerate(numbers):
+        for b in numbers[i + 1 :]:
+            if shapes[a].distance(shapes[b]) <= gap_m:
+                pairs.add(frozenset((a, b)))
+    return pairs, centroids
+
+
+def keymap_anchor_side(
+    anchor_affine: np.ndarray,
+    anchor_centroid: tuple[float, float],
+    target_centroid: tuple[float, float],
+) -> tuple[float, float] | None:
+    """Anchor-side direction (unit vector in anchor page pixels) toward the target.
+
+    The printed reciprocal-side claim pins the world bearing anchor->target in
+    the anchor's own image frame (see ``run_join``); the key map's region
+    centroids give the same bearing without OCR. Maps the world centroid
+    delta back through the anchor pose's linear part.
+    """
+    linear = anchor_affine[:, :2]
+    delta = np.array(
+        [
+            target_centroid[0] - anchor_centroid[0],
+            target_centroid[1] - anchor_centroid[1],
+        ]
+    )
+    try:
+        pixel_dir = np.linalg.solve(linear, delta)
+    except np.linalg.LinAlgError:
+        return None
+    norm = float(np.linalg.norm(pixel_dir))
+    if norm < 1e-9:
+        return None
+    return (float(pixel_dir[0] / norm), float(pixel_dir[1] / norm))
+
+
 def truth_pairs_by_number(volume: Path) -> set[frozenset[int]]:
     """Truth-derived adjacency: page footprints within TRUTH_ADJACENT_GAP_M."""
     from shapely.geometry import Polygon
@@ -1848,7 +1932,11 @@ def synthetic_anchor_affine(
 
 
 def collect_graph_measurements(
-    volume: Path, units: list[PageUnit], limit: int | None = None
+    volume: Path,
+    units: list[PageUnit],
+    limit: int | None = None,
+    extra_pairs: set[frozenset[int]] | None = None,
+    keymap_centroids: dict[int, tuple[float, float]] | None = None,
 ) -> list[dict]:
     """Run the matcher over every measurable mutual-adjacency edge.
 
@@ -1857,9 +1945,16 @@ def collect_graph_measurements(
     neither fitted -> both directions with synthetic keymap-posed anchors
     (these island edges are what the pose graph adds over greedy chaining).
     No verification gate here — sub-gate joins are kept as loose evidence.
+
+    ``extra_pairs`` supplies additional candidate pairs (e.g. from key-map
+    region adjacency) beyond the printed-number graph; for those, the printed
+    reciprocal side is unavailable, so the anchor-side direction gate is fed
+    from ``keymap_centroids`` (the region-centroid bearing) instead.
     """
     by_number = {u.number: u for u in units}
     pairs = detected_pairs(volume)
+    if extra_pairs:
+        pairs = pairs | extra_pairs
     params = edge_join.MatchParams()
     scale = volume_median_scale(units)
     adjacency = load_adjacency(volume)
@@ -1924,6 +2019,19 @@ def collect_graph_measurements(
         expected = (directions.get(anchor.number) or (None, 0.0))[0]
         anchor_dirs = image_neighbor_directions(adjacency, anchor.stem)
         anchor_side = (anchor_dirs.get(target.number) or (None, 0.0))[0]
+        # Key-map-derived pairs have no printed reciprocal claim; substitute the
+        # region-centroid bearing so the swing-killing anchor-side gate still fires.
+        if (
+            anchor_side is None
+            and keymap_centroids is not None
+            and anchor.number in keymap_centroids
+            and target.number in keymap_centroids
+        ):
+            anchor_side = keymap_anchor_side(
+                anchor_affine,
+                keymap_centroids[anchor.number],
+                keymap_centroids[target.number],
+            )
         exclusion = None
         if not synthetic:
             exclusion = [
@@ -2147,6 +2255,8 @@ def cmd_posegraph(
     remeasure: bool,
     limit: int | None,
     street_factors: bool = False,
+    keymap_adjacency: bool = False,
+    keymap_gap_m: float = 40.0,
 ) -> None:
     """Global pose-graph solve over all edge-join measurements.
 
@@ -2157,6 +2267,11 @@ def cmd_posegraph(
     wrong locks. Writes posegraph_all.jsonl (every grounded node, for
     `report --chain-source posegraph_all`) and posegraph.jsonl (previously
     unfitted nodes only, for `materialize --source posegraph`).
+
+    With ``keymap_adjacency`` the candidate pair set is augmented with key-map
+    region-adjacency pairs that involve a not-yet-fitted page (the printed graph
+    misses these on 4-digit-page volumes like LA); outputs get a ``_kmadj``
+    suffix so the printed-graph baseline is preserved for comparison.
     """
     from mapsnap.edge_join_graph import (
         AbsolutePrior,
@@ -2169,14 +2284,45 @@ def cmd_posegraph(
     units = load_page_units(volume)
     by_stem = {u.stem: u for u in units}
     out_dir = volume / "artifacts" / "edge_join"
-    meas_path = out_dir / "measurements.jsonl"
+    suffix = "_kmadj" if keymap_adjacency else ""
+    meas_path = out_dir / f"measurements{suffix}.jsonl"
+
+    extra_pairs: set[frozenset[int]] | None = None
+    keymap_centroids: dict[int, tuple[float, float]] | None = None
+    if keymap_adjacency:
+        km_pairs, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
+        real_numbers = {u.number for u in units}
+        fitted_numbers = {
+            u.number
+            for u in units
+            if u.fit_state == "fitted" and u.gen_affine is not None
+        }
+        detected = detected_pairs(volume)
+        # Keep only pairs between two real volume pages (the key map also reads
+        # stray lot/scale numbers) that connect a not-yet-fitted page and aren't
+        # already in the printed graph — fitted-fitted pairs would only re-refine
+        # already-placed sheets.
+        extra_pairs = {
+            pair
+            for pair in km_pairs
+            if pair <= real_numbers
+            and pair not in detected
+            and not pair <= fitted_numbers
+        }
+        print(
+            f"keymap region adjacency (gap<={keymap_gap_m:g}m): {len(km_pairs)} pairs,"
+            f" {len(extra_pairs)} new real pairs involving an unfitted page"
+        )
+
     if meas_path.exists() and not remeasure:
         records = [
             json.loads(line) for line in meas_path.read_text().splitlines() if line
         ]
         print(f"loaded {len(records)} cached measurements from {meas_path}")
     else:
-        records = collect_graph_measurements(volume, units, limit)
+        records = collect_graph_measurements(
+            volume, units, limit, extra_pairs, keymap_centroids
+        )
         meas_path.write_text("\n".join(json.dumps(r) for r in records))
         print(f"wrote {len(records)} measurements to {meas_path}")
 
@@ -2450,19 +2596,19 @@ def cmd_posegraph(
         for s in sorted(grounded, key=lambda s: by_stem[s].number)
         if incident.get(s) and (is_fitted(by_stem[s]) or supported(s))
     ]
-    (out_dir / "posegraph_all.jsonl").write_text(
+    (out_dir / f"posegraph_all{suffix}.jsonl").write_text(
         "\n".join(json.dumps(r) for r in all_records)
     )
     new_records = [r for r in all_records if not is_fitted(by_stem[r["target"]])]
-    (out_dir / "posegraph.jsonl").write_text(
+    (out_dir / f"posegraph{suffix}.jsonl").write_text(
         "\n".join(json.dumps(r) for r in new_records)
     )
     print(
-        f"\nwrote {len(all_records)} records to posegraph_all.jsonl,"
-        f" {len(new_records)} previously-unfitted to posegraph.jsonl"
+        f"\nwrote {len(all_records)} records to posegraph_all{suffix}.jsonl,"
+        f" {len(new_records)} previously-unfitted to posegraph{suffix}.jsonl"
     )
     print()
-    cmd_report(volume, "posegraph_all")
+    cmd_report(volume, f"posegraph_all{suffix}")
 
 
 def cmd_materialize(volume: Path, source: str) -> None:
@@ -2551,6 +2697,17 @@ def main() -> None:
         action="store_true",
         help="posegraph: refine with street-label line factors",
     )
+    parser.add_argument(
+        "--keymap-adjacency",
+        action="store_true",
+        help="posegraph: add key-map region-adjacency candidate pairs (writes *_kmadj)",
+    )
+    parser.add_argument(
+        "--keymap-gap-m",
+        type=float,
+        default=40.0,
+        help="posegraph: key-map region distance for adjacency (default: %(default)s)",
+    )
     args = parser.parse_args()
     if args.command == "stats":
         cmd_stats(args.volume)
@@ -2578,7 +2735,14 @@ def main() -> None:
             seeds=args.seeds,
         )
     elif args.command == "posegraph":
-        cmd_posegraph(args.volume, args.remeasure, args.limit, args.street_factors)
+        cmd_posegraph(
+            args.volume,
+            args.remeasure,
+            args.limit,
+            args.street_factors,
+            args.keymap_adjacency,
+            args.keymap_gap_m,
+        )
     elif args.command == "materialize":
         cmd_materialize(args.volume, args.source)
     elif args.command == "report":

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -113,7 +113,12 @@ def main() -> None:
     inputs = experiments.gather_inputs(
         dir_path, centerlines, truth if truth.exists() else None
     )
-    run_id = resolve_run_id(dir_path, args.tag, georef_extra, inputs, git)
+    # The config hash must see the snap setting: identical georef flags with
+    # snap on vs off produce different outputs and need different run ids
+    # (an id collision would silently SKIP the second variant as already
+    # archived).
+    id_tokens = [*georef_extra, *(["--no-snap"] if args.no_snap else [])]
+    run_id = resolve_run_id(dir_path, args.tag, id_tokens, inputs, git)
 
     archive_dir = dir_path / experiments.ARTIFACTS_DIRNAME / run_id
     if archive_dir.exists():

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -91,6 +91,14 @@ def main() -> None:
         metavar="NAME",
         help="Human-readable name recorded alongside the run id in the manifest.",
     )
+    parser.add_argument(
+        "--no-snap",
+        action="store_true",
+        help=(
+            "Skip the geometry-first OSM snap channel (rescue/arbitrate/"
+            "refine) and build the IIIF from RANSAC georefs alone."
+        ),
+    )
     args, georef_extra = parser.parse_known_args()
 
     dir_path = Path(args.dir)
@@ -116,9 +124,19 @@ def main() -> None:
         ["mapsnap", "georef", *images, "--centerlines", str(centerlines), *georef_extra]
     )
 
+    # The geometry-first snap channel: rescue unplaced pages, arbitrate fits
+    # OSM contradicts, refine mid-tier fits. Its pN.georef-osm.json sidecars
+    # take priority in the hybrid glob below.
+    if not args.no_snap:
+        run_cmd(["mapsnap", "snap", str(dir_path)])
+
     output_iiif = dir_path / f"{run_id}.iiif.json"
-    # Pass the georef glob as a literal string; make_iiif_georef does its own glob expansion.
-    georef_glob = str(dir_path / "*.georef.json")
+    # Pass the glob as a literal string; make_iiif_georef does its own glob
+    # expansion (first glob wins per page, so snap sidecars take priority).
+    if args.no_snap:
+        georef_glob = str(dir_path / "*.georef.json")
+    else:
+        georef_glob = f"{dir_path / '*.georef-osm.json'},{dir_path / '*.georef.json'}"
     run_cmd(
         [
             "mapsnap",

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -50,7 +50,8 @@ def georef_path_to_page_key(path: str) -> str | None:
 
     Accepts filenames ending in '_p16s.georef.json', '_p16.georef.json',
     '_p16s.gcps.georef.json' (the '.gcps' infix is optional), or the
-    neighbor-fit variant '_p16.georef-neighbor.json'.
+    neighbor-fit / OSM-snap variants '_p16.georef-neighbor.json' and
+    '_p16.georef-osm.json'.
 
     Any letter page suffix is kept (Sanborn sheets run 'a', 'b', … past the
     directional 's'/'n'/'e'/'w'/'l'/'r' letters), not just a known few — a
@@ -59,7 +60,7 @@ def georef_path_to_page_key(path: str) -> str | None:
     still parse here; drop_redundant_skeletons raises on them rather than guess.
     """
     m = re.search(
-        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor)?\.json$",
+        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor|-osm)?\.json$",
         path,
         re.IGNORECASE,
     )

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -304,6 +304,11 @@ def test_georef_path_neighbor_variant():
     assert georef_path_to_page_key("data/vol/p16s.georef-neighbor.json") == "p16s"
 
 
+def test_georef_path_osm_variant():
+    assert georef_path_to_page_key("data/vol/p147.georef-osm.json") == "p147"
+    assert georef_path_to_page_key("data/vol/p4l__2.georef-osm.json") == "p4l__2"
+
+
 def test_georef_path_other_variants_do_not_match():
     assert georef_path_to_page_key("data/vol/p16.georef-nofit.json") is None
     assert georef_path_to_page_key("data/vol/p16.georef-misscale.json") is None

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -18,6 +18,7 @@ The harness (osm_snap_experiment.py) loads volumes, composes PageContext
 objects, and evaluates against truth; nothing in this module reads truth data.
 """
 
+import dataclasses
 import math
 from dataclasses import dataclass, field
 
@@ -602,6 +603,14 @@ def snap_page(
     page_diag_m = math.hypot(ctx.width, ctx.height) * max(
         sp.m_per_px for sp in ctx.scale_priors
     )
+    # A small page (split panel) can cover less ground than the absolute
+    # minimum-overlap floor; cap the floor at half its own area or the NCC
+    # masks out every shift and no candidates ever surface.
+    page_area_m2 = (
+        ctx.width * ctx.height * min(sp.m_per_px for sp in ctx.scale_priors) ** 2
+    )
+    if params.min_overlap_m2 > 0.5 * page_area_m2:
+        params = dataclasses.replace(params, min_overlap_m2=0.5 * page_area_m2)
     half_m = ctx.radius_m + page_diag_m / 2 + 100.0
     points = skeleton_points(ctx.prob, params.mask_threshold, params.mask_min_area)
     sigma_px = max(params.blur_sigma_m / res, 0.5)

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -1,0 +1,767 @@
+"""Geometry-first georeferencing against OSM (truth-free library).
+
+Places a page by matching its road-UNet P(road) map directly against OSM
+centerlines rasterized in a local metre frame — no street-name OCR required,
+so the fit is robust to renamed streets and unreadable labels. The key map
+supplies the coarse location; explicit rotation/scale prior ladders seed the
+search; OCR street names, when available, *boost* a candidate's score but
+never gate it.
+
+Frames follow the edge-join convention (:class:`mapsnap.edge_join.FrameSpec`):
+equirectangular metres, north-up rows, so page pixels map into the raster with
+rotation only (page y-down and raster row-down cancel — no reflection). All
+rotation math below uses that identity: for directed vectors,
+``theta = page_angle - raster_angle`` (both y-down atan2 angles, and theta is
+the cv2.getRotationMatrix2D angle that match_at_rotation consumes).
+
+The harness (osm_snap_experiment.py) loads volumes, composes PageContext
+objects, and evaluates against truth; nothing in this module reads truth data.
+"""
+
+import math
+from dataclasses import dataclass, field
+
+import cv2
+import numpy as np
+
+from mapsnap.edge_join import (
+    CHAMFER_CLAMP_M,
+    FrameSpec,
+    JoinCandidate,
+    MatchParams,
+    match_at_rotation,
+    refine_and_rank,
+    rotation_candidates,
+    skeleton_points,
+)
+from mapsnap.georef_from_labels import LabelFeature, project_to_polyline
+from mapsnap.streets import Block, street_base_name
+from mapsnap.utils import haversine_m
+
+OSM_RES_M = 2.0  # raster resolution
+OSM_WIDTH_M = 12.0  # stroked corridor width for the OSM "P(road)" analog
+REFINE_SHIFT_MAX_M = 30.0  # chamfer refinement may not slide farther than this
+CONTAINMENT_MIN = 0.35  # of the footprint inside the (buffered) keymap region
+CONTAINMENT_BUFFER_M = 60.0
+RADIUS_SLACK_M = 60.0  # post-refinement slack on the center-distance gate
+THETA_DEDUPE_DEG = 3.0
+MAX_PRIOR_THETAS = 8
+MERGE_SEPARATION_M = 60.0  # candidates closer than this are the same lock
+CALIBRATED_RADIUS_MARGIN_M = 100.0
+CALIBRATED_RADIUS_MIN_M = 150.0
+
+# select_score weights (hand-tuned; every term is logged per candidate so a
+# re-ranking experiment can refit them on cached candidates).
+W_NAME = 1.0
+W_CONTAIN = 0.3
+W_PRIOR = 0.1
+
+# The recipe validated by the issue-#128 exploration: generous overlap window
+# (the page may sit entirely inside the OSM frame, unlike an edge join) and a
+# deeper top-K since ranking happens downstream.
+OSM_MATCH_PARAMS = MatchParams(
+    min_overlap_m2=30_000.0,
+    max_overlap_frac=1.0,
+    top_k=8,
+    mask_min_area=500,
+)
+
+
+@dataclass
+class RotationPrior:
+    """One rung of the rotation-prior ladder, in cv2/match_at_rotation degrees."""
+
+    theta_deg: float
+    sigma_deg: float
+    # "label-pair-exact" | "label-osm-mod180" | "ransac-neighbor"
+    # | "adjacency-keymap" | "mask-mod90"
+    source: str
+
+
+@dataclass
+class ScalePrior:
+    """One candidate page scale (metres per page pixel)."""
+
+    m_per_px: float
+    sigma_log: float
+    source: str  # "volume-median" | "keymap-region" | "family-rung"
+
+
+@dataclass
+class NameAlignment:
+    """OCR street-name agreement with a candidate pose (a boost, never a gate)."""
+
+    score: float
+    n_labels: int
+    n_hits: int
+    hits: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class SnapCandidate:
+    """One candidate placement of a page against OSM, with all ranking features."""
+
+    world_affine: np.ndarray  # 2x3 page px -> (lon, lat)
+    center: tuple[float, float]  # (lon, lat) of the posed page center
+    theta_deg: float
+    theta_source: str
+    scale_m_per_px: float
+    scale_source: str
+    scale_adjust: float
+    ncc: float
+    ncc_fine: float
+    chamfer_mean_m: float
+    inlier_frac: float
+    n_points: int
+    jtj_eig_ratio: float
+    overlap_frac: float
+    refine_shift_m: float
+    center_dist_m: float
+    verification: float  # edge_join verification_score (-inf if implausible)
+    region_containment: float | None = None
+    prior_theta_residual_sigma: float | None = None
+    name: NameAlignment | None = None
+    plausible: bool = True
+    gate_reasons: list[str] = field(default_factory=list)
+
+    def select_score(self) -> float:
+        """The ranking score: matcher verification plus soft evidence bonuses."""
+        if not math.isfinite(self.verification):
+            return -math.inf
+        score = self.verification
+        if self.name is not None:
+            score += W_NAME * self.name.score
+        if self.region_containment is not None:
+            score += W_CONTAIN * self.region_containment
+        if self.prior_theta_residual_sigma is not None:
+            score += W_PRIOR * max(0.0, 1.0 - self.prior_theta_residual_sigma)
+        return score
+
+
+@dataclass
+class PageContext:
+    """Everything snap_page needs about one target page (all truth-free)."""
+
+    stem: str
+    number: int | None
+    width: int
+    height: int
+    prob: np.ndarray  # road-UNet P(road) at page resolution
+    search_centers: list[tuple[float, float]]  # keymap centers + region centroids
+    radius_m: float  # calibrated search radius
+    rotation_priors: list[RotationPrior]
+    scale_priors: list[ScalePrior]
+    keymap_regions: list[list[list[float]]] | None = None  # world rings
+    label_features: list[LabelFeature] | None = None
+    block_index: dict[str, list[Block]] | None = None
+
+
+def frame_around(
+    center_lonlat: tuple[float, float], *, half_m: float, res_m: float = OSM_RES_M
+) -> FrameSpec:
+    """A square FrameSpec of ±half_m metres about a lon/lat center."""
+    size = int(round(2 * half_m / res_m))
+    return FrameSpec(
+        origin=center_lonlat,
+        x_min=-half_m,
+        y_max=half_m,
+        res_m=res_m,
+        shape=(size, size),
+    )
+
+
+def frame_bounds_lonlat(frame: FrameSpec) -> tuple[float, float, float, float]:
+    """(min_lon, max_lon, min_lat, max_lat) covered by the frame."""
+    kx, ky = frame.metre_scales()
+    rows, cols = frame.shape
+    x_max = frame.x_min + cols * frame.res_m
+    y_min = frame.y_max - rows * frame.res_m
+    return (
+        frame.origin[0] + frame.x_min / kx,
+        frame.origin[0] + x_max / kx,
+        frame.origin[1] + y_min / ky,
+        frame.origin[1] + frame.y_max / ky,
+    )
+
+
+def osm_rasters(
+    frame: FrameSpec, features: list[dict], *, width_m: float = OSM_WIDTH_M
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """(prob, valid, skeleton) rasters of OSM centerlines in the frame.
+
+    prob strokes each centerline at ``width_m`` — the OSM analog of a road-UNet
+    P(road) map, playing the "fixed" role in match_at_rotation. skeleton is the
+    same polylines at 1 px: the exact centerline (no thinning needed), which
+    the chamfer distance transform is built from. valid is all-true — OSM
+    knowledge covers the whole frame, unlike an edge-join anchor page.
+    """
+    rows, cols = frame.shape
+    prob = np.zeros((rows, cols), np.float32)
+    skeleton = np.zeros((rows, cols), np.uint8)
+    min_lon, max_lon, min_lat, max_lat = frame_bounds_lonlat(frame)
+    kx, ky = frame.metre_scales()
+    thickness = max(2, int(round(width_m / frame.res_m)))
+    for feature in features:
+        geometry = feature.get("geometry") or {}
+        if geometry.get("type") == "LineString":
+            lines = [geometry["coordinates"]]
+        elif geometry.get("type") == "MultiLineString":
+            lines = geometry["coordinates"]
+        else:
+            continue
+        for line in lines:
+            if len(line) < 2:
+                continue
+            pts = np.asarray(line, dtype=np.float64)[:, :2]
+            if (
+                pts[:, 0].max() < min_lon
+                or pts[:, 0].min() > max_lon
+                or pts[:, 1].max() < min_lat
+                or pts[:, 1].min() > max_lat
+            ):
+                continue
+            px = np.empty_like(pts)
+            px[:, 0] = ((pts[:, 0] - frame.origin[0]) * kx - frame.x_min) / frame.res_m
+            px[:, 1] = (frame.y_max - (pts[:, 1] - frame.origin[1]) * ky) / frame.res_m
+            poly = px.round().astype(np.int32)
+            cv2.polylines(prob, [poly], False, 1.0, thickness)
+            cv2.polylines(skeleton, [poly], False, 1, 1)
+    valid = np.ones((rows, cols), dtype=bool)
+    return prob, valid, skeleton.astype(bool)
+
+
+def osm_distance_m(skeleton: np.ndarray, res_m: float = OSM_RES_M) -> np.ndarray:
+    """Clamped distance transform (metres) from the OSM centerline skeleton."""
+    inverted = (~skeleton).astype(np.uint8)
+    distance = cv2.distanceTransform(inverted, cv2.DIST_L2, 3) * res_m
+    return np.minimum(distance, CHAMFER_CLAMP_M)
+
+
+def pose_theta_deg(pose: np.ndarray) -> float:
+    """The cv2 rotation angle of a page-px -> raster-px similarity pose."""
+    return math.degrees(math.atan2(pose[0, 1], pose[0, 0]))
+
+
+def affine_theta_deg(affine_local: np.ndarray, frame: FrameSpec) -> float:
+    """The cv2 rotation angle of a page-px -> lon/lat affine, via the frame."""
+    return pose_theta_deg(frame.page_to_raster_affine(affine_local))
+
+
+def wrap_deg(value: float) -> float:
+    """Fold an angle in degrees to (-180, 180]."""
+    return (value + 180.0) % 360.0 - 180.0
+
+
+def raster_angle_deg(dlon: float, dlat: float, kx: float, ky: float) -> float:
+    """y-down raster-frame angle of a world direction given in lon/lat deltas."""
+    return math.degrees(math.atan2(-dlat * ky, dlon * kx))
+
+
+def dedupe_thetas(
+    priors: list[RotationPrior],
+    tolerance_deg: float = THETA_DEDUPE_DEG,
+    cap: int = MAX_PRIOR_THETAS,
+) -> list[RotationPrior]:
+    """Drop near-duplicate thetas, keeping the first (highest-rung) of each."""
+    kept: list[RotationPrior] = []
+    for prior in priors:
+        if any(
+            abs(wrap_deg(prior.theta_deg - k.theta_deg)) <= tolerance_deg for k in kept
+        ):
+            continue
+        kept.append(prior)
+        if len(kept) >= cap:
+            break
+    return kept
+
+
+def cluster_rotation(
+    thetas: list[tuple[float, float]], tolerance_deg: float = 30.0
+) -> tuple[float, int]:
+    """Weighted circular mean of the largest rotation-consistent cluster.
+
+    Each entry is (theta_deg, weight). A spurious pair (misread neighbor
+    number, wrong centroid) implies a rotation inconsistent with the true
+    ones and falls outside the dominant cluster. Returns (mean_deg, n_inliers);
+    (0, 0) for fewer than two entries.
+    """
+    if len(thetas) < 2:
+        return 0.0, 0
+    best: list[int] = []
+    best_weight = -1.0
+    for center, _ in thetas:
+        inliers = [
+            i
+            for i, (theta, _) in enumerate(thetas)
+            if abs(wrap_deg(theta - center)) <= tolerance_deg
+        ]
+        weight = sum(thetas[i][1] for i in inliers)
+        if len(inliers) > len(best) or (
+            len(inliers) == len(best) and weight > best_weight
+        ):
+            best, best_weight = inliers, weight
+    sines = sum(math.sin(math.radians(thetas[i][0])) * thetas[i][1] for i in best)
+    cosines = sum(math.cos(math.radians(thetas[i][0])) * thetas[i][1] for i in best)
+    if sines == 0 and cosines == 0:
+        return 0.0, 0
+    return math.degrees(math.atan2(sines, cosines)), len(best)
+
+
+def unique_street_features(
+    features: list[LabelFeature],
+) -> list[tuple[LabelFeature, list[str]]]:
+    """(representative feature, candidate street texts) per unambiguous label.
+
+    prepare_label_features emits one feature per candidate street of an
+    ambiguous label; a label is usable here only when all its candidates are
+    directional variants of one physical street (K STREET NE/NW/...), whose
+    blocks then merge into one segment soup.
+    """
+    texts_per_center: dict[tuple[float, float], set[str]] = {}
+    for feature in features:
+        texts_per_center.setdefault(feature.center, set()).add(feature.text)
+    result: list[tuple[LabelFeature, list[str]]] = []
+    seen: set[tuple[float, float]] = set()
+    for feature in features:
+        if feature.center in seen:
+            continue
+        texts = texts_per_center[feature.center]
+        if len({street_base_name(t) for t in texts}) > 1:
+            continue
+        seen.add(feature.center)
+        result.append((feature, sorted(texts)))
+    return result
+
+
+def label_blocks(texts: list[str], block_index: dict[str, list[Block]]) -> list[Block]:
+    """The merged block list for a label's candidate street texts."""
+    blocks: list[Block] = []
+    for text in texts:
+        blocks.extend(block_index.get(text, []))
+    return blocks
+
+
+def label_osm_rotations(
+    features: list[LabelFeature],
+    block_index: dict[str, list[Block]],
+    near_lonlat: tuple[float, float],
+) -> list[RotationPrior]:
+    """Rung (a): rotation priors from OCR street labels vs OSM bearings.
+
+    One matched label pins the rotation mod 180 (its pixel long-axis maps onto
+    its street's tangent, but either way along it) -> two directed candidates.
+    A pair of labels on two *distinct* streets resolves the flip: the pixel
+    offset A->B mapped through the right rotation points the same way as the
+    world offset between the streets; the wrong flip reverses it exactly ->
+    one "label-pair-exact" candidate.
+
+    The streets' tangents/positions are taken at their nearest approach to
+    ``near_lonlat`` (the key-map location) — the best page-position estimate
+    available before any pose exists.
+    """
+    kx = 111_320.0 * math.cos(math.radians(near_lonlat[1]))
+    ky = 110_540.0
+    usable: list[tuple[LabelFeature, tuple[float, float], float]] = []
+    undirected: list[RotationPrior] = []
+    for feature, texts in unique_street_features(features):
+        blocks = label_blocks(texts, block_index)
+        projected = project_to_polyline(
+            near_lonlat[0], near_lonlat[1], blocks, extrapolate=False
+        )
+        if projected is None:
+            continue
+        nlon, nlat, tangent = projected
+        # The tangent is an angle in lon/lat-degree space; convert its unit
+        # vector to the metre frame before taking the raster-frame angle.
+        tangent_raster = raster_angle_deg(math.cos(tangent), math.sin(tangent), kx, ky)
+        theta = (math.degrees(feature.dir_pix) - tangent_raster) % 180.0
+        usable.append((feature, (nlon, nlat), theta))
+        undirected.append(RotationPrior(theta, 4.0, "label-osm-mod180"))
+        undirected.append(RotationPrior(theta - 180.0, 4.0, "label-osm-mod180"))
+
+    exact: list[RotationPrior] = []
+    for i, (feat_a, world_a, theta_a) in enumerate(usable):
+        for feat_b, world_b, _ in usable[i + 1 :]:
+            if street_base_name(feat_a.text) == street_base_name(feat_b.text):
+                continue
+            world_dx = (world_b[0] - world_a[0]) * kx
+            world_dy_north = (world_b[1] - world_a[1]) * ky
+            if math.hypot(world_dx, world_dy_north) < 30.0:
+                continue  # streets cross here; the offset direction is noise
+            world_angle = math.degrees(math.atan2(-world_dy_north, world_dx))
+            page_dx = feat_b.center[0] - feat_a.center[0]
+            page_dy = feat_b.center[1] - feat_a.center[1]
+            if math.hypot(page_dx, page_dy) < 1e-6:
+                continue
+            page_angle = math.degrees(math.atan2(page_dy, page_dx))
+            # theta = page_angle - raster_angle for directed vectors; of the
+            # two flips theta_a/theta_a+180, keep the one agreeing in sign.
+            for theta in (theta_a, theta_a - 180.0):
+                if abs(wrap_deg(page_angle - world_angle - theta)) <= 60.0:
+                    exact.append(
+                        RotationPrior(wrap_deg(theta), 4.0, "label-pair-exact")
+                    )
+                    break
+    return exact + undirected
+
+
+def adjacency_keymap_rotations(
+    image_directions: dict[int, tuple[tuple[float, float], float]],
+    centroids: dict[int, tuple[float, float]],
+    own_centroid: tuple[float, float],
+) -> list[RotationPrior]:
+    """Rung (b): rotation from printed-neighbor directions vs keymap geometry.
+
+    A neighbor's printed number sits on the margin toward that neighbor
+    (image frame); the key map's region centroids give the same direction in
+    the world. Each pair implies a directed rotation; the largest consistent
+    cluster wins.
+    """
+    kx = 111_320.0 * math.cos(math.radians(own_centroid[1]))
+    ky = 110_540.0
+    implied: list[tuple[float, float]] = []
+    for number, (direction, confidence) in image_directions.items():
+        neighbor = centroids.get(number)
+        if neighbor is None:
+            continue
+        dlon = neighbor[0] - own_centroid[0]
+        dlat = neighbor[1] - own_centroid[1]
+        if math.hypot(dlon * kx, dlat * ky) < 1e-6:
+            continue
+        world_angle = raster_angle_deg(dlon, dlat, kx, ky)
+        page_angle = math.degrees(math.atan2(direction[1], direction[0]))
+        implied.append((wrap_deg(page_angle - world_angle), max(confidence, 0.05)))
+    theta, inliers = cluster_rotation(implied)
+    if inliers >= 2:
+        return [RotationPrior(theta, 12.0, "adjacency-keymap")]
+    return []
+
+
+def page_scale_priors(
+    volume_m_per_px: float,
+    region_rings: list[list[list[float]]] | None,
+    width: int,
+    height: int,
+) -> list[ScalePrior]:
+    """The scale-prior ladder: volume median, plus a family rung on evidence.
+
+    The key-map region's area implies a page scale; when it disagrees with the
+    volume median by roughly a power of two (half/double-scale sheets), the
+    corresponding family rung is added as a second candidate rather than
+    trusting the schematic region size directly.
+    """
+    from mapsnap.keymap.locate import region_scale_m_per_px
+
+    priors = [ScalePrior(volume_m_per_px, 0.05, "volume-median")]
+    if region_rings:
+        region_scale = region_scale_m_per_px(
+            [[(p[0], p[1]) for p in ring] for ring in region_rings], width, height
+        )
+        if region_scale and region_scale > 0:
+            rung = round(math.log2(region_scale / volume_m_per_px))
+            if rung != 0 and abs(math.log2(region_scale / volume_m_per_px)) >= 0.6:
+                priors.append(
+                    ScalePrior(volume_m_per_px * (2.0**rung), 0.05, "family-rung")
+                )
+    return priors
+
+
+def calibrated_radius_m(
+    residuals_m: list[float], locator_radius_m: float
+) -> tuple[float, str]:
+    """Per-volume search radius from fitted pages' keymap-vs-fit residuals.
+
+    The locator's default radius (~2x page spacing) is far looser than the key
+    map's actual placement error; tightening the NCC search window to the
+    observed p90 (+margin) removes most lattice aliases before they are ever
+    scored. Falls back to the locator radius when too few fits exist.
+    """
+    if len(residuals_m) < 5:
+        return locator_radius_m, "locator"
+    p90 = float(np.percentile(residuals_m, 90))
+    radius = p90 + CALIBRATED_RADIUS_MARGIN_M
+    radius = max(CALIBRATED_RADIUS_MIN_M, min(radius, locator_radius_m))
+    return radius, "calibrated"
+
+
+def name_alignment(
+    features: list[LabelFeature],
+    block_index: dict[str, list[Block]],
+    world_affine: np.ndarray,
+    *,
+    tau_m: float = 25.0,
+    max_dist_m: float = 60.0,
+    max_angle_deg: float = 25.0,
+) -> NameAlignment:
+    """Agreement between OCR street labels and OSM at a candidate pose.
+
+    Each unambiguous label's center is projected through the pose and snapped
+    to its own street's polyline; a hit needs both proximity and a matching
+    direction. The +2 in the denominator keeps one lucky label from dominating
+    while a renamed street (no match anywhere) scores 0, never negative.
+    """
+    lat0 = world_affine[1, 2]
+    kx = 111_320.0 * math.cos(math.radians(lat0))
+    ky = 110_540.0
+    eligible = unique_street_features(features)
+    hits: list[dict] = []
+    total = 0.0
+    for feature, texts in eligible:
+        blocks = label_blocks(texts, block_index)
+        if not blocks:
+            continue
+        px, py = feature.center
+        lon = world_affine[0, 0] * px + world_affine[0, 1] * py + world_affine[0, 2]
+        lat = world_affine[1, 0] * px + world_affine[1, 1] * py + world_affine[1, 2]
+        projected = project_to_polyline(lon, lat, blocks, extrapolate=False)
+        if projected is None:
+            continue
+        nlon, nlat, tangent = projected
+        dist = haversine_m(lat, lon, nlat, nlon)
+        if dist > max_dist_m:
+            continue
+        # Mapped label direction vs street tangent, both as metre-frame angles.
+        dx_page, dy_page = math.cos(feature.dir_pix), math.sin(feature.dir_pix)
+        dlon = world_affine[0, 0] * dx_page + world_affine[0, 1] * dy_page
+        dlat = world_affine[1, 0] * dx_page + world_affine[1, 1] * dy_page
+        label_angle = math.degrees(math.atan2(dlat * ky, dlon * kx))
+        tangent_angle = math.degrees(
+            math.atan2(math.sin(tangent) * ky, math.cos(tangent) * kx)
+        )
+        diff = abs(label_angle - tangent_angle) % 180.0
+        diff = min(diff, 180.0 - diff)
+        if diff > max_angle_deg:
+            continue
+        value = math.exp(-dist / tau_m)
+        total += value
+        hits.append(
+            {
+                "text": feature.text,
+                "dist_m": round(dist, 1),
+                "angle_deg": round(diff, 1),
+            }
+        )
+    n_labels = len(eligible)
+    return NameAlignment(
+        score=total / (n_labels + 2), n_labels=n_labels, n_hits=len(hits), hits=hits
+    )
+
+
+def region_containment_frac(
+    world_affine: np.ndarray,
+    page_size: tuple[int, int],
+    regions: list[list[list[float]]],
+) -> float:
+    """Fraction of the posed footprint inside the (buffered) keymap region."""
+    from shapely.geometry import Polygon
+    from shapely.ops import unary_union
+
+    lon_r, lat_r = regions[0][0][0], regions[0][0][1]
+    kxr = 111_320.0 * math.cos(math.radians(lat_r))
+    kyr = 110_540.0
+
+    def ring_metres(ring: list[list[float]]) -> list[tuple[float, float]]:
+        return [((lon - lon_r) * kxr, (lat - lat_r) * kyr) for lon, lat in ring]
+
+    region_poly = unary_union(
+        [Polygon(ring_metres(r)).buffer(0) for r in regions]
+    ).buffer(CONTAINMENT_BUFFER_M)
+    width, height = page_size
+    corners = []
+    for x, y in [(0, 0), (width, 0), (width, height), (0, height)]:
+        lon = world_affine[0, 0] * x + world_affine[0, 1] * y + world_affine[0, 2]
+        lat = world_affine[1, 0] * x + world_affine[1, 1] * y + world_affine[1, 2]
+        corners.append([lon, lat])
+    footprint = Polygon(ring_metres(corners))
+    if footprint.area <= 0:
+        return 0.0
+    return float(footprint.intersection(region_poly).area / footprint.area)
+
+
+def snap_page(
+    ctx: PageContext,
+    features: list[dict],
+    params: MatchParams = OSM_MATCH_PARAMS,
+) -> list[SnapCandidate]:
+    """Candidate placements of a page against OSM around its keymap location.
+
+    Per search center: rasterize OSM into a local frame, run masked NCC at
+    every (rotation prior x scale prior), clamp-refine with chamfer, then
+    attach the truth-free ranking features (name alignment, containment,
+    prior residuals, refine shift). Candidates from all centers are merged,
+    near-duplicate locks deduped, and the top params.top_k returned by
+    select_score.
+    """
+    res = params.resolution_m
+    page_diag_m = math.hypot(ctx.width, ctx.height) * max(
+        sp.m_per_px for sp in ctx.scale_priors
+    )
+    half_m = ctx.radius_m + page_diag_m / 2 + 100.0
+    points = skeleton_points(ctx.prob, params.mask_threshold, params.mask_min_area)
+    sigma_px = max(params.blur_sigma_m / res, 0.5)
+    border_px = max(1, int(round(REFINE_SHIFT_MAX_M / res)))
+    page_center = np.array([ctx.width / 2.0, ctx.height / 2.0, 1.0])
+
+    collected: list[SnapCandidate] = []
+    for center in ctx.search_centers:
+        frame = frame_around(center, half_m=half_m, res_m=res)
+        osm_prob, valid, skeleton = osm_rasters(frame, features)
+        if not skeleton.any():
+            continue
+        distance = osm_distance_m(skeleton, res)
+        fixed_blur = cv2.GaussianBlur(osm_prob, (0, 0), sigma_px)
+        region = np.ones(frame.shape, dtype=bool)
+        region[:border_px, :] = False
+        region[-border_px:, :] = False
+        region[:, :border_px] = False
+        region[:, -border_px:] = False
+        search_center = frame.lonlat_to_raster(*center)
+        search_radius_px = ctx.radius_m / res
+
+        # The prior ladder, plus the mask-mod-90 sweep — always appended so the
+        # theta set is never empty and covers any 180-flip a prior missed.
+        thetas = dedupe_thetas(ctx.rotation_priors)
+        for theta in rotation_candidates(
+            osm_prob, ctx.prob, params.jitter_deg, fixed_valid=valid
+        ):
+            if not any(
+                abs(wrap_deg(theta - k.theta_deg)) <= THETA_DEDUPE_DEG for k in thetas
+            ):
+                thetas.append(RotationPrior(theta, 4.0, "mask-mod90"))
+
+        candidates: list[JoinCandidate] = []
+        provenance: dict[int, tuple[RotationPrior, ScalePrior]] = {}
+        for scale_prior in ctx.scale_priors:
+            raster_scale = scale_prior.m_per_px / res
+            for prior in thetas:
+                for candidate in match_at_rotation(
+                    fixed_blur,
+                    valid,
+                    ctx.prob,
+                    scale=raster_scale,
+                    theta=prior.theta_deg,
+                    params=params,
+                    search_center=search_center,
+                    search_radius_px=search_radius_px,
+                ):
+                    provenance[id(candidate)] = (prior, scale_prior)
+                    candidates.append(candidate)
+        if not candidates:
+            continue
+        initial_centers = {id(c): tuple(c.pose @ page_center) for c in candidates}
+        ranked = refine_and_rank(
+            candidates,
+            distance,
+            points,
+            fixed_valid=valid,
+            page_shape=ctx.prob.shape[:2],
+            max_overlap_frac=params.max_overlap_frac,
+            region=region,
+            fixed_prob=osm_prob,
+            target_prob=ctx.prob,
+            fine_sigma_px=max(params.fine_sigma_m / res, 0.5),
+            solve_scale=True,
+        )
+        for candidate in ranked:
+            prior, scale_prior = provenance[id(candidate)]
+            refined_center = candidate.pose @ page_center
+            initial = initial_centers[id(candidate)]
+            refine_shift = (
+                math.hypot(
+                    refined_center[0] - initial[0], refined_center[1] - initial[1]
+                )
+                * res
+            )
+            world = frame.raster_pose_to_world_affine(candidate.pose)
+            lon_c = (
+                world[0, 0] * page_center[0]
+                + world[0, 1] * page_center[1]
+                + world[0, 2]
+            )
+            lat_c = (
+                world[1, 0] * page_center[0]
+                + world[1, 1] * page_center[1]
+                + world[1, 2]
+            )
+            center_dist = min(
+                haversine_m(lat_c, lon_c, c[1], c[0]) for c in ctx.search_centers
+            )
+            snap = SnapCandidate(
+                world_affine=world,
+                center=(lon_c, lat_c),
+                theta_deg=candidate.theta_deg,
+                theta_source=prior.source,
+                scale_m_per_px=scale_prior.m_per_px,
+                scale_source=scale_prior.source,
+                scale_adjust=candidate.scale_adjust,
+                ncc=candidate.ncc,
+                ncc_fine=candidate.ncc_fine,
+                chamfer_mean_m=candidate.chamfer_mean_m,
+                inlier_frac=candidate.inlier_frac,
+                n_points=candidate.n_points,
+                jtj_eig_ratio=candidate.jtj_eig_ratio,
+                overlap_frac=candidate.overlap_frac,
+                refine_shift_m=refine_shift,
+                center_dist_m=center_dist,
+                verification=candidate.verification_score(),
+                plausible=candidate.plausible,
+            )
+            if refine_shift > REFINE_SHIFT_MAX_M:
+                snap.plausible = False
+                snap.gate_reasons.append("refine-shift")
+            if center_dist > ctx.radius_m + RADIUS_SLACK_M:
+                snap.plausible = False
+                snap.gate_reasons.append("radius")
+            if ctx.keymap_regions:
+                snap.region_containment = region_containment_frac(
+                    world, (ctx.width, ctx.height), ctx.keymap_regions
+                )
+                if snap.region_containment < CONTAINMENT_MIN:
+                    snap.plausible = False
+                    snap.gate_reasons.append("containment")
+            if ctx.rotation_priors:
+                # Both flips of a mod-180 prior are present as entries, so a
+                # plain directed comparison is correct for every source.
+                snap.prior_theta_residual_sigma = min(
+                    abs(wrap_deg(candidate.theta_deg - p.theta_deg)) / p.sigma_deg
+                    for p in ctx.rotation_priors
+                )
+            if ctx.label_features and ctx.block_index:
+                snap.name = name_alignment(ctx.label_features, ctx.block_index, world)
+            if not snap.plausible:
+                snap.verification = -math.inf
+            collected.append(snap)
+
+    return merge_candidates(collected, params.top_k)
+
+
+def merge_candidates(
+    candidates: list[SnapCandidate], top_k: int
+) -> list[SnapCandidate]:
+    """Dedupe near-identical locks across frames and keep the best top_k.
+
+    Implausible candidates rank behind all plausible ones (select_score -inf)
+    but are retained up to the cap so the harness can report near-misses.
+    """
+    ordered = sorted(candidates, key=lambda c: -c.select_score())
+    kept: list[SnapCandidate] = []
+    for candidate in ordered:
+        duplicate = False
+        for existing in kept:
+            separation = haversine_m(
+                candidate.center[1],
+                candidate.center[0],
+                existing.center[1],
+                existing.center[0],
+            )
+            if (
+                separation < MERGE_SEPARATION_M
+                and abs(wrap_deg(candidate.theta_deg - existing.theta_deg)) < 10.0
+            ):
+                duplicate = True
+                break
+        if not duplicate:
+            kept.append(candidate)
+        if len(kept) >= top_k:
+            break
+    return kept

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -27,10 +27,12 @@ import numpy as np
 
 from mapsnap.edge_join import (
     CHAMFER_CLAMP_M,
+    INLIER_M,
     FrameSpec,
     JoinCandidate,
     MatchParams,
     match_at_rotation,
+    pose_ncc,
     refine_and_rank,
     rotation_candidates,
     skeleton_points,
@@ -583,6 +585,80 @@ def region_containment_frac(
     if footprint.area <= 0:
         return 0.0
     return float(footprint.intersection(region_poly).area / footprint.area)
+
+
+def evaluate_pose(
+    ctx: PageContext,
+    features: list[dict],
+    world_affine: np.ndarray,
+    params: MatchParams = OSM_MATCH_PARAMS,
+) -> dict | None:
+    """Score an EXISTING pose with the matcher's own evidence (no search).
+
+    The arbitration head-to-head: an incumbent RANSAC pose and a snap
+    candidate are judged by identical features — road-skeleton chamfer against
+    the OSM centerlines, fine content correlation, and name alignment — so
+    "challenger beats incumbent" compares like with like. The verification
+    formula matches JoinCandidate.verification_score exactly. Returns None
+    when the pose cannot be evaluated (no OSM in the frame, too few skeleton
+    points).
+    """
+    res = params.resolution_m
+    center_x, center_y = ctx.width / 2.0, ctx.height / 2.0
+    lon_c = (
+        world_affine[0, 0] * center_x
+        + world_affine[0, 1] * center_y
+        + world_affine[0, 2]
+    )
+    lat_c = (
+        world_affine[1, 0] * center_x
+        + world_affine[1, 1] * center_y
+        + world_affine[1, 2]
+    )
+    diag_m = math.hypot(ctx.width, ctx.height) * max(
+        sp.m_per_px for sp in ctx.scale_priors
+    )
+    frame = frame_around((lon_c, lat_c), half_m=diag_m / 2 + 100.0, res_m=res)
+    osm_prob, valid, skeleton = osm_rasters(frame, features)
+    if not skeleton.any():
+        return None
+    distance = osm_distance_m(skeleton, res)
+    pose = frame.page_to_raster_affine(world_affine)
+    points = skeleton_points(ctx.prob, params.mask_threshold, params.mask_min_area)
+    if len(points) < 10:
+        return None
+    if len(points) > 3000:
+        points = points[:: len(points) // 3000 + 1]
+    placed = np.column_stack([points, np.ones(len(points))]) @ pose.T
+    rows = np.clip(placed[:, 1].round().astype(int), 0, distance.shape[0] - 1)
+    cols = np.clip(placed[:, 0].round().astype(int), 0, distance.shape[1] - 1)
+    sampled = distance[rows, cols]
+    inlier_frac = float((sampled < INLIER_M).mean())
+    chamfer_mean = float(sampled.mean())
+    ncc_fine = pose_ncc(
+        osm_prob,
+        valid,
+        ctx.prob,
+        pose,
+        sigma_px=max(params.fine_sigma_m / res, 0.5),
+    )
+    evaluation: dict = {
+        "verification": round(
+            inlier_frac + ncc_fine - chamfer_mean / CHAMFER_CLAMP_M, 4
+        ),
+        "inlier_frac": round(inlier_frac, 4),
+        "chamfer_mean_m": round(chamfer_mean, 2),
+        "ncc_fine": round(ncc_fine, 4),
+        "n_points": int(len(sampled)),
+    }
+    if ctx.label_features and ctx.block_index:
+        name = name_alignment(ctx.label_features, ctx.block_index, world_affine)
+        evaluation["name"] = {
+            "score": round(name.score, 4),
+            "n_labels": name.n_labels,
+            "n_hits": name.n_hits,
+        }
+    return evaluation
 
 
 def snap_page(

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -41,7 +41,11 @@ from mapsnap.utils import haversine_m
 OSM_RES_M = 2.0  # raster resolution
 OSM_WIDTH_M = 12.0  # stroked corridor width for the OSM "P(road)" analog
 REFINE_SHIFT_MAX_M = 30.0  # chamfer refinement may not slide farther than this
-CONTAINMENT_MIN = 0.35  # of the footprint inside the (buffered) keymap region
+# Hard containment gate: only egregious slides fail it. Schematic keymap
+# regions run small relative to true page footprints (Hudson true locks sit
+# near 0.33), so the run_join-style 0.35 threshold kills good fits here;
+# discrimination comes from the ranking bonus and the radius gate instead.
+CONTAINMENT_MIN = 0.15  # of the footprint inside the (buffered) keymap region
 CONTAINMENT_BUFFER_M = 60.0
 RADIUS_SLACK_M = 60.0  # post-refinement slack on the center-distance gate
 THETA_DEDUPE_DEG = 3.0
@@ -134,7 +138,9 @@ class SnapCandidate:
         if self.region_containment is not None:
             score += W_CONTAIN * self.region_containment
         if self.prior_theta_residual_sigma is not None:
-            score += W_PRIOR * max(0.0, 1.0 - self.prior_theta_residual_sigma)
+            # Signed: within 1 sigma earns the bonus, a gross disagreement
+            # (e.g. a 180-flip against agreeing directed priors) costs it.
+            score += W_PRIOR * max(-1.0, 1.0 - self.prior_theta_residual_sigma)
         return score
 
 
@@ -719,12 +725,16 @@ def snap_page(
                 if snap.region_containment < CONTAINMENT_MIN:
                     snap.plausible = False
                     snap.gate_reasons.append("containment")
-            if ctx.rotation_priors:
-                # Both flips of a mod-180 prior are present as entries, so a
-                # plain directed comparison is correct for every source.
+            # Only DIRECTED priors can flag a 180-flip: the mod-180 rung emits
+            # both flips as entries, so including it would let the wrong flip
+            # always match one of the pair and pin the residual at zero.
+            directed = [
+                p for p in ctx.rotation_priors if p.source != "label-osm-mod180"
+            ]
+            if directed:
                 snap.prior_theta_residual_sigma = min(
                     abs(wrap_deg(candidate.theta_deg - p.theta_deg)) / p.sigma_deg
-                    for p in ctx.rotation_priors
+                    for p in directed
                 )
             if ctx.label_features and ctx.block_index:
                 snap.name = name_alignment(ctx.label_features, ctx.block_index, world)

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -43,11 +43,12 @@ from mapsnap.osm_snap import (
     PageContext,
     RotationPrior,
     SnapCandidate,
+    adjacency_keymap_rotations,
     affine_theta_deg,
     calibrated_radius_m,
+    evaluate_pose,
     frame_around,
     label_osm_rotations,
-    adjacency_keymap_rotations,
     osm_rasters,
     page_scale_priors,
     snap_page,
@@ -521,6 +522,21 @@ def build_page_context(
     if prob is None:
         return None, "no_prob"
     centers, regions = page_keymap_data(vctx, unit)
+    if unit.fit_state == "fitted" and unit.gen_affine is not None:
+        # For arbitration the incumbent pose itself is the natural search
+        # init — it also reaches fitted pages the keymap never placed.
+        lon_c = (
+            unit.gen_affine[0, 0] * unit.width / 2
+            + unit.gen_affine[0, 1] * unit.height / 2
+            + unit.gen_affine[0, 2]
+        )
+        lat_c = (
+            unit.gen_affine[1, 0] * unit.width / 2
+            + unit.gen_affine[1, 1] * unit.height / 2
+            + unit.gen_affine[1, 2]
+        )
+        if all(haversine_m(lat_c, lon_c, b, a) > 50.0 for a, b in centers):
+            centers = centers + [(lon_c, lat_c)]
     if not centers:
         return None, "no_keymap"
     labels = page_label_features(vctx, unit)
@@ -659,6 +675,18 @@ def page_record(
             for p in ctx.scale_priors
         ],
     }
+    if unit.fit_state == "fitted" and unit.gen_affine is not None:
+        # Arbitration head-to-head: score the incumbent RANSAC pose with the
+        # same evidence the challenger candidates carry.
+        incumbent = evaluate_pose(ctx, vctx.features, unit.gen_affine)
+        if incumbent is not None:
+            incumbent["world_affine"] = [
+                [float(v) for v in row] for row in unit.gen_affine
+            ]
+            incumbent["effective_gcps"] = unit.inlier_intersections
+            if unit.rmse_ft is not None:
+                incumbent["rmse_ft"] = round(unit.rmse_ft, 1)
+            record["incumbent"] = incumbent
     candidates = snap_page(ctx, vctx.features)
     if not candidates:
         record["status"] = "no_candidates"
@@ -753,11 +781,10 @@ def cmd_candidates(
         for u in vctx.units
         if (all_pages and u.fit_state != "split") or u.fit_state in RESCUE_STATES
     ]
-    targets += [
-        u
-        for u in vctx.panel_units
-        if (all_pages and u.fit_state == "fitted") or u.fit_state in RESCUE_STATES
-    ]
+    # Panels are rescue-only even under --all-pages: arbitration challenges
+    # base fitted pages, and fitted panels are the least reliable fits in the
+    # volume — not worth the compute to challenge.
+    targets += [u for u in vctx.panel_units if u.fit_state in RESCUE_STATES]
     if pages:
         wanted = set(pages)
         targets = [u for u in targets if u.stem in wanted]
@@ -817,7 +844,9 @@ def load_candidates(volume: Path) -> list[dict]:
 
 def cmd_report(volume: Path) -> None:
     """Recall / ranking diagnostics for the cached candidates, against truth."""
-    records = load_candidates(volume)
+    records = [
+        r for r in load_candidates(volume) if r.get("fit_state") in RESCUE_STATES
+    ]
     by_status: dict[str, int] = {}
     for record in records:
         by_status[record["status"]] = by_status.get(record["status"], 0) + 1
@@ -989,7 +1018,9 @@ def simulate_delta_net(
 
 def cmd_sweep(volume: Path) -> None:
     """Grid the abstention gates and print the simulated Δnet for each."""
-    records = load_candidates(volume)
+    records = [
+        r for r in load_candidates(volume) if r.get("fit_state") in RESCUE_STATES
+    ]
     weights, total_land = truth_land_weights(volume)
     print(f"== {volume.name}: simulated Δnet over gate grid ==")
     print(f"  {'gate':>6} " + "".join(f"m>={m:<4.1f}" + " " * 14 for m in GATE_MARGINS))
@@ -1008,9 +1039,114 @@ def cmd_sweep(volume: Path) -> None:
 
 GATE_SCORES = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
 GATE_MARGINS = [0.0, 0.1, 0.25, 0.5]
+ARBITRATE_GATES = [1.5, 1.75, 2.0, 2.25, 2.5, 2.75]
+
+
+def cmd_sweep_arbitrate(volume: Path) -> None:
+    """Grid the arbitration gate; print the simulated Δnet from challenges."""
+    records = load_candidates(volume)
+    weights, total_land = truth_land_weights(volume)
+
+    def bucket_value(rmse: float | None) -> int:
+        if rmse is None:
+            return 0
+        if rmse <= 25.0:
+            return 1
+        if rmse >= 200.0:
+            return -1
+        return 0
+
+    print(f"== {volume.name}: simulated arbitration Δnet ==")
+    for gate in ARBITRATE_GATES:
+        delta = 0.0
+        challenged = improved = worsened = unweighted = 0
+        details = []
+        for record in records:
+            if record.get("fit_state") != "fitted":
+                continue
+            challenge = arbitrate_challenge(record, gate)
+            if challenge is None:
+                continue
+            challenged += 1
+            old_rmse = (record.get("incumbent") or {}).get("rmse_ft")
+            new_rmse = record["candidates"][0].get("rmse_ft")
+            if new_rmse is not None and old_rmse is not None:
+                if new_rmse < old_rmse:
+                    improved += 1
+                elif new_rmse > old_rmse:
+                    worsened += 1
+                details.append(f"{record['target']}:{old_rmse:.0f}->{new_rmse:.0f}")
+            weight = weights.get(record["target"])
+            if weight is None or old_rmse is None or new_rmse is None:
+                unweighted += 1
+                continue
+            delta += weight * (bucket_value(new_rmse) - bucket_value(old_rmse))
+        net = delta / total_land if total_land else 0.0
+        print(
+            f"  gate {gate:>5.2f}: {net * 100:+5.1f}%  {challenged} challenged"
+            f" ({improved} better, {worsened} worse, {unweighted} unweighted)"
+        )
+        if details:
+            print("      " + "  ".join(details[:10]))
 
 
 VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
+
+# Arbitration: a snap candidate may replace a placed RANSAC fit only when it
+# is a confident, unambiguous lock that clearly disagrees with the incumbent
+# AND beats it on the shared evidence (geometry verification + name score).
+ARBITRATE_MIN_DISAGREE_FT = 100.0
+
+
+def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
+    """The challenge decision for one fitted page, or None to keep RANSAC.
+
+    Truth-free head-to-head: the challenger must clear the (high) arbitration
+    score gate with an unambiguous margin, disagree with the incumbent by more
+    than the mid-tier threshold, and win on BOTH shared-evidence axes — the
+    matcher's geometric verification and the street-name alignment. Ties keep
+    the incumbent: replacing a placed page is the risky direction.
+    """
+    incumbent = record.get("incumbent")
+    candidates = record.get("candidates") or []
+    if not incumbent or not candidates:
+        return None
+    top = candidates[0]
+    score = top.get("select_score")
+    if score is None or score < arbitrate_gate:
+        return None
+    margin = distinct_margin(record)
+    if margin is None or margin < 0.25:
+        return None
+    disagreement = grid_rmse_ft_between(
+        np.array(incumbent["world_affine"]),
+        np.array(top["world_affine"]),
+        record["width"],
+        record["height"],
+    )
+    if disagreement < ARBITRATE_MIN_DISAGREE_FT:
+        return None
+    incumbent_verification = incumbent.get("verification")
+    top_verification = top.get("verification")
+    if incumbent_verification is None or top_verification is None:
+        return None
+    if top_verification <= incumbent_verification:
+        return None
+    incumbent_name = (incumbent.get("name") or {}).get("score") or 0.0
+    top_name = (top.get("name") or {}).get("score") or 0.0
+    if top_name < incumbent_name:
+        return None
+    return {
+        "target": record["target"],
+        "chosen": 0,
+        "reason": "challenge",
+        "challenge": True,
+        "select_score": score,
+        "disagreement_ft": round(disagreement, 1),
+        "incumbent_verification": incumbent_verification,
+        "challenger_verification": top_verification,
+    }
+
 
 # Sheet-integrity gate for split panels: every panel is a rigid crop of one
 # sheet, so a panel placement determines the WHOLE sheet's placement exactly
@@ -1129,30 +1265,62 @@ def panel_allowed_candidates(
     return result
 
 
-def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -> None:
+def select_union(
+    volume: Path,
+    records: list[dict],
+    gate_score: float,
+    gate_margin: float,
+    allowed: dict[str, set[int] | None],
+) -> list[dict]:
+    """The two dev-calibrated committees, combined: the energy mode (at its
+    conservative gate) resolves joint/ambiguous pages, and the per-page argmax
+    gate is the floor for pages the energy abstains on."""
+    by_target = {
+        s["target"]: s
+        for s in select_volume(volume, records, VOLUME_MODE_GATE, allowed)
+    }
+    selections = []
+    for choice in select_argmax(records, gate_score, gate_margin, allowed):
+        volume_choice = by_target.get(choice["target"])
+        if volume_choice is not None and volume_choice.get("chosen") is not None:
+            selections.append(volume_choice)
+        else:
+            selections.append(choice)
+    return selections
+
+
+def cmd_select(
+    volume: Path,
+    mode: str,
+    gate_score: float,
+    gate_margin: float,
+    arbitrate_gate: float = 2.0,
+) -> None:
     """Pick one candidate (or abstain) per page; write selection_<mode>.jsonl."""
     records = load_candidates(volume)
-    allowed = panel_allowed_candidates(volume, records)
+    # Fitted pages' records (from `candidates --all-pages`) exist solely for
+    # arbitration; the rescue committees must never treat them as targets.
+    rescue = [r for r in records if r.get("fit_state") in RESCUE_STATES]
+    allowed = panel_allowed_candidates(volume, rescue)
     out_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
     if mode == "volume":
-        selections = select_volume(volume, records, gate_score, allowed)
+        selections = select_volume(volume, rescue, gate_score, allowed)
     elif mode == "union":
-        # The two dev-calibrated committees are complementary: the energy mode
-        # (at its conservative gate) resolves joint/ambiguous pages, and the
-        # per-page argmax gate is the floor for pages the energy abstains on.
-        by_target = {
-            s["target"]: s
-            for s in select_volume(volume, records, VOLUME_MODE_GATE, allowed)
-        }
-        selections = []
-        for choice in select_argmax(records, gate_score, gate_margin, allowed):
-            volume_choice = by_target.get(choice["target"])
-            if volume_choice is not None and volume_choice.get("chosen") is not None:
-                selections.append(volume_choice)
-            else:
-                selections.append(choice)
+        selections = select_union(volume, rescue, gate_score, gate_margin, allowed)
+    elif mode == "arbitrate":
+        # The union rescue selection, plus challenges to placed RANSAC fits.
+        selections = select_union(volume, rescue, gate_score, gate_margin, allowed)
+        challenged = 0
+        for record in records:
+            if record.get("fit_state") != "fitted":
+                continue
+            challenge = arbitrate_challenge(record, arbitrate_gate)
+            if challenge is not None:
+                selections.append(challenge)
+                challenged += 1
+        print(f"{challenged} challenges accepted")
     else:
-        selections = select_argmax(records, gate_score, gate_margin, allowed)
+        selections = select_argmax(rescue, gate_score, gate_margin, allowed)
     accepted = sum(1 for s in selections if s.get("chosen") is not None)
     with out_path.open("w") as handle:
         for choice in selections:
@@ -1706,6 +1874,7 @@ def cmd_materialize(volume: Path, mode: str) -> None:
             "osm_snap": {
                 "previous_state": record["fit_state"],
                 "mode": mode,
+                "challenge": bool(choice.get("challenge")),
                 "select_score": candidate.get("select_score"),
                 "margin": record.get("margin"),
                 "verification": candidate.get("verification"),
@@ -1746,19 +1915,27 @@ def main() -> None:
     p_rep.add_argument(
         "--sweep", action="store_true", help="grid the gates, print simulated Δnet"
     )
+    p_rep.add_argument(
+        "--sweep-arbitrate",
+        action="store_true",
+        help="grid the arbitration gate over fitted-page challenges",
+    )
 
     p_sel = sub.add_parser("select", help="pick candidates / abstain per page")
     p_sel.add_argument("volume", type=Path)
     p_sel.add_argument(
-        "--mode", choices=["argmax", "volume", "union"], default="argmax"
+        "--mode", choices=["argmax", "volume", "union", "arbitrate"], default="argmax"
     )
     p_sel.add_argument("--gate-score", type=float, default=1.0)
     p_sel.add_argument("--gate-margin", type=float, default=0.25)
+    p_sel.add_argument("--arbitrate-gate", type=float, default=2.0)
 
     p_mat = sub.add_parser("materialize", help="write pN.georef-osm.json sidecars")
     p_mat.add_argument("volume", type=Path)
     p_mat.add_argument(
-        "--mode", choices=["argmax", "volume", "union"], default="argmax"
+        "--mode",
+        choices=["argmax", "volume", "union", "arbitrate"],
+        default="argmax",
     )
 
     p_re = sub.add_parser("reannotate", help="refresh cached rmse annotations")
@@ -1775,12 +1952,20 @@ def main() -> None:
             vis=not args.no_vis,
         )
     elif args.command == "report":
-        if args.sweep:
+        if args.sweep_arbitrate:
+            cmd_sweep_arbitrate(args.volume)
+        elif args.sweep:
             cmd_sweep(args.volume)
         else:
             cmd_report(args.volume)
     elif args.command == "select":
-        cmd_select(args.volume, args.mode, args.gate_score, args.gate_margin)
+        cmd_select(
+            args.volume,
+            args.mode,
+            args.gate_score,
+            args.gate_margin,
+            args.arbitrate_gate,
+        )
     elif args.command == "materialize":
         cmd_materialize(args.volume, args.mode)
     elif args.command == "reannotate":

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -69,6 +69,7 @@ class VolumeContext:
 
     volume: Path
     units: list[PageUnit]
+    panel_units: list[PageUnit]
     features: list[dict]
     locator: KeymapLocator | None
     volume_m_per_px: float
@@ -224,6 +225,149 @@ def attach_missing_truth(volume: Path, units: list[PageUnit]) -> int:
     return annotated
 
 
+def panel_base(stem: str) -> str | None:
+    """The base page stem of a panel stem ('p474__1' -> 'p474'), or None."""
+    if "__" not in stem:
+        return None
+    return stem.rpartition("__")[0]
+
+
+def load_panel_units(volume: Path) -> list[PageUnit]:
+    """One PageUnit per split-panel jpg (pN__k.jpg), with truth attached.
+
+    A panel jpg is the base jpg cropped to its panel polygon's bounding box
+    (split.write_panels), so panel px -> base px is a pure translation by the
+    bbox origin. Truth comes from the truth split item whose OIM panel polygon
+    best overlaps ours in canvas coordinates — the same IoU rule compare_pages
+    uses, so OIM's split numbering need not match ours — translated into the
+    panel's own pixel frame.
+    """
+    from mapsnap.compare_iiif_georef import (
+        MIN_SPLIT_IOU,
+        annotation_transform_type,
+        extract_gcps,
+        fit_transform,
+        label_split_index,
+        load_split_polygons,
+        polygon_iou,
+        ring_to_polygon,
+    )
+    from mapsnap.edge_join_experiment import (
+        TruthFit,
+        page_fit_state,
+        scale_affine_to_local,
+    )
+    from mapsnap.keymap.fit_keymap import page_number
+    from mapsnap.road_model import page_world_affine
+    from mapsnap.utils import jpeg_dimensions, source_id_to_page_key
+
+    truth_path = volume / "main.iiif.json"
+    splits_by_parent: dict[str, list[dict]] = {}
+    if truth_path.exists():
+        for item in json.loads(truth_path.read_text()).get("items", []):
+            key = source_id_to_page_key(
+                item.get("target", {}).get("source", {}).get("id"),
+                item.get("label", ""),
+            )
+            if "__" in key:
+                splits_by_parent.setdefault(key.split("__")[0].lower(), []).append(item)
+
+    units: list[PageUnit] = []
+    for jpg in sorted(volume.glob("p*__*.jpg")):
+        stem = jpg.stem
+        base = panel_base(stem)
+        index_str = stem.rpartition("__")[2]
+        if base is None or not index_str.isdigit():
+            continue
+        number = page_number(base)
+        panels_path = volume / f"{base}.panels.json"
+        if number is None or not panels_path.exists():
+            continue
+        panels_doc = json.loads(panels_path.read_text())
+        rings = panels_doc.get("panels", [])
+        index = int(index_str)
+        if not (1 <= index <= len(rings)):
+            continue
+        ring = rings[index - 1]
+        width, height = jpeg_dimensions(jpg)
+        state, georef = page_fit_state(volume, stem)
+
+        truth: TruthFit | None = None
+        items = splits_by_parent.get(base.lower())
+        if items:
+            source = items[0]["target"]["source"]
+            canvas_scale = float(source["width"]) / panels_doc["width"]
+            our_polygon = ring_to_polygon(
+                [[x * canvas_scale, y * canvas_scale] for x, y in ring]
+            )
+            oim_path = next(
+                (
+                    p
+                    for p in (volume / "oim").glob("*.panels.json")
+                    if p.name.lower() == f"{base.lower()}.panels.json"
+                ),
+                None,
+            )
+            oim_polygons = load_split_polygons(oim_path) if oim_path else {}
+            best_iou, best_item = 0.0, None
+            for item in items:
+                item_index = label_split_index(item)
+                polygon = oim_polygons.get(item_index) if item_index else None
+                if polygon is None:
+                    continue
+                iou = polygon_iou(our_polygon, polygon)
+                if iou > best_iou:
+                    best_iou, best_item = iou, item
+            if best_item is not None and best_iou >= MIN_SPLIT_IOU:
+                gcps = extract_gcps(best_item)
+                if len(gcps) >= 2:
+                    base_local = scale_affine_to_local(
+                        fit_transform(gcps, annotation_transform_type(best_item)),
+                        best_item["target"]["source"]["width"],
+                        panels_doc["width"],
+                    )
+                    x0 = max(0, int(min(x for x, _ in ring)))
+                    y0 = max(0, int(min(y for _, y in ring)))
+                    panel_affine = base_local.copy()
+                    panel_affine[:, 2] = base_local @ np.array([x0, y0, 1.0])
+                    truth = TruthFit(
+                        affine_local=panel_affine,
+                        gcp_count=len(gcps),
+                        transform_type=annotation_transform_type(best_item),
+                    )
+
+        gen_affine = None
+        keymap_centers: list[tuple[float, float]] = []
+        keymap_radius = 0.0
+        keymap_regions = None
+        if georef is not None:
+            if state == "fitted":
+                gen_affine = page_world_affine(georef)
+            keymap = georef.get("keymap") or {}
+            keymap_centers = [tuple(c) for c in keymap.get("centers", [])]
+            keymap_radius = float(keymap.get("radius_m") or 0.0)
+            keymap_regions = keymap.get("regions") or None
+
+        units.append(
+            PageUnit(
+                stem=stem,
+                number=number,
+                width=width,
+                height=height,
+                fit_state=state,
+                truth=truth,
+                split_truth=False,
+                gen_affine=gen_affine,
+                inlier_intersections=0,
+                inlier_streets=0,
+                keymap_centers=keymap_centers,
+                keymap_radius_m=keymap_radius,
+                keymap_regions=keymap_regions,
+            )
+        )
+    return units
+
+
 def load_volume_context(volume: Path) -> VolumeContext:
     units = load_page_units(volume)
     attach_missing_truth(volume, units)
@@ -240,6 +384,7 @@ def load_volume_context(volume: Path) -> VolumeContext:
     return VolumeContext(
         volume=volume,
         units=units,
+        panel_units=load_panel_units(volume),
         features=features,
         locator=locator,
         volume_m_per_px=volume_median_scale(units),
@@ -317,11 +462,26 @@ def rotation_priors_for(
     if labels is not None and search_centers:
         features, block_index = labels
         priors.extend(label_osm_rotations(features, block_index, search_centers[0]))
+    base = panel_base(unit.stem)
+    if base is not None:
+        # A fitted sibling panel is the same physical sheet: its rotation is
+        # the most reliable directed prior a panel can get.
+        for sibling in vctx.panel_units:
+            if (
+                sibling.stem != unit.stem
+                and panel_base(sibling.stem) == base
+                and sibling.fit_state == "fitted"
+            ):
+                theta = unit_theta_deg(sibling)
+                if theta is not None:
+                    priors.append(RotationPrior(theta, 6.0, "ransac-neighbor"))
     own_centroid = vctx.region_centroids.get(unit.number)
     if own_centroid is None and search_centers:
         own_centroid = search_centers[0]
     if own_centroid is not None:
-        image_directions = image_neighbor_directions(vctx.adjacency, unit.stem)
+        # Printed neighbor claims live on the base sheet's margins; the crop
+        # preserves orientation, so the base stem's directions apply to a panel.
+        image_directions = image_neighbor_directions(vctx.adjacency, base or unit.stem)
         priors.extend(
             adjacency_keymap_rotations(
                 image_directions, vctx.region_centroids, own_centroid
@@ -363,7 +523,31 @@ def build_page_context(
         return None, "no_keymap"
     labels = page_label_features(vctx, unit)
     priors = rotation_priors_for(vctx, unit, centers, labels)
-    scales = page_scale_priors(vctx.volume_m_per_px, regions, unit.width, unit.height)
+    base = panel_base(unit.stem)
+    radius = vctx.radius_m
+    if base is not None:
+        # The keymap places the SHEET; a panel's center can sit up to half the
+        # base diagonal away from it, so widen the center-search accordingly.
+        # The region's area implies the sheet's scale (which the panel shares),
+        # so the family-rung test runs against the BASE dims, not the panel's.
+        base_unit = next((u for u in vctx.units if u.stem == base), None)
+        if base_unit is not None:
+            scales = page_scale_priors(
+                vctx.volume_m_per_px, regions, base_unit.width, base_unit.height
+            )
+            base_diag = (
+                math.hypot(base_unit.width, base_unit.height) * vctx.volume_m_per_px
+            )
+            panel_diag = math.hypot(unit.width, unit.height) * vctx.volume_m_per_px
+            radius = vctx.radius_m + max(0.0, (base_diag - panel_diag) / 2)
+        else:
+            scales = page_scale_priors(
+                vctx.volume_m_per_px, None, unit.width, unit.height
+            )
+    else:
+        scales = page_scale_priors(
+            vctx.volume_m_per_px, regions, unit.width, unit.height
+        )
     ctx = PageContext(
         stem=unit.stem,
         number=unit.number,
@@ -371,7 +555,7 @@ def build_page_context(
         height=unit.height,
         prob=prob,
         search_centers=centers,
-        radius_m=vctx.radius_m,
+        radius_m=radius,
         rotation_priors=priors,
         scale_priors=scales,
         keymap_regions=regions,
@@ -515,6 +699,33 @@ def write_contact_sheet(
         cv2.imwrite(str(out_dir / f"{unit.stem}_{rank + 1}{suffix}.png"), rgb)
 
 
+def ensure_probs(volume: Path, stems: list[str]) -> None:
+    """Run road-UNet inference for stems missing a cached P(road) map."""
+    missing = [
+        s
+        for s in stems
+        if load_prob(volume, s) is None and (volume / f"{s}.jpg").exists()
+    ]
+    if not missing:
+        return
+    import torch  # noqa: F401  (import check before loading model)
+
+    from mapsnap.keymap.number_model import select_device
+    from mapsnap.road_model import load_model, predict_page
+
+    out_dir = volume / "artifacts" / "edge_join" / "roadprob"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    device = select_device()
+    model = load_model(Path("models/road_unet.pt"), device)
+    for stem in missing:
+        gray = cv2.imread(str(volume / f"{stem}.jpg"), cv2.IMREAD_GRAYSCALE)
+        if gray is None:
+            continue
+        prob = predict_page(model, gray, device)
+        cv2.imwrite(str(out_dir / f"{stem}.png"), (prob * 255).round().astype(np.uint8))
+    print(f"  inferred {len(missing)} P(road) maps")
+
+
 def cmd_candidates(
     volume: Path,
     pages: list[str] | None,
@@ -540,11 +751,24 @@ def cmd_candidates(
         for u in vctx.units
         if (all_pages and u.fit_state != "split") or u.fit_state in RESCUE_STATES
     ]
+    targets += [
+        u
+        for u in vctx.panel_units
+        if (all_pages and u.fit_state == "fitted") or u.fit_state in RESCUE_STATES
+    ]
     if pages:
         wanted = set(pages)
         targets = [u for u in targets if u.stem in wanted]
     if limit is not None:
         targets = targets[:limit]
+    ensure_probs(
+        volume,
+        [
+            u.stem
+            for u in targets
+            if "__" in u.stem and (u.stem not in existing or recompute or pages)
+        ],
+    )
 
     print(
         f"{volume.name}: {len(targets)} target pages, radius "
@@ -882,7 +1106,7 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
 
     from mapsnap.score import LocalFrame
 
-    units = load_page_units(volume)
+    units = load_page_units(volume) + load_panel_units(volume)
     stem_to_number = {u.stem: u.number for u in units}
     region_pairs, centroids = keymap_region_adjacency(volume)
     pairs = detected_pairs(volume) | region_pairs
@@ -933,15 +1157,17 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
         and u.gen_affine is not None
         and not (u.stem.endswith("s") and u.stem[:-1] in fitted_stems)
     ]
-    fitted_by_number: dict[int, Polygon] = {}
+    fitted_polys: dict[str, Polygon] = {}
+    number_to_fitted: dict[int, list[str]] = {}
     for unit in fitted_units:
         assert unit.gen_affine is not None
-        fitted_by_number[unit.number] = polygon_of(
+        fitted_polys[unit.stem] = polygon_of(
             [[float(v) for v in row] for row in unit.gen_affine],
             unit.width,
             unit.height,
         )
-    fitted_polygons = list(fitted_by_number.values())
+        number_to_fitted.setdefault(unit.number, []).append(unit.stem)
+    fitted_polygons = list(fitted_polys.values())
 
     def iou_over_min(a: Polygon, b: Polygon) -> float:
         smaller = min(a.area, b.area)
@@ -954,9 +1180,10 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
     # at 0.32-0.43 IoU-over-min against their fitted neighbors), so a fixed
     # threshold either misses slides or punishes correct seams.
     observed = [
-        iou_over_min(fitted_by_number[a], fitted_by_number[b])
+        iou_over_min(fitted_polys[sa], fitted_polys[sb])
         for a, b in (tuple(pair) for pair in pairs)
-        if a in fitted_by_number and b in fitted_by_number
+        for sa in number_to_fitted.get(a, [])
+        for sb in number_to_fitted.get(b, [])
     ]
     if len(observed) >= 5:
         p90 = float(np.percentile(observed, 90))
@@ -983,17 +1210,38 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
         centroid = centroids.get(number)
         return frame.to_xy(*centroid) if centroid else None
 
+    def coupled(stem_a: str, stem_b: str) -> str | None:
+        """'sibling' | 'adjacent' | None: whether two stems interact at all."""
+        base_a, base_b = panel_base(stem_a), panel_base(stem_b)
+        if base_a is not None and base_a == base_b:
+            return "sibling"
+        na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
+        if na is not None and nb is not None and frozenset((na, nb)) in pairs:
+            return "adjacent"
+        return None
+
     def pairwise(stem_a: str, ka: int | None, stem_b: str, kb: int | None) -> float:
         if ka is None or kb is None:
             return 0.0
-        na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
-        if na is None or nb is None or frozenset((na, nb)) not in pairs:
+        coupling = coupled(stem_a, stem_b)
+        if coupling is None:
             return 0.0
         energy = W_OVERLAP * overlap_penalty(
             iou_over_min(polygons[(stem_a, ka)], polygons[(stem_b, kb)]),
             overlap_soft,
             overlap_hard,
         )
+        # The centroid geometry terms describe SHEET centers; a panel's center
+        # legitimately sits away from its sheet's keymap centroid, so any pair
+        # involving a panel keeps only the overlap term (siblings of one sheet
+        # must simply not land on top of each other).
+        if (
+            coupling == "sibling"
+            or panel_base(stem_a) is not None
+            or panel_base(stem_b) is not None
+        ):
+            return energy
+        na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
         ca, cb = centroid_xy(na), centroid_xy(nb)
         if ca and cb:
             xa, ya = centers_xy[(stem_a, ka)]
@@ -1011,15 +1259,14 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
                 energy -= W_SIDE * max(0.0, cosine)
         return energy
 
-    # Connected components over the adjacency among eligible pages.
+    # Connected components over the coupling graph among eligible pages.
     stems = sorted(eligible)
     neighbors: dict[str, set[str]] = {s: set() for s in stems}
     for sa in stems:
         for sb in stems:
             if sa >= sb:
                 continue
-            na, nb = stem_to_number.get(sa), stem_to_number.get(sb)
-            if na is not None and nb is not None and frozenset((na, nb)) in pairs:
+            if coupled(sa, sb) is not None:
                 neighbors[sa].add(sb)
                 neighbors[sb].add(sa)
     components: list[list[str]] = []
@@ -1140,8 +1387,9 @@ def cmd_reannotate(volume: Path) -> None:
     unit's truth affine, including pages that attach_missing_truth
     now covers (case-mismatched keys and split-only truth). Rewrites candidates.jsonl in place.
     """
-    units = {u.stem: u for u in load_page_units(volume)}
-    newly = attach_missing_truth(volume, list(units.values()))
+    unit_list = load_page_units(volume) + load_panel_units(volume)
+    units = {u.stem: u for u in unit_list}
+    newly = attach_missing_truth(volume, unit_list)
     records = load_candidates(volume)
     changed = 0
     for record in records:
@@ -1209,6 +1457,18 @@ def cmd_materialize(volume: Path, mode: str) -> None:
                 ]
             )
         _, georef = page_fit_state(volume, choice["target"])
+        if not georef or not georef.get("keymap"):
+            # A panel with no own sidecar borrows the keymap block from any
+            # sibling variant of the same sheet (the sheet is what the keymap
+            # places). The stale-osm cleanup above already ran, so a sibling's
+            # georef-osm sidecar can only be one written earlier this loop.
+            base = panel_base(choice["target"])
+            if base is not None:
+                for sibling in sorted(volume.glob(f"{base}__*.georef*.json")):
+                    sibling_doc = json.loads(sibling.read_text())
+                    if sibling_doc.get("keymap"):
+                        georef = sibling_doc
+                        break
         doc: dict = {
             "width": width,
             "height": height,

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -608,6 +608,41 @@ def truth_land_weights(volume: Path) -> tuple[dict[str, float], float]:
     return weights, total
 
 
+DISTINCT_SEPARATION_M = 100.0
+DISTINCT_THETA_DEG = 10.0
+
+
+def distinct_margin(record: dict) -> float | None:
+    """Rank-1's select_score lead over the best *distinct* alternative lock.
+
+    Near-identical twins (the same lock found from two search centers, within
+    100 m and 10 degrees) are not ambiguity — a margin computed against them
+    wrongly abstains on confident pages. If no distinct alternative exists the
+    margin is infinite. None when the top candidate is implausible.
+    """
+    candidates = record.get("candidates") or []
+    if not candidates or candidates[0].get("select_score") is None:
+        return None
+    top = candidates[0]
+    for candidate in candidates[1:]:
+        if candidate.get("select_score") is None:
+            continue
+        separation = haversine_m(
+            top["center"][1],
+            top["center"][0],
+            candidate["center"][1],
+            candidate["center"][0],
+        )
+        theta_gap = abs(
+            (candidate["theta_deg"] - top["theta_deg"] + 180.0) % 360.0 - 180.0
+        )
+        if separation > DISTINCT_SEPARATION_M or theta_gap > DISTINCT_THETA_DEG:
+            # Candidates are sorted by select_score, so the first distinct
+            # alternative is the strongest one.
+            return top["select_score"] - candidate["select_score"]
+    return math.inf
+
+
 def simulate_delta_net(
     records: list[dict],
     weights: dict[str, float],
@@ -623,7 +658,7 @@ def simulate_delta_net(
             continue
         top = record["candidates"][0]
         score = top.get("select_score")
-        margin = record.get("margin")
+        margin = distinct_margin(record)
         if score is None or score < gate_score:
             continue
         if margin is None or margin < gate_margin:
@@ -669,15 +704,29 @@ def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -
     """Pick one candidate (or abstain) per page; write selection_<mode>.jsonl."""
     records = load_candidates(volume)
     out_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
+    if mode == "volume":
+        selections = select_volume(volume, records, gate_score)
+    else:
+        selections = select_argmax(records, gate_score, gate_margin)
+    accepted = sum(1 for s in selections if s.get("chosen") is not None)
+    with out_path.open("w") as handle:
+        for choice in selections:
+            handle.write(json.dumps(choice) + "\n")
+    print(f"{accepted}/{len(selections)} pages accepted -> {out_path}")
+
+
+def select_argmax(
+    records: list[dict], gate_score: float, gate_margin: float
+) -> list[dict]:
+    """v0: per-page rank-1 with abstention gates."""
     selections = []
-    accepted = 0
     for record in records:
         stem = record["target"]
         choice: dict = {"target": stem, "chosen": None, "reason": record["status"]}
         if record.get("status") == "ok" and record.get("candidates"):
             top = record["candidates"][0]
             score = top.get("select_score")
-            margin = record.get("margin")
+            margin = distinct_margin(record)
             if score is None:
                 choice["reason"] = "implausible"
             elif score < gate_score:
@@ -690,14 +739,297 @@ def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -
                     "chosen": 0,
                     "reason": "accepted",
                     "select_score": score,
-                    "margin": margin,
+                    "margin": None if math.isinf(margin) else round(margin, 4),
                 }
-                accepted += 1
         selections.append(choice)
-    with out_path.open("w") as handle:
-        for choice in selections:
-            handle.write(json.dumps(choice) + "\n")
-    print(f"{accepted}/{len(selections)} pages accepted -> {out_path}")
+    return selections
+
+
+# --- v1: volume-wide discrete selection ------------------------------------
+
+W_OVERLAP = 3.0
+W_ADJACENT = 0.5
+W_SIDE = 0.3
+OVERLAP_SOFT = 0.15  # IoU-over-min where the penalty starts
+OVERLAP_HARD = 0.5  # and where it becomes prohibitive
+ADJACENT_SIGMA_M = 150.0  # schematic keymap-centroid geometry
+EXHAUSTIVE_LIMIT = 20_000
+
+
+def overlap_penalty(iou_over_min: float, soft: float, hard: float) -> float:
+    """0 below soft, quadratic to hard, prohibitive above."""
+    if iou_over_min <= soft:
+        return 0.0
+    if iou_over_min >= hard:
+        return 1e6
+    frac = (iou_over_min - soft) / (hard - soft)
+    return frac * frac
+
+
+def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[dict]:
+    """v1: joint selection over per-page candidate sets.
+
+    Energy = per-page unary (a pick must beat abstention by its select_score
+    over the gate) + pairwise terms on keymap/printed adjacency edges:
+    footprint-overlap penalty (including against FITTED pages — this is what
+    kills a one-block slide, which collides with a placed neighbor where the
+    truth does not), keymap-centroid distance consistency, and a side-agreement
+    reward. Connected components solve exhaustively when small, else ICM from
+    several greedy orderings.
+    """
+    from shapely.geometry import Polygon
+
+    from mapsnap.score import LocalFrame
+
+    units = load_page_units(volume)
+    stem_to_number = {u.stem: u.number for u in units}
+    region_pairs, centroids = keymap_region_adjacency(volume)
+    pairs = detected_pairs(volume) | region_pairs
+
+    eligible: dict[str, dict] = {}
+    for record in records:
+        if record.get("status") != "ok" or not record.get("candidates"):
+            continue
+        options = [
+            (k, c)
+            for k, c in enumerate(record["candidates"])
+            if c.get("select_score") is not None
+        ]
+        if options:
+            eligible[record["target"]] = {"record": record, "options": options}
+    if not eligible:
+        return select_argmax(records, gate_score, gate_margin=0.0)
+
+    first = next(iter(eligible.values()))["options"][0][1]
+    frame = LocalFrame(first["center"][0], first["center"][1])
+
+    def polygon_of(affine: list[list[float]], width: int, height: int) -> Polygon:
+        ring = []
+        for x, y in [(0, 0), (width, 0), (width, height), (0, height)]:
+            lon = affine[0][0] * x + affine[0][1] * y + affine[0][2]
+            lat = affine[1][0] * x + affine[1][1] * y + affine[1][2]
+            ring.append(frame.to_xy(lon, lat))
+        return Polygon(ring).buffer(0)
+
+    polygons: dict[tuple[str, int], Polygon] = {}
+    centers_xy: dict[tuple[str, int], tuple[float, float]] = {}
+    for stem, entry in eligible.items():
+        record = entry["record"]
+        for k, candidate in entry["options"]:
+            polygons[(stem, k)] = polygon_of(
+                candidate["world_affine"], record["width"], record["height"]
+            )
+            centers_xy[(stem, k)] = frame.to_xy(*candidate["center"])
+
+    # Fitted context, with skeleton twins deduped: a fitted pNs maps the same
+    # ground as fitted pN, and its ~100% overlap would poison both the
+    # calibration below and every candidate that legitimately touches pN.
+    fitted_stems = {u.stem for u in units if u.fit_state == "fitted"}
+    fitted_units = [
+        u
+        for u in units
+        if u.fit_state == "fitted"
+        and u.gen_affine is not None
+        and not (u.stem.endswith("s") and u.stem[:-1] in fitted_stems)
+    ]
+    fitted_by_number: dict[int, Polygon] = {}
+    for unit in fitted_units:
+        assert unit.gen_affine is not None
+        fitted_by_number[unit.number] = polygon_of(
+            [[float(v) for v in row] for row in unit.gen_affine],
+            unit.width,
+            unit.height,
+        )
+    fitted_polygons = list(fitted_by_number.values())
+
+    def iou_over_min(a: Polygon, b: Polygon) -> float:
+        smaller = min(a.area, b.area)
+        if smaller <= 0:
+            return 0.0
+        return a.intersection(b).area / smaller
+
+    # Calibrate the overlap thresholds from the volume's own adjacent fitted
+    # pairs: Sanborn sheets legitimately share strips (Hudson true locks sit
+    # at 0.32-0.43 IoU-over-min against their fitted neighbors), so a fixed
+    # threshold either misses slides or punishes correct seams.
+    observed = [
+        iou_over_min(fitted_by_number[a], fitted_by_number[b])
+        for a, b in (tuple(pair) for pair in pairs)
+        if a in fitted_by_number and b in fitted_by_number
+    ]
+    if len(observed) >= 5:
+        p90 = float(np.percentile(observed, 90))
+        overlap_soft = min(0.5, max(OVERLAP_SOFT, p90 + 0.05))
+    else:
+        overlap_soft = OVERLAP_SOFT
+    overlap_hard = min(0.85, overlap_soft + 0.3)
+
+    def unary(stem: str, k: int | None) -> float:
+        if k is None:
+            return 0.0
+        candidate = dict(eligible[stem]["options"])[k]
+        energy = -(candidate["select_score"] - gate_score)
+        polygon = polygons[(stem, k)]
+        for fitted in fitted_polygons:
+            energy += W_OVERLAP * overlap_penalty(
+                iou_over_min(polygon, fitted), overlap_soft, overlap_hard
+            )
+        return energy
+
+    def centroid_xy(number: int | None) -> tuple[float, float] | None:
+        if number is None:
+            return None
+        centroid = centroids.get(number)
+        return frame.to_xy(*centroid) if centroid else None
+
+    def pairwise(stem_a: str, ka: int | None, stem_b: str, kb: int | None) -> float:
+        if ka is None or kb is None:
+            return 0.0
+        na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
+        if na is None or nb is None or frozenset((na, nb)) not in pairs:
+            return 0.0
+        energy = W_OVERLAP * overlap_penalty(
+            iou_over_min(polygons[(stem_a, ka)], polygons[(stem_b, kb)]),
+            overlap_soft,
+            overlap_hard,
+        )
+        ca, cb = centroid_xy(na), centroid_xy(nb)
+        if ca and cb:
+            xa, ya = centers_xy[(stem_a, ka)]
+            xb, yb = centers_xy[(stem_b, kb)]
+            realized = (xb - xa, yb - ya)
+            expected = (cb[0] - ca[0], cb[1] - ca[1])
+            gap = math.hypot(realized[0] - expected[0], realized[1] - expected[1])
+            energy += W_ADJACENT * min(3.0, (gap / ADJACENT_SIGMA_M) ** 2)
+            norm_r = math.hypot(*realized)
+            norm_e = math.hypot(*expected)
+            if norm_r > 1e-6 and norm_e > 1e-6:
+                cosine = (realized[0] * expected[0] + realized[1] * expected[1]) / (
+                    norm_r * norm_e
+                )
+                energy -= W_SIDE * max(0.0, cosine)
+        return energy
+
+    # Connected components over the adjacency among eligible pages.
+    stems = sorted(eligible)
+    neighbors: dict[str, set[str]] = {s: set() for s in stems}
+    for sa in stems:
+        for sb in stems:
+            if sa >= sb:
+                continue
+            na, nb = stem_to_number.get(sa), stem_to_number.get(sb)
+            if na is not None and nb is not None and frozenset((na, nb)) in pairs:
+                neighbors[sa].add(sb)
+                neighbors[sb].add(sa)
+    components: list[list[str]] = []
+    seen: set[str] = set()
+    for stem in stems:
+        if stem in seen:
+            continue
+        component = []
+        queue = [stem]
+        seen.add(stem)
+        while queue:
+            current = queue.pop()
+            component.append(current)
+            for other in neighbors[current]:
+                if other not in seen:
+                    seen.add(other)
+                    queue.append(other)
+        components.append(sorted(component))
+
+    def stem_options(stem: str) -> list[int | None]:
+        choices: list[int | None] = [None]
+        choices.extend(k for k, _ in eligible[stem]["options"])
+        return choices
+
+    assignment: dict[str, int | None] = {}
+    for component in components:
+        choices_per_stem = [stem_options(stem) for stem in component]
+        size = 1
+        for choices in choices_per_stem:
+            size *= len(choices)
+
+        def total_energy(assign: dict[str, int | None]) -> float:
+            energy = sum(unary(s, assign[s]) for s in component)
+            for i, sa in enumerate(component):
+                for sb in component[i + 1 :]:
+                    energy += pairwise(sa, assign[sa], sb, assign[sb])
+            return energy
+
+        if size <= EXHAUSTIVE_LIMIT:
+            import itertools
+
+            best_assign_c: dict[str, int | None] | None = None
+            best_energy = math.inf
+            for combo in itertools.product(*choices_per_stem):
+                assign: dict[str, int | None] = dict(zip(component, combo))
+                energy = total_energy(assign)
+                if energy < best_energy:
+                    best_energy = energy
+                    best_assign_c = assign
+            assert best_assign_c is not None
+            assignment.update(best_assign_c)
+        else:
+            # ICM from a few deterministic starts: best-unary and abstain-all.
+            best_assign = None
+            best_energy = math.inf
+            starts: list[dict[str, int | None]] = [
+                {s: eligible[s]["options"][0][0] for s in component},
+                {s: None for s in component},
+            ]
+            for start in starts:
+                assign = dict(start)
+                for _ in range(20):
+                    changed = False
+                    for stem in component:
+                        stem_choices = stem_options(stem)
+                        best_k = assign[stem]
+                        best_local = math.inf
+                        for k in stem_choices:
+                            trial = dict(assign)
+                            trial[stem] = k
+                            energy = total_energy(trial)
+                            if energy < best_local:
+                                best_local = energy
+                                best_k = k
+                        if best_k != assign[stem]:
+                            assign[stem] = best_k
+                            changed = True
+                    if not changed:
+                        break
+                energy = total_energy(assign)
+                if energy < best_energy:
+                    best_energy = energy
+                    best_assign = assign
+            assert best_assign is not None
+            assignment.update(best_assign)
+
+    selections = []
+    for record in records:
+        stem = record["target"]
+        if stem not in eligible:
+            selections.append(
+                {"target": stem, "chosen": None, "reason": record["status"]}
+            )
+            continue
+        chosen = assignment.get(stem)
+        if chosen is None:
+            selections.append(
+                {"target": stem, "chosen": None, "reason": "energy-abstain"}
+            )
+        else:
+            candidate = dict(eligible[stem]["options"])[chosen]
+            selections.append(
+                {
+                    "target": stem,
+                    "chosen": chosen,
+                    "reason": "energy",
+                    "select_score": candidate["select_score"],
+                    "rank": chosen,
+                }
+            )
+    return selections
 
 
 def osm_variant_path(volume: Path, stem: str) -> Path:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -258,7 +258,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
         scale_affine_to_local,
     )
     from mapsnap.keymap.fit_keymap import page_number
-    from mapsnap.road_model import page_world_affine
+    from mapsnap.road_model import effective_gcp_count, page_world_affine
     from mapsnap.utils import jpeg_dimensions, source_id_to_page_key
 
     truth_path = volume / "main.iiif.json"
@@ -337,12 +337,14 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                     )
 
         gen_affine = None
+        effective_gcps = 0
         keymap_centers: list[tuple[float, float]] = []
         keymap_radius = 0.0
         keymap_regions = None
         if georef is not None:
             if state == "fitted":
                 gen_affine = page_world_affine(georef)
+                effective_gcps = effective_gcp_count(georef)
             keymap = georef.get("keymap") or {}
             keymap_centers = [tuple(c) for c in keymap.get("centers", [])]
             keymap_radius = float(keymap.get("radius_m") or 0.0)
@@ -358,7 +360,7 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
                 truth=truth,
                 split_truth=False,
                 gen_affine=gen_affine,
-                inlier_intersections=0,
+                inlier_intersections=effective_gcps,
                 inlier_streets=0,
                 keymap_centers=keymap_centers,
                 keymap_radius_m=keymap_radius,
@@ -1010,29 +1012,147 @@ GATE_MARGINS = [0.0, 0.1, 0.25, 0.5]
 
 VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
 
+# Sheet-integrity gate for split panels: every panel is a rigid crop of one
+# sheet, so a panel placement determines the WHOLE sheet's placement exactly
+# (the crop is a pure translation). Two placements of the same sheet — from a
+# candidate and a fitted sibling, or from two co-accepted candidates — must
+# agree to within this corner tolerance. Correct fits agree to ~10-30 m;
+# LA p1408__2's along-the-cut-line alias disagreed by 258 m while still
+# touching its sibling, which is why mere contiguity was not enough.
+SHEET_AGREE_TOL_M = 60.0
+# A fitted sibling anchors the sheet-agreement gate only when its own fit has
+# real evidence: eff>=3 panels measure <=57ft everywhere truth exists, while
+# eff<=2 panels range to 6640ft — agreeing with those rejects true candidates.
+SIBLING_ANCHOR_MIN_GCPS = 3
+# A panel with no reliable anchor and no co-accepted sibling may still be
+# accepted on its own score, at a much higher bar than base pages: small
+# pages alias more readily, and this is where their confident failures live.
+PANEL_SOLO_GATE = 2.2
+
+
+def panel_ring_origin(ring: list[list[float]]) -> tuple[int, int]:
+    """The bbox origin write_panels cropped this panel at (base-jpg px)."""
+    return (
+        max(0, int(min(x for x, _ in ring))),
+        max(0, int(min(y for _, y in ring))),
+    )
+
+
+def implied_sheet_corners(
+    affine: np.ndarray,
+    origin: tuple[int, int],
+    sheet_size: tuple[float, float],
+) -> list[tuple[float, float]]:
+    """The full sheet's corner lon/lats implied by one panel's affine."""
+    x0, y0 = origin
+    sheet = affine.copy()
+    sheet[:, 2] = affine @ np.array([-x0, -y0, 1.0])
+    width, height = sheet_size
+    corners = []
+    for x, y in [(0, 0), (width, 0), (width, height), (0, height)]:
+        corners.append(
+            (
+                sheet[0, 0] * x + sheet[0, 1] * y + sheet[0, 2],
+                sheet[1, 0] * x + sheet[1, 1] * y + sheet[1, 2],
+            )
+        )
+    return corners
+
+
+def sheets_agree(a: list[tuple[float, float]], b: list[tuple[float, float]]) -> bool:
+    """Whether two implied-sheet placements agree within SHEET_AGREE_TOL_M."""
+    worst = max(haversine_m(pa[1], pa[0], pb[1], pb[0]) for pa, pb in zip(a, b))
+    return worst <= SHEET_AGREE_TOL_M
+
+
+def panel_allowed_candidates(
+    volume: Path, records: list[dict]
+) -> dict[str, set[int] | None]:
+    """Per panel stem: candidate indices whose implied sheet placement agrees
+    with every fitted sibling's. None = no fitted sibling to check against
+    (the volume-energy mutual-agreement terms are then the only constraint).
+    """
+    panel_units = load_panel_units(volume)
+    by_base: dict[str, list[PageUnit]] = {}
+    for unit in panel_units:
+        base = panel_base(unit.stem)
+        if base is not None:
+            by_base.setdefault(base, []).append(unit)
+
+    result: dict[str, set[int] | None] = {}
+    panels_cache: dict[str, dict] = {}
+
+    def doc_of(base: str) -> dict:
+        if base not in panels_cache:
+            panels_cache[base] = json.loads(
+                (volume / f"{base}.panels.json").read_text()
+            )
+        return panels_cache[base]
+
+    for record in records:
+        stem = record["target"]
+        base = panel_base(stem)
+        if base is None or record.get("status") != "ok":
+            continue
+        siblings = [
+            u
+            for u in by_base.get(base, [])
+            if u.stem != stem
+            and u.fit_state == "fitted"
+            and u.gen_affine is not None
+            and u.inlier_intersections >= SIBLING_ANCHOR_MIN_GCPS
+        ]
+        if not siblings:
+            result[stem] = None
+            continue
+        panels_doc = doc_of(base)
+        rings = panels_doc["panels"]
+        sheet_size = (panels_doc["width"], panels_doc["height"])
+        origin = panel_ring_origin(rings[int(stem.rpartition("__")[2]) - 1])
+        sibling_sheets = []
+        for sibling in siblings:
+            assert sibling.gen_affine is not None
+            sibling_origin = panel_ring_origin(
+                rings[int(sibling.stem.rpartition("__")[2]) - 1]
+            )
+            sibling_sheets.append(
+                implied_sheet_corners(sibling.gen_affine, sibling_origin, sheet_size)
+            )
+        allowed: set[int] = set()
+        for k, candidate in enumerate(record.get("candidates") or []):
+            candidate_sheet = implied_sheet_corners(
+                np.array(candidate["world_affine"]), origin, sheet_size
+            )
+            if all(sheets_agree(candidate_sheet, s) for s in sibling_sheets):
+                allowed.add(k)
+        result[stem] = allowed
+    return result
+
 
 def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -> None:
     """Pick one candidate (or abstain) per page; write selection_<mode>.jsonl."""
     records = load_candidates(volume)
+    allowed = panel_allowed_candidates(volume, records)
     out_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
     if mode == "volume":
-        selections = select_volume(volume, records, gate_score)
+        selections = select_volume(volume, records, gate_score, allowed)
     elif mode == "union":
         # The two dev-calibrated committees are complementary: the energy mode
         # (at its conservative gate) resolves joint/ambiguous pages, and the
         # per-page argmax gate is the floor for pages the energy abstains on.
         by_target = {
-            s["target"]: s for s in select_volume(volume, records, VOLUME_MODE_GATE)
+            s["target"]: s
+            for s in select_volume(volume, records, VOLUME_MODE_GATE, allowed)
         }
         selections = []
-        for choice in select_argmax(records, gate_score, gate_margin):
+        for choice in select_argmax(records, gate_score, gate_margin, allowed):
             volume_choice = by_target.get(choice["target"])
             if volume_choice is not None and volume_choice.get("chosen") is not None:
                 selections.append(volume_choice)
             else:
                 selections.append(choice)
     else:
-        selections = select_argmax(records, gate_score, gate_margin)
+        selections = select_argmax(records, gate_score, gate_margin, allowed)
     accepted = sum(1 for s in selections if s.get("chosen") is not None)
     with out_path.open("w") as handle:
         for choice in selections:
@@ -1041,14 +1161,37 @@ def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -
 
 
 def select_argmax(
-    records: list[dict], gate_score: float, gate_margin: float
+    records: list[dict],
+    gate_score: float,
+    gate_margin: float,
+    panel_allowed: dict[str, set[int] | None] | None = None,
 ) -> list[dict]:
-    """v0: per-page rank-1 with abstention gates."""
+    """v0: per-page rank-1 with abstention gates.
+
+    Panels face the sheet-integrity gate on top of the usual ones: rank-1 must
+    agree with any reliable fitted sibling's implied sheet; a panel with no
+    reliable anchor is held to the much higher PANEL_SOLO_GATE instead.
+    """
+    panel_allowed = panel_allowed or {}
     selections = []
     for record in records:
         stem = record["target"]
         choice: dict = {"target": stem, "chosen": None, "reason": record["status"]}
         if record.get("status") == "ok" and record.get("candidates"):
+            if panel_base(stem) is not None:
+                allowed = panel_allowed.get(stem)
+                if allowed is not None and 0 not in allowed:
+                    choice["reason"] = "sheet-agreement"
+                    selections.append(choice)
+                    continue
+                if allowed is None:
+                    top_score = record["candidates"][0].get("select_score")
+                    if top_score is None or top_score < PANEL_SOLO_GATE:
+                        choice["reason"] = (
+                            f"panel-solo score {top_score} < {PANEL_SOLO_GATE}"
+                        )
+                        selections.append(choice)
+                        continue
             top = record["candidates"][0]
             score = top.get("select_score")
             margin = distinct_margin(record)
@@ -1091,7 +1234,12 @@ def overlap_penalty(iou_over_min: float, soft: float, hard: float) -> float:
     return frac * frac
 
 
-def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[dict]:
+def select_volume(
+    volume: Path,
+    records: list[dict],
+    gate_score: float,
+    panel_allowed: dict[str, set[int] | None] | None = None,
+) -> list[dict]:
     """v1: joint selection over per-page candidate sets.
 
     Energy = per-page unary (a pick must beat abstention by its select_score
@@ -1101,11 +1249,17 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
     truth does not), keymap-centroid distance consistency, and a side-agreement
     reward. Connected components solve exhaustively when small, else ICM from
     several greedy orderings.
+
+    Panels additionally face sheet-integrity constraints: options inconsistent
+    with a fitted sibling are dropped up front, page-space-adjacent sibling
+    picks must land next to each other, and an accepted panel with no fitted
+    sibling must have a co-accepted contiguous sibling backing it up.
     """
     from shapely.geometry import Polygon
 
     from mapsnap.score import LocalFrame
 
+    panel_allowed = panel_allowed or {}
     units = load_page_units(volume) + load_panel_units(volume)
     stem_to_number = {u.stem: u.number for u in units}
     region_pairs, centroids = keymap_region_adjacency(volume)
@@ -1120,10 +1274,36 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
             for k, c in enumerate(record["candidates"])
             if c.get("select_score") is not None
         ]
+        allowed = panel_allowed.get(record["target"])
+        if allowed is not None:
+            options = [(k, c) for k, c in options if k in allowed]
         if options:
             eligible[record["target"]] = {"record": record, "options": options}
     if not eligible:
         return select_argmax(records, gate_score, gate_margin=0.0)
+
+    # Implied-sheet corners per eligible panel candidate, for the mutual
+    # sheet-agreement constraint between co-accepted siblings.
+    panels_cache: dict[str, dict] = {}
+
+    def sheet_corners_of(stem: str, candidate: dict) -> list[tuple[float, float]]:
+        base = panel_base(stem)
+        assert base is not None
+        if base not in panels_cache:
+            panels_cache[base] = json.loads(
+                (volume / f"{base}.panels.json").read_text()
+            )
+        doc = panels_cache[base]
+        origin = panel_ring_origin(doc["panels"][int(stem.rpartition("__")[2]) - 1])
+        return implied_sheet_corners(
+            np.array(candidate["world_affine"]), origin, (doc["width"], doc["height"])
+        )
+
+    sheet_corners: dict[tuple[str, int], list[tuple[float, float]]] = {}
+    for stem, entry in eligible.items():
+        if panel_base(stem) is not None:
+            for k, candidate in entry["options"]:
+                sheet_corners[(stem, k)] = sheet_corners_of(stem, candidate)
 
     first = next(iter(eligible.values()))["options"][0][1]
     frame = LocalFrame(first["center"][0], first["center"][1])
@@ -1149,12 +1329,17 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
     # Fitted context, with skeleton twins deduped: a fitted pNs maps the same
     # ground as fitted pN, and its ~100% overlap would poison both the
     # calibration below and every candidate that legitimately touches pN.
+    # Fitted PANELS are excluded outright — their own placements are the least
+    # reliable in the volume (LA's fitted p1499n__3 sits 392ft off and lies on
+    # p1484's true ground), so they cannot serve as overlap evidence; panel
+    # consistency is enforced by the sheet-agreement machinery instead.
     fitted_stems = {u.stem for u in units if u.fit_state == "fitted"}
     fitted_units = [
         u
         for u in units
         if u.fit_state == "fitted"
         and u.gen_affine is not None
+        and panel_base(u.stem) is None
         and not (u.stem.endswith("s") and u.stem[:-1] in fitted_stems)
     ]
     fitted_polys: dict[str, Polygon] = {}
@@ -1176,15 +1361,23 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
         return a.intersection(b).area / smaller
 
     # Calibrate the overlap thresholds from the volume's own adjacent fitted
-    # pairs: Sanborn sheets legitimately share strips (Hudson true locks sit
-    # at 0.32-0.43 IoU-over-min against their fitted neighbors), so a fixed
-    # threshold either misses slides or punishes correct seams.
-    observed = [
-        iou_over_min(fitted_polys[sa], fitted_polys[sb])
-        for a, b in (tuple(pair) for pair in pairs)
-        for sa in number_to_fitted.get(a, [])
-        for sb in number_to_fitted.get(b, [])
-    ]
+    # BASE pairs: Sanborn sheets legitimately share strips (Hudson true locks
+    # sit at 0.32-0.43 IoU-over-min against their fitted neighbors), so a
+    # fixed threshold either misses slides or punishes correct seams. One
+    # value per NUMBER pair — the max over member sheets — because a page
+    # number can name a whole lettered family (LA p1499a..q) of which only
+    # one member actually neighbors the partner; flooding the distribution
+    # with the other members' near-zero overlaps drags the percentile down
+    # and tightens the gate onto true seams.
+    observed = []
+    for a, b in (tuple(pair) for pair in pairs):
+        values = [
+            iou_over_min(fitted_polys[sa], fitted_polys[sb])
+            for sa in number_to_fitted.get(a, [])
+            for sb in number_to_fitted.get(b, [])
+        ]
+        if values:
+            observed.append(max(values))
     if len(observed) >= 5:
         p90 = float(np.percentile(observed, 90))
         overlap_soft = min(0.5, max(OVERLAP_SOFT, p90 + 0.05))
@@ -1211,10 +1404,17 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
         return frame.to_xy(*centroid) if centroid else None
 
     def coupled(stem_a: str, stem_b: str) -> str | None:
-        """'sibling' | 'adjacent' | None: whether two stems interact at all."""
+        """'sibling' | 'adjacent' | None: whether two stems interact at all.
+
+        Panels couple ONLY with their siblings: coupling them into the wider
+        adjacency graph balloons component sizes (degrading the solver) for a
+        constraint the unary fitted-overlap term already carries.
+        """
         base_a, base_b = panel_base(stem_a), panel_base(stem_b)
         if base_a is not None and base_a == base_b:
             return "sibling"
+        if base_a is not None or base_b is not None:
+            return None
         na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
         if na is not None and nb is not None and frozenset((na, nb)) in pairs:
             return "adjacent"
@@ -1226,21 +1426,17 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
         coupling = coupled(stem_a, stem_b)
         if coupling is None:
             return 0.0
+        if coupling == "sibling":
+            # Rigid-sheet constraint: two co-accepted panels of one sheet must
+            # imply (nearly) the same full-sheet placement.
+            if sheets_agree(sheet_corners[(stem_a, ka)], sheet_corners[(stem_b, kb)]):
+                return 0.0
+            return 1e6
         energy = W_OVERLAP * overlap_penalty(
             iou_over_min(polygons[(stem_a, ka)], polygons[(stem_b, kb)]),
             overlap_soft,
             overlap_hard,
         )
-        # The centroid geometry terms describe SHEET centers; a panel's center
-        # legitimately sits away from its sheet's keymap centroid, so any pair
-        # involving a panel keeps only the overlap term (siblings of one sheet
-        # must simply not land on top of each other).
-        if (
-            coupling == "sibling"
-            or panel_base(stem_a) is not None
-            or panel_base(stem_b) is not None
-        ):
-            return energy
         na, nb = stem_to_number.get(stem_a), stem_to_number.get(stem_b)
         ca, cb = centroid_xy(na), centroid_xy(nb)
         if ca and cb:
@@ -1319,7 +1515,13 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
             assert best_assign_c is not None
             assignment.update(best_assign_c)
         else:
-            # ICM from a few deterministic starts: best-unary and abstain-all.
+            # ICM from two deterministic starts: best-unary and abstain-all.
+            # Deliberately NOT more: the best-unary start biases convergence
+            # toward acceptance, and on the dev volumes that bias scores
+            # better than the energy model's own global optimum — the ADJ
+            # term over-penalizes true placements where keymap centroids are
+            # unreliable (LA's lettered sheets), so a stronger optimizer
+            # abstains on pages the weak one correctly keeps.
             best_assign = None
             best_energy = math.inf
             starts: list[dict[str, int | None]] = [
@@ -1352,6 +1554,32 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
                     best_assign = assign
             assert best_assign is not None
             assignment.update(best_assign)
+
+    # Post-pass: an accepted panel with no reliable fitted anchor needs either
+    # a co-accepted sibling backing it up (their mutual sheet agreement is
+    # enforced by the pairwise term) or a solo score above PANEL_SOLO_GATE —
+    # an ordinary score on a lone small panel is not trustworthy evidence.
+    # Dropping one panel can orphan another, so iterate.
+    changed_post = True
+    while changed_post:
+        changed_post = False
+        for stem, chosen in list(assignment.items()):
+            if chosen is None:
+                continue
+            if stem not in panel_allowed:
+                continue  # not a panel
+            if panel_allowed[stem] is not None:
+                continue  # has reliable anchors: gated in the options filter
+            base = panel_base(stem)
+            supported = any(
+                other != stem and other_chosen is not None and panel_base(other) == base
+                for other, other_chosen in assignment.items()
+            )
+            if not supported:
+                score = dict(eligible[stem]["options"])[chosen].get("select_score")
+                if score is None or score < PANEL_SOLO_GATE:
+                    assignment[stem] = None
+                    changed_post = True
 
     selections = []
     for record in records:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -497,8 +497,10 @@ def rotation_priors_for(
         priors.extend(label_osm_rotations(features, block_index, search_centers[0]))
     base = panel_base(unit.stem)
     if base is not None:
-        # A fitted sibling panel is the same physical sheet: its rotation is
-        # the most reliable directed prior a panel can get.
+        # A fitted sibling panel's rotation, as one rung of the ladder. Split
+        # sheets are usually inset composites whose insets can be rotated
+        # differently on the paper, so this is a useful hint, not a certainty
+        # — the mask sweep below covers the disagreeing cases.
         for sibling in vctx.panel_units:
             if (
                 sibling.stem != unit.stem
@@ -1262,13 +1264,22 @@ def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
     }
 
 
-# Sheet-integrity gate for split panels: every panel is a rigid crop of one
-# sheet, so a panel placement determines the WHOLE sheet's placement exactly
-# (the crop is a pure translation). Two placements of the same sheet — from a
-# candidate and a fitted sibling, or from two co-accepted candidates — must
-# agree to within this corner tolerance. Correct fits agree to ~10-30 m;
-# LA p1408__2's along-the-cut-line alias disagreed by 258 m while still
-# touching its sibling, which is why mere contiguity was not enough.
+# Sheet-agreement gate for split panels. The GEOMETRY is exact: a panel jpg
+# is a bbox crop of the base jpg (pure translation), so one panel's pose
+# determines the whole base image's implied placement. The original intent
+# was that siblings of one sheet must imply the SAME placement — but that
+# premise assumes the sheet is one contiguous map cut into pieces, and
+# measured against every fitted sibling pair in the 12 truth volumes, real
+# Sanborn split pages are INSET COMPOSITES instead: separate neighborhood
+# maps pasted onto one sheet of paper, whose implied sheets disagree by
+# 233-2143 m. In practice, therefore, this gate acts as a conservative
+# BLANKET BLOCK: a panel with a reliably-fitted sibling effectively has no
+# agreeing candidates and is not rescued at all (that block is what stopped
+# KC's four would-be panel disasters, e.g. p555__2 at 753 ft with select
+# 2.58 — a score no threshold would have caught); accepted panels reach the
+# iiif through the solo-score or mutual paths instead. The honest redesign —
+# per-inset gating instead of the sheet fiction — is tracked in the PR's
+# next steps; the behavior here is what the 12-volume scores validated.
 SHEET_AGREE_TOL_M = 60.0
 # A fitted sibling anchors the sheet-agreement gate only when its own fit has
 # real evidence: eff>=3 panels measure <=57ft everywhere truth exists, while
@@ -1621,11 +1632,13 @@ def select_volume(
     reward. Connected components solve exhaustively when small, else ICM from
     several greedy orderings.
 
-    Panels additionally face rigid-sheet constraints: options whose implied
-    full-sheet placement disagrees with a reliable fitted sibling's are
-    dropped up front, co-accepted sibling picks must imply the same sheet
+    Panels additionally face the sheet-agreement machinery: options whose
+    implied full-sheet placement disagrees with a reliable fitted sibling's
+    are dropped up front, co-accepted sibling picks must imply the same sheet
     (the pairwise sheets_agree term), and an accepted panel with no reliable
-    anchor needs a co-accepted sibling or a PANEL_SOLO_GATE score.
+    anchor needs a co-accepted sibling or a PANEL_SOLO_GATE score. NOTE:
+    real split sheets are inset composites (see SHEET_AGREE_TOL_M), so in
+    practice the first two conditions blanket-block rather than discriminate.
     """
     from shapely.geometry import Polygon
 

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1096,6 +1096,13 @@ VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
 # is a confident, unambiguous lock that clearly disagrees with the incumbent
 # AND beats it on the shared evidence (geometry verification + name score).
 ARBITRATE_MIN_DISAGREE_FT = 100.0
+# ... and only when the incumbent is geometrically INDEFENSIBLE: across all 11
+# truth-graded challenges (dev + holdout), every correct overturn had
+# incumbent verification <= 0.05 and every wrong one >= 0.12. A plausible
+# incumbent losing narrowly is the OSM-divergence trap (Chicago's 1950 core:
+# a 400ft slide matches MODERN OSM better than the truth does), so arbitration
+# is disaster recovery for fits OSM actively contradicts — not relitigation.
+INCUMBENT_DEFENSIBLE_VERIFICATION = 0.1
 
 
 def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
@@ -1129,6 +1136,8 @@ def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
     incumbent_verification = incumbent.get("verification")
     top_verification = top.get("verification")
     if incumbent_verification is None or top_verification is None:
+        return None
+    if incumbent_verification >= INCUMBENT_DEFENSIBLE_VERIFICATION:
         return None
     if top_verification <= incumbent_verification:
         return None

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -222,6 +222,10 @@ def attach_missing_truth(volume: Path, units: list[PageUnit]) -> int:
         fit = truth_fit(item, unit.width)
         if fit is not None:
             unit.truth = fit
+            if unit.gen_affine is not None:
+                unit.rmse_ft = grid_rmse_ft_between(
+                    fit.affine_local, unit.gen_affine, unit.width, unit.height
+                )
             annotated += 1
     return annotated
 
@@ -1103,6 +1107,56 @@ ARBITRATE_MIN_DISAGREE_FT = 100.0
 # a 400ft slide matches MODERN OSM better than the truth does), so arbitration
 # is disaster recovery for fits OSM actively contradicts — not relitigation.
 INCUMBENT_DEFENSIBLE_VERIFICATION = 0.1
+# Refinement: adopting an AGREEING challenger that clearly wins the evidence
+# head-to-head. RANSAC's mid-tier error is label-placement noise; the snap
+# pose is chamfer-locked to the street grid, so when the two agree on the
+# lock, the snap is simply the more precise estimator (25-50ft incumbents:
+# challenger closer to truth 93% of the time, median 33ft -> 12ft). The
+# margin protects already-good incumbents from churn; 0.1 is the dev elbow
+# (47 bucket gains / 2 losses on the dev volumes).
+REFINE_VER_MARGIN = 0.1
+
+
+def refine_adoption(record: dict) -> dict | None:
+    """Adopt an agreeing challenger as a precision refinement, or None.
+
+    The complement of arbitrate_challenge: same head-to-head evidence, but for
+    challengers that AGREE with the incumbent (within the arbitration
+    disagreement floor) and beat its verification by a clear margin. This is
+    what reaches the 25-100ft mid-tier that arbitration structurally cannot
+    touch (a correct challenger agrees with those incumbents).
+    """
+    incumbent = record.get("incumbent")
+    candidates = record.get("candidates") or []
+    if not incumbent or not candidates:
+        return None
+    top = candidates[0]
+    if top.get("select_score") is None:
+        return None
+    incumbent_verification = incumbent.get("verification")
+    top_verification = top.get("verification")
+    if incumbent_verification is None or top_verification is None:
+        return None
+    if top_verification <= incumbent_verification + REFINE_VER_MARGIN:
+        return None
+    disagreement = grid_rmse_ft_between(
+        np.array(incumbent["world_affine"]),
+        np.array(top["world_affine"]),
+        record["width"],
+        record["height"],
+    )
+    if disagreement >= ARBITRATE_MIN_DISAGREE_FT:
+        return None  # that far apart is arbitration territory, not refinement
+    return {
+        "target": record["target"],
+        "chosen": 0,
+        "reason": "refine",
+        "refine": True,
+        "select_score": top["select_score"],
+        "disagreement_ft": round(disagreement, 1),
+        "incumbent_verification": incumbent_verification,
+        "challenger_verification": top_verification,
+    }
 
 
 def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
@@ -1319,7 +1373,7 @@ def cmd_select(
     elif mode == "arbitrate":
         # The union rescue selection, plus challenges to placed RANSAC fits.
         selections = select_union(volume, rescue, gate_score, gate_margin, allowed)
-        challenged = 0
+        challenged = refined = 0
         for record in records:
             if record.get("fit_state") != "fitted":
                 continue
@@ -1327,7 +1381,12 @@ def cmd_select(
             if challenge is not None:
                 selections.append(challenge)
                 challenged += 1
-        print(f"{challenged} challenges accepted")
+                continue
+            refinement = refine_adoption(record)
+            if refinement is not None:
+                selections.append(refinement)
+                refined += 1
+        print(f"{challenged} challenges, {refined} refinements accepted")
     else:
         selections = select_argmax(rescue, gate_score, gate_margin, allowed)
     accepted = sum(1 for s in selections if s.get("chosen") is not None)
@@ -1818,6 +1877,20 @@ def cmd_reannotate(volume: Path) -> None:
                 ),
                 1,
             )
+        incumbent = record.get("incumbent")
+        if incumbent is not None:
+            if unit.truth is not None and unit.gen_affine is not None:
+                incumbent["rmse_ft"] = round(
+                    grid_rmse_ft_between(
+                        unit.truth.affine_local,
+                        unit.gen_affine,
+                        unit.width,
+                        unit.height,
+                    ),
+                    1,
+                )
+            else:
+                incumbent.pop("rmse_ft", None)
     out_path = artifacts_dir(volume) / "candidates.jsonl"
     with out_path.open("w") as handle:
         for record in records:
@@ -1884,6 +1957,7 @@ def cmd_materialize(volume: Path, mode: str) -> None:
                 "previous_state": record["fit_state"],
                 "mode": mode,
                 "challenge": bool(choice.get("challenge")),
+                "refine": bool(choice.get("refine")),
                 "select_score": candidate.get("select_score"),
                 "margin": record.get("margin"),
                 "verification": candidate.get("verification"),

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -141,8 +141,92 @@ def keymap_fit_residuals(units: list[PageUnit]) -> list[float]:
     return residuals
 
 
+def attach_missing_truth(volume: Path, units: list[PageUnit]) -> int:
+    """Attach truth to pages load_page_units missed; returns pages annotated.
+
+    Two classes were invisible to the harness (their candidates carried no
+    rmse, so the gate sweep was blind to them) even though `mapsnap score`
+    scores their placements: (1) unsplit truth items whose page key differs
+    from the jpg stem only in letter case (Chicago 'p51N' vs 'p51n'); (2)
+    pages whose truth exists only as split items — a whole-page placement of
+    such a sheet is scored against its LARGEST truth split (the whole-canvas
+    stand-in rule in match_split_pairs), so that split's transform is the
+    right truth here, with rmse sampled over the full canvas exactly like
+    analyze_pair's whole-page grid.
+    """
+    from mapsnap.compare_iiif_georef import (
+        annotation_transform_type,
+        extract_gcps,
+        fit_transform,
+        label_split_index,
+        load_split_polygons,
+    )
+    from mapsnap.edge_join_experiment import TruthFit, scale_affine_to_local
+    from mapsnap.utils import source_id_to_page_key
+
+    truth_path = volume / "main.iiif.json"
+    if not truth_path.exists():
+        return 0
+    unsplit_by_lower: dict[str, dict] = {}
+    splits_by_parent: dict[str, list[dict]] = {}
+    for item in json.loads(truth_path.read_text()).get("items", []):
+        key = source_id_to_page_key(
+            item.get("target", {}).get("source", {}).get("id"), item.get("label", "")
+        )
+        if "__" in key:
+            splits_by_parent.setdefault(key.split("__")[0].lower(), []).append(item)
+        else:
+            unsplit_by_lower.setdefault(key.lower(), item)
+
+    def truth_fit(item: dict, local_width: int) -> TruthFit | None:
+        gcps = extract_gcps(item)
+        if len(gcps) < 2:
+            return None
+        affine_full = fit_transform(gcps, annotation_transform_type(item))
+        return TruthFit(
+            affine_local=scale_affine_to_local(
+                affine_full, item["target"]["source"]["width"], local_width
+            ),
+            gcp_count=len(gcps),
+            transform_type=annotation_transform_type(item),
+        )
+
+    annotated = 0
+    for unit in units:
+        if unit.truth is not None:
+            continue
+        stem_lower = unit.stem.lower()
+        item = unsplit_by_lower.get(stem_lower)
+        if item is None:
+            items = splits_by_parent.get(stem_lower)
+            if not items:
+                continue
+            panels_path = next(
+                (
+                    p
+                    for p in (volume / "oim").glob("*.panels.json")
+                    if p.name.lower() == f"{stem_lower}.panels.json"
+                ),
+                None,
+            )
+            panels = load_split_polygons(panels_path) if panels_path else {}
+
+            def panel_area(split_item: dict) -> float:
+                index = label_split_index(split_item)
+                polygon = panels.get(index) if index is not None else None
+                return polygon.area if polygon is not None else 0.0
+
+            item = max(items, key=lambda i: (panel_area(i), len(extract_gcps(i))))
+        fit = truth_fit(item, unit.width)
+        if fit is not None:
+            unit.truth = fit
+            annotated += 1
+    return annotated
+
+
 def load_volume_context(volume: Path) -> VolumeContext:
     units = load_page_units(volume)
+    attach_missing_truth(volume, units)
     centerlines_path = default_centerlines(volume)
     if centerlines_path is None:
         sys.exit(f"no centerlines.geojson under {volume}")
@@ -700,12 +784,29 @@ GATE_SCORES = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
 GATE_MARGINS = [0.0, 0.1, 0.25, 0.5]
 
 
+VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
+
+
 def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -> None:
     """Pick one candidate (or abstain) per page; write selection_<mode>.jsonl."""
     records = load_candidates(volume)
     out_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
     if mode == "volume":
         selections = select_volume(volume, records, gate_score)
+    elif mode == "union":
+        # The two dev-calibrated committees are complementary: the energy mode
+        # (at its conservative gate) resolves joint/ambiguous pages, and the
+        # per-page argmax gate is the floor for pages the energy abstains on.
+        by_target = {
+            s["target"]: s for s in select_volume(volume, records, VOLUME_MODE_GATE)
+        }
+        selections = []
+        for choice in select_argmax(records, gate_score, gate_margin):
+            volume_choice = by_target.get(choice["target"])
+            if volume_choice is not None and volume_choice.get("chosen") is not None:
+                selections.append(volume_choice)
+            else:
+                selections.append(choice)
     else:
         selections = select_argmax(records, gate_score, gate_margin)
     accepted = sum(1 for s in selections if s.get("chosen") is not None)
@@ -1032,6 +1133,48 @@ def select_volume(volume: Path, records: list[dict], gate_score: float) -> list[
     return selections
 
 
+def cmd_reannotate(volume: Path) -> None:
+    """Refresh the rmse_ft annotations on cached candidates from current truth.
+
+    Cheap (no matching): recomputes every candidate's grid rmse against the
+    unit's truth affine, including pages that attach_missing_truth
+    now covers (case-mismatched keys and split-only truth). Rewrites candidates.jsonl in place.
+    """
+    units = {u.stem: u for u in load_page_units(volume)}
+    newly = attach_missing_truth(volume, list(units.values()))
+    records = load_candidates(volume)
+    changed = 0
+    for record in records:
+        unit = units.get(record["target"])
+        if unit is None:
+            continue
+        has_truth = unit.truth is not None
+        if record.get("has_truth") != has_truth:
+            record["has_truth"] = has_truth
+            changed += 1
+        for candidate in record.get("candidates") or []:
+            if unit.truth is None:
+                candidate.pop("rmse_ft", None)
+                continue
+            candidate["rmse_ft"] = round(
+                grid_rmse_ft_between(
+                    unit.truth.affine_local,
+                    np.array(candidate["world_affine"]),
+                    unit.width,
+                    unit.height,
+                ),
+                1,
+            )
+    out_path = artifacts_dir(volume) / "candidates.jsonl"
+    with out_path.open("w") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    print(
+        f"{volume.name}: {newly} split-truth pages attached, "
+        f"{changed} records flipped has_truth"
+    )
+
+
 def osm_variant_path(volume: Path, stem: str) -> Path:
     return volume / f"{stem}.georef-osm.json"
 
@@ -1118,13 +1261,20 @@ def main() -> None:
 
     p_sel = sub.add_parser("select", help="pick candidates / abstain per page")
     p_sel.add_argument("volume", type=Path)
-    p_sel.add_argument("--mode", choices=["argmax", "volume"], default="argmax")
+    p_sel.add_argument(
+        "--mode", choices=["argmax", "volume", "union"], default="argmax"
+    )
     p_sel.add_argument("--gate-score", type=float, default=1.0)
     p_sel.add_argument("--gate-margin", type=float, default=0.25)
 
     p_mat = sub.add_parser("materialize", help="write pN.georef-osm.json sidecars")
     p_mat.add_argument("volume", type=Path)
-    p_mat.add_argument("--mode", choices=["argmax", "volume"], default="argmax")
+    p_mat.add_argument(
+        "--mode", choices=["argmax", "volume", "union"], default="argmax"
+    )
+
+    p_re = sub.add_parser("reannotate", help="refresh cached rmse annotations")
+    p_re.add_argument("volume", type=Path)
 
     args = parser.parse_args()
     if args.command == "candidates":
@@ -1145,6 +1295,8 @@ def main() -> None:
         cmd_select(args.volume, args.mode, args.gate_score, args.gate_margin)
     elif args.command == "materialize":
         cmd_materialize(args.volume, args.mode)
+    elif args.command == "reannotate":
+        cmd_reannotate(args.volume)
 
 
 if __name__ == "__main__":

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -375,8 +375,34 @@ def load_panel_units(volume: Path) -> list[PageUnit]:
     return units
 
 
-def load_volume_context(volume: Path) -> VolumeContext:
-    units = load_page_units(volume)
+def georef_variant_mtime(volume: Path, stem: str) -> int | None:
+    """mtime of the stem's current georef-variant sidecar, or None for none.
+
+    The staleness key for cached candidates: `mapsnap fit` re-runs georef
+    before snap, and a page whose fit changed (or whose fit STATE changed)
+    must be re-matched — its cached record carries the old incumbent pose.
+    """
+    from mapsnap.edge_join_experiment import GEOREF_VARIANTS
+
+    for variant in GEOREF_VARIANTS:
+        path = volume / f"{stem}.{variant}.json"
+        if path.exists():
+            return int(path.stat().st_mtime)
+    return None
+
+
+def candidates_record_fresh(record: dict, unit: PageUnit, mtime: int | None) -> bool:
+    """Whether a cached candidates record still matches the page's fit state."""
+    return (
+        record.get("fit_state") == unit.fit_state
+        and record.get("georef_mtime") == mtime
+    )
+
+
+def load_volume_context(
+    volume: Path, units: list[PageUnit] | None = None
+) -> VolumeContext:
+    units = units if units is not None else load_page_units(volume)
     attach_missing_truth(volume, units)
     centerlines_path = default_centerlines(volume)
     if centerlines_path is None:
@@ -641,15 +667,14 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
     return record
 
 
-def page_record(
-    vctx: VolumeContext, unit: PageUnit, limit_note: str | None = None
-) -> dict:
+def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
     """Generate the full candidates.jsonl record for one page."""
     ctx, status = build_page_context(vctx, unit)
     record: dict = {
         "target": unit.stem,
         "status": status,
         "fit_state": unit.fit_state,
+        "georef_mtime": georef_variant_mtime(vctx.volume, unit.stem),
         "width": unit.width,
         "height": unit.height,
         "has_truth": unit.truth is not None,
@@ -745,12 +770,12 @@ def ensure_probs(volume: Path, stems: list[str]) -> None:
     import torch  # noqa: F401  (import check before loading model)
 
     from mapsnap.keymap.number_model import select_device
-    from mapsnap.road_model import load_model, predict_page
+    from mapsnap.road_model import ROAD_MODEL_PATH, load_model, predict_page
 
     out_dir = volume / "artifacts" / "edge_join" / "roadprob"
     out_dir.mkdir(parents=True, exist_ok=True)
     device = select_device()
-    model = load_model(Path("models/road_unet.pt"), device)
+    model = load_model(ROAD_MODEL_PATH, device)
     for stem in missing:
         gray = cv2.imread(str(volume / f"{stem}.jpg"), cv2.IMREAD_GRAYSCALE)
         if gray is None:
@@ -769,10 +794,22 @@ def cmd_candidates(
     vis: bool,
 ) -> None:
     """Generate candidates.jsonl for the volume's rescue targets."""
-    vctx = load_volume_context(volume)
     out_dir = artifacts_dir(volume)
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / "candidates.jsonl"
+    units = load_page_units(volume)
+    if not any(u.fit_state == "fitted" and u.gen_affine is not None for u in units):
+        # Nothing to calibrate scale/radius/rotation against — and nothing for
+        # the channel to do that could be trusted. Leave an empty candidates
+        # file so select/materialize no-op cleanly instead of erroring.
+        print(
+            f"{volume.name}: no fitted pages to calibrate against; "
+            "skipping snap candidates."
+        )
+        if not out_path.exists():
+            out_path.write_text("")
+        return
+    vctx = load_volume_context(volume, units)
     existing: dict[str, dict] = {}
     if out_path.exists():
         for line in out_path.read_text().splitlines():
@@ -813,7 +850,15 @@ def cmd_candidates(
         vis_dir.mkdir(exist_ok=True)
     done = 0
     for unit in targets:
-        if unit.stem in existing and not recompute and not pages:
+        cached = existing.get(unit.stem)
+        if (
+            cached is not None
+            and not recompute
+            and not pages
+            and candidates_record_fresh(
+                cached, unit, georef_variant_mtime(volume, unit.stem)
+            )
+        ):
             continue
         record = page_record(vctx, unit)
         existing[unit.stem] = record
@@ -1094,6 +1139,12 @@ def cmd_sweep_arbitrate(volume: Path) -> None:
             print("      " + "  ".join(details[:10]))
 
 
+# The frozen production gates (dev-swept; `mapsnap snap` uses these): the
+# per-page rescue score/margin gates, the volume-energy conservative elbow,
+# and the arbitration score gate.
+PRODUCTION_GATE_SCORE = 1.25
+PRODUCTION_GATE_MARGIN = 0.25
+PRODUCTION_ARBITRATE_GATE = 1.5
 VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
 
 # Arbitration: a snap candidate may replace a placed RANSAC fit only when it
@@ -1177,7 +1228,7 @@ def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
     if score is None or score < arbitrate_gate:
         return None
     margin = distinct_margin(record)
-    if margin is None or margin < 0.25:
+    if margin is None or margin < PRODUCTION_GATE_MARGIN:
         return None
     disagreement = grid_rmse_ft_between(
         np.array(incumbent["world_affine"]),
@@ -1328,6 +1379,89 @@ def panel_allowed_candidates(
     return result
 
 
+SNAP_LOG_BEGIN = "==== mapsnap snap ===="
+SNAP_LOG_END = "==== end mapsnap snap ===="
+
+
+def append_snap_logs(
+    volume: Path, records: list[dict], selections: list[dict], mode: str
+) -> None:
+    """Append each page's snap decision to its pN.txt georef log.
+
+    The RANSAC georeferencer captures its per-page log to <stem>.txt; the
+    debugger surfaces that file, so the snap channel's decision belongs there
+    too. Idempotent: any previous snap section is replaced, not duplicated.
+    """
+    by_target = {s["target"]: s for s in selections}
+    for record in records:
+        stem = record["target"]
+        choice = by_target.get(stem)
+        lines = [
+            SNAP_LOG_BEGIN,
+            f"mode: {mode}   status: {record['status']}   "
+            f"fit_state: {record['fit_state']}",
+        ]
+        priors = record.get("priors", {}).get("rotation", [])
+        if priors:
+            lines.append(
+                "rotation priors: "
+                + ", ".join(f"{p['theta_deg']:.0f}deg({p['source']})" for p in priors)
+            )
+        for rank, candidate in enumerate((record.get("candidates") or [])[:3]):
+            name = candidate.get("name") or {}
+            lines.append(
+                f"#{rank + 1}: select={candidate.get('select_score')} "
+                f"ver={candidate.get('verification')} "
+                f"theta={candidate['theta_deg']:.0f}deg({candidate['theta_source']}) "
+                f"name={name.get('n_hits')}/{name.get('n_labels')} "
+                f"center_dist={candidate['center_dist_m']:.0f}m"
+                + (
+                    f" rmse={candidate['rmse_ft']:.0f}ft(vs truth)"
+                    if candidate.get("rmse_ft") is not None
+                    else ""
+                )
+            )
+        incumbent = record.get("incumbent")
+        if incumbent:
+            name = incumbent.get("name") or {}
+            lines.append(
+                f"incumbent: ver={incumbent.get('verification')} "
+                f"name={name.get('n_hits')}/{name.get('n_labels')}"
+                + (
+                    f" rmse={incumbent['rmse_ft']:.0f}ft(vs truth)"
+                    if incumbent.get("rmse_ft") is not None
+                    else ""
+                )
+            )
+        if choice is None:
+            outcome = (
+                "incumbent kept" if record["fit_state"] == "fitted" else "no entry"
+            )
+        elif choice.get("chosen") is None:
+            outcome = f"abstain ({choice.get('reason')})"
+        else:
+            kind = (
+                "challenge"
+                if choice.get("challenge")
+                else "refine"
+                if choice.get("refine")
+                else "rescue"
+            )
+            outcome = f"{kind}: candidate #{choice['chosen'] + 1} accepted"
+        lines.append(f"outcome: {outcome}")
+        lines.append(SNAP_LOG_END)
+
+        path = volume / f"{stem}.txt"
+        text = path.read_text() if path.exists() else ""
+        if SNAP_LOG_BEGIN in text:
+            head, _, rest = text.partition(SNAP_LOG_BEGIN)
+            _, _, tail = rest.partition(SNAP_LOG_END)
+            text = head + tail.lstrip("\n")
+        if text and not text.endswith("\n"):
+            text += "\n"
+        path.write_text(text + "\n".join(lines) + "\n")
+
+
 def select_union(
     volume: Path,
     records: list[dict],
@@ -1393,6 +1527,7 @@ def cmd_select(
     with out_path.open("w") as handle:
         for choice in selections:
             handle.write(json.dumps(choice) + "\n")
+    append_snap_logs(volume, records, selections, mode)
     print(f"{accepted}/{len(selections)} pages accepted -> {out_path}")
 
 
@@ -1486,10 +1621,11 @@ def select_volume(
     reward. Connected components solve exhaustively when small, else ICM from
     several greedy orderings.
 
-    Panels additionally face sheet-integrity constraints: options inconsistent
-    with a fitted sibling are dropped up front, page-space-adjacent sibling
-    picks must land next to each other, and an accepted panel with no fitted
-    sibling must have a co-accepted contiguous sibling backing it up.
+    Panels additionally face rigid-sheet constraints: options whose implied
+    full-sheet placement disagrees with a reliable fitted sibling's are
+    dropped up front, co-accepted sibling picks must imply the same sheet
+    (the pairwise sheets_agree term), and an accepted panel with no reliable
+    anchor needs a co-accepted sibling or a PANEL_SOLO_GATE score.
     """
     from shapely.geometry import Polygon
 
@@ -1959,7 +2095,14 @@ def cmd_materialize(volume: Path, mode: str) -> None:
                 "challenge": bool(choice.get("challenge")),
                 "refine": bool(choice.get("refine")),
                 "select_score": candidate.get("select_score"),
-                "margin": record.get("margin"),
+                # The margin selection actually gated on: rank-1's lead over
+                # the best DISTINCT lock (raw rank1-rank2 is misleading when
+                # the runner-up is a near-identical twin).
+                "margin": (
+                    None
+                    if (margin := distinct_margin(record)) is None or math.isinf(margin)
+                    else round(margin, 4)
+                ),
                 "verification": candidate.get("verification"),
                 "ncc_fine": candidate.get("ncc_fine"),
                 "inlier_frac": candidate.get("inlier_frac"),
@@ -2007,11 +2150,19 @@ def main() -> None:
     p_sel = sub.add_parser("select", help="pick candidates / abstain per page")
     p_sel.add_argument("volume", type=Path)
     p_sel.add_argument(
-        "--mode", choices=["argmax", "volume", "union", "arbitrate"], default="argmax"
+        "--mode",
+        choices=["argmax", "volume", "union", "arbitrate"],
+        default="argmax",
+        help=(
+            "argmax/volume: single rescue committee; union: both committees; "
+            "arbitrate: union PLUS challenges and refinements of placed fits"
+        ),
     )
-    p_sel.add_argument("--gate-score", type=float, default=1.0)
-    p_sel.add_argument("--gate-margin", type=float, default=0.25)
-    p_sel.add_argument("--arbitrate-gate", type=float, default=2.0)
+    p_sel.add_argument("--gate-score", type=float, default=PRODUCTION_GATE_SCORE)
+    p_sel.add_argument("--gate-margin", type=float, default=PRODUCTION_GATE_MARGIN)
+    p_sel.add_argument(
+        "--arbitrate-gate", type=float, default=PRODUCTION_ARBITRATE_GATE
+    )
 
     p_mat = sub.add_parser("materialize", help="write pN.georef-osm.json sidecars")
     p_mat.add_argument("volume", type=Path)

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1,0 +1,819 @@
+"""Truth-aware harness for the geometry-first OSM matcher (osm_snap.py).
+
+Commands:
+  candidates DIR   generate snap candidates for the volume's unplaced pages
+                   -> artifacts/osm_snap/candidates.jsonl (+ vis/ contact sheets)
+  report DIR       recall / rank-1 / near-miss diagnostics against truth
+
+The matcher itself lives in osm_snap.py and is truth-free; truth
+(main.iiif.json) is used here only to annotate each candidate with its
+rmse_ft so ranking quality can be measured. Production selection and
+materialization run from candidates.jsonl without touching truth.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from mapsnap.edge_join_experiment import (
+    PageUnit,
+    detected_pairs,
+    grid_rmse_ft_between,
+    keymap_region_adjacency,
+    load_page_units,
+    load_prob,
+    volume_median_scale,
+)
+from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
+from mapsnap.keymap.align_page_region import (
+    image_neighbor_directions,
+    load_adjacency,
+    volume_filter_params,
+)
+from mapsnap.keymap.locate import KeymapLocator
+from mapsnap.osm_snap import (
+    PageContext,
+    RotationPrior,
+    SnapCandidate,
+    affine_theta_deg,
+    calibrated_radius_m,
+    frame_around,
+    label_osm_rotations,
+    adjacency_keymap_rotations,
+    osm_rasters,
+    page_scale_priors,
+    snap_page,
+)
+from mapsnap.streets import Block, build_block_index
+from mapsnap.utils import default_centerlines, haversine_m
+
+# Pages the rescue channel may place: everything the iiif glob does not see.
+RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
+
+
+def artifacts_dir(volume: Path) -> Path:
+    return volume / "artifacts" / "osm_snap"
+
+
+@dataclass
+class VolumeContext:
+    """Once-per-volume inputs shared by every page's candidate generation."""
+
+    volume: Path
+    units: list[PageUnit]
+    features: list[dict]
+    locator: KeymapLocator | None
+    volume_m_per_px: float
+    adjacency: dict
+    region_centroids: dict[int, tuple[float, float]]
+    filter_params: dict
+    radius_m: float
+    radius_source: str
+    median_theta_deg: float | None
+
+
+def ring_centroid(ring: list[list[float]]) -> tuple[float, float]:
+    """Vertex-mean centroid of a [lon, lat] ring."""
+    return (
+        sum(p[0] for p in ring) / len(ring),
+        sum(p[1] for p in ring) / len(ring),
+    )
+
+
+def unit_theta_deg(unit: PageUnit) -> float | None:
+    """The cv2 rotation of a fitted unit's affine, or None."""
+    if unit.gen_affine is None:
+        return None
+    lon = unit.gen_affine[0, 2]
+    lat = unit.gen_affine[1, 2]
+    frame = frame_around((lon, lat), half_m=100.0)
+    return affine_theta_deg(unit.gen_affine, frame)
+
+
+def volume_median_theta(units: list[PageUnit]) -> float | None:
+    """Circular-mean rotation of the volume's fitted pages, in cv2 degrees."""
+    sines = cosines = 0.0
+    n = 0
+    for unit in units:
+        theta = unit_theta_deg(unit) if unit.fit_state == "fitted" else None
+        if theta is None:
+            continue
+        sines += math.sin(math.radians(theta))
+        cosines += math.cos(math.radians(theta))
+        n += 1
+    if n == 0:
+        return None
+    return math.degrees(math.atan2(sines, cosines))
+
+
+def keymap_fit_residuals(units: list[PageUnit]) -> list[float]:
+    """Fitted pages' distances (m) from their keymap location to the fit center."""
+    residuals = []
+    for unit in units:
+        if unit.fit_state != "fitted" or unit.gen_affine is None:
+            continue
+        anchors = list(unit.keymap_centers)
+        for ring in unit.keymap_regions or []:
+            anchors.append(ring_centroid(ring))
+        if not anchors:
+            continue
+        lon_c = (
+            unit.gen_affine[0, 0] * unit.width / 2
+            + unit.gen_affine[0, 1] * unit.height / 2
+            + unit.gen_affine[0, 2]
+        )
+        lat_c = (
+            unit.gen_affine[1, 0] * unit.width / 2
+            + unit.gen_affine[1, 1] * unit.height / 2
+            + unit.gen_affine[1, 2]
+        )
+        residuals.append(
+            min(haversine_m(lat_c, lon_c, lat, lon) for lon, lat in anchors)
+        )
+    return residuals
+
+
+def load_volume_context(volume: Path) -> VolumeContext:
+    units = load_page_units(volume)
+    centerlines_path = default_centerlines(volume)
+    if centerlines_path is None:
+        sys.exit(f"no centerlines.geojson under {volume}")
+    features = json.loads(centerlines_path.read_text())["features"]
+    keymaps = sorted((volume / "raw").glob("*.keymap.json"))
+    locator = KeymapLocator.from_keymaps(keymaps) if keymaps else None
+    _, region_centroids = keymap_region_adjacency(volume)
+    residuals = keymap_fit_residuals(units)
+    locator_radius = locator.radius_m if locator else 600.0
+    radius, radius_source = calibrated_radius_m(residuals, locator_radius)
+    return VolumeContext(
+        volume=volume,
+        units=units,
+        features=features,
+        locator=locator,
+        volume_m_per_px=volume_median_scale(units),
+        adjacency=load_adjacency(volume),
+        region_centroids=region_centroids,
+        filter_params=volume_filter_params(volume),
+        radius_m=radius,
+        radius_source=radius_source,
+        median_theta_deg=volume_median_theta(units),
+    )
+
+
+def page_keymap_data(
+    vctx: VolumeContext, unit: PageUnit
+) -> tuple[list[tuple[float, float]], list[list[list[float]]] | None]:
+    """(search centers, region rings) for a page, from its sidecar or the locator.
+
+    Search centers are every keymap detection of the page number plus each
+    region ring's centroid (split blocks can sit far apart; the matcher tries
+    each). Deduped within 50 m.
+    """
+    centers = list(unit.keymap_centers)
+    regions = unit.keymap_regions
+    if not centers and vctx.locator is not None:
+        entry = vctx.locator.page_keymap(unit.number)
+        if entry:
+            centers = [tuple(c) for c in entry["centers"]]
+            regions = entry.get("regions")
+    for ring in regions or []:
+        centers.append(ring_centroid(ring))
+    deduped: list[tuple[float, float]] = []
+    for lon, lat in centers:
+        if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in deduped):
+            deduped.append((lon, lat))
+    return deduped, regions
+
+
+def page_label_features(
+    vctx: VolumeContext, unit: PageUnit
+) -> tuple[list[LabelFeature], dict[str, list[Block]]] | None:
+    """(label features, restricted block index) for a page, or None.
+
+    The vocabulary is restricted to streets near the page's keymap location
+    (falling back to the key-map rectangles), exactly as the main pipeline's
+    --keymap path does, so label matching behaves the same way here.
+    """
+    streets_path = vctx.volume / f"{unit.stem}.streets.json"
+    if not streets_path.exists() or vctx.locator is None:
+        return None
+    near = vctx.locator.restricted_features(unit.number, vctx.features)
+    if near is None:
+        near = vctx.locator.rectangle_features(vctx.features)
+    if not near:
+        return None
+    block_index = build_block_index({"type": "FeatureCollection", "features": near})
+    sink = io.StringIO()
+    with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+        features = prepare_label_features(
+            str(streets_path),
+            block_index,
+            (unit.width, unit.height),
+            **vctx.filter_params,
+        )
+    return features, block_index
+
+
+def rotation_priors_for(
+    vctx: VolumeContext,
+    unit: PageUnit,
+    search_centers: list[tuple[float, float]],
+    labels: tuple[list[LabelFeature], dict[str, list[Block]]] | None,
+) -> list[RotationPrior]:
+    """The rung-ordered rotation-prior ladder for one page (mask rung excluded)."""
+    priors: list[RotationPrior] = []
+    if labels is not None and search_centers:
+        features, block_index = labels
+        priors.extend(label_osm_rotations(features, block_index, search_centers[0]))
+    own_centroid = vctx.region_centroids.get(unit.number)
+    if own_centroid is None and search_centers:
+        own_centroid = search_centers[0]
+    if own_centroid is not None:
+        image_directions = image_neighbor_directions(vctx.adjacency, unit.stem)
+        priors.extend(
+            adjacency_keymap_rotations(
+                image_directions, vctx.region_centroids, own_centroid
+            )
+        )
+    by_number = {u.number: u for u in vctx.units}
+    neighbor_thetas: list[float] = []
+    for pair in detected_pairs(vctx.volume):
+        if unit.number not in pair:
+            continue
+        (other,) = pair - {unit.number}
+        neighbor = by_number.get(other)
+        if neighbor is not None and neighbor.fit_state == "fitted":
+            theta = unit_theta_deg(neighbor)
+            if theta is not None:
+                neighbor_thetas.append(theta)
+    if neighbor_thetas:
+        sines = sum(math.sin(math.radians(t)) for t in neighbor_thetas)
+        cosines = sum(math.cos(math.radians(t)) for t in neighbor_thetas)
+        priors.append(
+            RotationPrior(
+                math.degrees(math.atan2(sines, cosines)), 8.0, "ransac-neighbor"
+            )
+        )
+    elif vctx.median_theta_deg is not None:
+        priors.append(RotationPrior(vctx.median_theta_deg, 15.0, "volume-median-theta"))
+    return priors
+
+
+def build_page_context(
+    vctx: VolumeContext, unit: PageUnit
+) -> tuple[PageContext | None, str]:
+    """(PageContext, status) for one page; context is None unless status 'ok'."""
+    prob = load_prob(vctx.volume, unit.stem)
+    if prob is None:
+        return None, "no_prob"
+    centers, regions = page_keymap_data(vctx, unit)
+    if not centers:
+        return None, "no_keymap"
+    labels = page_label_features(vctx, unit)
+    priors = rotation_priors_for(vctx, unit, centers, labels)
+    scales = page_scale_priors(vctx.volume_m_per_px, regions, unit.width, unit.height)
+    ctx = PageContext(
+        stem=unit.stem,
+        number=unit.number,
+        width=unit.width,
+        height=unit.height,
+        prob=prob,
+        search_centers=centers,
+        radius_m=vctx.radius_m,
+        rotation_priors=priors,
+        scale_priors=scales,
+        keymap_regions=regions,
+        label_features=labels[0] if labels else None,
+        block_index=labels[1] if labels else None,
+    )
+    return ctx, "ok"
+
+
+def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
+    """JSON-serializable record of one candidate, with truth rmse if known."""
+    record = {
+        "world_affine": [[float(v) for v in row] for row in candidate.world_affine],
+        "center": [round(candidate.center[0], 7), round(candidate.center[1], 7)],
+        "theta_deg": round(candidate.theta_deg, 2),
+        "theta_source": candidate.theta_source,
+        "scale_m_per_px": round(candidate.scale_m_per_px, 4),
+        "scale_source": candidate.scale_source,
+        "scale_adjust": round(candidate.scale_adjust, 4),
+        "ncc": round(candidate.ncc, 4),
+        "ncc_fine": round(candidate.ncc_fine, 4),
+        "chamfer_mean_m": round(candidate.chamfer_mean_m, 2),
+        "inlier_frac": round(candidate.inlier_frac, 4),
+        "n_points": candidate.n_points,
+        "jtj_eig_ratio": round(candidate.jtj_eig_ratio, 6),
+        "overlap_frac": round(candidate.overlap_frac, 4),
+        "refine_shift_m": round(candidate.refine_shift_m, 1),
+        "center_dist_m": round(candidate.center_dist_m, 1),
+        "verification": round(candidate.verification, 4)
+        if math.isfinite(candidate.verification)
+        else None,
+        "select_score": round(candidate.select_score(), 4)
+        if math.isfinite(candidate.select_score())
+        else None,
+        "plausible": candidate.plausible,
+        "gate_reasons": candidate.gate_reasons,
+    }
+    if candidate.region_containment is not None:
+        record["region_containment"] = round(candidate.region_containment, 3)
+    if candidate.prior_theta_residual_sigma is not None:
+        record["prior_theta_residual_sigma"] = round(
+            candidate.prior_theta_residual_sigma, 2
+        )
+    if candidate.name is not None:
+        record["name"] = {
+            "score": round(candidate.name.score, 4),
+            "n_labels": candidate.name.n_labels,
+            "n_hits": candidate.name.n_hits,
+            "hits": candidate.name.hits,
+        }
+    if unit.truth is not None:
+        record["rmse_ft"] = round(
+            grid_rmse_ft_between(
+                unit.truth.affine_local,
+                candidate.world_affine,
+                unit.width,
+                unit.height,
+            ),
+            1,
+        )
+    return record
+
+
+def page_record(
+    vctx: VolumeContext, unit: PageUnit, limit_note: str | None = None
+) -> dict:
+    """Generate the full candidates.jsonl record for one page."""
+    ctx, status = build_page_context(vctx, unit)
+    record: dict = {
+        "target": unit.stem,
+        "status": status,
+        "fit_state": unit.fit_state,
+        "width": unit.width,
+        "height": unit.height,
+        "has_truth": unit.truth is not None,
+    }
+    if ctx is None:
+        return record
+    record["search"] = {
+        "centers": [[round(c[0], 7), round(c[1], 7)] for c in ctx.search_centers],
+        "radius_m": round(vctx.radius_m, 1),
+        "radius_source": vctx.radius_source,
+    }
+    record["priors"] = {
+        "rotation": [
+            {
+                "theta_deg": round(p.theta_deg, 2),
+                "sigma_deg": p.sigma_deg,
+                "source": p.source,
+            }
+            for p in ctx.rotation_priors
+        ],
+        "scale": [
+            {
+                "m_per_px": round(p.m_per_px, 4),
+                "sigma_log": p.sigma_log,
+                "source": p.source,
+            }
+            for p in ctx.scale_priors
+        ],
+    }
+    candidates = snap_page(ctx, vctx.features)
+    if not candidates:
+        record["status"] = "no_candidates"
+        return record
+    record["candidates"] = [candidate_record(c, unit) for c in candidates]
+    scores = [
+        c["select_score"] for c in record["candidates"] if c["select_score"] is not None
+    ]
+    record["margin"] = (
+        round(scores[0] - scores[1], 4)
+        if len(scores) >= 2
+        else (round(scores[0], 4) if scores else None)
+    )
+    return record
+
+
+def write_contact_sheet(
+    vctx: VolumeContext, unit: PageUnit, record: dict, out_dir: Path
+) -> None:
+    """Red/green overlay PNGs of the top-2 candidates for eyeballing."""
+    prob = load_prob(vctx.volume, unit.stem)
+    if prob is None:
+        return
+    for rank, candidate in enumerate(record.get("candidates", [])[:2]):
+        world = np.array(candidate["world_affine"])
+        center = (candidate["center"][0], candidate["center"][1])
+        diag_m = math.hypot(unit.width, unit.height) * candidate["scale_m_per_px"] / 2
+        frame = frame_around(center, half_m=diag_m + 100.0)
+        osm_prob, _, _ = osm_rasters(frame, vctx.features)
+        pose = frame.page_to_raster_affine(world)
+        warped = cv2.warpAffine(prob, pose, (frame.shape[1], frame.shape[0]))
+        rgb = np.zeros((*frame.shape, 3), np.uint8)
+        rgb[:, :, 1] = (osm_prob * 200).astype(np.uint8)
+        rgb[:, :, 2] = (warped * 255).astype(np.uint8)
+        scale = min(1.0, 1000.0 / max(rgb.shape[:2]))
+        if scale < 1.0:
+            rgb = cv2.resize(rgb, None, fx=scale, fy=scale)
+        rmse = candidate.get("rmse_ft")
+        suffix = f"_{rmse:.0f}ft" if rmse is not None else ""
+        cv2.imwrite(str(out_dir / f"{unit.stem}_{rank + 1}{suffix}.png"), rgb)
+
+
+def cmd_candidates(
+    volume: Path,
+    pages: list[str] | None,
+    all_pages: bool,
+    limit: int | None,
+    recompute: bool,
+    vis: bool,
+) -> None:
+    """Generate candidates.jsonl for the volume's rescue targets."""
+    vctx = load_volume_context(volume)
+    out_dir = artifacts_dir(volume)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "candidates.jsonl"
+    existing: dict[str, dict] = {}
+    if out_path.exists():
+        for line in out_path.read_text().splitlines():
+            if line.strip():
+                record = json.loads(line)
+                existing[record["target"]] = record
+
+    targets = [
+        u
+        for u in vctx.units
+        if (all_pages and u.fit_state != "split") or u.fit_state in RESCUE_STATES
+    ]
+    if pages:
+        wanted = set(pages)
+        targets = [u for u in targets if u.stem in wanted]
+    if limit is not None:
+        targets = targets[:limit]
+
+    print(
+        f"{volume.name}: {len(targets)} target pages, radius "
+        f"{vctx.radius_m:.0f}m ({vctx.radius_source}), scale "
+        f"{vctx.volume_m_per_px:.3f} m/px"
+    )
+    vis_dir = out_dir / "vis"
+    if vis:
+        vis_dir.mkdir(exist_ok=True)
+    done = 0
+    for unit in targets:
+        if unit.stem in existing and not recompute and not pages:
+            continue
+        record = page_record(vctx, unit)
+        existing[unit.stem] = record
+        done += 1
+        best = (record.get("candidates") or [{}])[0]
+        rmse = best.get("rmse_ft")
+        print(
+            f"  {unit.stem:<8} {record['status']:<14}"
+            f" cands={len(record.get('candidates', []))}"
+            + (f" best_rmse={rmse:.0f}ft" if rmse is not None else "")
+            + (
+                f" score={best['select_score']}"
+                if best.get("select_score") is not None
+                else ""
+            )
+        )
+        if vis and record.get("candidates"):
+            write_contact_sheet(vctx, unit, record, vis_dir)
+        # Rewrite after every page so an interrupted run keeps its progress.
+        with out_path.open("w") as handle:
+            for stem in sorted(existing):
+                handle.write(json.dumps(existing[stem]) + "\n")
+    print(f"{done} pages computed; {len(existing)} total in {out_path}")
+
+
+def load_candidates(volume: Path) -> list[dict]:
+    path = artifacts_dir(volume) / "candidates.jsonl"
+    if not path.exists():
+        sys.exit(f"{path} missing; run `candidates` first")
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def cmd_report(volume: Path) -> None:
+    """Recall / ranking diagnostics for the cached candidates, against truth."""
+    records = load_candidates(volume)
+    by_status: dict[str, int] = {}
+    for record in records:
+        by_status[record["status"]] = by_status.get(record["status"], 0) + 1
+    print(f"== {volume.name}: {len(records)} pages ==")
+    print("  status: " + ", ".join(f"{k}={v}" for k, v in sorted(by_status.items())))
+
+    scored = [
+        r
+        for r in records
+        if r["status"] == "ok" and r.get("has_truth") and r.get("candidates")
+    ]
+    if not scored:
+        print("  no truth-scored pages")
+        return
+    recall50 = rank1_50 = rank1_25 = 0
+    best_rmses: list[float] = []
+    print(
+        f"  {'page':<9}{'state':<9}{'cands':>6}{'best set':>10}{'rank-1':>9}"
+        f"{'score':>8}{'margin':>8}  theta_src"
+    )
+    for record in scored:
+        candidates = record["candidates"]
+        rmses = [c["rmse_ft"] for c in candidates if "rmse_ft" in c]
+        if not rmses:
+            continue
+        best_in_set = min(rmses)
+        top = candidates[0]
+        top_rmse = top.get("rmse_ft")
+        if best_in_set <= 50.0:
+            recall50 += 1
+        if top_rmse is not None and top_rmse <= 50.0:
+            rank1_50 += 1
+        if top_rmse is not None and top_rmse <= 25.0:
+            rank1_25 += 1
+        if top_rmse is not None:
+            best_rmses.append(top_rmse)
+        print(
+            f"  {record['target']:<9}{record['fit_state']:<9}{len(candidates):>6}"
+            f"{best_in_set:>9.0f}f{top_rmse:>8.0f}f"
+            f"{top.get('select_score') if top.get('select_score') is not None else float('nan'):>8.2f}"
+            f"{record.get('margin') if record.get('margin') is not None else float('nan'):>8.2f}"
+            f"  {top['theta_source']}"
+        )
+    n = len(scored)
+    print(
+        f"  truth-in-top-K (<=50ft): {recall50}/{n} ({recall50 / n:.0%})   "
+        f"rank-1 <=50ft: {rank1_50}/{n} ({rank1_50 / n:.0%})   "
+        f"rank-1 <=25ft: {rank1_25}/{n} ({rank1_25 / n:.0%})"
+    )
+    if best_rmses:
+        best_rmses.sort()
+        median = best_rmses[len(best_rmses) // 2]
+        print(f"  rank-1 rmse: median {median:.0f}ft, max {best_rmses[-1]:.0f}ft")
+
+
+def truth_land_weights(volume: Path) -> tuple[dict[str, float], float]:
+    """(land m² per unsplit truth page key, total land over ALL truth items).
+
+    Approximates the `mapsnap score` land weighting closely enough to tune
+    gates on cached candidates without re-running iiif+score per setting; the
+    final numbers always come from the real pipeline.
+    """
+    from shapely.geometry import Polygon
+
+    from mapsnap.score import (
+        LocalFrame,
+        land_fraction,
+        street_tree,
+        truth_footprint_ring,
+    )
+    from mapsnap.utils import source_id_to_page_key
+
+    items = json.loads((volume / "main.iiif.json").read_text()).get("items", [])
+    centerlines = default_centerlines(volume)
+    weights: dict[str, float] = {}
+    total = 0.0
+    frame: LocalFrame | None = None
+    tree = None
+    for item in items:
+        ring = truth_footprint_ring(item)
+        if not ring:
+            continue
+        if frame is None:
+            frame = LocalFrame(ring[0][0], ring[0][1])
+            assert centerlines is not None
+            tree = street_tree(centerlines, frame)
+        polygon = Polygon([frame.to_xy(lon, lat) for lon, lat in ring]).buffer(0)
+        if polygon.is_empty or polygon.area <= 0:
+            continue
+        assert tree is not None
+        land = polygon.area * land_fraction(polygon, tree)
+        total += land
+        key = source_id_to_page_key(
+            item.get("target", {}).get("source", {}).get("id"), item.get("label", "")
+        )
+        if "__" not in key:
+            weights[key] = weights.get(key, 0.0) + land
+    return weights, total
+
+
+def simulate_delta_net(
+    records: list[dict],
+    weights: dict[str, float],
+    total_land: float,
+    gate_score: float,
+    gate_margin: float,
+) -> tuple[float, int, int, int]:
+    """(simulated Δnet, accepted, good adds, disaster adds) at one gate setting."""
+    accepted = good = disaster = 0
+    delta = 0.0
+    for record in records:
+        if record.get("status") != "ok" or not record.get("candidates"):
+            continue
+        top = record["candidates"][0]
+        score = top.get("select_score")
+        margin = record.get("margin")
+        if score is None or score < gate_score:
+            continue
+        if margin is None or margin < gate_margin:
+            continue
+        accepted += 1
+        rmse = top.get("rmse_ft")
+        weight = weights.get(record["target"])
+        if rmse is None or weight is None:
+            continue
+        if rmse <= 25.0:
+            good += 1
+            delta += weight
+        elif rmse >= 200.0:
+            disaster += 1
+            delta -= weight
+    return (delta / total_land if total_land else 0.0), accepted, good, disaster
+
+
+def cmd_sweep(volume: Path) -> None:
+    """Grid the abstention gates and print the simulated Δnet for each."""
+    records = load_candidates(volume)
+    weights, total_land = truth_land_weights(volume)
+    print(f"== {volume.name}: simulated Δnet over gate grid ==")
+    print(f"  {'gate':>6} " + "".join(f"m>={m:<4.1f}" + " " * 14 for m in GATE_MARGINS))
+    for gate in GATE_SCORES:
+        cells = []
+        for margin in GATE_MARGINS:
+            delta, accepted, good, disaster = simulate_delta_net(
+                records, weights, total_land, gate, margin
+            )
+            cells.append(
+                f"{delta * 100:+5.1f}% ({accepted:>2}a {good:>2}g {disaster}d)"
+            )
+        print(f"  {gate:>6.2f} " + "  ".join(cells))
+    print("  (a=accepted, g=good <=25ft, d=disaster >=200ft; Δnet is land-weighted)")
+
+
+GATE_SCORES = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+GATE_MARGINS = [0.0, 0.1, 0.25, 0.5]
+
+
+def cmd_select(volume: Path, mode: str, gate_score: float, gate_margin: float) -> None:
+    """Pick one candidate (or abstain) per page; write selection_<mode>.jsonl."""
+    records = load_candidates(volume)
+    out_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
+    selections = []
+    accepted = 0
+    for record in records:
+        stem = record["target"]
+        choice: dict = {"target": stem, "chosen": None, "reason": record["status"]}
+        if record.get("status") == "ok" and record.get("candidates"):
+            top = record["candidates"][0]
+            score = top.get("select_score")
+            margin = record.get("margin")
+            if score is None:
+                choice["reason"] = "implausible"
+            elif score < gate_score:
+                choice["reason"] = f"score {score:.2f} < {gate_score}"
+            elif margin is None or margin < gate_margin:
+                choice["reason"] = f"margin {margin} < {gate_margin}"
+            else:
+                choice = {
+                    "target": stem,
+                    "chosen": 0,
+                    "reason": "accepted",
+                    "select_score": score,
+                    "margin": margin,
+                }
+                accepted += 1
+        selections.append(choice)
+    with out_path.open("w") as handle:
+        for choice in selections:
+            handle.write(json.dumps(choice) + "\n")
+    print(f"{accepted}/{len(selections)} pages accepted -> {out_path}")
+
+
+def osm_variant_path(volume: Path, stem: str) -> Path:
+    return volume / f"{stem}.georef-osm.json"
+
+
+def cmd_materialize(volume: Path, mode: str) -> None:
+    """Write pN.georef-osm.json sidecars for the selection's accepted pages."""
+    from mapsnap.edge_join_experiment import page_fit_state
+
+    records = {r["target"]: r for r in load_candidates(volume)}
+    selection_path = artifacts_dir(volume) / f"selection_{mode}.jsonl"
+    if not selection_path.exists():
+        sys.exit(f"{selection_path} missing; run `select --mode {mode}` first")
+    # Remove every sidecar this channel owns before writing: a stale one from
+    # a looser gate would silently keep scoring.
+    for stale in volume.glob("p*.georef-osm.json"):
+        stale.unlink()
+    written = 0
+    for line in selection_path.read_text().splitlines():
+        choice = json.loads(line)
+        if choice.get("chosen") is None:
+            continue
+        record = records[choice["target"]]
+        candidate = record["candidates"][choice["chosen"]]
+        affine = np.array(candidate["world_affine"])
+        width, height = record["width"], record["height"]
+        corners = []
+        for x, y in [(0, 0), (width, 0), (width, height), (0, height)]:
+            corners.append(
+                [
+                    affine[0, 0] * x + affine[0, 1] * y + affine[0, 2],
+                    affine[1, 0] * x + affine[1, 1] * y + affine[1, 2],
+                ]
+            )
+        _, georef = page_fit_state(volume, choice["target"])
+        doc: dict = {
+            "width": width,
+            "height": height,
+            "corners": corners,
+            "streets": [],
+            "intersections": [],
+            "osm_snap": {
+                "previous_state": record["fit_state"],
+                "mode": mode,
+                "select_score": candidate.get("select_score"),
+                "margin": record.get("margin"),
+                "verification": candidate.get("verification"),
+                "ncc_fine": candidate.get("ncc_fine"),
+                "inlier_frac": candidate.get("inlier_frac"),
+                "name_score": (candidate.get("name") or {}).get("score"),
+                "theta_deg": candidate.get("theta_deg"),
+                "theta_source": candidate.get("theta_source"),
+                "scale_source": candidate.get("scale_source"),
+                "rmse_ft": candidate.get("rmse_ft"),
+            },
+        }
+        if georef and georef.get("keymap"):
+            doc["keymap"] = georef["keymap"]
+        osm_variant_path(volume, choice["target"]).write_text(json.dumps(doc, indent=2))
+        written += 1
+    print(f"{written} pN.georef-osm.json sidecars written in {volume}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_cand = sub.add_parser("candidates", help="generate snap candidates")
+    p_cand.add_argument("volume", type=Path)
+    p_cand.add_argument("--pages", type=str, default=None, help="comma-separated stems")
+    p_cand.add_argument(
+        "--all-pages",
+        action="store_true",
+        help="include fitted pages (arbitration study), not just rescue targets",
+    )
+    p_cand.add_argument("--limit", type=int, default=None)
+    p_cand.add_argument("--recompute", action="store_true")
+    p_cand.add_argument("--no-vis", action="store_true", help="skip contact sheets")
+
+    p_rep = sub.add_parser("report", help="ranking diagnostics vs truth")
+    p_rep.add_argument("volume", type=Path)
+    p_rep.add_argument(
+        "--sweep", action="store_true", help="grid the gates, print simulated Δnet"
+    )
+
+    p_sel = sub.add_parser("select", help="pick candidates / abstain per page")
+    p_sel.add_argument("volume", type=Path)
+    p_sel.add_argument("--mode", choices=["argmax", "volume"], default="argmax")
+    p_sel.add_argument("--gate-score", type=float, default=1.0)
+    p_sel.add_argument("--gate-margin", type=float, default=0.25)
+
+    p_mat = sub.add_parser("materialize", help="write pN.georef-osm.json sidecars")
+    p_mat.add_argument("volume", type=Path)
+    p_mat.add_argument("--mode", choices=["argmax", "volume"], default="argmax")
+
+    args = parser.parse_args()
+    if args.command == "candidates":
+        cmd_candidates(
+            args.volume,
+            args.pages.split(",") if args.pages else None,
+            args.all_pages,
+            args.limit,
+            args.recompute,
+            vis=not args.no_vis,
+        )
+    elif args.command == "report":
+        if args.sweep:
+            cmd_sweep(args.volume)
+        else:
+            cmd_report(args.volume)
+    elif args.command == "select":
+        cmd_select(args.volume, args.mode, args.gate_score, args.gate_margin)
+    elif args.command == "materialize":
+        cmd_materialize(args.volume, args.mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -1,0 +1,150 @@
+"""Tests for the snap harness's production decision core.
+
+arbitrate_challenge / refine_adoption decide whether to REPLACE a placed
+RANSAC fit — the riskiest action in the pipeline — so their gates are pinned
+here with the failure modes that motivated them (see the osm-snap PR).
+"""
+
+import numpy as np
+
+from mapsnap.edge_join_experiment import PageUnit
+from mapsnap.osm_snap_experiment import (
+    SNAP_LOG_BEGIN,
+    SNAP_LOG_END,
+    append_snap_logs,
+    arbitrate_challenge,
+    candidates_record_fresh,
+    refine_adoption,
+)
+
+# A page-local degree scale of ~0.6 m/px at the test latitude.
+KX = 111_320.0 * 0.766  # cos(40 deg)
+SCALE_DEG = 0.6 / KX
+
+
+def affine(lon_shift_m: float = 0.0) -> list[list[float]]:
+    """A north-up page->lonlat affine, optionally slid east by metres."""
+    return [
+        [SCALE_DEG, 0.0, -74.0 + lon_shift_m / KX],
+        [0.0, -SCALE_DEG * 111_320.0 * 0.766 / 110_540.0, 40.0],
+    ]
+
+
+def fitted_record(
+    incumbent_ver: float,
+    challenger_ver: float,
+    shift_m: float,
+    incumbent_name: float = 0.1,
+    challenger_name: float = 0.3,
+    select: float = 2.0,
+) -> dict:
+    return {
+        "target": "p1",
+        "status": "ok",
+        "fit_state": "fitted",
+        "width": 1000,
+        "height": 1000,
+        "incumbent": {
+            "world_affine": affine(),
+            "verification": incumbent_ver,
+            "name": {"score": incumbent_name, "n_hits": 1, "n_labels": 3},
+        },
+        "candidates": [
+            {
+                "world_affine": affine(shift_m),
+                "center": [-74.0 + (500 * SCALE_DEG) + shift_m / KX, 39.99],
+                "theta_deg": 0.0,
+                "theta_source": "label-pair-exact",
+                "center_dist_m": 50.0,
+                "select_score": select,
+                "verification": challenger_ver,
+                "name": {"score": challenger_name, "n_hits": 2, "n_labels": 3},
+            },
+        ],
+    }
+
+
+def test_challenge_requires_indefensible_incumbent():
+    # A plausible incumbent (ver >= 0.1) is never overturned, however strong
+    # the challenger: the Chicago modern-OSM trap (wrong poses matching
+    # today's grid better than the truth does).
+    record = fitted_record(incumbent_ver=0.6, challenger_ver=1.5, shift_m=100.0)
+    assert arbitrate_challenge(record, 1.5) is None
+    # An OSM-contradicted incumbent with a strongly disagreeing, evidence-
+    # winning challenger is replaced.
+    record = fitted_record(incumbent_ver=-0.3, challenger_ver=1.5, shift_m=100.0)
+    challenge = arbitrate_challenge(record, 1.5)
+    assert challenge is not None and challenge["challenge"]
+    assert challenge["disagreement_ft"] > 100.0
+
+
+def test_challenge_requires_real_disagreement_and_name_parity():
+    # Agreement (< 100ft ~ 30m) is refinement territory, not a challenge.
+    record = fitted_record(incumbent_ver=-0.3, challenger_ver=1.5, shift_m=15.0)
+    assert arbitrate_challenge(record, 1.5) is None
+    # Names must not get worse.
+    record = fitted_record(
+        incumbent_ver=-0.3,
+        challenger_ver=1.5,
+        shift_m=100.0,
+        incumbent_name=0.5,
+        challenger_name=0.2,
+    )
+    assert arbitrate_challenge(record, 1.5) is None
+
+
+def test_refine_adopts_agreeing_evidence_winner_only():
+    # An agreeing challenger clearly winning verification is adopted.
+    record = fitted_record(incumbent_ver=0.8, challenger_ver=1.2, shift_m=15.0)
+    adoption = refine_adoption(record)
+    assert adoption is not None and adoption["refine"]
+    # Within the margin (< +0.1): keep the incumbent — no churn on good fits.
+    record = fitted_record(incumbent_ver=0.8, challenger_ver=0.85, shift_m=15.0)
+    assert refine_adoption(record) is None
+    # Far apart is arbitration territory, not refinement.
+    record = fitted_record(incumbent_ver=0.8, challenger_ver=1.2, shift_m=100.0)
+    assert refine_adoption(record) is None
+
+
+def make_unit(fit_state: str) -> PageUnit:
+    return PageUnit(
+        stem="p1",
+        number=1,
+        width=1000,
+        height=1000,
+        fit_state=fit_state,
+        truth=None,
+        split_truth=False,
+        gen_affine=np.array(affine()) if fit_state == "fitted" else None,
+        inlier_intersections=0,
+        inlier_streets=0,
+        keymap_centers=[],
+        keymap_radius_m=0.0,
+    )
+
+
+def test_candidates_record_fresh_tracks_fit_changes():
+    record = {"fit_state": "fitted", "georef_mtime": 111}
+    assert candidates_record_fresh(record, make_unit("fitted"), 111)
+    # A re-run georef rewrote the sidecar: the cached incumbent is stale.
+    assert not candidates_record_fresh(record, make_unit("fitted"), 222)
+    # The page's fit STATE changed (fitted -> nofit or vice versa).
+    assert not candidates_record_fresh(record, make_unit("nofit"), 111)
+    # Legacy records (no georef_mtime) always recompute once.
+    assert not candidates_record_fresh(
+        {"fit_state": "fitted"}, make_unit("fitted"), 111
+    )
+
+
+def test_append_snap_logs_is_idempotent(tmp_path):
+    record = fitted_record(incumbent_ver=0.8, challenger_ver=1.2, shift_m=15.0)
+    selection = refine_adoption(record)
+    assert selection is not None
+    (tmp_path / "p1.txt").write_text("georef log line\n")
+    for _ in range(2):
+        append_snap_logs(tmp_path, [record], [selection], "arbitrate")
+    text = (tmp_path / "p1.txt").read_text()
+    assert text.startswith("georef log line\n")
+    assert text.count(SNAP_LOG_BEGIN) == 1
+    assert text.count(SNAP_LOG_END) == 1
+    assert "refine: candidate #1 accepted" in text

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -1,0 +1,412 @@
+"""Synthetic-fixture tests for the geometry-first OSM matcher.
+
+Convention bugs (cv2 theta sign, y-down frames, lon/lat anisotropy) are the
+costliest failure class here, so every prior rung and the frame math get a
+round-trip test against a synthetic world with known geometry before any
+real-data use.
+"""
+
+import math
+
+import cv2
+import numpy as np
+
+from mapsnap.edge_join import MatchParams
+from mapsnap.georef_from_labels import LabelFeature
+from mapsnap.osm_snap import (
+    CHAMFER_CLAMP_M,
+    PageContext,
+    RotationPrior,
+    ScalePrior,
+    SnapCandidate,
+    adjacency_keymap_rotations,
+    affine_theta_deg,
+    calibrated_radius_m,
+    cluster_rotation,
+    dedupe_thetas,
+    frame_around,
+    label_osm_rotations,
+    merge_candidates,
+    name_alignment,
+    osm_distance_m,
+    osm_rasters,
+    page_scale_priors,
+    pose_theta_deg,
+    snap_page,
+    wrap_deg,
+)
+from mapsnap.streets import build_block_index
+
+LON0, LAT0 = -74.0, 40.0
+KX = 111_320.0 * math.cos(math.radians(LAT0))
+KY = 110_540.0
+
+
+def lonlat(x_m: float, y_north_m: float) -> list[float]:
+    """World lon/lat of a point given in metres east/north of the test origin."""
+    return [LON0 + x_m / KX, LAT0 + y_north_m / KY]
+
+
+def street(name: str, points_m: list[tuple[float, float]]) -> dict:
+    """A GeoJSON street feature from metre coordinates."""
+    return {
+        "properties": {"street_name": name},
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [lonlat(x, y) for x, y in points_m],
+        },
+    }
+
+
+# An irregular grid: no run of gaps repeats reversed anywhere, so neither a
+# translation nor a 180-degree flip can re-align the visible corridors.
+VERTICALS_M = [-520, -400, -230, -60, 20, 160, 340, 500]
+HORIZONTALS_M = [-460, -310, -150, -30, 60, 220, 380, 530]
+
+
+def grid_features() -> list[dict]:
+    features = [
+        street(f"V{i} STREET", [(x, -600), (x, 600)]) for i, x in enumerate(VERTICALS_M)
+    ]
+    features += [
+        street(f"H{i} STREET", [(-600, y), (600, y)])
+        for i, y in enumerate(HORIZONTALS_M)
+    ]
+    # A dead-end street: content asymmetry like a real city, so a flip cannot
+    # even partially correlate.
+    features.append(street("STUB STREET", [(-600, 140), (40, 140)]))
+    return features
+
+
+def extract_page(
+    world: np.ndarray, pose: np.ndarray, size: tuple[int, int]
+) -> np.ndarray:
+    """Sample a 'page' image from a raster given the page->raster pose."""
+    inverse = cv2.invertAffineTransform(pose)
+    return cv2.warpAffine(world, inverse, size)
+
+
+def test_frame_roundtrip() -> None:
+    frame = frame_around((LON0, LAT0), half_m=500.0)
+    theta = math.radians(20.0)
+    scale_deg = 0.6 / KX  # ~0.6 m/px expressed in degrees of longitude
+    affine = np.array(
+        [
+            [scale_deg * math.cos(theta), scale_deg * math.sin(theta), LON0 + 1e-4],
+            [scale_deg * math.sin(theta), -scale_deg * math.cos(theta), LAT0 - 1e-4],
+        ]
+    )
+    pose = frame.page_to_raster_affine(affine)
+    back = frame.raster_pose_to_world_affine(pose)
+    assert np.allclose(affine, back, atol=1e-12)
+    # A page point mapped by the affine then projected into the frame must land
+    # where the composed pose puts it.
+    lon = affine[0, 0] * 40 + affine[0, 1] * 70 + affine[0, 2]
+    lat = affine[1, 0] * 40 + affine[1, 1] * 70 + affine[1, 2]
+    col, row = frame.lonlat_to_raster(lon, lat)
+    via_pose = pose @ np.array([40.0, 70.0, 1.0])
+    assert math.hypot(col - via_pose[0], row - via_pose[1]) < 1e-6
+
+
+def test_osm_raster_geometry() -> None:
+    frame = frame_around((LON0, LAT0), half_m=200.0)
+    prob, valid, skeleton = osm_rasters(frame, [street("A", [(0, -300), (0, 300)])])
+    assert valid.all()
+    rows, cols = frame.shape
+    center_col = cols // 2
+    # The stroked corridor covers ~12 m (6 px) about the center column.
+    assert prob[rows // 2, center_col] == 1.0
+    assert prob[rows // 2, center_col - 2] == 1.0
+    assert prob[rows // 2, center_col + 20] == 0.0
+    # The skeleton is a single-pixel centerline.
+    skeleton_cols = np.nonzero(skeleton[rows // 2])[0]
+    assert len(skeleton_cols) <= 2
+    assert abs(skeleton_cols.mean() - center_col) <= 1.5
+    distance = osm_distance_m(skeleton)
+    assert distance[rows // 2, center_col] <= 2.0
+    assert distance[rows // 2, 5] == CHAMFER_CLAMP_M
+
+
+def test_pose_theta_roundtrip() -> None:
+    frame = frame_around((LON0, LAT0), half_m=500.0)
+    for theta in [-135.0, -45.0, 0.0, 30.0, 90.0]:
+        pose = cv2.getRotationMatrix2D((0.0, 0.0), theta, 0.4)
+        pose[:, 2] += [250.0, 250.0]
+        assert abs(wrap_deg(pose_theta_deg(pose) - theta)) < 1e-9
+        world = frame.raster_pose_to_world_affine(pose)
+        assert abs(wrap_deg(affine_theta_deg(world, frame) - theta)) < 1e-9
+
+
+def test_dedupe_thetas_keeps_first_of_near_duplicates() -> None:
+    priors = [
+        RotationPrior(10.0, 4.0, "label-pair-exact"),
+        RotationPrior(11.5, 8.0, "ransac-neighbor"),
+        RotationPrior(-170.0, 4.0, "label-osm-mod180"),
+        RotationPrior(100.0, 4.0, "mask-mod90"),
+    ]
+    kept = dedupe_thetas(priors)
+    assert [p.source for p in kept] == [
+        "label-pair-exact",
+        "label-osm-mod180",
+        "mask-mod90",
+    ]
+
+
+def test_cluster_rotation_rejects_outlier() -> None:
+    theta, inliers = cluster_rotation([(20.0, 1.0), (24.0, 1.0), (150.0, 1.0)])
+    assert inliers == 2
+    assert abs(theta - 22.0) < 1.0
+
+
+def test_label_osm_rotations_single_label_gives_both_flips() -> None:
+    features = [street("V4 STREET", [(30, -600), (30, 600)])]
+    block_index = build_block_index({"type": "FeatureCollection", "features": features})
+    # A north-up page: a label along the north-south street reads vertically.
+    label = LabelFeature(
+        raw_text="V4",
+        text="V4 STREET",
+        center=(180.0, 210.0),
+        dir_pix=math.pi / 2,
+        long_side=80.0,
+        short_side=12.0,
+    )
+    priors = label_osm_rotations([label], block_index, (LON0, LAT0))
+    sources = {p.source for p in priors}
+    assert sources == {"label-osm-mod180"}
+    thetas = sorted(wrap_deg(p.theta_deg) for p in priors)
+    assert abs(thetas[0] - (-180.0)) < 1e-6 or abs(thetas[0] - 0.0) < 1e-6
+    assert len({round(t % 180.0, 3) for t in thetas}) == 1
+
+
+def test_label_pair_resolves_flip() -> None:
+    features = [
+        street("AAA STREET", [(-100, -600), (-100, 600)]),
+        street("BBB STREET", [(100, -600), (100, 600)]),
+    ]
+    block_index = build_block_index({"type": "FeatureCollection", "features": features})
+    # North-up page, 1 m/px, centered on the origin: AAA appears at page
+    # x=50, BBB at x=250 (page center x=150).
+    label_a = LabelFeature(
+        raw_text="AAA",
+        text="AAA STREET",
+        center=(50.0, 210.0),
+        dir_pix=math.pi / 2,
+        long_side=80.0,
+        short_side=12.0,
+    )
+    label_b = LabelFeature(
+        raw_text="BBB",
+        text="BBB STREET",
+        center=(250.0, 190.0),
+        dir_pix=math.pi / 2,
+        long_side=80.0,
+        short_side=12.0,
+    )
+    priors = label_osm_rotations([label_a, label_b], block_index, (LON0, LAT0))
+    exact = [p for p in priors if p.source == "label-pair-exact"]
+    assert exact, "two labels on distinct parallel streets must resolve the flip"
+    assert all(abs(wrap_deg(p.theta_deg)) < 5.0 for p in exact)
+
+
+def test_adjacency_keymap_rotations() -> None:
+    centroids = {
+        10: (LON0, LAT0 + 400 / KY),  # north neighbor
+        11: (LON0 + 400 / KX, LAT0),  # east neighbor
+    }
+    # North-up page: the north neighbor's number prints on the top margin, the
+    # east neighbor's on the right margin.
+    image_directions = {
+        10: ((0.0, -1.0), 0.9),
+        11: ((1.0, 0.0), 0.8),
+    }
+    priors = adjacency_keymap_rotations(image_directions, centroids, (LON0, LAT0))
+    assert len(priors) == 1
+    assert abs(wrap_deg(priors[0].theta_deg)) < 1.0
+
+    # A page rotated cv2 +90: north is now toward page +x (right margin).
+    rotated_directions = {
+        10: ((1.0, 0.0), 0.9),
+        11: ((0.0, 1.0), 0.8),
+    }
+    priors = adjacency_keymap_rotations(rotated_directions, centroids, (LON0, LAT0))
+    assert len(priors) == 1
+    assert abs(wrap_deg(priors[0].theta_deg - 90.0)) < 1.0
+
+
+def test_page_scale_priors_family_rung() -> None:
+    # Region area implying ~2x the median scale adds a family rung.
+    side_m = 600.0
+    ring = [lonlat(0, 0), lonlat(side_m, 0), lonlat(side_m, side_m), lonlat(0, side_m)]
+    priors = page_scale_priors(1.0, [ring], 300, 300)
+    assert [p.source for p in priors] == ["volume-median", "family-rung"]
+    assert abs(priors[1].m_per_px - 2.0) < 1e-6
+    # A region matching the median adds nothing.
+    side_m = 300.0
+    ring = [lonlat(0, 0), lonlat(side_m, 0), lonlat(side_m, side_m), lonlat(0, side_m)]
+    priors = page_scale_priors(1.0, [ring], 300, 300)
+    assert [p.source for p in priors] == ["volume-median"]
+
+
+def test_calibrated_radius() -> None:
+    assert calibrated_radius_m([50.0] * 3, 600.0) == (600.0, "locator")
+    radius, source = calibrated_radius_m([40.0, 55.0, 60.0, 70.0, 90.0] * 2, 600.0)
+    assert source == "calibrated"
+    assert 150.0 <= radius <= 200.0
+    # A wild p90 clamps to the locator radius; a tiny one to the floor.
+    assert calibrated_radius_m([2000.0] * 10, 600.0)[0] == 600.0
+    assert calibrated_radius_m([1.0] * 10, 600.0)[0] == 150.0
+
+
+def test_name_alignment_correct_beats_shifted_and_renamed_scores_zero() -> None:
+    features = [
+        street("AAA STREET", [(-100, -600), (-100, 600)]),
+        street("BBB STREET", [(100, -600), (100, 600)]),
+    ]
+    block_index = build_block_index({"type": "FeatureCollection", "features": features})
+    labels = [
+        LabelFeature("AAA", "AAA STREET", (50.0, 210.0), math.pi / 2, 80.0, 12.0),
+        LabelFeature("BBB", "BBB STREET", (250.0, 190.0), math.pi / 2, 80.0, 12.0),
+    ]
+    # North-up 1 m/px affine centered on the origin (page 300x420).
+    correct = np.array(
+        [[1.0 / KX, 0.0, LON0 - 150.0 / KX], [0.0, -1.0 / KY, LAT0 + 210.0 / KY]]
+    )
+    shifted = correct.copy()
+    shifted[0, 2] += 80.0 / KX  # slide 80 m east: labels miss their streets
+    good = name_alignment(labels, block_index, correct)
+    bad = name_alignment(labels, block_index, shifted)
+    assert good.n_hits == 2
+    assert good.score > bad.score
+    # A renamed street matches nothing: score 0, never negative.
+    renamed = name_alignment(
+        [LabelFeature("ZZZ", "ZZZ STREET", (50.0, 210.0), math.pi / 2, 80.0, 12.0)],
+        block_index,
+        correct,
+    )
+    assert renamed.score == 0.0
+    assert renamed.n_hits == 0
+
+
+def make_world_and_page(
+    theta_deg: float, page_size: tuple[int, int] = (300, 420)
+) -> tuple[np.ndarray, np.ndarray, tuple[float, float]]:
+    """(page P(road), truth page->lonlat affine, page-center lonlat)."""
+    world_frame = frame_around((LON0, LAT0), half_m=1200.0)
+    world_prob, _, _ = osm_rasters(world_frame, grid_features())
+    width, height = page_size
+    center_m = (20.0, 30.0)  # metres east/north of the origin
+    center_px = world_frame.lonlat_to_raster(*lonlat(*center_m))
+    # 1 m/px page scale -> 0.5 raster px per page px at the 2 m frame.
+    pose = cv2.getRotationMatrix2D((width / 2, height / 2), theta_deg, 0.5)
+    moved = pose @ np.array([width / 2, height / 2, 1.0])
+    pose[:, 2] += [center_px[0] - moved[0], center_px[1] - moved[1]]
+    page = extract_page(world_prob, pose, page_size)
+    affine = world_frame.raster_pose_to_world_affine(pose)
+    lon_c = affine[0, 0] * width / 2 + affine[0, 1] * height / 2 + affine[0, 2]
+    lat_c = affine[1, 0] * width / 2 + affine[1, 1] * height / 2 + affine[1, 2]
+    return page, affine, (lon_c, lat_c)
+
+
+def affine_corner_error_m(a: np.ndarray, b: np.ndarray, size: tuple[int, int]) -> float:
+    """Max corner displacement (metres) between two page->lonlat affines."""
+    width, height = size
+    worst = 0.0
+    for x, y in [(0, 0), (width, 0), (width, height), (0, height)]:
+        lon_a = a[0, 0] * x + a[0, 1] * y + a[0, 2]
+        lat_a = a[1, 0] * x + a[1, 1] * y + a[1, 2]
+        lon_b = b[0, 0] * x + b[0, 1] * y + b[0, 2]
+        lat_b = b[1, 0] * x + b[1, 1] * y + b[1, 2]
+        worst = max(worst, math.hypot((lon_a - lon_b) * KX, (lat_a - lat_b) * KY))
+    return worst
+
+
+def test_snap_recovers_synthetic_pose() -> None:
+    theta_true = 25.0
+    page, truth_affine, center = make_world_and_page(theta_true)
+    # Init 100 m off the true center with no rotation priors: the mask-mod-90
+    # sweep alone must propose the right rotation and the irregular grid must
+    # disambiguate the translation.
+    init = (center[0] + 60.0 / KX, center[1] - 80.0 / KY)
+    ctx = PageContext(
+        stem="p1",
+        number=1,
+        width=300,
+        height=420,
+        prob=page,
+        search_centers=[init],
+        radius_m=300.0,
+        rotation_priors=[],
+        scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
+    )
+    params = MatchParams(
+        min_overlap_m2=30_000.0, max_overlap_frac=1.0, top_k=8, mask_min_area=200
+    )
+    candidates = snap_page(ctx, grid_features(), params)
+    assert candidates, "the matcher must produce candidates"
+    best = candidates[0]
+    assert best.plausible
+    assert abs(wrap_deg(best.theta_deg - theta_true)) < 1.5
+    assert affine_corner_error_m(best.world_affine, truth_affine, (300, 420)) < 8.0
+    assert best.theta_source == "mask-mod90"
+
+
+def test_snap_flipped_prior_recovered_by_mask_sweep() -> None:
+    # A wrong 180-degree prior must not poison the result: the mask sweep
+    # appends the true rotation and the content correlation picks it.
+    theta_true = 25.0
+    page, truth_affine, center = make_world_and_page(theta_true)
+    ctx = PageContext(
+        stem="p1",
+        number=1,
+        width=300,
+        height=420,
+        prob=page,
+        search_centers=[center],
+        radius_m=250.0,
+        rotation_priors=[RotationPrior(theta_true - 180.0, 4.0, "adjacency-keymap")],
+        scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
+    )
+    params = MatchParams(
+        min_overlap_m2=30_000.0, max_overlap_frac=1.0, top_k=8, mask_min_area=200
+    )
+    candidates = snap_page(ctx, grid_features(), params)
+    assert candidates
+    best = candidates[0]
+    assert abs(wrap_deg(best.theta_deg - theta_true)) < 1.5
+    assert affine_corner_error_m(best.world_affine, truth_affine, (300, 420)) < 8.0
+
+
+def make_candidate(select: float, lon: float, theta: float = 0.0) -> SnapCandidate:
+    # verification carries the whole select_score here (no bonuses attached).
+    return SnapCandidate(
+        world_affine=np.zeros((2, 3)),
+        center=(lon, LAT0),
+        theta_deg=theta,
+        theta_source="mask-mod90",
+        scale_m_per_px=1.0,
+        scale_source="volume-median",
+        scale_adjust=1.0,
+        ncc=0.5,
+        ncc_fine=0.3,
+        chamfer_mean_m=5.0,
+        inlier_frac=0.5,
+        n_points=1000,
+        jtj_eig_ratio=0.1,
+        overlap_frac=0.0,
+        refine_shift_m=3.0,
+        center_dist_m=50.0,
+        verification=select,
+    )
+
+
+def test_merge_candidates_dedupes_same_lock() -> None:
+    near = 10.0 / KX  # 10 m apart: the same lock found from two centers
+    a = make_candidate(1.5, LON0)
+    b = make_candidate(1.2, LON0 + near)
+    c = make_candidate(1.0, LON0 + 500.0 / KX)
+    kept = merge_candidates([b, a, c], top_k=8)
+    assert [k.verification for k in kept] == [1.5, 1.0]
+    # The same location at a different rotation is a distinct lock.
+    d = make_candidate(1.1, LON0 + near, theta=90.0)
+    kept = merge_candidates([a, d], top_k=8)
+    assert len(kept) == 2

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -376,6 +376,30 @@ def test_snap_flipped_prior_recovered_by_mask_sweep() -> None:
     assert affine_corner_error_m(best.world_affine, truth_affine, (300, 420)) < 8.0
 
 
+def test_evaluate_pose_truth_beats_shifted() -> None:
+    from mapsnap.osm_snap import evaluate_pose
+
+    page, truth_affine, center = make_world_and_page(25.0)
+    ctx = PageContext(
+        stem="p1",
+        number=1,
+        width=300,
+        height=420,
+        prob=page,
+        search_centers=[center],
+        radius_m=250.0,
+        rotation_priors=[],
+        scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
+    )
+    good = evaluate_pose(ctx, grid_features(), truth_affine)
+    shifted_affine = truth_affine.copy()
+    shifted_affine[0, 2] += 60.0 / KX  # slide 60 m east
+    bad = evaluate_pose(ctx, grid_features(), shifted_affine)
+    assert good is not None and bad is not None
+    assert good["verification"] > bad["verification"]
+    assert good["inlier_frac"] > bad["inlier_frac"]
+
+
 def make_candidate(select: float, lon: float, theta: float = 0.0) -> SnapCandidate:
     # verification carries the whole select_score here (no bonuses attached).
     return SnapCandidate(

--- a/mapsnap/pipeline_rerun.py
+++ b/mapsnap/pipeline_rerun.py
@@ -17,7 +17,8 @@ Per volume:
   4. ``mapsnap ocr --reuse-boxes --allow-missing-boxes`` re-recognizes every page (panels
      supersede their parent), auto-discovering the georeferenced key maps;
   5. ``mapsnap adjacency --reuse-boxes`` rebuilds the printed-neighbor adjacency graph;
-  6. ``mapsnap fit --tag <tag>`` georeferences, builds the IIIF AnnotationPage, and
+  6. ``mapsnap fit --tag <tag>`` georeferences, runs the geometry-first snap
+     channel (rescue/arbitrate/refine), builds the IIIF AnnotationPage, and
      compares against truth.
 
 Steps are resumable per volume via ``.pipeline/rerun-<tag>-<step>.done`` stamps (the tag

--- a/mapsnap/road_model.py
+++ b/mapsnap/road_model.py
@@ -217,6 +217,10 @@ def predict_page(
     return probabilities / weights
 
 
+# The shipped checkpoint, anchored to the repo so commands work from any CWD.
+ROAD_MODEL_PATH = Path(__file__).resolve().parent.parent / "models" / "road_unet.pt"
+
+
 def load_model(model_path: Path, device) -> "UNet":
     """Load a trained road UNet from a checkpoint, moved to ``device`` and set to eval mode.
 

--- a/mapsnap/snap.py
+++ b/mapsnap/snap.py
@@ -35,14 +35,6 @@ Usage:
 import argparse
 from pathlib import Path
 
-# The production gates, frozen from the dev-volume sweeps (see the osm-snap
-# PR for the calibration story): argmax rescue gate + distinct margin, the
-# volume-energy conservative elbow (VOLUME_MODE_GATE), the arbitration score
-# gate, and the refinement verification margin (REFINE_VER_MARGIN).
-GATE_SCORE = 1.25
-GATE_MARGIN = 0.25
-ARBITRATE_GATE = 1.5
-
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -69,7 +61,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # The production gates are frozen alongside the selection code (see the
+    # osm-snap PR for the calibration story); VOLUME_MODE_GATE and
+    # REFINE_VER_MARGIN live there too.
     from mapsnap.osm_snap_experiment import (
+        PRODUCTION_ARBITRATE_GATE,
+        PRODUCTION_GATE_MARGIN,
+        PRODUCTION_GATE_SCORE,
         cmd_candidates,
         cmd_materialize,
         cmd_select,
@@ -84,7 +82,13 @@ def main() -> None:
         recompute=args.recompute,
         vis=False,
     )
-    cmd_select(args.dir, mode, GATE_SCORE, GATE_MARGIN, ARBITRATE_GATE)
+    cmd_select(
+        args.dir,
+        mode,
+        PRODUCTION_GATE_SCORE,
+        PRODUCTION_GATE_MARGIN,
+        PRODUCTION_ARBITRATE_GATE,
+    )
     cmd_materialize(args.dir, mode)
 
 

--- a/mapsnap/snap.py
+++ b/mapsnap/snap.py
@@ -1,0 +1,92 @@
+"""Geometry-first OSM snap: rescue, arbitrate, and refine a volume's fits.
+
+The production entry point for the osm_snap channel (see osm_snap.py for the
+matcher and osm_snap_experiment.py for the underlying commands). Matches each
+page's road-UNet P(road) map against OSM centerlines rasterized in a local
+metre frame — no street-name OCR required — and writes pN.georef-osm.json
+sidecars for three kinds of placements:
+
+  - RESCUE: pages the RANSAC georeferencer left unplaced (nofit/misscale/
+    1gcp/outlier variants, plus split panels), placed from their key-map
+    location via rotation/scale prior ladders and gated selection;
+  - ARBITRATION: replacements for placed fits that OSM actively contradicts
+    (incumbent verification < 0.1) when a confident challenger disagrees by
+    >100 ft and wins the shared-evidence head-to-head;
+  - REFINEMENT: adoption of a challenger that AGREES with a placed fit
+    (<100 ft) and beats its verification by a clear margin — the mid-tier
+    precision polish (agreeing snap poses beat 25-100 ft RANSAC fits 85-93%
+    of the time).
+
+Everything here is truth-free; main.iiif.json, when present, only annotates
+diagnostics. Road-UNet P(road) maps are inferred on demand (cached under
+artifacts/edge_join/roadprob/). Build the volume IIIF with the osm-first
+hybrid glob so the sidecars win where they exist:
+
+    mapsnap iiif <ref> '<dir>/*.georef-osm.json,<dir>/*.georef.json' ...
+
+(`mapsnap fit` does this automatically.) First run costs UNet inference plus
+NCC matching (roughly 10-30 minutes per volume); candidates are cached in
+artifacts/osm_snap/candidates.jsonl and reruns are seconds.
+
+Usage:
+    mapsnap snap DIR [--rescue-only] [--recompute]
+"""
+
+import argparse
+from pathlib import Path
+
+# The production gates, frozen from the dev-volume sweeps (see the osm-snap
+# PR for the calibration story): argmax rescue gate + distinct margin, the
+# volume-energy conservative elbow (VOLUME_MODE_GATE), the arbitration score
+# gate, and the refinement verification margin (REFINE_VER_MARGIN).
+GATE_SCORE = 1.25
+GATE_MARGIN = 0.25
+ARBITRATE_GATE = 1.5
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Geometry-first OSM snap: rescue unplaced pages, arbitrate "
+            "OSM-contradicted fits, and refine mid-tier fits. Writes "
+            "pN.georef-osm.json sidecars; include them osm-first in the "
+            "IIIF glob."
+        )
+    )
+    parser.add_argument("dir", metavar="DIR", type=Path, help="Volume directory")
+    parser.add_argument(
+        "--rescue-only",
+        action="store_true",
+        help=(
+            "Only place unplaced pages; skip the fitted-page candidate pass "
+            "(and with it arbitration and refinement). Much cheaper."
+        ),
+    )
+    parser.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Ignore cached candidates and re-match every target page.",
+    )
+    args = parser.parse_args()
+
+    from mapsnap.osm_snap_experiment import (
+        cmd_candidates,
+        cmd_materialize,
+        cmd_select,
+    )
+
+    mode = "union" if args.rescue_only else "arbitrate"
+    cmd_candidates(
+        args.dir,
+        pages=None,
+        all_pages=not args.rescue_only,
+        limit=None,
+        recompute=args.recompute,
+        vis=False,
+    )
+    cmd_select(args.dir, mode, GATE_SCORE, GATE_MARGIN, ARBITRATE_GATE)
+    cmd_materialize(args.dir, mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -255,6 +255,30 @@ def normalize_street(text: str) -> str:
     return " ".join(words)
 
 
+DIRECTIONAL_SUFFIXES = {
+    "NORTH",
+    "SOUTH",
+    "EAST",
+    "WEST",
+    "NORTHEAST",
+    "NORTHWEST",
+    "SOUTHEAST",
+    "SOUTHWEST",
+}
+
+
+def street_base_name(name: str) -> str:
+    """A street name with any trailing directional word removed.
+
+    "K STREET SOUTHEAST" and "K STREET NORTHWEST" are quadrant segments of
+    one physical street, not two candidate matches.
+    """
+    words = name.split()
+    if len(words) > 1 and words[-1] in DIRECTIONAL_SUFFIXES:
+        return " ".join(words[:-1])
+    return name
+
+
 def is_number_only(text: str) -> bool:
     """Return True if text contains no alphabetic characters (e.g. block numbers)."""
     return not bool(re.search(r"[a-zA-Z]", text))


### PR DESCRIPTION
Adds a **geometry-first georeferencing channel** that matches each page's road-UNet P(road) mask directly against OSM street geometry — no street-name OCR in the loop — and uses it three ways: to **rescue** pages the RANSAC georeferencer couldn't place, to **arbitrate** (replace) placed fits that OSM actively contradicts, and to **refine** mid-tier fits to street-grid precision. Validates the thesis of #128.

**Land-weighted net score across the 12 truth volumes: 55.5 → 69.8** (good share 58.7% → 72.7%, disaster share 3.1% → 2.9%). Every volume improves. Two volumes (NO-1951, Champaign) now exceed the 90-point target.

## Per-volume journey

Each stage's IIIF (plus its `mapsnap compare` `.txt` for the debugger) is checkpointed in every volume directory: **`snap-base`** (RANSAC only) → **`snap-union2`** (+ rescue & split panels) → **`snap-arb`** (+ arbitration) → **`snap-refine`** (+ refinement = the production configuration).

| Volume | base | +rescue | +arbitration | +refinement | total Δ |
|---|---|---|---|---|---|
| Washington DC | 36.6 | 58.8 | 58.8 | **76.1** | **+39.5** |
| Hudson | 33.5 | 37.8 | 39.9 | **49.5** | +16.0 |
| Nashville | 39.1 | 40.8 | 45.5 | **53.8** | +14.7 |
| Kansas City | 53.9 | 55.2 | 56.0 | **68.3** | +14.4 |
| New Orleans 1896 | 39.0 | 40.1 | 41.8 | **49.7** | +10.7 |
| Los Angeles | 66.5 | 70.0 | 70.8 | **76.1** | +9.6 |
| Detroit | 59.4 | 62.6 | 63.7 | **68.3** | +8.9 |
| New Orleans 1951 | 84.4 | 84.4 | 85.5 | **93.3** | +8.9 |
| Grand Rapids | 57.9 | 57.9 | 57.9 | **64.0** | +6.1 |
| Brooklyn | 71.6 | 73.8 | 73.8 | **77.6** | +6.0 |
| Chicago | 69.4 | 69.4 | 69.4 | **75.2** | +5.8 |
| Champaign | 90.5 | 90.5 | 90.5 | **92.7** | +2.2 |
| **AGGREGATE** | **55.5** | **60.3** | **61.1** | **69.8** | **+14.3** |

(The pre-existing baseline was reported as 55.0 before this branch; +0.5 of the journey is a truth-accounting fix, not pipeline improvement — see "missing truth splits" below.)

## How it works

**Matching (`mapsnap/osm_snap.py`, truth-free).** OSM centerlines are rasterized into a local equirectangular metre frame (2 m/px, 12 m stroke — an OSM analog of the road-UNet's P(road) output). The page's P(road) map is matched against it with the edge-join machinery from #125: masked FFT cross-correlation proposes top-K translations per candidate rotation; chamfer least-squares on the road skeleton polishes each pose. Search is centered on the page's key-map location with a **per-volume calibrated radius** (p90 of fitted pages' keymap-vs-fit residuals — tightening Hudson from ~500 m to 150 m was one of the single biggest levers).

**Rotation & scale priors** seed the search as explicit, provenance-tagged ladders:
- *label-pair-exact*: two OCR'd labels on distinct streets fix the exact rotation (the street tangent gives it mod 180°; the world offset between the two streets resolves the flip);
- *label-osm-mod180*: one matched label, both flips emitted;
- *adjacency-keymap*: printed neighbor-number directions vs key-map region centroid bearings;
- *ransac-neighbor*: rotation borrowed from fitted neighbors (or a fitted sibling panel — the same physical sheet);
- *mask-mod90*: dominant road-orientation sweep, always appended so the set is never empty;
- scale: volume median, plus a half/double family rung when the key-map region area disagrees by ~2×.

**Ranking.** Each candidate carries the matcher's verification (chamfer inlier fraction + fine content correlation − mean chamfer) plus soft evidence: **street-name alignment** (labels projected through the pose, snapped to same-named OSM streets — a boost, never a gate, so renamed streets still georeference), key-map region containment, and rotation-prior agreement.

**Selection** (`osm_snap_experiment.py`, `select`) combines two dev-calibrated committees: a per-page argmax with score/margin gates (margin measured against the best *distinct* lock, not near-identical twins) and a volume-wide energy minimization (footprint overlap against fitted pages — with thresholds calibrated from how much the volume's own adjacent fitted sheets' footprints overlap; no page-to-page seam matching is involved — plus key-map adjacency-consistency and side terms, solved exactly per connected component). Split panels additionally face **sheet-agreement gates**: a panel's affine extends exactly to an implied placement of the whole scanned sheet (the crop is a pure translation), and candidates must agree with any reliable fitted sibling's implied sheet (effective GCPs ≥ 3, ~60 m tolerance); no-anchor panels need a much higher solo score. **Caveat, found in review**: measured against every fitted sibling pair in the corpus, real Sanborn split pages are *inset composites* (separate neighborhood maps on one sheet of paper — implied sheets disagree by 233–2143 m), not contiguous maps cut apart. So in practice this gate blanket-blocks rescue of panels that have a reliable fitted sibling rather than discriminating geometrically. That conservative behavior is exactly what the 12-volume scores validated (it is what stopped KC's four would-be panel disasters, including a 753 ft lock at select 2.58 that no score threshold would catch), but the mechanism's honest description is a block, not a constraint check — see next steps.

**Arbitration & refinement** run the same evidence head-to-head on placed fits: `evaluate_pose` scores the incumbent RANSAC pose with the identical verification formula and name alignment. A **challenge** (replacement) requires a confident challenger that disagrees by >100 ft, wins on both evidence axes, *and* an incumbent that is geometrically indefensible (verification < 0.1). A **refinement** adopts a challenger that *agrees* (<100 ft) and beats the incumbent's verification by ≥ 0.1 — measured on truth, an agreeing snap pose beats a 25–50 ft RANSAC fit 93% of the time (median 33 → 12 ft) and a 50–100 ft fit 85% of the time, because RANSAC's mid-tier error is street-label placement noise while the snap pose is chamfer-locked to the street grid.

**Production surface.** `mapsnap snap DIR` runs candidates → select → materialize at the frozen gates and writes `pN.georef-osm.json` sidecars. `mapsnap fit` invokes it after `georef` and builds the IIIF from the osm-first hybrid glob (`*.georef-osm.json,*.georef.json` — first glob wins per page), which carries the channel into `run-oim`, `run-loc`, and `rerun` unchanged. Opt out with `--no-snap`. First run per volume costs UNet inference + matching (~10–30 min); candidates are cached in `artifacts/osm_snap/candidates.jsonl` and reruns take seconds.

## Illustrations

(Image files are staged locally in `pr-images/` — drag them into the placeholders below. See also the volume-viewer DC progression in the comments.)

**A clean rescue lock.** DC p130, unplaceable by street-name OCR, snapped at 4 ft: the page's road-UNet corridors (red) fuse with the OSM grid (green) into yellow across the entire footprint.

<img width="414" height="414" alt="01-rescue-lock-dc-p130-4ft" src="https://github.com/user-attachments/assets/f21c339c-db26-408f-9d84-f1cf7959ddb4" />

**Why gating matters — a confident grid alias.** Detroit p85 at 368 ft: the page's uniform corridors lock onto *alternating* OSM streets. The interior aliases perfectly; only the page edges (the top corridor with no green partner) give it away.

<img width="351" height="351" alt="02-grid-alias-detroit-p85-368ft" src="https://github.com/user-attachments/assets/fd1ab6e2-d6a7-49fd-9f5a-883003f81241" />

**Refinement.** DC p201: the RANSAC incumbent (left) sits 87 ft off — every corridor slightly misregistered; the adopted agreeing challenger (right) locks to 12 ft. This one move, repeated 274 times, is the +8.7-point step.

<img width="1502" height="748" alt="03-refinement-dc-p201-87ft-to-12ft" src="https://github.com/user-attachments/assets/b75a1553-3dc7-4977-9921-ca4ed5b529bf" />

**Split sheets are inset composites.** Champaign p4's four panels' true placements: scattered kilometres apart, one rotated — the paper layout has no relation to ground geometry, which is why the sheet-agreement gate acts as a block rather than a geometric check (#154).

<img width="1400" height="1400" alt="04-inset-composite-champaign-p4" src="https://github.com/user-attachments/assets/69ec8950-5f4f-4681-ab60-6a384c6be7c6" />

**Channel architecture.**

```mermaid
flowchart LR
    G["mapsnap georef
(RANSAC on street OCR)"] --> S
    subgraph S["mapsnap snap"]
        C["candidates
P(road) vs OSM raster:
prior ladders → NCC → chamfer
+ evaluate_pose(incumbent)"] --> SEL
        subgraph SEL["select --mode arbitrate"]
            R["rescue
(unplaced pages,
union of 2 committees)"]
            A["arbitrate
(incumbent ver < 0.1,
disagree > 100 ft)"]
            F["refine
(agree < 100 ft,
ver margin ≥ 0.1)"]
        end
        SEL --> M["materialize
pN.georef-osm.json"]
    end
    M --> I["mapsnap iiif
osm-first hybrid glob"]
    G --> I
    I --> CMP["mapsnap compare / score"]
```

## Glossary

- **P(road)** — per-pixel road probability from the road-UNet (#125), cached as `artifacts/edge_join/roadprob/*.png`.
- **Snap / snap pose** — a placement obtained by matching P(road) against rasterized OSM geometry.
- **Incumbent / challenger** — the existing RANSAC fit for a page / the top snap candidate for the same page.
- **Rescue** — placing a page that has no `pN.georef.json` (nofit/misscale/1gcp/outlier variants, or nothing at all).
- **Arbitration** — replacing an incumbent that OSM contradicts with a strongly disagreeing challenger.
- **Refinement** — adopting an agreeing challenger as a more precise estimate of the same lock.
- **Verification** — the matcher's truth-free pose quality: chamfer inlier fraction + fine NCC − mean chamfer/30 m.
- **select_score** — verification + name-alignment + containment + prior-agreement bonuses; the ranking/gating score.
- **Distinct margin** — select_score lead of rank-1 over the best candidate that is a genuinely different lock (>100 m or >10° away).
- **NCC** — normalized cross-correlation (Padfield masked FFT form) used for the translation search.
- **Chamfer** — the page's road-skeleton points projected through a pose and read against the OSM centerline distance transform: the *mean* (clamped at 30 m) measures overall fit, and the **inlier fraction** is the share of skeleton points landing within 5 m of an OSM centerline — how much of the page's road network locks onto the grid.
- **Keymap** — the volume's index sheet; its georeferenced page-number detections and segmented block regions give each page a coarse location and footprint.
- **Sheet agreement** — the split-panel gate. A panel jpg is a bounding-box crop of the base sheet, so one panel's pose implies a placement of the whole scanned sheet; the gate demands siblings imply the same one. Because real split sheets are inset composites (see lessons learned), this in practice blocks sibling-of-fitted panels from rescue rather than checking geometry.
- **eff / effective GCPs** — effective ground-control-point count of a fit; ≥3 marks a fit reliable enough to anchor sheet agreement.
- **IoU-over-min** — intersection area over the smaller footprint's area; the overlap measure in the volume energy.
- **Net score** — the `mapsnap score` metric: land-weighted share of truth pages ≤25 ft minus share ≥200 ft (#148).
- **GEOREF_VARIANTS** — sidecar suffixes (`georef`, `-nofit`, `-misscale`, `-1gcp`, `-outlier`, `-neighbor`, `-osm`) recording each page's fit state.
- **OIM** — OldInsuranceMaps.net, the source of truth annotations (`main.iiif.json`) and manual split regions.

## Lessons learned / dead ends

- **Truth data had two silent holes**, both now fixed and guarded: (1) truth keys differing from jpg stems only in letter case left 111 Chicago pages invisible to the experiment harness; (2) four volumes had truth split items but no `oim/*.panels.json`, so *no placement of those pages could ever be scored* — KC's real baseline was ~4 points higher than reported. `mapsnap compare` (and through it `score`) now warns loudly on the second condition; `mapsnap oim-split-truth` inputs for KC/Detroit/NO-1896 were fetched and built.
- **Score alone cannot gate small pages.** Split panels produced confident wrong locks (847 ft at select 2.28) interleaved with true locks. Contiguity with the fitted sibling was not enough — an alias slid *along the cut line* still touches it. The rigid-sheet agreement constraint (exact, geometric) was the fix, and it later blocked four would-be KC disasters including a 753 ft lock at select 2.58.
- **Fitted split panels are the least reliable fits in a volume** (eff ≤ 2 panels range to 6640 ft off). They are excluded from the overlap-evidence context and from sheet-agreement anchoring; agreeing with a bad anchor rejects true candidates.
- **The modern-OSM trap**: in Chicago's rebuilt 1950 core, a 400 ft-wrong pose can match *today's* OSM better than the truth does, with name evidence tied. This produced the only bad arbitration challenges and motivated the incumbent-defensibility gate (challenge only fits with verification < 0.1). Across all 11 truth-graded challenges the gate separates perfectly (correct overturns ≤ 0.05, wrong ones ≥ 0.12).
- **A stronger optimizer made scores worse.** Adding ICM restarts found the volume energy's true optimum — which abstains on pages the accept-biased two-start version correctly keeps, because the adjacency term over-penalizes true placements where key-map centroids are unreliable (LA's lettered sheets). The two-start bias is kept deliberately, with a comment.
- **Calibrate against the volume's own geometry, not constants**: the keymap search radius (p90 of fitted residuals), the overlap thresholds (p90 of fitted seam overlaps, one value per number pair — exhaustive member combos flood the distribution with near-zeros), and the containment gate (0.35 borrowed from edge-join killed true 10 ft locks; schematic regions run small).
- **Directed priors only for flip detection**: the mod-180 rotation rung emits both flips, so including it in the prior-agreement feature pinned the residual at zero and masked 180° flips.
- **Small pages need a proportional NCC floor**: the fixed 30,000 m² minimum overlap exceeded some panels' entire ground area, silently masking every shift.
- **The rigid-sheet premise is false for real splits** (post-merge-review finding): split pages are inset composites whose paper layout is unrelated to ground geometry — every fitted sibling pair measured disagrees on its implied sheet by 233–2143 m. The sheet-agreement gate therefore protects by blanket-blocking, not by discrimination; its net effect is validated, its label was wrong.
- Earlier related dead ends that shaped this design: edge-to-edge page joins alone (NO-GO on LA — seam quality, not connectivity, was the limiter), and keymap-coupled adjacency for the pose graph (connectivity worked, disasters neutralized the gains). The discrete-candidates-plus-gated-selection shape here is what those experiments pointed to.

## Debugging

Each page's snap decision (priors, top-3 candidate evidence, incumbent evaluation, outcome) is appended to the same `pN.txt` log the RANSAC georeferencer writes, marker-delimited, so the debugger's log view covers both channels. Per volume: `snap-base` / `snap-union2` / `snap-arb` / `snap-refine` `.iiif.json` + `.txt` render the journey stages in the debugger (`&files=` interface). `artifacts/osm_snap/candidates.jsonl` holds every candidate with full feature vectors and truth RMSE where available; `selection_*.jsonl` the per-mode decisions; `vis/` red/green contact sheets of top-2 candidates per page. Intermediate experiment tags (`snap-v0`, `snap-v1`, `snap-v1b`, `snap-union`) and the 1-GCP ablation tags (`exp-with1gcp`, `exp-no1gcp`) also remain on disk.

## Next steps

- **Re-sweep the refinement margin** (#153) with the larger graded-challenge population now available; the current 0.1 was a small-sample dev elbow, and some agreeing-but-unadopted challengers in 25–100 ft likely remain capturable.
- **Recall residual**: Hudson's OSM-divergent waterfront (27.7% of its land has no matchable modern geometry), no-keymap pages (Nashville 12.7% — a keymap-read fix, e.g. GR's leading-'7' truncation), and Detroit's translational grid aliasing (v2 pose-graph fusion of snap candidates as absolute-pose hypotheses is designed but unbuilt).
- **Remaining disaster tail** (2.9%): all pre-existing RANSAC placements; per-volume `oim-split-truth` for volumes beyond the three fixed here would also let more split placements be credited.
- **Per-inset panel gating** (#154): replace the sheet-agreement fiction with per-inset treatment (each panel gated independently on keymap containment/solo score, with the blanket block on sibling-of-fitted panels kept until something beats it empirically); auto-detecting the rare contiguous-split sheet via fitted-sibling agreement is the cheap first step.
- **Runtime** (#155): the matching sweep (not UNet inference) dominates the ~10–30 min/volume. Cheap algorithmic wins first (theta-ladder pruning under confident priors, shared OSM rasters between incumbent evaluation and matching, an STRtree cull for giant centerline files), then page-level multiprocessing, then optionally batched GPU FFT correlation.
- **Gate calibration debt**, disclosed: the incumbent-defensibility threshold and the panel solo gate were calibrated on all available graded events (11 and ~14 respectively — too few for clean dev/holdout splits). More truth volumes would firm these up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
