### PR TITLE
Score truth split panels over their own regions (bad-split sensitivity)

### DIFF
--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -27,6 +27,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
+from shapely.geometry import Point as ShapelyPoint
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import box
 
@@ -37,6 +38,9 @@ EARTH_RADIUS_FT = 20_925_524.0
 MIN_SPLIT_IOU = (
     0.1  # minimum panel overlap to treat a truth and generated split as the same region
 )
+# A truth panel is graded only when this fraction of its region is actually
+# displayed by some generated annotation; below it, the panel is unplaced.
+TRUTH_REGION_COVERAGE_MIN = 0.5
 
 
 def extract_metadata_int(item: dict, label: str) -> int | None:
@@ -248,6 +252,26 @@ def sample_grid(width: float, height: float, n: int = 7) -> list[tuple[float, fl
     return [(f_x * width, f_y * height) for f_y in fracs for f_x in fracs]
 
 
+def truth_region_grid(polygon: ShapelyPolygon, n: int = 7) -> list[tuple[float, float]]:
+    """Grid sample points inside a truth panel's polygon (canvas pixels).
+
+    Samples an n×n lattice over the polygon's bounds (with the same
+    corner-avoiding fractions as sample_grid) and keeps the interior points,
+    so a split panel is graded over ITS OWN region rather than the whole
+    canvas. Falls back to the full lattice for degenerate slivers that
+    contain fewer than five lattice points.
+    """
+    min_x, min_y, max_x, max_y = polygon.bounds
+    fracs = [(k + 1) / (n + 1) for k in range(n)]
+    lattice = [
+        (min_x + f_x * (max_x - min_x), min_y + f_y * (max_y - min_y))
+        for f_y in fracs
+        for f_x in fracs
+    ]
+    inside = [p for p in lattice if polygon.contains(ShapelyPoint(p))]
+    return inside if len(inside) >= 5 else lattice
+
+
 def truth_distortion(A: np.ndarray) -> tuple[float, float]:
     """Compute skew (°) and anisotropy from the truth affine linear part.
 
@@ -288,13 +312,21 @@ def angle_diff(a: float, b: float) -> float:
     return d - 360.0 if d > 180.0 else d
 
 
-def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
+def analyze_pair(
+    truth_item: dict,
+    gen_item: dict,
+    grid: list[tuple[float, float]] | None = None,
+) -> dict:
     """Compute accuracy metrics for one page by comparing two IIIF georef annotations.
 
     Returns a dict with keys: page_key, gen_page_key, n_truth, n_gen, rmse_ft, max_ft,
     trans_ft, rot_err, scale_pct, skew_deg, aniso. page_key uses the truth's split
     numbering; gen_page_key uses the matched generated split's numbering (they can differ
     when OIM and our splitter number panels differently).
+
+    ``grid`` overrides the sample points (canvas pixels) the error is measured
+    over — compare_pages passes a truth panel's own region so a split page is
+    graded on what the generated annotation actually displays there.
     """
     source_id = truth_item["target"]["source"].get("id")
     page_key = source_id_to_page_key(source_id, truth_item["label"])
@@ -311,24 +343,26 @@ def analyze_pair(truth_item: dict, gen_item: dict) -> dict:
     width = float(truth_item["target"]["source"]["width"])
     height = float(truth_item["target"]["source"]["height"])
 
-    # For split sub-images with known canvas placement, sample only within the
-    # split region so the error metric covers actual split pixels, not the full canvas.
-    split_cx = extract_metadata_float(gen_item, "split_canvas_x")
-    split_cy = extract_metadata_float(gen_item, "split_canvas_y")
-    split_cw = extract_metadata_float(gen_item, "split_canvas_w")
-    split_ch = extract_metadata_float(gen_item, "split_canvas_h")
+    if grid is None:
+        # For split sub-images with known canvas placement, sample only within
+        # the split region so the error metric covers actual split pixels, not
+        # the full canvas.
+        split_cx = extract_metadata_float(gen_item, "split_canvas_x")
+        split_cy = extract_metadata_float(gen_item, "split_canvas_y")
+        split_cw = extract_metadata_float(gen_item, "split_canvas_w")
+        split_ch = extract_metadata_float(gen_item, "split_canvas_h")
 
-    if (
-        split_cx is not None
-        and split_cy is not None
-        and split_cw is not None
-        and split_ch is not None
-    ):
-        grid = [
-            (x + split_cx, y + split_cy) for x, y in sample_grid(split_cw, split_ch)
-        ]
-    else:
-        grid = sample_grid(width, height)
+        if (
+            split_cx is not None
+            and split_cy is not None
+            and split_cw is not None
+            and split_ch is not None
+        ):
+            grid = [
+                (x + split_cx, y + split_cy) for x, y in sample_grid(split_cw, split_ch)
+            ]
+        else:
+            grid = sample_grid(width, height)
 
     # Positional errors at grid sample points.
     errors: list[float] = []
@@ -581,62 +615,6 @@ def load_split_polygons(
     }
 
 
-def match_split_pairs(
-    truth_items: list[dict],
-    gen_items: list[dict],
-    truth_polygons: dict[int, ShapelyPolygon],
-    gen_polygons: dict[int, ShapelyPolygon],
-    canvas_polygon: ShapelyPolygon | None = None,
-) -> tuple[list[tuple[dict, dict]], list[dict]]:
-    """Associate truth and generated split annotations by panel-polygon overlap.
-
-    OIM's split numbering need not match ours, so pairs are chosen by greatest panel IoU
-    globally: every (truth, generated) pair with IoU >= MIN_SPLIT_IOU is considered, and
-    the highest-overlap pairs are assigned first (each split used once). Choosing globally
-    rather than per-truth-in-file-order matters — a truth split that merely grazes a
-    generated panel must not claim it ahead of the truth split that actually overlaps it.
-
-    When OIM split a page but we kept it whole, the generated annotation has no split index;
-    canvas_polygon (the full page) then stands in as its panel, so it pairs with the truth
-    split it most overlaps — i.e. the largest split. Both sides' polygons are in canvas
-    coordinates. Returns (pairs, unmatched_truth_items).
-    """
-
-    def gen_polygon(gen: dict) -> ShapelyPolygon | None:
-        gen_index = annotation_split_index(gen)
-        if gen_index is not None:
-            return gen_polygons.get(gen_index)
-        return canvas_polygon  # unsplit page: one panel covering the whole canvas
-
-    candidates: list[tuple[float, int, int]] = []  # (iou, truth_idx, gen_idx)
-    for ti, truth in enumerate(truth_items):
-        truth_index = label_split_index(truth)
-        truth_poly = truth_polygons.get(truth_index) if truth_index else None
-        if truth_poly is None:
-            continue
-        for gi, gen in enumerate(gen_items):
-            gen_poly = gen_polygon(gen)
-            if gen_poly is None:
-                continue
-            iou = polygon_iou(truth_poly, gen_poly)
-            if iou >= MIN_SPLIT_IOU:
-                candidates.append((iou, ti, gi))
-
-    candidates.sort(reverse=True)  # assign highest-overlap pairs first
-    used_truth: set[int] = set()
-    used_gen: set[int] = set()
-    pairs: list[tuple[dict, dict]] = []
-    for _iou, ti, gi in candidates:
-        if ti in used_truth or gi in used_gen:
-            continue
-        pairs.append((truth_items[ti], gen_items[gi]))
-        used_truth.add(ti)
-        used_gen.add(gi)
-
-    unmatched = [t for ti, t in enumerate(truth_items) if ti not in used_truth]
-    return pairs, unmatched
-
-
 def redundant_skeleton_keys(truth_keys: set[str], generated_keys: set[str]) -> set[str]:
     """Truth page keys to drop under the skeleton rule.
 
@@ -730,14 +708,45 @@ def compare_pages(
         gen_polygons = load_split_polygons(
             gen_dir / f"{page_key}.panels.json", source_dims
         )
-        # If we kept the page whole, a generated annotation with no split index stands in
-        # for a panel covering the full canvas, matching the largest truth split.
+        # A generated annotation with no split index displays the whole canvas.
         canvas_polygon = box(0.0, 0.0, source_dims[0], source_dims[1])
-        pairs, unmatched = match_split_pairs(
-            truth_splits, gen_items, truth_polygons, gen_polygons, canvas_polygon
-        )
-        rows.extend(analyze_pair(t, g) for t, g in pairs)
-        missing.extend(analyze_truth_only(t) for t in unmatched)
+
+        def generated_region(gen: dict) -> ShapelyPolygon | None:
+            gen_index = annotation_split_index(gen)
+            if gen_index is not None:
+                return gen_polygons.get(gen_index)
+            return canvas_polygon
+
+        # Grade every truth panel over ITS OWN region, against whatever
+        # generated annotation covers that region (one-to-many: a whole-page
+        # placement covers, and is graded on, every truth panel). This is what
+        # makes the metric sensitive to bad splits: a page georeferenced
+        # whole onto one inset of a composite sheet displays the OTHER
+        # insets' imagery in the wrong place, and grading those regions under
+        # the same transform turns them into disasters — whereas an honest
+        # abstention leaves them merely unplaced. A truth panel mostly
+        # uncovered (below TRUTH_REGION_COVERAGE_MIN) counts as unplaced.
+        for truth in truth_splits:
+            truth_index = label_split_index(truth)
+            truth_poly = truth_polygons.get(truth_index) if truth_index else None
+            if truth_poly is None or truth_poly.is_empty:
+                missing.append(analyze_truth_only(truth))
+                continue
+            best_gen: dict | None = None
+            best_coverage = 0.0
+            for gen in gen_items:
+                region = generated_region(gen)
+                if region is None or region.is_empty:
+                    continue
+                coverage = truth_poly.intersection(region).area / truth_poly.area
+                if coverage > best_coverage:
+                    best_coverage, best_gen = coverage, gen
+            if best_gen is None or best_coverage < TRUTH_REGION_COVERAGE_MIN:
+                missing.append(analyze_truth_only(truth))
+                continue
+            rows.append(
+                analyze_pair(truth, best_gen, grid=truth_region_grid(truth_poly))
+            )
     return rows, missing
 
 

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -252,23 +252,34 @@ def sample_grid(width: float, height: float, n: int = 7) -> list[tuple[float, fl
     return [(f_x * width, f_y * height) for f_y in fracs for f_x in fracs]
 
 
-def truth_region_grid(polygon: ShapelyPolygon, n: int = 7) -> list[tuple[float, float]]:
+def truth_region_grid(
+    polygon: ShapelyPolygon, n: int = 7, min_points: int = 49
+) -> list[tuple[float, float]]:
     """Grid sample points inside a truth panel's polygon (canvas pixels).
 
-    Samples an n×n lattice over the polygon's bounds (with the same
-    corner-avoiding fractions as sample_grid) and keeps the interior points,
-    so a split panel is graded over ITS OWN region rather than the whole
-    canvas. Falls back to the full lattice for degenerate slivers that
-    contain fewer than five lattice points.
+    Samples a lattice over the polygon's bounds (with the same corner-avoiding
+    fractions as sample_grid) and keeps the interior points, so a split panel
+    is graded over ITS OWN region rather than the whole canvas. Non-convex
+    panels (L-shapes) fill only part of their bounds, so the lattice is
+    densified until at least ``min_points`` land inside — a rectangle's 7×7
+    grid keeps all 49, and an L deserves the same effective density (at 7×7,
+    Champaign p21's L keeps only 24 points and understates its converged RMSE
+    by ~6%). Falls back to the last lattice for degenerate slivers containing
+    fewer than five points at any density.
     """
     min_x, min_y, max_x, max_y = polygon.bounds
-    fracs = [(k + 1) / (n + 1) for k in range(n)]
-    lattice = [
-        (min_x + f_x * (max_x - min_x), min_y + f_y * (max_y - min_y))
-        for f_y in fracs
-        for f_x in fracs
-    ]
-    inside = [p for p in lattice if polygon.contains(ShapelyPoint(p))]
+    lattice: list[tuple[float, float]] = []
+    inside: list[tuple[float, float]] = []
+    for lattice_n in (n, 11, 15, 21, 31):
+        fracs = [(k + 1) / (lattice_n + 1) for k in range(lattice_n)]
+        lattice = [
+            (min_x + f_x * (max_x - min_x), min_y + f_y * (max_y - min_y))
+            for f_y in fracs
+            for f_x in fracs
+        ]
+        inside = [p for p in lattice if polygon.contains(ShapelyPoint(p))]
+        if len(inside) >= min_points:
+            return inside
     return inside if len(inside) >= 5 else lattice
 
 

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -222,7 +222,6 @@ def test_split_regions_correct_whole_page_credits_every_panel(tmp_path):
             },
         }
 
-
     truth = {"items": [item("x p7 [1]"), item("x p7 [2]")]}
     gen = {"items": [item("x p7")]}
     (tmp_path / "oim").mkdir(exist_ok=True)
@@ -243,6 +242,25 @@ def test_split_regions_correct_whole_page_credits_every_panel(tmp_path):
     assert missing == []
     assert sorted(r["page_key"] for r in rows) == ["p7__1", "p7__2"]
     assert all(r["rmse_ft"] < 25.0 for r in rows)
+
+
+def test_truth_region_grid_densifies_l_shapes():
+    from shapely.geometry import Polygon
+
+    from mapsnap.compare_iiif_georef import truth_region_grid
+
+    # A rectangle keeps its full 7x7 lattice.
+    rect = Polygon([(0, 0), (400, 0), (400, 200), (0, 200)])
+    assert len(truth_region_grid(rect)) == 49
+    # An L filling ~57% of its bounds densifies until it has at least the
+    # same effective sample count as a rectangle, all inside the polygon.
+    ell = Polygon([(0, 0), (400, 0), (400, 100), (100, 100), (100, 400), (0, 400)])
+    points = truth_region_grid(ell)
+    assert len(points) >= 49
+    assert all(
+        ell.contains(__import__("shapely.geometry", fromlist=["Point"]).Point(p))
+        for p in points
+    )
 
 
 def test_parse_svg_polygon():

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -10,7 +10,6 @@ from mapsnap.compare_iiif_georef import (
     annotation_split_index,
     annotations_by_source,
     load_split_polygons,
-    match_split_pairs,
     page_label,
     parse_svg_polygon,
     polygon_iou,
@@ -106,79 +105,144 @@ def test_load_split_polygons_scales_generated_panels(tmp_path):
     assert gen[1].bounds == (0.0, 0.0, 400.0, 800.0)
 
 
-def test_match_split_pairs_associates_by_polygon_overlap_ignoring_numbering():
-    # Truth split 1 is the left half, split 2 the right half (canvas coords).
-    truth_polygons = {1: _square(0, 0, 100), 2: _square(100, 0, 100)}
-    truth_items = [{"label": "P [1]"}, {"label": "P [2]"}]
-    # Our numbering is reversed: gen __1 sits on the right, __2 on the left.
-    gen_items = [
-        {"id": "http://x/p__1/georef"},
-        {"id": "http://x/p__2/georef"},
-    ]
-    gen_polygons = {1: _square(100, 0, 100), 2: _square(0, 0, 100)}
+def _split_volume(tmp_path, gen_items, gen_panels=None):
+    """Write a truth file with two split panels at DIFFERENT transforms.
 
-    pairs, unmatched = match_split_pairs(
-        truth_items, gen_items, truth_polygons, gen_polygons
+    Truth p7 [1] covers the left half of a 400x200 canvas; p7 [2] the right
+    half, georeferenced ~0.01 deg (~1km) away — an inset composite. Returns
+    (truth_path, gen_path).
+    """
+
+    def features(origin_lon):
+        return [
+            {
+                "properties": {"resourceCoords": [x, y]},
+                "geometry": {"coordinates": [origin_lon + x * 1e-6, 40.0 + y * 1e-6]},
+            }
+            for x, y in [(0, 0), (150, 0), (0, 150)]
+        ]
+
+    def item(label, origin_lon, item_id="https://x/p7/georef"):
+        return {
+            "id": item_id,
+            "label": label,
+            "target": {
+                "source": {
+                    "id": "https://loc.gov/x/g123-0007/info.json",
+                    "width": 400,
+                    "height": 200,
+                },
+            },
+            "body": {
+                "transformation": {"type": "polynomial", "options": {"order": 1}},
+                "features": features(origin_lon),
+            },
+        }
+
+    truth = {"items": [item("x p7 [1]", -74.0), item("x p7 [2]", -73.99)]}
+    (tmp_path / "oim").mkdir(exist_ok=True)
+    _write_panels(
+        tmp_path / "oim" / "p7.panels.json",
+        400,
+        200,
+        [
+            [[0, 0], [200, 0], [200, 200], [0, 200]],
+            [[200, 0], [400, 0], [400, 200], [200, 200]],
+        ],
     )
+    gen = {"items": [item(*args) for args in gen_items]}
+    if gen_panels is not None:
+        _write_panels(tmp_path / "p7.panels.json", 400, 200, gen_panels)
+    truth_path = tmp_path / "main.iiif.json"
+    gen_path = tmp_path / "gen.iiif.json"
+    truth_path.write_text(json.dumps(truth))
+    gen_path.write_text(json.dumps(gen))
+    return truth_path, gen_path
 
-    assert unmatched == []
-    paired = {t["label"]: g["id"] for t, g in pairs}
-    assert paired == {"P [1]": "http://x/p__2/georef", "P [2]": "http://x/p__1/georef"}
+
+def test_split_regions_whole_page_on_one_inset_is_a_disaster(tmp_path):
+    # Scenario A: our splitter failed and the whole page georeferenced onto
+    # truth panel 1's location. Panel 1's region grades well — but panel 2's
+    # imagery is DISPLAYED ~1km from where it belongs, and grading its region
+    # under the same transform must expose that as a huge error rather than
+    # scoring identically to an honest abstention.
+    from mapsnap.compare_iiif_georef import compare_pages
+
+    truth_path, gen_path = _split_volume(tmp_path, [("x p7", -74.0)])
+    rows, missing = compare_pages(truth_path, gen_path)
+    assert missing == []
+    by_key = {r["page_key"]: r for r in rows}
+    assert by_key["p7__1"]["rmse_ft"] < 25.0
+    assert by_key["p7__2"]["rmse_ft"] > 1000.0
 
 
-def test_match_split_pairs_unsplit_page_matches_largest_truth_split():
-    # OIM split the page into 3 panels of different sizes; we kept it whole, so the
-    # generated annotation has no split index and stands in as the full canvas.
-    truth_polygons = {
-        1: _square(0, 0, 100),  # area 10_000
-        2: _square(0, 0, 200),  # area 40_000 — largest
-        3: _square(0, 0, 50),  # area 2_500 — below MIN_SPLIT_IOU vs the canvas
-    }
-    truth_items = [{"label": "P [3]"}, {"label": "P [2]"}, {"label": "P [1]"}]
-    gen_items = [{"id": "http://x/p3/georef"}]  # no __N → unsplit page
-    canvas = _square(0, 0, 300)  # area 90_000
+def test_split_regions_honest_abstention_is_merely_missing(tmp_path):
+    # Scenario B: we split correctly, placed panel 1, declined panel 2.
+    from mapsnap.compare_iiif_georef import compare_pages
 
-    pairs, unmatched = match_split_pairs(
-        truth_items, gen_items, truth_polygons, {}, canvas_polygon=canvas
+    truth_path, gen_path = _split_volume(
+        tmp_path,
+        [("x p7 [1]", -74.0, "https://x/p7__1/georef")],
+        gen_panels=[[[0, 0], [200, 0], [200, 200], [0, 200]]],
     )
-
-    assert len(pairs) == 1
-    truth, gen = pairs[0]
-    assert truth["label"] == "P [2]"  # the largest split
-    assert gen["id"] == "http://x/p3/georef"
-    assert {t["label"] for t in unmatched} == {"P [1]", "P [3]"}
+    rows, missing = compare_pages(truth_path, gen_path)
+    assert [r["page_key"] for r in rows] == ["p7__1"]
+    assert rows[0]["rmse_ft"] < 25.0
+    assert len(missing) == 1
 
 
-def test_match_split_pairs_unmatched_when_no_gen_polygon():
-    truth_polygons = {1: _square(0, 0, 100)}
-    truth_items = [{"label": "P [1]"}]
-    pairs, unmatched = match_split_pairs(truth_items, [], truth_polygons, {})
-    assert pairs == []
-    assert unmatched == truth_items
+def test_split_regions_correct_whole_page_credits_every_panel(tmp_path):
+    # A contiguous split placed correctly as a whole page: BOTH truth panels
+    # grade well (the old largest-split stand-in rule credited only one).
+    from mapsnap.compare_iiif_georef import compare_pages
+
+    def features(origin_lon):
+        return [
+            {
+                "properties": {"resourceCoords": [x, y]},
+                "geometry": {"coordinates": [origin_lon + x * 1e-6, 40.0 + y * 1e-6]},
+            }
+            for x, y in [(0, 0), (150, 0), (0, 150)]
+        ]
+
+    def item(label):
+        return {
+            "id": "https://x/p7/georef",
+            "label": label,
+            "target": {
+                "source": {
+                    "id": "https://loc.gov/x/g123-0007/info.json",
+                    "width": 400,
+                    "height": 200,
+                },
+            },
+            "body": {
+                "transformation": {"type": "polynomial", "options": {"order": 1}},
+                "features": features(-74.0),
+            },
+        }
 
 
-def test_match_split_pairs_picks_best_overlap_not_file_order():
-    # The single generated panel overlaps truth [1] strongly; truth [3], listed first,
-    # only grazes it. The grazing split must not claim the generated panel ahead of the
-    # real match (regression for the champaign p4__3 mismatch).
-    truth_polygons = {
-        1: _square(0, 0, 100),
-        2: _square(200, 0, 100),
-        3: _square(99, 0, 2),  # tiny overlap with the generated panel's right edge
-    }
-    truth_items = [{"label": "P [3]"}, {"label": "P [2]"}, {"label": "P [1]"}]
-    gen_items = [{"id": "http://x/p__1/georef"}]
-    gen_polygons = {1: _square(0, 0, 100)}
-
-    pairs, unmatched = match_split_pairs(
-        truth_items, gen_items, truth_polygons, gen_polygons
+    truth = {"items": [item("x p7 [1]"), item("x p7 [2]")]}
+    gen = {"items": [item("x p7")]}
+    (tmp_path / "oim").mkdir(exist_ok=True)
+    _write_panels(
+        tmp_path / "oim" / "p7.panels.json",
+        400,
+        200,
+        [
+            [[0, 0], [200, 0], [200, 200], [0, 200]],
+            [[200, 0], [400, 0], [400, 200], [200, 200]],
+        ],
     )
-
-    assert len(pairs) == 1
-    truth, gen = pairs[0]
-    assert truth["label"] == "P [1]"
-    assert gen["id"] == "http://x/p__1/georef"
-    assert {t["label"] for t in unmatched} == {"P [2]", "P [3]"}
+    truth_path = tmp_path / "main.iiif.json"
+    gen_path = tmp_path / "gen.iiif.json"
+    truth_path.write_text(json.dumps(truth))
+    gen_path.write_text(json.dumps(gen))
+    rows, missing = compare_pages(truth_path, gen_path)
+    assert missing == []
+    assert sorted(r["page_key"] for r in rows) == ["p7__1", "p7__2"]
+    assert all(r["rmse_ft"] < 25.0 for r in rows)
 
 
 def test_parse_svg_polygon():

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -150,11 +150,11 @@ def attach_missing_truth(volume: Path, units: list[PageUnit]) -> int:
     rmse, so the gate sweep was blind to them) even though `mapsnap score`
     scores their placements: (1) unsplit truth items whose page key differs
     from the jpg stem only in letter case (Chicago 'p51N' vs 'p51n'); (2)
-    pages whose truth exists only as split items — a whole-page placement of
-    such a sheet is scored against its LARGEST truth split (the whole-canvas
-    stand-in rule in match_split_pairs), so that split's transform is the
-    right truth here, with rmse sampled over the full canvas exactly like
-    analyze_pair's whole-page grid.
+    pages whose truth exists only as split items. The scorer now grades each
+    truth panel over its own region; for this harness's page-level
+    diagnostics we approximate with the LARGEST truth split's transform
+    (rmse over the full canvas), which matches the scorer for the panel a
+    whole-page placement actually fits.
     """
     from mapsnap.compare_iiif_georef import (
         annotation_transform_type,


### PR DESCRIPTION
Makes the score metric sensitive to bad splits, in both directions. Previously these two outcomes scored **identically**:

- **Scenario A**: the splitter fails (or a split page is georeferenced whole), and the page lands on one inset of a composite sheet. The other insets' imagery is *displayed kilometres from where it belongs* — but their truth panels just scored "unplaced."
- **Scenario B**: the splitter works, one panel is placed, the others are honestly abstained. Also "unplaced."

Scenario B is objectively better; now the metric agrees.

## What changed

Truth split panels are no longer paired one-to-one with generated annotations (with an unsplit placement standing in for the *largest* truth panel). Instead, **every truth panel is graded over its own region**: the RMSE grid is sampled inside the panel's `oim/pN.panels.json` polygon, against whichever generated annotation **covers** that region (one-to-many; coverage below `TRUTH_REGION_COVERAGE_MIN = 0.5` counts as unplaced). `match_split_pairs` is superseded and removed; three scenario tests pin the semantics.

Three concrete effects:
1. **Wrong-content display becomes a disaster** (Scenario A). A whole-page or wrong-inset placement is graded on every truth region it covers; regions displayed under the wrong transform grade at their true (huge) error instead of vanishing into "unplaced."
2. **Correct coverage earns full credit.** A whole-page placement that correctly displays several truth panels is credited for each of them (the old rule credited only the largest).
3. **Matched panels are measured where their content actually is.** The old metric sampled the grid over the *generated* annotation's split-canvas rectangle (or the whole canvas), which extends past the truth panel into masked-out or extrapolated area — and affine-vs-affine disagreement grows with distance from the GCP centroid, inflating RMSE. The new grid stays inside the truth polygon.

## Why a score could go UP: Champaign, in detail

Champaign moves **92.7 → 97.8** (+5.1), which looks paradoxical for a stricter metric until you trace it. Two pages tell the whole story:

**p21__2 — effect 3, worth the entire +5.1.** Both of p21's panels were split and RANSAC-fitted all along. Under the old metric the p21__2 pair was graded over *our* panel's split-canvas rectangle, whose cut lines differ from OIM's — so the 7×7 grid included canvas outside the truth panel, where the two affines are extrapolated apart. Result: 27.4 ft, a hair **over** the 25 ft good bar, worth zero. Graded inside the truth panel's own polygon — where the imagery it's responsible for actually lies — the same placement measures **18.2 ft**: good. p21__2 happens to be the volume's largest panel (5.3% of Champaign's land), and one threshold crossing on a big panel in a 33-page volume is +5.3 good share. **The placement never changed; only where it was measured.** The old score under-credited it, which is the answer to "did I misunderstand the old score": for split pairs, the old grading region was the *generated* annotation's display rectangle, not the truth panel — a subtle asymmetry that could penalize correct fits for canvas they weren't responsible for.

**p3 — Scenario A itself, newly visible.** p3 is a three-inset composite sheet that our pipeline georeferenced **whole**, landing (well) on the middle inset: truth p3__2 grades at 15 ft under both metrics. But the whole-page transform also *displays* insets 1 and 3, kilometres from their true locations. Old metric: the whole-canvas stand-in paired only with the largest panel; p3__1 and p3__3 scored unplaced — indistinguishable from honest abstention. New metric: their regions are covered, so they grade — at **7,411 ft and 2,159 ft**, disasters. They're small panels (0.1% of land each), so the penalty is −0.2; the p21__2 correction dominates and Champaign nets +5.1.

The same decomposition explains every mover: Grand Rapids +2.0 (effect 2/3 credits on split sheets), LA **−1.4** (effect 1: five panels displayed under the wrong inset's transform — p1442__1 at 10,239 ft, p1470__2 at 12,110 ft, and the p1499K/L family at 900–8,900 ft — previously invisible, now costed).

## Per-volume movement (final `snap-refine` configuration)

| Volume | old | new | Δ |
|---|---|---|---|
| Champaign | 92.7 | **97.8** | +5.1 |
| Grand Rapids | 64.0 | **66.0** | +2.0 |
| Los Angeles | 76.1 | **74.7** | −1.4 |
| Kansas City | 68.3 | 68.2 | −0.1 |
| Washington DC | 76.1 | 76.0 | −0.1 |
| Brooklyn, Chicago, Detroit, Hudson, Nashville, NO-1896, NO-1951 | — | — | 0.0 |
| **AGGREGATE** | **69.8** | **70.0** | **+0.2** |

The baseline shifts too (55.5 → 55.7), so the snap channel's measured contribution is unchanged. This is a **re-baseline**: numbers in older discussions/PRs use the previous metric.

## Robustness: non-convex panels

Review of Champaign's p21 surfaced a sampling subtlety: its second panel is an **L-shape** filling 57% of its bounding box, so a 7×7 bbox lattice keeps only ~24 interior points and understates the converged RMSE by ~6% (18.2 ft at n=7 vs 19.3 ft at 2,121 points — still safely under the bar, so Champaign's number stands). The grid now **densifies until non-convex panels get at least the 49 interior points a rectangle gets**. That honesty pass moved Grand Rapids 67.7 → 66.0: a third of its apparent gain was sparse-sampling luck on panels near the threshold. A test pins the L-shape density.

## Follow-ups this enables

- LA's newly visible wrong-content panels are an actionable target class (they overlap heavily with #154's per-inset panel work, which now has score incentive attached).
- The metric now polices the splitter itself: regressions that stop splitting composite sheets cost points instead of hiding.
- The experiment harness's `attach_missing_truth` still uses the largest-split approximation for per-candidate diagnostics (noted in its docstring); the scorer is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
