### PR TITLE
Fix two blockers that break snap on any new volume

### DIFF
--- a/mapsnap/keymap/keymap_patches.py
+++ b/mapsnap/keymap/keymap_patches.py
@@ -19,21 +19,44 @@ import numpy as np
 # PATCH_SIZE window captures the number plus its block context.
 SCALE = 0.25
 
-# A scan whose larger side is below this is assumed to already be at SCALE (25%); a
-# larger one is full resolution and must be downscaled by SCALE to reach working res.
-FULL_SCALE_THRESHOLD = 4000
+# Working long side the models are trained at. Every key map in the dev corpus lands
+# in 1831-2106 px under the plain SCALE rule, so a number is ~40px across all of them.
+TARGET_LONG_SIDE = 1950
+
+# How far off TARGET_LONG_SIDE a plain SCALE (or 1.0) may land and still be used as-is.
+# The band spans 1658-2243 px, comfortably covering the corpus's own spread.
+LONG_SIDE_TOLERANCE = 0.15
 
 
 def working_scale(
-    width: int, height: int, *, full_threshold: int = FULL_SCALE_THRESHOLD
+    width: int,
+    height: int,
+    *,
+    target_long_side: int = TARGET_LONG_SIDE,
+    tolerance: float = LONG_SIDE_TOLERANCE,
 ) -> float:
     """Factor to bring an image (and its label coords) to working resolution.
 
-    Returns SCALE for a full-resolution scan (larger side >= full_threshold) and 1.0 for
-    one already downscaled to ~25%, so both reach the same ~40px-per-number working size.
+    Page numbers are only legible to the models at the size they were trained on, so
+    what matters is the WORKING long side, not the scan's own resolution. A plain 1.0
+    (already downscaled) or SCALE (full-resolution scan) is preferred when it lands
+    near ``target_long_side`` — that is every scan in the dev corpus, and resampling
+    them would be pointless churn. A scan at an unexpected DPI, where neither lands in
+    the band, is normalised to ``target_long_side`` instead: Asheville's 4400x5400 key
+    map is only 1350px at SCALE, which put its numbers at ~28px and left them unread.
+
     Label coordinates live in the image's own pixel space, so the same factor applies.
     """
-    return SCALE if max(width, height) >= full_threshold else 1.0
+    long_side = max(width, height)
+    if long_side <= 0:
+        return 1.0
+    for candidate in (1.0, SCALE):  # prefer not resampling at all
+        if (
+            abs(long_side * candidate - target_long_side)
+            <= tolerance * target_long_side
+        ):
+            return candidate
+    return target_long_side / long_side
 
 
 # Side length (px, at SCALE) of the square patches fed to the CNN.

--- a/mapsnap/keymap/keymap_patches_test.py
+++ b/mapsnap/keymap/keymap_patches_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from mapsnap.keymap.keymap_patches import (
+    TARGET_LONG_SIDE,
     build_image_patches,
     crop_excludes_numbers,
     crop_patch,
@@ -25,11 +26,28 @@ def test_crop_excludes_numbers():
     )
 
 
-def test_working_scale_full_vs_quarter():
-    assert working_scale(5866, 7323) == 0.25  # full-res scan
-    assert working_scale(1446, 2038) == 1.0  # already 25%
-    assert working_scale(3999, 3999) == 1.0  # both sides below threshold
-    assert working_scale(4000, 100) == 0.25  # one side at threshold
+def test_working_scale_prefers_plain_factors_in_band():
+    # Every dev-corpus key map: SCALE lands near the target, so use it as-is.
+    assert working_scale(5866, 7323) == 0.25  # chicago, working 1831
+    assert working_scale(6091, 8422) == 0.25  # washington dc, working 2106
+    # Already downscaled to ~25%: no resampling at all.
+    assert working_scale(1446, 2038) == 1.0
+
+
+def test_working_scale_normalises_unexpected_resolutions():
+    # Asheville: 4400x5400 is only 1350px at SCALE, far below the trained size,
+    # so it is normalised to the target instead.
+    assert working_scale(4400, 5400) == TARGET_LONG_SIDE / 5400
+    assert round(5400 * working_scale(4400, 5400)) == TARGET_LONG_SIDE
+    # Neither 1.0 nor SCALE lands in the band for these either.
+    assert working_scale(3999, 3999) == TARGET_LONG_SIDE / 3999
+    assert working_scale(4000, 100) == TARGET_LONG_SIDE / 4000
+    # A thumbnail well under the target is scaled up to it.
+    assert working_scale(1100, 1350) == TARGET_LONG_SIDE / 1350
+
+
+def test_working_scale_degenerate():
+    assert working_scale(0, 0) == 1.0
 
 
 def test_scale_points():

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -394,7 +394,16 @@ def georef_variant_mtime(volume: Path, stem: str) -> int | None:
 
 
 def candidates_record_fresh(record: dict, unit: PageUnit, mtime: int | None) -> bool:
