### PR TITLE
Debugger: toggle to show a page's road-probability map

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -86,6 +86,29 @@ function resolveDataUrl(file: string): string {
   if (/^https?:\/\//.test(file) || file.startsWith('/')) return file;
   return import.meta.env.BASE_URL.replace(/\/$/, '') + '/' + file;
 }
+
+// The standard road-probability map path for a `data/<vol>/<stem>.jpg` image
+// (`data/<vol>/artifacts/edge_join/roadprob/<stem>.png`), or null for a non-data path.
+function roadProbPath(imagePath: string): string | null {
+  const slash = imagePath.lastIndexOf('/');
+  if (slash < 0 || !imagePath.startsWith('data/')) return null;
+  return `${imagePath.slice(0, slash)}/artifacts/edge_join/roadprob/${pageStem(imagePath)}.png`;
+}
+
+// Whether a sibling road-probability map exists at `url`. The dev server falls
+// back to the SPA (text/html) for a missing file, so an image content-type is
+// the reliable signal that the PNG is really there.
+async function roadMapExists(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return (
+      response.ok &&
+      (response.headers.get('content-type')?.startsWith('image/') ?? false)
+    );
+  } catch {
+    return false;
+  }
+}
 /**
  * Debug API exposed on `window.mapsnap` so data can be injected without the UI
  * (e.g. from the browser console or automated tests). `loadJson` accepts either
@@ -130,6 +153,10 @@ export function App() {
   const [jsonHeight, setJsonHeight] = useState(0);
   const [imageSrc, setImageSrc] = useState('');
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
+  // URL of the page's road-probability map when one exists at the standard
+  // location, and whether to show it in place of the image.
+  const [roadMapSrc, setRoadMapSrc] = useState<string | null>(null);
+  const [showRoadMap, setShowRoadMap] = useState(false);
   const [detections, setDetections] = useState<Detection[]>([]);
   const [panels, setPanels] = useState<PanelPolygon[]>([]);
   const [panelLabels, setPanelLabels] = useState<string[] | undefined>(
@@ -444,6 +471,9 @@ export function App() {
       setImageStem(pageStem(imageFile.name));
       fallbackWidth = el.naturalWidth;
       fallbackHeight = el.naturalHeight;
+      // A dropped file has no data-directory path, so there is no road map to offer.
+      setShowRoadMap(false);
+      setRoadMapSrc(null);
     }
 
     if (jsonFile) {
@@ -473,6 +503,14 @@ export function App() {
         setImageStem(pageStem(imageFile));
         fallbackWidth = el.naturalWidth;
         fallbackHeight = el.naturalHeight;
+        // Offer the road-probability map toggle when a sibling map exists.
+        setShowRoadMap(false);
+        setRoadMapSrc(null);
+        const probPath = roadProbPath(imageFile);
+        if (probPath) {
+          const probUrl = resolveDataUrl(probPath);
+          if (await roadMapExists(probUrl)) setRoadMapSrc(probUrl);
+        }
       }
 
       if (jsonFile) {
@@ -546,6 +584,9 @@ export function App() {
       <ImageColumn
         mode={mode}
         imageSrc={imageSrc}
+        roadMapSrc={roadMapSrc}
+        showRoadMap={showRoadMap}
+        setShowRoadMap={setShowRoadMap}
         jsonWidth={overlayWidth}
         jsonHeight={overlayHeight}
         streets={streets}

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -21,6 +21,11 @@ export type Mode =
 interface ImageColumnProps {
   mode: Mode;
   imageSrc: string;
+  /** URL of this page's road-probability map, when one exists; enables the toggle below. */
+  roadMapSrc: string | null;
+  /** When true (and roadMapSrc is set), show the road-probability map instead of the image. */
+  showRoadMap: boolean;
+  setShowRoadMap: (value: boolean) => void;
   jsonWidth: number;
   jsonHeight: number;
   streets: Street[];
@@ -55,6 +60,9 @@ export function ImageColumn(props: ImageColumnProps) {
   const {
     mode,
     imageSrc,
+    roadMapSrc,
+    showRoadMap,
+    setShowRoadMap,
     jsonWidth,
     jsonHeight,
     streets,
@@ -141,7 +149,7 @@ export function ImageColumn(props: ImageColumnProps) {
         >
           <img
             ref={imgRef}
-            src={imageSrc}
+            src={showRoadMap && roadMapSrc ? roadMapSrc : imageSrc}
             style={{ aspectRatio: `${jsonWidth} / ${jsonHeight}` }}
           />
           {detectionsMode && (
@@ -192,6 +200,18 @@ export function ImageColumn(props: ImageColumnProps) {
       ) : (
         <div className={`drop-placeholder${dragOver ? ' drag-over' : ''}`}>
           Drop image here
+        </div>
+      )}
+
+      {roadMapSrc && (
+        <div className="image-controls">
+          <input
+            type="checkbox"
+            id="show-road-map"
+            checked={showRoadMap}
+            onChange={(e) => setShowRoadMap(e.target.checked)}
+          />
+          <label htmlFor="show-road-map">Show P(road) map</label>
         </div>
       )}
 


### PR DESCRIPTION
When viewing an individual page in the debugger via `?files=` and a road-probability map exists at the standard location (`data/<vol>/artifacts/edge_join/roadprob/<stem>.png`), the image column now shows a **"Show P(road) map"** checkbox that swaps the base image for that map.

For example, `?files=data/new_orleans_la_1896_vol_2/p158.jpg,…/p158.streets.json` picks up `…/artifacts/edge_join/roadprob/p158.png`.

## How it works

- On load, the derived sibling roadprob path is probed with a `HEAD` request. The dev server falls back to the SPA (`text/html`) for a missing file, so an `image/*` content-type is the reliable signal that the map is really there — the checkbox only renders when it is.
- Toggling swaps only the displayed `<img src>`. The map is the same dimensions as the page, so the street/detection overlays stay aligned, and the detection crop previews in the table keep using the original page image.
- Dropped files (no data-directory path) never get the toggle.

## Verified

- `p158` (has a road map): the toggle appears, checking it swaps the image to the heatmap with the street-detection overlays still aligned.
- `p101__1` (JPG but no road map): no checkbox.
- All app tests pass; typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