-    """Whether a cached candidates record still matches the page's fit state."""
+    """Whether a cached candidates record still matches the page's fit state.
+
+    Only a successful record is ever fresh. A failure ('no_prob', 'no_keymap')
+    turns on inputs this check does not track — the P(road) cache and the key
+    map's own sidecars — so caching one would pin the page behind a stale
+    failure even after the input is fixed. Recomputing a failure is cheap: it
+    fails at the same gate before any matching work.
+    """
+    if record.get("status") != "ok":
+        return False
     return (
         record.get("fit_state") == unit.fit_state
         and record.get("georef_mtime") == mtime
@@ -835,12 +844,16 @@ def cmd_candidates(
         targets = [u for u in targets if u.stem in wanted]
     if limit is not None:
         targets = targets[:limit]
+    # Every target needs a P(road) map, whole pages included. (This once
+    # inferred only "__" panels, on the assumption that whole-page maps already
+    # existed from an edge-join `infer` run — true of the dev volumes, false of
+    # any new volume, which then had every whole page rejected as 'no_prob'.)
     ensure_probs(
         volume,
         [
             u.stem
             for u in targets
-            if "__" in u.stem and (u.stem not in existing or recompute or pages)
+            if load_prob(volume, u.stem) is None or recompute or pages
         ],
     )
 

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -231,7 +231,7 @@ def make_unit(fit_state: str) -> PageUnit:
 
 
 def test_candidates_record_fresh_tracks_fit_changes():
-    record = {"fit_state": "fitted", "georef_mtime": 111}
+    record = {"fit_state": "fitted", "georef_mtime": 111, "status": "ok"}
     assert candidates_record_fresh(record, make_unit("fitted"), 111)
     # A re-run georef rewrote the sidecar: the cached incumbent is stale.
     assert not candidates_record_fresh(record, make_unit("fitted"), 222)
@@ -239,8 +239,17 @@ def test_candidates_record_fresh_tracks_fit_changes():
     assert not candidates_record_fresh(record, make_unit("nofit"), 111)
     # Legacy records (no georef_mtime) always recompute once.
     assert not candidates_record_fresh(
-        {"fit_state": "fitted"}, make_unit("fitted"), 111
+        {"fit_state": "fitted", "status": "ok"}, make_unit("fitted"), 111
     )
+    # Failures are always retried: they turn on the P(road) cache and the key
+    # map's sidecars, which this check does not track, so caching one would pin
+    # the page behind a stale failure even after that input is fixed.
+    base = {"fit_state": "fitted", "georef_mtime": 111}
+    for status in ("no_prob", "no_keymap", "implausible"):
+        assert not candidates_record_fresh(
+            {**base, "status": status}, make_unit("fitted"), 111
+        )
+    assert candidates_record_fresh({**base, "status": "ok"}, make_unit("fitted"), 111)
 
 
 def test_append_snap_logs_is_idempotent(tmp_path):


### PR DESCRIPTION
Found on Asheville, the first fresh volume since osm-snap merged.

`ensure_probs` only inferred P(road) for "__" split panels, on the assumption that whole-page maps already existed from an edge-join `infer` run. That holds for the dev volumes (hudson 93, chicago 113, DC 136 cached whole-page maps) and for nothing else: Asheville had 18 of 106, so 88 targets were rejected as 'no_prob' at the first gate and snap placed and challenged nothing.

Candidate records also cached those failures. Freshness only tracked fit_state and georef mtime, so a 'no_prob'/'no_keymap' record stayed "fresh" after the input that caused it was fixed, pinning the page behind a stale failure. Only successful records are cached now; recomputing a failure is cheap, since it fails at the same gate before any matching work.

working_scale was a binary 0.25/1.0 switch, which assumes every full-resolution scan shares a DPI. Asheville's key map is 4400x5400 against a corpus of 5484-6830 x 7323-8422, so 0.25 put it at a 1350px working long side and its page numbers at ~28px against the ~40px the models were trained on: 4 numbers read on a sheet carrying 50+. It now prefers a plain 1.0 or 0.25 when that lands within 15% of a 1950px target and normalizes to the target otherwise, so every dev-corpus key map still resolves to exactly 0.25 and only odd-DPI scans resample.

Asheville: P(road) maps 18 -> 106, fitted pages reaching the matcher 0/57 -> 57/57, refinements 0 -> 16; page numbers read 4 -> 32 and rescue pages reaching the matcher 3 -> 26. Rescue placements stay 0 — those candidates score a median 0.59 against the 1.25 gate, so the channel now abstains on evidence rather than on a missing input.