### PR TITLE
Reorganize key-map truth data around the volumes it describes

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -6,8 +6,8 @@
  * shape) and the browser calls it with `typedApi<API>()` (requests are checked
  * against the same types). See https://github.com/danvk/crosswalk.
  *
- * Binary endpoints (the `/iiif` image service, `/api/keymaps/:name` JPEGs, and
- * the `/mapsnap` static build) are not JSON and are served as plain Express
+ * Binary endpoints (the `/iiif` image service, `/api/keymaps/*` key-map images,
+ * and the `/mapsnap` static build) are not JSON and are served as plain Express
  * middleware in server.ts, so they are not part of this interface.
  */
 
@@ -17,7 +17,11 @@ import type {
   VolumeListResponse,
 } from './iiifAnnotations.ts';
 import type { CompareResponse } from './compareTxt.ts';
-import type { ImageInfo, LabelsJson } from '../src/keymap/types.ts';
+import type {
+  ImageInfo,
+  LabelsJson,
+  LabelsWriteRequest,
+} from '../src/keymap/types.ts';
 import type { AdjacencyData } from '../src/types.ts';
 
 /** Response of GET /iiif-api/adjacency — the volume's adjacency.json, or null when absent. */
@@ -35,10 +39,15 @@ export interface KeymapImagesResponse {
   images: ImageInfo[];
 }
 
-/** GET /api/labels/:name — the sidecar, or a marker that none exists yet. */
+/** Query naming one key-map page, e.g. `{ id: "queens_1950/vol2/p0" }`. */
+export interface KeymapTarget {
+  id: string;
+}
+
+/** GET /api/labels — the sidecar, or a marker that none exists yet. */
 export type LabelsResponse = LabelsJson | { exists: false };
 
-/** Response of PUT /api/labels/:name. */
+/** Response of PUT /api/labels. */
 export interface LabelsWriteResponse {
   ok: boolean;
 }
@@ -123,9 +132,9 @@ export interface API {
   '/api/images': {
     get: GetEndpoint<KeymapImagesResponse>;
   };
-  '/api/labels/:name': {
-    get: GetEndpoint<LabelsResponse>;
-    put: Endpoint<LabelsJson, LabelsWriteResponse>;
+  '/api/labels': {
+    get: GetEndpoint<LabelsResponse, KeymapTarget>;
+    put: Endpoint<LabelsWriteRequest, LabelsWriteResponse, KeymapTarget>;
   };
   '/notes-api/notes': {
     get: GetEndpoint<NotesResponse, VolumeQuery>;

--- a/app/server/keymapPages.test.ts
+++ b/app/server/keymapPages.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  findKeymapPages,
+  readLabelCount,
+  resolveKeymapPage,
+} from './keymapPages.ts';
+
+let dataDir: string;
+
+// A data directory covering the layouts the labeler has to handle: a plain
+// volume, a nested one, a page listed only for its truth labels, a keymap
+// sidecar with no image, and a non-key-map page.
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'keymap-pages-'));
+  const write = async (relative: string, contents = '{}') => {
+    const path = join(dataDir, relative);
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, contents);
+  };
+  await write('champaign/raw/p1.jpg', 'jpeg');
+  await write('champaign/raw/p1.keymap.json');
+  await write('champaign/raw/truth/p1.labels.json', '{"labels":[{},{},{}]}');
+  await write('champaign/raw/p7.jpg', 'jpeg'); // an ordinary page, not a key map
+  await write('queens_1950/vol2/raw/p0.png', 'png');
+  await write('queens_1950/vol2/raw/p0.keymap.json');
+  await write('detroit/raw/p0.jpg', 'jpeg'); // truth only: no keymap.json
+  await write('detroit/raw/truth/p0.labels.json', '{"labels":[]}');
+  await write('detroit/raw/p9.keymap.json'); // no image alongside it
+  await write('detroit/oim/p0.keymap.json'); // outside raw/: not a key map
+});
+
+describe('findKeymapPages', () => {
+  it('finds key maps in plain and nested volumes, ignoring other pages', async () => {
+    const pages = await findKeymapPages(dataDir);
+    expect(pages.map((page) => page.id)).toEqual([
+      'champaign/p1',
+      'detroit/p0',
+      'queens_1950/vol2/p0',
+    ]);
+  });
+
+  it('reports whether each page has a keymap.json', async () => {
+    const pages = await findKeymapPages(dataDir);
+    const byId = Object.fromEntries(pages.map((p) => [p.id, p.hasKeymap]));
+    expect(byId).toEqual({
+      'champaign/p1': true,
+      'queens_1950/vol2/p0': true,
+      // Listed only because it has truth labels.
+      'detroit/p0': false,
+    });
+  });
+
+  it('points at the truth sidecar and the image, whatever its extension', async () => {
+    const pages = await findKeymapPages(dataDir);
+    const nested = pages.find((page) => page.id === 'queens_1950/vol2/p0')!;
+    expect(nested.imagePath).toBe(join(dataDir, 'queens_1950/vol2/raw/p0.png'));
+    expect(nested.labelsPath).toBe(
+      join(dataDir, 'queens_1950/vol2/raw/truth/p0.labels.json'),
+    );
+  });
+});
+
+describe('resolveKeymapPage', () => {
+  it('resolves plain and nested page ids', async () => {
+    expect((await resolveKeymapPage(dataDir, 'champaign/p1'))?.stem).toBe('p1');
+    const nested = await resolveKeymapPage(dataDir, 'queens_1950/vol2/p0');
+    expect(nested?.volume).toBe('queens_1950/vol2');
+  });
+
+  it('resolves a page that is not a key map, since only ids are checked', async () => {
+    const page = await resolveKeymapPage(dataDir, 'champaign/p7');
+    expect(page?.hasKeymap).toBe(false);
+  });
+
+  it('rejects ids that name no image', async () => {
+    expect(await resolveKeymapPage(dataDir, 'detroit/p9')).toBeNull();
+    expect(await resolveKeymapPage(dataDir, 'champaign/nope')).toBeNull();
+    expect(await resolveKeymapPage(dataDir, 'novolume/p1')).toBeNull();
+  });
+
+  it('rejects ids that could escape the data directory', async () => {
+    for (const id of [
+      '../champaign/p1',
+      'champaign/../../p1',
+      'champaign/raw/../p1',
+      '/etc/passwd',
+      'champaign',
+      '',
+      'a/b/c/d',
+      'champaign\\p1',
+    ]) {
+      expect(await resolveKeymapPage(dataDir, id)).toBeNull();
+    }
+  });
+});
+
+describe('readLabelCount', () => {
+  it('counts labels, and reports null when there is no sidecar', async () => {
+    expect(
+      await readLabelCount(join(dataDir, 'champaign/raw/truth/p1.labels.json')),
+    ).toBe(3);
+    expect(
+      await readLabelCount(join(dataDir, 'detroit/raw/truth/p0.labels.json')),
+    ).toBe(0);
+    expect(await readLabelCount(join(dataDir, 'nope.labels.json'))).toBeNull();
+  });
+});

--- a/app/server/keymapPages.ts
+++ b/app/server/keymapPages.ts
@@ -1,0 +1,182 @@
+/**
+ * Locating key-map pages and their truth sidecars under the data directory.
+ *
+ * A key map is a page in some volume's `raw/` directory carrying a
+ * `<stem>.keymap.json` sidecar; its truth labels live beside it in
+ * `raw/truth/<stem>.labels.json`. Volumes may be nested one level (e.g.
+ * `data/queens_1950/vol2/raw/`), so a page is identified by the slash-joined
+ * volume path and stem — "queens_1950/vol2/p0", "champaign_ill_1915/p1" —
+ * which is also what the UI displays.
+ */
+
+import { readFile, readdir } from 'fs/promises';
+import { join } from 'path';
+
+/** Extensions a raw page image may use, in the order they are probed. */
+const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png'];
+
+/** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
+const MAX_VOLUME_DEPTH = 2;
+
+/** A key-map page: where its files live and which of them exist. */
+export interface KeymapPage {
+  /** Slash-joined volume path and stem, e.g. "queens_1950/vol2/p0". */
+  id: string;
+  /** Volume directory relative to the data dir, e.g. "queens_1950/vol2". */
+  volume: string;
+  /** Page stem within `raw/`, e.g. "p0". */
+  stem: string;
+  /** Absolute path of the page image. */
+  imagePath: string;
+  /** Absolute path of the truth sidecar, which need not exist yet. */
+  labelsPath: string;
+  /** Whether the page has a `<stem>.keymap.json` detection sidecar. */
+  hasKeymap: boolean;
+}
+
+// The page image for a stem, probing the known extensions; null if none exists.
+function findImage(
+  rawFiles: Set<string>,
+  rawDir: string,
+  stem: string,
+): string | null {
+  for (const extension of IMAGE_EXTENSIONS) {
+    if (rawFiles.has(stem + extension)) return join(rawDir, stem + extension);
+  }
+  return null;
+}
+
+// Describe one page of a volume, or null when it has no image to label.
+function pageFor(
+  volume: string,
+  rawDir: string,
+  rawFiles: Set<string>,
+  stem: string,
+): KeymapPage | null {
+  const imagePath = findImage(rawFiles, rawDir, stem);
+  if (!imagePath) return null;
+  return {
+    id: `${volume}/${stem}`,
+    volume,
+    stem,
+    imagePath,
+    labelsPath: join(rawDir, 'truth', `${stem}.labels.json`),
+    hasKeymap: rawFiles.has(`${stem}.keymap.json`),
+  };
+}
+
+/**
+ * Volume directories (relative to `dataDir`) that contain a `raw/` subdirectory.
+ *
+ * Descends at most {@link MAX_VOLUME_DEPTH} levels and stops at the first
+ * `raw/`-bearing directory on each branch, so a volume's own subdirectories
+ * (`oim/`, `artifacts/`, …) are never scanned.
+ */
+async function findVolumes(
+  dataDir: string,
+  relative = '',
+  depth = 0,
+): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(join(dataDir, relative), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const directories = entries.filter(
+    (entry) => entry.isDirectory() && !entry.name.startsWith('.'),
+  );
+  if (relative && directories.some((entry) => entry.name === 'raw')) {
+    return [relative];
+  }
+  if (depth >= MAX_VOLUME_DEPTH) return [];
+  const volumes: string[] = [];
+  for (const entry of directories) {
+    if (entry.name === 'raw') continue;
+    const path = relative ? `${relative}/${entry.name}` : entry.name;
+    volumes.push(...(await findVolumes(dataDir, path, depth + 1)));
+  }
+  return volumes;
+}
+
+/**
+ * Every key-map page under the data directory, sorted by id.
+ *
+ * A page qualifies if it has a `keymap.json` sidecar — the detection output
+ * that marks a sheet as a key map — *or* an existing truth sidecar, so labels
+ * written for a page whose key-map detection has not been run stay reachable
+ * in the labeler rather than dropping out of the list.
+ */
+export async function findKeymapPages(dataDir: string): Promise<KeymapPage[]> {
+  const pages: KeymapPage[] = [];
+  for (const volume of await findVolumes(dataDir)) {
+    const rawDir = join(dataDir, volume, 'raw');
+    let rawFiles: string[];
+    try {
+      rawFiles = await readdir(rawDir);
+    } catch {
+      continue;
+    }
+    let truthFiles: string[] = [];
+    try {
+      truthFiles = await readdir(join(rawDir, 'truth'));
+    } catch {
+      // No truth directory yet; the volume's labeled pages are simply none.
+    }
+    const present = new Set(rawFiles);
+    const stems = new Set([
+      ...rawFiles
+        .filter((file) => file.endsWith('.keymap.json'))
+        .map((file) => file.slice(0, -'.keymap.json'.length)),
+      ...truthFiles
+        .filter((file) => file.endsWith('.labels.json'))
+        .map((file) => file.slice(0, -'.labels.json'.length)),
+    ]);
+    for (const stem of stems) {
+      const page = pageFor(volume, rawDir, present, stem);
+      if (page) pages.push(page); // a sidecar with no page image is unlabelable
+    }
+  }
+  pages.sort((a, b) => a.id.localeCompare(b.id));
+  return pages;
+}
+
+/**
+ * Resolve a page id to its file paths, or null if it does not name a page.
+ *
+ * Rejects ids that could escape the data directory (empty, `.`/`..` or
+ * backslash-bearing segments) and ids with no page image, so a non-null result
+ * is always a real page under `dataDir`.
+ */
+export async function resolveKeymapPage(
+  dataDir: string,
+  id: string,
+): Promise<KeymapPage | null> {
+  const parts = id.split('/');
+  if (parts.length < 2 || parts.length > MAX_VOLUME_DEPTH + 1) return null;
+  const unsafe = (part: string) =>
+    part === '' || part === '.' || part === '..' || part.includes('\\');
+  if (parts.some(unsafe)) return null;
+  const stem = parts[parts.length - 1]!;
+  const volume = parts.slice(0, -1).join('/');
+  const rawDir = join(dataDir, volume, 'raw');
+  let rawFiles: string[];
+  try {
+    rawFiles = await readdir(rawDir);
+  } catch {
+    return null;
+  }
+  return pageFor(volume, rawDir, new Set(rawFiles), stem);
+}
+
+/** Number of labels in a page's truth sidecar, or null when it has none. */
+export async function readLabelCount(
+  labelsPath: string,
+): Promise<number | null> {
+  try {
+    const data = JSON.parse(await readFile(labelsPath, 'utf8'));
+    return Array.isArray(data.labels) ? data.labels.length : 0;
+  } catch {
+    return null; // missing or unreadable sidecar
+  }
+}

--- a/app/server/keymapRoutes.ts
+++ b/app/server/keymapRoutes.ts
@@ -1,85 +1,83 @@
 /**
- * Key-map truth API (fixed to <data>/keymaps).
+ * Key-map truth API over the volumes' `raw/` directories.
  *
- * `registerKeymapImages` mounts the raw key-map JPEG endpoint; `registerKeymapApi`
- * registers the typed JSON endpoints (image list + label sidecars) on the shared
- * crosswalk router.
+ * `registerKeymapImages` mounts the raw key-map image endpoint;
+ * `registerKeymapApi` registers the typed JSON endpoints (page list + label
+ * sidecars) on the shared crosswalk router. Pages are addressed by the ids
+ * described in ./keymapPages — "queens_1950/vol2/p0" — which contain slashes,
+ * so the JSON endpoints take the id as a query parameter and the image
+ * endpoint takes it as a wildcard path.
  */
 
-import { readdir, readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { basename, dirname } from 'path';
 import type { Express } from 'express';
 import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API, KeymapImagesResponse } from './api.ts';
+import {
+  findKeymapPages,
+  readLabelCount,
+  resolveKeymapPage,
+} from './keymapPages.ts';
 import type { ImageInfo } from '../src/keymap/types.ts';
 
-// Reject a name that could escape the keymaps directory. A `:name` route param
-// is one path segment but can still carry an encoded slash, so this guards the
-// label sidecar path against traversal.
-function isSafeName(name: string): boolean {
-  return !name.includes('/') && !name.includes('\\') && !name.includes('..');
-}
-
-// Map an image filename to its labels sidecar filename (foo.jpg → foo.labels.json).
-function labelsFilename(imageName: string): string {
-  return imageName.replace(/\.[^.]+$/, '') + '.labels.json';
-}
-
-/** Mount the raw key-map image endpoint under `/api/keymaps/:name`. */
-export function registerKeymapImages(app: Express, keymapsDir: string): void {
-  app.get('/api/keymaps/:name', (req, res) => {
-    const { name } = req.params;
-    if (!isSafeName(name)) return res.sendStatus(400);
-    res.sendFile(join(keymapsDir, name));
+/**
+ * Mount the raw key-map image endpoint under `/api/keymaps/<page id>`.
+ *
+ * The `(*)` makes `:id` greedy so it captures the slashes in a page id;
+ * resolveKeymapPage is what keeps it from reaching outside the data directory.
+ */
+export function registerKeymapImages(app: Express, dataDir: string): void {
+  app.get('/api/keymaps/:id(*)', async (req, res) => {
+    const page = await resolveKeymapPage(dataDir, req.params.id);
+    if (!page) return res.sendStatus(404);
+    res.sendFile(page.imagePath);
   });
 }
 
-/** Register the typed key-map image-list and label-sidecar API (`/api/*`). */
+/** Register the typed key-map page-list and label-sidecar API (`/api/*`). */
 export function registerKeymapApi(
   router: TypedRouter<API>,
-  keymapsDir: string,
+  dataDir: string,
 ): void {
-  // List the available key map images, each with its current label count (if any).
+  // List the key-map pages of every volume, each with its current label count.
   router.get('/api/images', async (): Promise<KeymapImagesResponse> => {
-    const files = await readdir(keymapsDir);
-    const images = files.filter((f) => /\.jpe?g$/i.test(f)).sort();
-    const withMeta: ImageInfo[] = await Promise.all(
-      images.map(async (name) => {
-        let labelCount: number | null = null;
-        try {
-          const text = await readFile(
-            join(keymapsDir, labelsFilename(name)),
-            'utf8',
-          );
-          labelCount = (JSON.parse(text).labels ?? []).length;
-        } catch {
-          // no sidecar yet
-        }
-        return { name, labelCount };
-      }),
+    const pages = await findKeymapPages(dataDir);
+    const images: ImageInfo[] = await Promise.all(
+      pages.map(async (page) => ({
+        name: page.id,
+        labelCount: await readLabelCount(page.labelsPath),
+        hasKeymap: page.hasKeymap,
+      })),
     );
-    return { images: withMeta };
+    return { images };
   });
 
-  // Read a key map image's labels sidecar, or report that none exists yet.
-  router.get('/api/labels/:name', async ({ name }) => {
-    if (!isSafeName(name)) throw new HTTPError(400, 'bad name');
+  // Read a page's truth sidecar, or report that none exists yet.
+  router.get('/api/labels', async (_params, request) => {
+    const page = await resolveKeymapPage(dataDir, request.query.id);
+    if (!page) throw new HTTPError(400, `no such key map: ${request.query.id}`);
     try {
-      const text = await readFile(
-        join(keymapsDir, labelsFilename(name)),
-        'utf8',
-      );
-      return JSON.parse(text);
+      return JSON.parse(await readFile(page.labelsPath, 'utf8'));
     } catch {
       return { exists: false };
     }
   });
 
-  // Write a key map image's labels sidecar.
-  router.put('/api/labels/:name', async ({ name }, body) => {
-    if (!isSafeName(name)) throw new HTTPError(400, 'bad name');
-    const path = join(keymapsDir, labelsFilename(name));
-    await writeFile(path, JSON.stringify(body, null, 2) + '\n');
+  // Write a page's truth sidecar, creating the volume's truth/ directory on
+  // first save. The server fills in `image`, since it alone knows which file
+  // the page's stem resolved to.
+  router.put('/api/labels', async (_params, body, request) => {
+    const page = await resolveKeymapPage(dataDir, request.query.id);
+    if (!page) throw new HTTPError(400, `no such key map: ${request.query.id}`);
+    const sidecar = {
+      image: basename(page.imagePath),
+      width: body.width,
+      height: body.height,
+      labels: body.labels,
+    };
+    await mkdir(dirname(page.labelsPath), { recursive: true });
+    await writeFile(page.labelsPath, JSON.stringify(sidecar, null, 2) + '\n');
     return { ok: true };
   });
 }

--- a/app/server/main.ts
+++ b/app/server/main.ts
@@ -15,7 +15,7 @@
  * here; a production build (`npm run build`) is served standalone at /mapsnap.
  */
 
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import express from 'express';
 import { TypedRouter } from 'crosswalk';
 import type { API } from './api.ts';
@@ -24,7 +24,6 @@ import { registerKeymapApi, registerKeymapImages } from './keymapRoutes.ts';
 import { registerNotesApi } from './notesRoutes.ts';
 
 const dataDir = resolve(process.argv[2] ?? '../data');
-const keymapsDir = join(dataDir, 'keymaps');
 const port = parseInt(process.argv[3] ?? '8182', 10);
 
 const app = express();
@@ -40,15 +39,15 @@ app.use((req, res, next) => {
   next();
 });
 
-// Binary endpoints (raw Express): the IIIF image service and key-map JPEGs.
+// Binary endpoints (raw Express): the IIIF image service and key-map images.
 // Registered before the typed router so their more specific paths win.
 registerIiifImages(app, dataDir);
-registerKeymapImages(app, keymapsDir);
+registerKeymapImages(app, dataDir);
 
 // The typed JSON API (crosswalk), defined by the API interface in ./api.
 const router = new TypedRouter<API>(app);
 registerIiifApi(router, dataDir);
-registerKeymapApi(router, keymapsDir);
+registerKeymapApi(router, dataDir);
 registerNotesApi(router, dataDir);
 
 // Serve the data directory under the app base so `?files=data/...` deep links
@@ -60,6 +59,5 @@ app.use('/mapsnap', express.static(resolve('dist')));
 app.listen(port, () => {
   console.error(`mapsnap server running at http://localhost:${port}`);
   console.error(`  data:    ${dataDir}`);
-  console.error(`  keymaps: ${keymapsDir}`);
   console.error(`  UI (after build): http://localhost:${port}/mapsnap/`);
 });

--- a/app/src/keymap/BoxSizeControls.tsx
+++ b/app/src/keymap/BoxSizeControls.tsx
@@ -1,0 +1,40 @@
+import { MAX_BOX_SIZE, MIN_BOX_SIZE } from './labels';
+
+interface BoxSizeControlsProps {
+  boxWidth: number;
+  boxHeight: number;
+  onChangeWidth: (width: number) => void;
+  onChangeHeight: (height: number) => void;
+}
+
+/**
+ * Sliders for the label box's size in image pixels.
+ *
+ * The box is purely a visualization — labels are stored as points — so these
+ * only affect the overlay on the image and the crop each preview shows, and
+ * nothing here is written to the sidecar.
+ */
+export function BoxSizeControls(props: BoxSizeControlsProps) {
+  const { boxWidth, boxHeight, onChangeWidth, onChangeHeight } = props;
+  const sliders = [
+    { label: 'Box width', value: boxWidth, onChange: onChangeWidth },
+    { label: 'Box height', value: boxHeight, onChange: onChangeHeight },
+  ];
+  return (
+    <div className="box-size-controls">
+      {sliders.map(({ label, value, onChange }) => (
+        <label key={label} className="box-size-slider">
+          <span className="box-size-label">{label}</span>
+          <input
+            type="range"
+            min={MIN_BOX_SIZE}
+            max={MAX_BOX_SIZE}
+            value={value}
+            onChange={(e) => onChange(Number(e.target.value))}
+          />
+          <span className="box-size-value">{value}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/app/src/keymap/ImageList.tsx
+++ b/app/src/keymap/ImageList.tsx
@@ -6,7 +6,7 @@ interface ImageListProps {
   onSelect: (name: string) => void;
 }
 
-/** Left-column list of available key map images, with their label counts. */
+/** Left-column list of available key map pages, with their label counts. */
 export function ImageList(props: ImageListProps) {
   const { images, selectedName, onSelect } = props;
   return (
@@ -18,8 +18,17 @@ export function ImageList(props: ImageListProps) {
             key={info.name}
             className={info.name === selectedName ? 'selected' : undefined}
             onClick={() => onSelect(info.name)}
+            title={
+              info.hasKeymap
+                ? info.name
+                : `${info.name} (no keymap.json; listed because it has truth labels)`
+            }
           >
-            <span className="image-name">{info.name}</span>
+            <span
+              className={info.hasKeymap ? 'image-name' : 'image-name no-keymap'}
+            >
+              {info.name}
+            </span>
             {info.labelCount !== null && (
               <span className="label-count">{info.labelCount}</span>
             )}

--- a/app/src/keymap/KeymapApp.tsx
+++ b/app/src/keymap/KeymapApp.tsx
@@ -4,7 +4,13 @@ import { pointInPolygon } from '../geometry';
 import { useElementSize } from '../hooks/useElementSize';
 import { loadImage } from '../loadImage';
 import { fetchImages, fetchLabels, imageUrl, saveLabels } from './api';
-import { createLabelsJson, labelBox, labelBoxSize } from './labels';
+import {
+  createLabelsJson,
+  labelBox,
+  DEFAULT_BOX_HEIGHT,
+  DEFAULT_BOX_WIDTH,
+} from './labels';
+import { BoxSizeControls } from './BoxSizeControls';
 import { ImageList } from './ImageList';
 import { LabelsOverlay } from './LabelsOverlay';
 import { LabelsTable } from './LabelsTable';
@@ -26,6 +32,11 @@ export function KeymapApp() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [showOnlyUnlabeled, setShowOnlyUnlabeled] = useState(false);
+  // Visualization only: the box drawn around each label point and cropped for
+  // its preview. Kept across image selections so the size a sheet's numbers
+  // want is set once, not per page.
+  const [boxWidth, setBoxWidth] = useState(DEFAULT_BOX_WIDTH);
+  const [boxHeight, setBoxHeight] = useState(DEFAULT_BOX_HEIGHT);
 
   const [imgRef, imgSize] = useElementSize<HTMLImageElement>();
   // Only persist labels that changed via user edits, not freshly loaded ones.
@@ -70,7 +81,7 @@ export function KeymapApp() {
       try {
         await saveLabels(
           selectedName,
-          createLabelsJson(selectedName, imageWidth, imageHeight, labels),
+          createLabelsJson(imageWidth, imageHeight, labels),
         );
         setSaveStatus('saved');
         setImages((prev) =>
@@ -95,9 +106,6 @@ export function KeymapApp() {
     setLabels(next);
   }
 
-  // Box size scaled to the image's resolution (full vs. 25%-scale).
-  const box = labelBoxSize(imageWidth, imageHeight);
-
   // Add a label at the click point, or select an existing one if clicked.
   function handleImageClick(e: React.MouseEvent): void {
     if (!selectedName || !imgSize.width || !imgSize.height) return;
@@ -106,7 +114,7 @@ export function KeymapApp() {
     const y = ((e.clientY - rect.top) * imageHeight) / imgSize.height;
     const current = labelsRef.current;
     const hitIndex = current.findIndex((label) =>
-      pointInPolygon(x, y, labelBox(label.x, label.y, box.width, box.height)),
+      pointInPolygon(x, y, labelBox(label.x, label.y, boxWidth, boxHeight)),
     );
     if (hitIndex >= 0) {
       setSelectedIndex(hitIndex);
@@ -168,8 +176,8 @@ export function KeymapApp() {
             <LabelsOverlay
               labels={labels}
               selectedIndex={selectedIndex}
-              boxWidth={box.width}
-              boxHeight={box.height}
+              boxWidth={boxWidth}
+              boxHeight={boxHeight}
               displayWidth={imgSize.width}
               displayHeight={imgSize.height}
               imageWidth={imageWidth}
@@ -200,13 +208,19 @@ export function KeymapApp() {
           />
           Only show labels without text
         </label>
+        <BoxSizeControls
+          boxWidth={boxWidth}
+          boxHeight={boxHeight}
+          onChangeWidth={setBoxWidth}
+          onChangeHeight={setBoxHeight}
+        />
         <LabelsTable
           labels={labels}
           selectedIndex={selectedIndex}
           showOnlyUnlabeled={showOnlyUnlabeled}
           image={imageEl}
-          boxWidth={box.width}
-          boxHeight={box.height}
+          boxWidth={boxWidth}
+          boxHeight={boxHeight}
           onSelect={setSelectedIndex}
           onChangeText={handleChangeText}
           onDelete={handleDelete}

--- a/app/src/keymap/api.ts
+++ b/app/src/keymap/api.ts
@@ -1,31 +1,37 @@
 import { typedApi } from 'crosswalk';
 import { jsonFetch } from '../apiFetch';
 import type { API } from '../../server/api';
-import type { ImageInfo, LabelsJson } from './types';
+import type { ImageInfo, LabelsJson, LabelsWriteRequest } from './types';
 
 const api = typedApi<API>({ fetch: jsonFetch });
 
-/** URL the server serves a key map image from (a binary, non-JSON endpoint). */
-export function imageUrl(name: string): string {
-  return `/api/keymaps/${encodeURIComponent(name)}`;
+/**
+ * URL the server serves a key map image from (a binary, non-JSON endpoint).
+ *
+ * Page ids contain slashes ("queens_1950/vol2/p0") and the endpoint is a
+ * wildcard path, so each segment is encoded separately to keep them.
+ */
+export function imageUrl(id: string): string {
+  const path = id.split('/').map(encodeURIComponent).join('/');
+  return `/api/keymaps/${path}`;
 }
 
-/** Fetch the list of available key map images with their label counts. */
+/** Fetch the list of available key map pages with their label counts. */
 export async function fetchImages(): Promise<ImageInfo[]> {
   const { images } = await api.get('/api/images')();
   return images;
 }
 
-/** Fetch an image's labels sidecar, or null if none exists yet. */
-export async function fetchLabels(name: string): Promise<LabelsJson | null> {
-  const data = await api.get('/api/labels/:name')({ name });
+/** Fetch a page's labels sidecar, or null if none exists yet. */
+export async function fetchLabels(id: string): Promise<LabelsJson | null> {
+  const data = await api.get('/api/labels')(null, { id });
   return 'exists' in data ? null : data;
 }
 
-/** Write an image's labels sidecar. */
+/** Write a page's labels sidecar. */
 export async function saveLabels(
-  name: string,
-  data: LabelsJson,
+  id: string,
+  data: LabelsWriteRequest,
 ): Promise<void> {
-  await api.put('/api/labels/:name')({ name }, data);
+  await api.put('/api/labels')({}, data, { id });
 }

--- a/app/src/keymap/keymap.css
+++ b/app/src/keymap/keymap.css
@@ -14,7 +14,7 @@
   position: sticky;
   top: 16px;
   flex-shrink: 0;
-  width: 220px;
+  width: 260px;
   font-family: sans-serif;
   font-size: 13px;
   max-height: calc(100vh - 32px);
@@ -51,10 +51,16 @@
   font-weight: bold;
 }
 
+/* Page ids carry the volume path ("queens_1950/vol2/p0"), so wrap rather than
+   truncate — the stem at the end is the part worth reading. */
 .image-list .image-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+}
+
+/* Listed for its truth labels alone: no keymap.json marks it as a key map. */
+.image-list .image-name.no-keymap {
+  color: #777;
+  font-style: italic;
 }
 
 .image-list .label-count {
@@ -125,6 +131,42 @@
   font-family: sans-serif;
   font-size: 13px;
   color: #333;
+}
+
+/* Box-size sliders: label, slider, and the current value in a fixed-width
+   column so the slider does not shift as the number's digit count changes. */
+.box-size-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 6px 0;
+  font-family: sans-serif;
+  font-size: 13px;
+  color: #333;
+}
+
+.box-size-slider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.box-size-slider .box-size-label {
+  flex-shrink: 0;
+  width: 72px;
+}
+
+.box-size-slider input[type='range'] {
+  flex: 1;
+  min-width: 0;
+}
+
+.box-size-slider .box-size-value {
+  flex-shrink: 0;
+  width: 30px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: #666;
 }
 
 .save-status.save-saved {

--- a/app/src/keymap/labels.test.ts
+++ b/app/src/keymap/labels.test.ts
@@ -3,16 +3,14 @@ import { pointInPolygon } from '../geometry';
 import {
   createLabelsJson,
   labelBox,
-  labelBoxSize,
-  LABEL_BOX_HEIGHT,
-  LABEL_BOX_WIDTH,
+  DEFAULT_BOX_HEIGHT,
+  DEFAULT_BOX_WIDTH,
 } from './labels';
 
 describe('createLabelsJson', () => {
   it('assembles the sidecar payload', () => {
     const labels = [{ x: 1, y: 2, text: '21' }];
-    expect(createLabelsJson('foo.jpg', 100, 200, labels)).toEqual({
-      image: 'foo.jpg',
+    expect(createLabelsJson(100, 200, labels)).toEqual({
       width: 100,
       height: 200,
       labels,
@@ -21,10 +19,10 @@ describe('createLabelsJson', () => {
 });
 
 describe('labelBox', () => {
-  it('centers a box of the default size on the point', () => {
-    const box = labelBox(100, 100);
-    const hw = LABEL_BOX_WIDTH / 2;
-    const hh = LABEL_BOX_HEIGHT / 2;
+  it('centers a box of the given size on the point', () => {
+    const box = labelBox(100, 100, DEFAULT_BOX_WIDTH, DEFAULT_BOX_HEIGHT);
+    const hw = DEFAULT_BOX_WIDTH / 2;
+    const hh = DEFAULT_BOX_HEIGHT / 2;
     expect(box).toEqual([
       [100 - hw, 100 - hh],
       [100 + hw, 100 - hh],
@@ -39,24 +37,11 @@ describe('labelBox', () => {
     expect(pointInPolygon(115, 105, box)).toBe(true);
     expect(pointInPolygon(200, 100, box)).toBe(false);
   });
-});
 
-describe('labelBoxSize', () => {
-  it('uses full size when a dimension exceeds 4000px', () => {
-    expect(labelBoxSize(5679, 8268)).toEqual({
-      width: LABEL_BOX_WIDTH,
-      height: LABEL_BOX_HEIGHT,
-    });
-    expect(labelBoxSize(4001, 1000)).toEqual({
-      width: LABEL_BOX_WIDTH,
-      height: LABEL_BOX_HEIGHT,
-    });
-  });
-
-  it('shrinks to 25% for smaller (quarter-scale) images', () => {
-    expect(labelBoxSize(1420, 2067)).toEqual({
-      width: Math.round(LABEL_BOX_WIDTH * 0.25),
-      height: Math.round(LABEL_BOX_HEIGHT * 0.25),
-    });
+  it('resizes with the slider values, so hit-testing tracks what is drawn', () => {
+    const wide = labelBox(100, 100, 300, 40);
+    expect(pointInPolygon(240, 100, wide)).toBe(true);
+    const narrow = labelBox(100, 100, 40, 40);
+    expect(pointInPolygon(240, 100, narrow)).toBe(false);
   });
 });

--- a/app/src/keymap/labels.ts
+++ b/app/src/keymap/labels.ts
@@ -1,54 +1,40 @@
-import type { Label, LabelsJson } from './types';
+import type { Label, LabelsWriteRequest } from './types';
 
 /**
- * Size, in image pixels, of the box drawn around a label point and of the
- * region shown in its preview, at full image resolution. Labels are stored as
- * points; the box is only for visualization. The box is wider than tall to suit
- * horizontal page numbers.
+ * Starting size, in image pixels, of the box drawn around a label point and of
+ * the region shown in its preview. Labels are stored as points and the box is
+ * only for visualization, so it never reaches the sidecar — the labeler's
+ * sliders adjust it live, starting wider than tall to suit horizontal page
+ * numbers.
  */
-export const LABEL_BOX_WIDTH = 160;
-export const LABEL_BOX_HEIGHT = 107;
+export const DEFAULT_BOX_WIDTH = 160;
+export const DEFAULT_BOX_HEIGHT = 107;
 
-/** A label box's pixel dimensions. */
-export interface BoxSize {
-  width: number;
-  height: number;
-}
+/** Range the box-size sliders span, in image pixels. */
+export const MIN_BOX_SIZE = 20;
+export const MAX_BOX_SIZE = 400;
 
 /**
- * Box size scaled to the image's resolution. Full-resolution key maps (any
- * dimension over 4000px) use the full box size; smaller images are assumed to
- * be 25%-scale, so the box shrinks to match.
+ * Build the labels.json payload for a page. The `image` field is left to the
+ * server, which resolves the page's stem to an actual image file.
  */
-export function labelBoxSize(imageWidth: number, imageHeight: number): BoxSize {
-  const isFullScale = imageWidth > 4000 || imageHeight > 4000;
-  const scale = isFullScale ? 1 : 0.25;
-  return {
-    width: Math.round(LABEL_BOX_WIDTH * scale),
-    height: Math.round(LABEL_BOX_HEIGHT * scale),
-  };
-}
-
-/** Build a labels.json payload for an image. */
 export function createLabelsJson(
-  image: string,
   width: number,
   height: number,
   labels: Label[],
-): LabelsJson {
-  return { image, width, height, labels };
+): LabelsWriteRequest {
+  return { width, height, labels };
 }
 
 /**
- * Axis-aligned box centered on (x, y), as a 4-point polygon in [x, y] order
- * (clockwise from top-left). Defaults to {@link LABEL_BOX_WIDTH} by
- * {@link LABEL_BOX_HEIGHT}.
+ * Axis-aligned box of the given size centered on (x, y), as a 4-point polygon
+ * in [x, y] order (clockwise from top-left).
  */
 export function labelBox(
   x: number,
   y: number,
-  width: number = LABEL_BOX_WIDTH,
-  height: number = LABEL_BOX_HEIGHT,
+  width: number,
+  height: number,
 ): [number, number][] {
   const hw = width / 2;
   const hh = height / 2;

--- a/app/src/keymap/types.ts
+++ b/app/src/keymap/types.ts
@@ -7,15 +7,25 @@ export interface Label {
 
 /** A <stem>.labels.json sidecar: truth labels for one key map image. */
 export interface LabelsJson {
+  /** Filename of the labeled image within the volume's `raw/`, e.g. "p0.jpg". */
   image: string;
   width: number;
   height: number;
   labels: Label[];
 }
 
-/** One key map image in the available-images list, with its label count. */
+/**
+ * A sidecar as written by the client: everything but `image`, which the server
+ * fills in because only it knows which file the page's stem resolved to.
+ */
+export type LabelsWriteRequest = Omit<LabelsJson, 'image'>;
+
+/** One key map page in the available-pages list, with its label count. */
 export interface ImageInfo {
+  /** Page id: volume path and stem, e.g. "queens_1950/vol2/p0". */
   name: string;
   /** Number of labels in the sidecar, or null if no sidecar exists yet. */
   labelCount: number | null;
+  /** Whether the page has a keymap.json sidecar (vs. being listed for its truth). */
+  hasKeymap: boolean;
 }

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -657,7 +657,7 @@ def redundant_skeleton_keys(truth_keys: set[str], generated_keys: set[str]) -> s
 
 
 def compare_pages(
-    truth_path: Path, generated_path: Path
+    truth_path: Path, generated_path: Path, oim_dir: Path | None = None
 ) -> tuple[list[dict], list[dict]]:
     """Compute per-page comparison rows for a truth/generated IIIF pair.
 
@@ -668,7 +668,11 @@ def compare_pages(
     """
     truth_by_source = annotations_by_source(truth_path)
     gen_by_source = annotations_by_source(generated_path)
-    oim_dir = truth_path.parent / "oim"
+    # OIM's split-panel polygons live in the VOLUME's oim/ directory. That is
+    # normally the truth file's own sibling, but a truth set kept elsewhere (an
+    # archived one under oim/, say) would otherwise send this looking in
+    # oim/oim/ and silently score every split panel as unplaced.
+    oim_dir = oim_dir if oim_dir is not None else truth_path.parent / "oim"
     gen_dir = generated_path.parent
 
     # Skeleton rule: a skeleton sheet ('s' suffix) and its full-color page map

--- a/mapsnap/download_loc_iiif.py
+++ b/mapsnap/download_loc_iiif.py
@@ -4,20 +4,54 @@ Reads a local LOC IIIF v2 manifest JSON file, extracts a page key from each
 canvas @id (e.g. "p451" from "...04720_04_1951-0451"), constructs a
 full-resolution IIIF image URL, and downloads it.
 
+A manifest can concatenate several LOC volumes, and each of those carries its
+own key map at page 0 — Grand Rapids' manifest holds volumes 07 and 08, whose
+"...-0000" canvases both reduce to "p0". Their page numbers are volume-prefixed
+(701-729, 809-846) so only page 0 ever collides, but the collision used to be
+silent: the first canvas wrote p0.jpg and the second was skipped as "already
+done", leaving the volume with half its key maps. Colliding keys are now
+suffixed in manifest order (p0a, p0b) so every canvas is kept. Keys that do not
+collide are untouched, so existing volumes keep their filenames.
+
 Usage:
-    python download_loc_iiif.py <iiif_file> [--dry-run]
+    python download_loc_iiif.py <iiif_file> [--pages p0a,p0b] [--dry-run]
 """
 
 import argparse
 import json
 import re
+import string
 import sys
 import time
-from collections import Counter
+from collections import Counter, defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 
 from mapsnap.download_oim_iiif import download_with_retry
 from mapsnap.utils import jpeg_dimensions, source_id_to_page_key
+
+
+@dataclass
+class CanvasTarget:
+    """One manifest canvas and the file it will be downloaded to."""
+
+    canvas: dict
+    output_dir: Path
+    #: The key this canvas's @id implies on its own ("p0").
+    base_key: str
+    #: The key actually used, after disambiguating collisions ("p0a").
+    page_key: str
+
+    @property
+    def label(self) -> str:
+        return self.canvas.get("label", "unknown")
+
+    @property
+    def path(self) -> Path:
+        return self.output_dir / f"{self.page_key}.jpg"
+
+    def image_url(self, scale: str) -> str:
+        return f"{self.canvas.get('@id', '')}/full/{scale}/0/default.jpg"
 
 
 def canvas_to_page_key(canvas_id: str, label: str) -> str:
@@ -35,30 +69,88 @@ def canvas_to_page_key(canvas_id: str, label: str) -> str:
     return last_segment
 
 
-def process_canvas(
-    canvas: dict,
-    output_dir: Path,
-    scale: str,
-    dry_run: bool,
-) -> Path:
+def disambiguate_keys(targets: list[CanvasTarget]) -> list[tuple[str, list[str]]]:
+    """Suffix page keys that collide within an output directory, in manifest order.
+
+    Two canvases reducing to the same key would otherwise write the same file,
+    and the second would be skipped as already downloaded. Colliding keys become
+    "<key>a", "<key>b", ... in the order the canvases appear; a suffix already
+    claimed by another canvas's own key is skipped, so a manifest holding both a
+    real "p0a" and two "p0"s cannot be made to collide again.
+
+    Mutates ``targets`` and returns the renames as (base_key, [new keys]) so the
+    caller can report them.
+    """
+    by_dir: dict[Path, list[CanvasTarget]] = defaultdict(list)
+    for target in targets:
+        by_dir[target.output_dir].append(target)
+
+    renames: list[tuple[str, list[str]]] = []
+    for group in by_dir.values():
+        counts = Counter(target.base_key for target in group)
+        taken = set(counts)
+        for base_key, count in counts.items():
+            if count < 2:
+                continue
+            colliding = [t for t in group if t.base_key == base_key]
+            suffixes = (s for s in string.ascii_lowercase if base_key + s not in taken)
+            new_keys = []
+            for target in colliding:
+                suffix = next(suffixes, None)
+                if suffix is None:
+                    raise ValueError(f"more than 26 canvases collide on {base_key!r}")
+                target.page_key = base_key + suffix
+                taken.add(target.page_key)
+                new_keys.append(target.page_key)
+            renames.append((base_key, new_keys))
+    return renames
+
+
+def select_pages(targets: list[CanvasTarget], wanted: set[str]) -> list[CanvasTarget]:
+    """Keep only the targets a --pages selection names.
+
+    A selection matches either the final page key ("p0a") or the base key it was
+    disambiguated from ("p0", which selects every one of its variants), so a
+    subset can be named without knowing in advance which keys collided.
+    """
+    return [t for t in targets if t.page_key in wanted or t.base_key in wanted]
+
+
+def load_targets(iiif_path: Path) -> list[CanvasTarget]:
+    """Every canvas of one manifest, keyed but not yet disambiguated."""
+    data: dict = json.loads(iiif_path.read_text())
+    sequences: list[dict] = data.get("sequences", [])
+    if not sequences:
+        print(f"No sequences found in {iiif_path}.", file=sys.stderr)
+        sys.exit(1)
+    canvases: list[dict] = sequences[0].get("canvases", [])
+    print(f"Found {len(canvases)} canvases in {iiif_path.name}.", file=sys.stderr)
+    targets = []
+    for canvas in canvases:
+        canvas_id: str = canvas.get("@id", "")
+        key = canvas_to_page_key(canvas_id, canvas.get("label", "unknown"))
+        assert key != "iiif", f"Could not extract valid page key from {canvas_id}"
+        targets.append(
+            CanvasTarget(canvas, iiif_path.parent, base_key=key, page_key=key)
+        )
+    return targets
+
+
+def process_canvas(target: CanvasTarget, scale: str, dry_run: bool) -> Path:
     """Download the full-resolution image for one canvas.
 
     Returns a Path to the output file, or raises on failure.
     """
-    canvas_id: str = canvas.get("@id", "")
-    label: str = canvas.get("label", "unknown")
-
-    page_key = canvas_to_page_key(canvas_id, label)
-    assert page_key != "iiif", f"Could not extract valid page key from {canvas_id}"
-    image_url = f"{canvas_id}/full/{scale}/0/default.jpg"
-    image_path = output_dir / f"{page_key}.jpg"
-
+    image_path = target.path
     if image_path.exists():
         print(f"  Already done: {image_path.name}", file=sys.stderr)
         return image_path
 
-    print(f"  {label} ({page_key}) {image_path} {image_url}", file=sys.stderr)
-
+    image_url = target.image_url(scale)
+    print(
+        f"  {target.label} ({target.page_key}) {image_path} {image_url}",
+        file=sys.stderr,
+    )
     if dry_run:
         return image_path
 
@@ -68,7 +160,6 @@ def process_canvas(
     time.sleep(15.0)
     dl_width, dl_height = jpeg_dimensions(image_path)
     print(f"    Downloaded: {dl_width}×{dl_height}", file=sys.stderr)
-
     return image_path
 
 
@@ -93,33 +184,52 @@ def main() -> None:
         'set to "pct:25", "pct:50", etc.',
     )
     parser.add_argument(
+        "--pages",
+        type=str,
+        default=None,
+        metavar="KEYS",
+        help=(
+            "Comma-separated page keys to download (e.g. 'p0a,p0b'), instead of "
+            "every canvas. A key that collided may be named either by its final "
+            "key ('p0a') or by the base key it came from ('p0', which selects "
+            "all its variants). Use --dry-run to list the keys."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print what would be downloaded without actually downloading",
     )
     args = parser.parse_args()
 
+    targets: list[CanvasTarget] = []
+    for iiif_file in args.iiif_files:
+        targets.extend(load_targets(Path(iiif_file)))
+
+    for base_key, new_keys in disambiguate_keys(targets):
+        print(
+            f"Collision: {len(new_keys)} canvases map to {base_key!r} "
+            f"-> {', '.join(new_keys)}",
+            file=sys.stderr,
+        )
+
+    if args.pages:
+        wanted = {p.strip() for p in args.pages.split(",") if p.strip()}
+        selected = select_pages(targets, wanted)
+        unmatched = (
+            wanted - {t.page_key for t in selected} - {t.base_key for t in selected}
+        )
+        if unmatched:
+            print(f"No canvas matches: {', '.join(sorted(unmatched))}", file=sys.stderr)
+        print(f"Selected {len(selected)} of {len(targets)} canvases.", file=sys.stderr)
+        targets = selected
+
     num_total = 0
     out_paths = Counter[Path]()
-    for iiif_file in args.iiif_files:
-        iiif_path = Path(iiif_file)
-        output_dir = iiif_path.parent
-        data: dict = json.load(iiif_path.open())
-
-        sequences: list[dict] = data.get("sequences", [])
-        if not sequences:
-            print("No sequences found in manifest.", file=sys.stderr)
-            sys.exit(1)
-        canvases: list[dict] = sequences[0].get("canvases", [])
-        print(f"Found {len(canvases)} canvases in {iiif_path.name}.", file=sys.stderr)
-
-        for i, canvas in enumerate(canvases, 1):
-            print(f"[{i}/{len(canvases)}] ", file=sys.stderr, end="")
-            out_path = process_canvas(
-                canvas, output_dir, scale=args.scale, dry_run=args.dry_run
-            )
-            out_paths[out_path] += 1
-            num_total += 1
+    for i, target in enumerate(targets, 1):
+        print(f"[{i}/{len(targets)}] ", file=sys.stderr, end="")
+        out_paths[process_canvas(target, scale=args.scale, dry_run=args.dry_run)] += 1
+        num_total += 1
 
     print(
         f"\nDone: {num_total} canvases {'would be ' if args.dry_run else ''}processed.",

--- a/mapsnap/download_loc_iiif_test.py
+++ b/mapsnap/download_loc_iiif_test.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import pytest
+
+from mapsnap.download_loc_iiif import (
+    CanvasTarget,
+    canvas_to_page_key,
+    disambiguate_keys,
+    select_pages,
+)
+
+LOC = (
+    "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114gm:g04023195307"
+)
+
+
+def target(segment: str, label: str = "Page", out: str = "/vol") -> CanvasTarget:
+    canvas_id = f"{LOC}:{segment}"
+    key = canvas_to_page_key(canvas_id, label)
+    return CanvasTarget({"@id": canvas_id, "label": label}, Path(out), key, key)
+
+
+def test_canvas_to_page_key():
+    assert canvas_to_page_key(f"{LOC}:04023_07_1953-0701", "Page 7") == "p701"
+    # Page 0 of any sub-volume reduces to the same key — the collision this
+    # module has to disambiguate.
+    assert canvas_to_page_key(f"{LOC}:04023_07_1953-0000", "Page 6") == "p0"
+    assert canvas_to_page_key(f"{LOC}:04023_08_1953-0000", "Page 36") == "p0"
+    # Front matter keeps its whole segment, so it never collides.
+    assert (
+        canvas_to_page_key(f"{LOC}:04023_07_1953-titl", "Title") == "04023_07_1953-titl"
+    )
+
+
+def test_disambiguate_leaves_unique_keys_alone():
+    targets = [target("04023_07_1953-0701"), target("04023_07_1953-0702")]
+    assert disambiguate_keys(targets) == []
+    assert [t.page_key for t in targets] == ["p701", "p702"]
+
+
+def test_disambiguate_suffixes_collisions_in_manifest_order():
+    targets = [
+        target("04023_07_1953-0000", "Page 6"),  # volume 07's key map
+        target("04023_07_1953-0701"),
+        target("04023_08_1953-0000", "Page 36"),  # volume 08's key map
+    ]
+    assert disambiguate_keys(targets) == [("p0", ["p0a", "p0b"])]
+    assert [t.page_key for t in targets] == ["p0a", "p701", "p0b"]
+    # The base key is retained so a --pages selection can still name it.
+    assert [t.base_key for t in targets] == ["p0", "p701", "p0"]
+
+
+def test_disambiguate_skips_a_suffix_another_canvas_already_owns():
+    # A manifest with a real "p0a" must not have a collision renamed onto it.
+    targets = [
+        target("04023_07_1953-0000", "Page 6"),
+        target("04023_08_1953-0000", "Page 36"),
+        target("04023_09_1953-000a", "Page 60"),
+    ]
+    assert [t.base_key for t in targets] == ["p0", "p0", "p0a"]
+    disambiguate_keys(targets)
+    assert [t.page_key for t in targets] == ["p0b", "p0c", "p0a"]
+
+
+def test_disambiguate_is_per_output_directory():
+    # The same key in two volumes is not a collision: different files.
+    targets = [
+        target("04023_07_1953-0000", out="/vol7"),
+        target("04023_08_1953-0000", out="/vol8"),
+    ]
+    assert disambiguate_keys(targets) == []
+    assert [t.page_key for t in targets] == ["p0", "p0"]
+
+
+def test_disambiguate_rejects_more_than_26_collisions():
+    targets = [target(f"04023_{i:02d}_1953-0000") for i in range(27)]
+    with pytest.raises(ValueError, match="more than 26"):
+        disambiguate_keys(targets)
+
+
+def test_select_pages_matches_final_or_base_key():
+    targets = [
+        target("04023_07_1953-0000", "Page 6"),
+        target("04023_08_1953-0000", "Page 36"),
+        target("04023_07_1953-0701"),
+    ]
+    disambiguate_keys(targets)
+    # The final key names one variant...
+    assert [t.page_key for t in select_pages(targets, {"p0a"})] == ["p0a"]
+    # ...and the base key names all of them, without having to know the suffixes.
+    assert [t.page_key for t in select_pages(targets, {"p0"})] == ["p0a", "p0b"]
+    assert [t.page_key for t in select_pages(targets, {"p701"})] == ["p701"]
+    assert select_pages(targets, {"p999"}) == []
+
+
+def test_target_path_and_url():
+    t = target("04023_07_1953-0701")
+    assert t.path == Path("/vol/p701.jpg")
+    assert t.image_url("full").endswith("-0701/full/full/0/default.jpg")
+    assert "pct:25" in t.image_url("pct:25")
+
+
+def test_find_target_matches_the_disambiguated_key():
+    from mapsnap.download_raw import find_target
+
+    targets = [
+        target("04023_07_1953-0000", "Page 6"),
+        target("04023_08_1953-0000", "Page 36"),
+        target("04023_07_1953-0701"),
+    ]
+    disambiguate_keys(targets)
+    # A scaled p0a.jpg must find the FIRST page-0 canvas, not fail on "p0".
+    assert find_target(targets, "p0a").label == "Page 6"
+    assert find_target(targets, "p0b").label == "Page 36"
+    assert find_target(targets, "p701").page_key == "p701"
+    with pytest.raises(ValueError, match="No canvas found"):
+        find_target(targets, "p0")

--- a/mapsnap/download_raw.py
+++ b/mapsnap/download_raw.py
@@ -9,34 +9,39 @@ Usage:
 """
 
 import argparse
-import json
+from dataclasses import replace
 from pathlib import Path
 
-from mapsnap.download_loc_iiif import canvas_to_page_key, process_canvas
+from mapsnap.download_loc_iiif import (
+    CanvasTarget,
+    disambiguate_keys,
+    load_targets,
+    process_canvas,
+)
 
 
-def find_canvas(canvases: list[dict], page_key: str) -> dict:
-    """Return the canvas whose derived page key matches page_key."""
-    for canvas in canvases:
-        canvas_id: str = canvas.get("@id", "")
-        label: str = canvas.get("label", "unknown")
-        if canvas_to_page_key(canvas_id, label) == page_key:
-            return canvas
+def find_target(targets: list[CanvasTarget], page_key: str) -> CanvasTarget:
+    """The canvas written as ``<page_key>.jpg``, or raise.
+
+    Matched on the disambiguated key, so a scaled p0a.jpg finds the first of the
+    two page-0 canvases a multi-volume manifest carries rather than failing.
+    """
+    for target in targets:
+        if target.page_key == page_key:
+            return target
     raise ValueError(f"No canvas found for page key {page_key!r}")
 
 
 def download_raw(jpg_path: Path, dry_run: bool = False) -> Path:
     """Download the full-resolution counterpart of a scaled-down LOC page JPG."""
     output_dir = jpg_path.parent
-    manifest_path = output_dir / "manifest.json"
-    data: dict = json.load(manifest_path.open())
-    canvases: list[dict] = data["sequences"][0]["canvases"]
-
-    canvas = find_canvas(canvases, jpg_path.stem)
+    targets = load_targets(output_dir / "manifest.json")
+    disambiguate_keys(targets)
+    target = find_target(targets, jpg_path.stem)
 
     raw_dir = output_dir / "raw"
     raw_dir.mkdir(exist_ok=True)
-    return process_canvas(canvas, raw_dir, scale="full", dry_run=dry_run)
+    return process_canvas(replace(target, output_dir=raw_dir), "full", dry_run)
 
 
 def main() -> None:

--- a/mapsnap/keymap/check_truth_labels.py
+++ b/mapsnap/keymap/check_truth_labels.py
@@ -175,8 +175,10 @@ def format_report(report: VolumeReport) -> str:
     n_labels = sum(f.n_labels for f in report.files)
     lines = [
         report.volume.name,
-        f"  {len(report.files)} truth file(s), {n_labels} labels "
-        f"vs {report.n_sheets} page images",
+        (
+            f"  {len(report.files)} truth file(s), {n_labels} labels "
+            f"vs {report.n_sheets} page images"
+        ),
     ]
     for file_report in report.files:
         stem = file_report.labels_path.name.replace(".labels.json", "")

--- a/mapsnap/keymap/check_truth_labels.py
+++ b/mapsnap/keymap/check_truth_labels.py
@@ -7,8 +7,14 @@ volume, every sheet should be labelled once, and the volume's own page images
 are the ground truth for both. This reports the three ways that can break:
 
   UNKNOWN     a label naming no page image ("35A?", "3S" for "35")
-  MISSING     a page image no label names (a number skipped on the key map)
+  MISSING     a page image NO truth file labels
   DUPLICATED  a label used twice for a sheet that is not split into panels
+
+UNKNOWN and DUPLICATED are per-file, since each is a slip made on one sheet.
+MISSING is per-volume: a volume's key maps divide the city between them (Los
+Angeles has pa and pb, Brooklyn a SW and a NE half), so a sheet drawn on one
+key map is not missing just because the other does not show it. It is only
+reported when no truth file in the volume names it.
 
 A split sheet is exempt from the duplicate check: the key map draws one region
 per panel, so a legitimately split page carries one label per panel.
@@ -48,20 +54,37 @@ class VolumePages:
 
 
 @dataclass
-class Report:
-    """What a single truth file got wrong, relative to the volume's images."""
+class FileReport:
+    """What one truth file got wrong on its own key map."""
 
     labels_path: Path
-    volume: Path
     n_labels: int
-    n_sheets: int
     unknown: list[tuple[str, str | None]] = field(default_factory=list)
-    missing: list[str] = field(default_factory=list)
     duplicated: list[tuple[str, int]] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
-        return not (self.unknown or self.missing or self.duplicated)
+        return not (self.unknown or self.duplicated)
+
+
+@dataclass
+class VolumeReport:
+    """A volume's truth files, plus the sheets none of them label."""
+
+    volume: Path
+    files: list[FileReport] = field(default_factory=list)
+    n_sheets: int = 0
+    missing: list[str] = field(default_factory=list)
+
+    @property
+    def n_problems(self) -> int:
+        return len(self.missing) + sum(
+            len(f.unknown) + len(f.duplicated) for f in self.files
+        )
+
+    @property
+    def ok(self) -> bool:
+        return self.n_problems == 0
 
 
 def sheet_label(stem: str) -> tuple[str, int | None] | None:
@@ -114,70 +137,82 @@ def suggest(label: str, known: set[str]) -> str | None:
     return stripped if stripped != label and stripped in known else None
 
 
-def check_truth_file(labels_path: Path, volume: Path) -> Report:
-    """Compare one <stem>.labels.json against its volume's page images."""
+def read_labels(labels_path: Path) -> list[str]:
+    """The non-empty label texts of one truth file, normalized."""
     doc = json.loads(labels_path.read_text())
-    texts = [
-        normalize_label(entry.get("text", ""))
-        for entry in doc.get("labels", [])
-        if normalize_label(entry.get("text", ""))
-    ]
+    texts = (normalize_label(e.get("text", "")) for e in doc.get("labels", []))
+    return [text for text in texts if text]
+
+
+def check_volume(volume: Path, labels_paths: list[Path]) -> VolumeReport:
+    """Check every truth file of one volume against its page images."""
     pages = volume_pages(volume)
     known = set(pages.stems)
-    counts = Counter(texts)
+    report = VolumeReport(volume=volume, n_sheets=len(known - pages.keymaps))
 
-    report = Report(
-        labels_path=labels_path,
-        volume=volume,
-        n_labels=len(texts),
-        n_sheets=len(known - pages.keymaps),
-    )
-    for label in sorted(set(texts) - known):
-        report.unknown.append((label, suggest(label, known)))
-    report.missing = sorted(known - set(texts) - pages.keymaps)
-    for label, count in sorted(counts.items()):
-        # A split sheet is drawn once per panel, so repeats are expected there.
-        if count > 1 and label in known and not pages.panels[label]:
-            report.duplicated.append((label, count))
+    labelled: set[str] = set()
+    for labels_path in labels_paths:
+        texts = read_labels(labels_path)
+        labelled.update(texts)
+        counts = Counter(texts)
+        file_report = FileReport(labels_path=labels_path, n_labels=len(texts))
+        for label in sorted(set(texts) - known):
+            file_report.unknown.append((label, suggest(label, known)))
+        for label, count in sorted(counts.items()):
+            # A split sheet is drawn once per panel, so repeats are expected.
+            if count > 1 and label in known and not pages.panels[label]:
+                file_report.duplicated.append((label, count))
+        report.files.append(file_report)
+
+    # Volume-wide: a sheet drawn on one key map is not missing from the volume
+    # just because another key map does not show it.
+    report.missing = sorted(known - labelled - pages.keymaps)
     return report
 
 
-def format_report(report: Report) -> str:
-    """Render one report as human-readable lines."""
+def format_report(report: VolumeReport) -> str:
+    """Render one volume's report as human-readable lines."""
+    n_labels = sum(f.n_labels for f in report.files)
     lines = [
-        f"{report.volume.name} / {report.labels_path.stem.replace('.labels', '')}",
-        f"  {report.n_labels} labels vs {report.n_sheets} page images",
+        report.volume.name,
+        f"  {len(report.files)} truth file(s), {n_labels} labels "
+        f"vs {report.n_sheets} page images",
     ]
-    if report.ok:
-        lines.append("  OK — every sheet labelled exactly once")
-        return "\n".join(lines)
-    if report.unknown:
-        lines.append(f"  UNKNOWN ({len(report.unknown)}) — label names no page image:")
-        for label, hint in report.unknown:
+    for file_report in report.files:
+        stem = file_report.labels_path.name.replace(".labels.json", "")
+        lines.append(f"  {stem} ({file_report.n_labels} labels)")
+        if file_report.ok:
+            lines.append("    no bad labels")
+        for label, hint in file_report.unknown:
             suffix = f"   (did you mean {hint}?)" if hint else ""
-            lines.append(f"    {label!r}{suffix}")
+            lines.append(f"    UNKNOWN {label!r} — names no page image{suffix}")
+        for label, count in file_report.duplicated:
+            lines.append(
+                f"    DUPLICATED {label} x{count} — repeated, but not a split sheet"
+            )
     if report.missing:
         lines.append(
-            f"  MISSING ({len(report.missing)}) — page image has no label: "
+            f"  MISSING ({len(report.missing)}) — labelled by no truth file: "
             + ", ".join(report.missing)
         )
-    if report.duplicated:
-        lines.append(
-            f"  DUPLICATED ({len(report.duplicated)}) — repeated, but not a split sheet:"
-        )
-        for label, count in report.duplicated:
-            lines.append(f"    {label} x{count}")
+    elif report.ok:
+        lines.append("  OK — every sheet labelled, no bad labels")
     return "\n".join(lines)
 
 
-def truth_files(target: Path) -> list[tuple[Path, Path]]:
-    """(labels file, volume) pairs for a volume directory or a labels file."""
-    if target.is_dir():
-        return [
-            (path, target) for path in sorted(target.glob("raw/truth/*.labels.json"))
-        ]
+def volume_of(target: Path) -> Path:
+    """The volume a target names, whether it is the directory or a labels file."""
     # <volume>/raw/truth/<stem>.labels.json
-    return [(target, target.parent.parent.parent)]
+    return target if target.is_dir() else target.parent.parent.parent
+
+
+def truth_files(volume: Path) -> list[Path]:
+    """Every truth file of a volume, sorted.
+
+    Always all of them, even when the caller named just one: the MISSING check
+    is only meaningful across a volume's whole set of key maps.
+    """
+    return sorted(volume.glob("raw/truth/*.labels.json"))
 
 
 def main() -> None:
@@ -189,24 +224,30 @@ def main() -> None:
         nargs="+",
         type=Path,
         metavar="VOLUME_OR_LABELS",
-        help="Volume directory (checks every raw/truth/*.labels.json) or a labels file.",
+        help=(
+            "Volume directory, or a labels file (its whole volume is checked "
+            "either way, since a volume's key maps share the sheets between them)."
+        ),
     )
     args = parser.parse_args()
 
-    pairs: list[tuple[Path, Path]] = []
+    volumes: list[Path] = []
     for target in args.targets:
-        found = truth_files(target)
-        if not found:
-            print(f"{target}: no raw/truth/*.labels.json found", file=sys.stderr)
-        pairs.extend(found)
+        volume = volume_of(target)
+        if volume not in volumes:
+            volumes.append(volume)
 
     problems = 0
-    for labels_path, volume in pairs:
-        report = check_truth_file(labels_path, volume)
+    for volume in volumes:
+        labels_paths = truth_files(volume)
+        if not labels_paths:
+            print(f"{volume}: no raw/truth/*.labels.json found", file=sys.stderr)
+            continue
+        report = check_volume(volume, labels_paths)
         print(format_report(report))
-        problems += len(report.unknown) + len(report.missing) + len(report.duplicated)
+        problems += report.n_problems
     if problems:
-        print(f"\n{problems} suspicious label(s) across {len(pairs)} file(s)")
+        print(f"\n{problems} suspicious label(s) across {len(volumes)} volume(s)")
     sys.exit(1 if problems else 0)
 
 

--- a/mapsnap/keymap/check_truth_labels.py
+++ b/mapsnap/keymap/check_truth_labels.py
@@ -1,0 +1,214 @@
+"""Sanity-check hand-labelled key-map truth against a volume's page images.
+
+Key-map page numbers are typed by hand from a scan, and the awkward ones —
+small raised letter suffixes, ornate fonts, numbers sitting on dark blocks —
+are easy to mistype or mis-read. Every label should name a real sheet in the
+volume, every sheet should be labelled once, and the volume's own page images
+are the ground truth for both. This reports the three ways that can break:
+
+  UNKNOWN     a label naming no page image ("35A?", "3S" for "35")
+  MISSING     a page image no label names (a number skipped on the key map)
+  DUPLICATED  a label used twice for a sheet that is not split into panels
+
+A split sheet is exempt from the duplicate check: the key map draws one region
+per panel, so a legitimately split page carries one label per panel.
+
+Usage:
+    uv run python -m mapsnap.keymap.check_truth_labels data/<volume>
+    uv run python -m mapsnap.keymap.check_truth_labels <...>/truth/p0.labels.json
+
+Exits non-zero when anything is reported, so it can gate a labelling session.
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# A page image stem: 'p' then digits, optionally a letter suffix, optionally a
+# '__N' split panel. Front matter ('pcover') and other names are not pages.
+PAGE_STEM = re.compile(r"^p(\d+[A-Za-z]?)(?:__(\d+))?$", re.IGNORECASE)
+
+
+@dataclass
+class VolumePages:
+    """The sheet labels a volume's page images imply."""
+
+    # Sheet label (upper-case, e.g. "35B") -> its whole-page image stem.
+    stems: dict[str, str] = field(default_factory=dict)
+    # Sheet label -> how many split panels it has (0 when not split).
+    panels: Counter = field(default_factory=Counter)
+    # Sheet labels belonging to key-map sheets, which never label themselves.
+    keymaps: set[str] = field(default_factory=set)
+    # Image stems that are not page images at all (front matter, etc.).
+    skipped: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Report:
+    """What a single truth file got wrong, relative to the volume's images."""
+
+    labels_path: Path
+    volume: Path
+    n_labels: int
+    n_sheets: int
+    unknown: list[tuple[str, str | None]] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    duplicated: list[tuple[str, int]] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not (self.unknown or self.missing or self.duplicated)
+
+
+def sheet_label(stem: str) -> tuple[str, int | None] | None:
+    """('35B', panel_index) for a page-image stem, or None if it is not a page.
+
+    ``panel_index`` is None for a whole page and the 1-based panel number for a
+    split ('p35B__2' -> ('35B', 2)).
+    """
+    match = PAGE_STEM.match(stem)
+    if not match:
+        return None
+    panel = int(match.group(2)) if match.group(2) else None
+    return match.group(1).upper(), panel
+
+
+def normalize_label(text: str) -> str:
+    """A truth label as it would be written on a page image ('  35b ' -> '35B')."""
+    return text.strip().upper()
+
+
+def volume_pages(volume: Path) -> VolumePages:
+    """Index a volume's page images by the sheet label each implies."""
+    pages = VolumePages()
+    for path in sorted(volume.glob("p*.jpg")):
+        parsed = sheet_label(path.stem)
+        if parsed is None:
+            pages.skipped.append(path.stem)
+            continue
+        label, panel = parsed
+        if panel is None:
+            pages.stems[label] = path.stem
+        else:
+            pages.panels[label] += 1
+    # A key map does not print its own number, so it is never "missing".
+    for path in (volume / "raw").glob("*.keymap.json"):
+        parsed = sheet_label(path.name.split(".")[0])
+        if parsed is not None:
+            pages.keymaps.add(parsed[0])
+    return pages
+
+
+def suggest(label: str, known: set[str]) -> str | None:
+    """A real sheet label this one was probably meant to be, or None.
+
+    Only the mechanical slips are suggested — stray punctuation such as the
+    "35A?" a labeller leaves to mark their own uncertainty — rather than
+    guessing at fuzzy matches, which would invite trusting a bad suggestion.
+    """
+    stripped = re.sub(r"[^0-9A-Z]", "", label)
+    return stripped if stripped != label and stripped in known else None
+
+
+def check_truth_file(labels_path: Path, volume: Path) -> Report:
+    """Compare one <stem>.labels.json against its volume's page images."""
+    doc = json.loads(labels_path.read_text())
+    texts = [
+        normalize_label(entry.get("text", ""))
+        for entry in doc.get("labels", [])
+        if normalize_label(entry.get("text", ""))
+    ]
+    pages = volume_pages(volume)
+    known = set(pages.stems)
+    counts = Counter(texts)
+
+    report = Report(
+        labels_path=labels_path,
+        volume=volume,
+        n_labels=len(texts),
+        n_sheets=len(known - pages.keymaps),
+    )
+    for label in sorted(set(texts) - known):
+        report.unknown.append((label, suggest(label, known)))
+    report.missing = sorted(known - set(texts) - pages.keymaps)
+    for label, count in sorted(counts.items()):
+        # A split sheet is drawn once per panel, so repeats are expected there.
+        if count > 1 and label in known and not pages.panels[label]:
+            report.duplicated.append((label, count))
+    return report
+
+
+def format_report(report: Report) -> str:
+    """Render one report as human-readable lines."""
+    lines = [
+        f"{report.volume.name} / {report.labels_path.stem.replace('.labels', '')}",
+        f"  {report.n_labels} labels vs {report.n_sheets} page images",
+    ]
+    if report.ok:
+        lines.append("  OK — every sheet labelled exactly once")
+        return "\n".join(lines)
+    if report.unknown:
+        lines.append(f"  UNKNOWN ({len(report.unknown)}) — label names no page image:")
+        for label, hint in report.unknown:
+            suffix = f"   (did you mean {hint}?)" if hint else ""
+            lines.append(f"    {label!r}{suffix}")
+    if report.missing:
+        lines.append(
+            f"  MISSING ({len(report.missing)}) — page image has no label: "
+            + ", ".join(report.missing)
+        )
+    if report.duplicated:
+        lines.append(
+            f"  DUPLICATED ({len(report.duplicated)}) — repeated, but not a split sheet:"
+        )
+        for label, count in report.duplicated:
+            lines.append(f"    {label} x{count}")
+    return "\n".join(lines)
+
+
+def truth_files(target: Path) -> list[tuple[Path, Path]]:
+    """(labels file, volume) pairs for a volume directory or a labels file."""
+    if target.is_dir():
+        return [
+            (path, target) for path in sorted(target.glob("raw/truth/*.labels.json"))
+        ]
+    # <volume>/raw/truth/<stem>.labels.json
+    return [(target, target.parent.parent.parent)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check hand-labelled key-map truth against a volume's page images."
+    )
+    parser.add_argument(
+        "targets",
+        nargs="+",
+        type=Path,
+        metavar="VOLUME_OR_LABELS",
+        help="Volume directory (checks every raw/truth/*.labels.json) or a labels file.",
+    )
+    args = parser.parse_args()
+
+    pairs: list[tuple[Path, Path]] = []
+    for target in args.targets:
+        found = truth_files(target)
+        if not found:
+            print(f"{target}: no raw/truth/*.labels.json found", file=sys.stderr)
+        pairs.extend(found)
+
+    problems = 0
+    for labels_path, volume in pairs:
+        report = check_truth_file(labels_path, volume)
+        print(format_report(report))
+        problems += len(report.unknown) + len(report.missing) + len(report.duplicated)
+    if problems:
+        print(f"\n{problems} suspicious label(s) across {len(pairs)} file(s)")
+    sys.exit(1 if problems else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/keymap/check_truth_labels_test.py
+++ b/mapsnap/keymap/check_truth_labels_test.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from mapsnap.keymap.check_truth_labels import (
+    check_truth_file,
+    normalize_label,
+    sheet_label,
+    suggest,
+    truth_files,
+    volume_pages,
+)
+
+
+def test_sheet_label():
+    assert sheet_label("p35") == ("35", None)
+    assert sheet_label("p35B") == ("35B", None)
+    assert sheet_label("p35b") == ("35B", None)  # stem case varies across volumes
+    assert sheet_label("p35B__2") == ("35B", 2)
+    assert sheet_label("p1499L") == ("1499L", None)
+    # Front matter and other non-page images.
+    assert sheet_label("pcover") is None
+    assert sheet_label("06372_01_1957-ind1") is None
+
+
+def test_normalize_label():
+    assert normalize_label("  35b ") == "35B"
+    assert normalize_label("") == ""
+
+
+def test_suggest_only_fixes_mechanical_slips():
+    known = {"35A", "60"}
+    # The labeller's own uncertainty marker.
+    assert suggest("35A?", known) == "35A"
+    # Stripping punctuation must still land on a real sheet.
+    assert suggest("99?", known) is None
+    # Already valid: nothing to suggest.
+    assert suggest("60", known) is None
+    # Not a fuzzy matcher — a genuine misreading gets no guess.
+    assert suggest("36A", known) is None
+
+
+@pytest.fixture
+def volume(tmp_path: Path) -> Path:
+    """A volume with a key map (p0), a split sheet (p4), and plain pages."""
+    (tmp_path / "raw").mkdir()
+    for stem in ["p0", "p1", "p2", "p3A", "p4", "p4__1", "p4__2", "pcover"]:
+        (tmp_path / f"{stem}.jpg").write_bytes(b"jpeg")
+    (tmp_path / "raw" / "p0.keymap.json").write_text("{}")
+    return tmp_path
+
+
+def write_truth(volume: Path, texts: list[str]) -> Path:
+    path = volume / "raw" / "truth" / "p0.labels.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"labels": [{"x": 0, "y": 0, "text": t} for t in texts]})
+    )
+    return path
+
+
+def test_volume_pages_indexes_sheets_panels_and_keymaps(volume: Path):
+    pages = volume_pages(volume)
+    assert set(pages.stems) == {"0", "1", "2", "3A", "4"}
+    assert pages.panels["4"] == 2  # p4__1, p4__2
+    assert pages.panels["1"] == 0
+    assert pages.keymaps == {"0"}  # p0 has a keymap.json sidecar
+    assert pages.skipped == ["pcover"]
+
+
+def test_clean_truth_reports_nothing(volume: Path):
+    # The key map does not label itself, and the split sheet is drawn per panel.
+    path = write_truth(volume, ["1", "2", "3A", "4", "4"])
+    report = check_truth_file(path, volume)
+    assert report.ok
+    assert report.n_sheets == 4  # p0 excluded as a key map
+
+
+def test_unknown_label_is_reported_with_a_suggestion(volume: Path):
+    path = write_truth(volume, ["1", "2", "3A?", "4", "4"])
+    report = check_truth_file(path, volume)
+    assert report.unknown == [("3A?", "3A")]
+    # The sheet it was meant to name is now also unlabelled.
+    assert report.missing == ["3A"]
+
+
+def test_missing_page_is_reported(volume: Path):
+    path = write_truth(volume, ["1", "3A", "4", "4"])
+    report = check_truth_file(path, volume)
+    assert report.missing == ["2"]
+    assert not report.unknown
+
+
+def test_duplicate_is_reported_only_for_unsplit_sheets(volume: Path):
+    path = write_truth(volume, ["1", "1", "2", "3A", "4", "4", "4"])
+    report = check_truth_file(path, volume)
+    # p1 is not split, so twice is a mistake; p4 has panels, so three times is fine.
+    assert report.duplicated == [("1", 2)]
+
+
+def test_truth_files_accepts_a_volume_or_a_labels_file(volume: Path):
+    path = write_truth(volume, ["1"])
+    assert truth_files(volume) == [(path, volume)]
+    assert truth_files(path) == [(path, volume)]

--- a/mapsnap/keymap/check_truth_labels_test.py
+++ b/mapsnap/keymap/check_truth_labels_test.py
@@ -4,11 +4,12 @@ from pathlib import Path
 import pytest
 
 from mapsnap.keymap.check_truth_labels import (
-    check_truth_file,
+    check_volume,
     normalize_label,
     sheet_label,
     suggest,
     truth_files,
+    volume_of,
     volume_pages,
 )
 
@@ -51,8 +52,8 @@ def volume(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def write_truth(volume: Path, texts: list[str]) -> Path:
-    path = volume / "raw" / "truth" / "p0.labels.json"
+def write_truth(volume: Path, texts: list[str], stem: str = "p0") -> Path:
+    path = volume / "raw" / "truth" / f"{stem}.labels.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps({"labels": [{"x": 0, "y": 0, "text": t} for t in texts]})
@@ -72,34 +73,64 @@ def test_volume_pages_indexes_sheets_panels_and_keymaps(volume: Path):
 def test_clean_truth_reports_nothing(volume: Path):
     # The key map does not label itself, and the split sheet is drawn per panel.
     path = write_truth(volume, ["1", "2", "3A", "4", "4"])
-    report = check_truth_file(path, volume)
+    report = check_volume(volume, [path])
     assert report.ok
     assert report.n_sheets == 4  # p0 excluded as a key map
 
 
 def test_unknown_label_is_reported_with_a_suggestion(volume: Path):
     path = write_truth(volume, ["1", "2", "3A?", "4", "4"])
-    report = check_truth_file(path, volume)
-    assert report.unknown == [("3A?", "3A")]
+    report = check_volume(volume, [path])
+    assert report.files[0].unknown == [("3A?", "3A")]
     # The sheet it was meant to name is now also unlabelled.
     assert report.missing == ["3A"]
 
 
 def test_missing_page_is_reported(volume: Path):
     path = write_truth(volume, ["1", "3A", "4", "4"])
-    report = check_truth_file(path, volume)
+    report = check_volume(volume, [path])
     assert report.missing == ["2"]
-    assert not report.unknown
+    assert not report.files[0].unknown
 
 
 def test_duplicate_is_reported_only_for_unsplit_sheets(volume: Path):
     path = write_truth(volume, ["1", "1", "2", "3A", "4", "4", "4"])
-    report = check_truth_file(path, volume)
+    report = check_volume(volume, [path])
     # p1 is not split, so twice is a mistake; p4 has panels, so three times is fine.
-    assert report.duplicated == [("1", 2)]
+    assert report.files[0].duplicated == [("1", 2)]
 
 
-def test_truth_files_accepts_a_volume_or_a_labels_file(volume: Path):
+def test_missing_is_volume_wide_across_several_key_maps(volume: Path):
+    # Two key maps divide the sheets between them (Los Angeles pa/pb): a sheet
+    # drawn on one is not missing just because the other does not show it.
+    (volume / "raw" / "pb.keymap.json").write_text("{}")
+    (volume / "pb.jpg").write_bytes(b"jpeg")
+    a = write_truth(volume, ["1", "2"], stem="p0")
+    b = write_truth(volume, ["3A", "4", "4"], stem="pb")
+    report = check_volume(volume, [a, b])
+    assert report.missing == []  # every sheet is labelled by ONE of the two
+    assert [f.n_labels for f in report.files] == [2, 3]
+    # A sheet neither key map labels is still reported, once.
+    c = write_truth(volume, ["1"], stem="p0")
+    report = check_volume(volume, [c, b])
+    assert report.missing == ["2"]
+
+
+def test_duplicates_stay_per_file(volume: Path):
+    # The same sheet appearing on both key maps is legitimate (overlapping
+    # coverage at a boundary); repeating it on ONE key map is the slip.
+    a = write_truth(volume, ["1", "2"], stem="p0")
+    (volume / "raw" / "pb.keymap.json").write_text("{}")
+    (volume / "pb.jpg").write_bytes(b"jpeg")
+    b = write_truth(volume, ["1", "3A", "4", "4"], stem="pb")
+    report = check_volume(volume, [a, b])
+    assert all(not f.duplicated for f in report.files)
+
+
+def test_volume_of_and_truth_files(volume: Path):
     path = write_truth(volume, ["1"])
-    assert truth_files(volume) == [(path, volume)]
-    assert truth_files(path) == [(path, volume)]
+    assert volume_of(volume) == volume
+    assert volume_of(path) == volume
+    # Naming one file still checks the volume's whole set.
+    other = write_truth(volume, ["2"], stem="pb")
+    assert truth_files(volume) == sorted([path, other])

--- a/mapsnap/keymap/keymap_patches.py
+++ b/mapsnap/keymap/keymap_patches.py
@@ -187,6 +187,40 @@ def build_image_patches(
 
 
 def labels_path_for(image_path: str) -> Path:
-    """Path of the .labels.json sidecar for an image."""
+    """Path of the .labels.json truth file for a key-map image.
+
+    Truth lives in a ``truth/`` directory beside the key map it labels — the
+    layout the labeler writes: ``<volume>/raw/p0.jpg`` is labelled by
+    ``<volume>/raw/truth/p0.labels.json``.
+    """
     p = Path(image_path)
-    return p.parent / (p.name.split(".")[0] + ".labels.json")
+    return p.parent / "truth" / (p.name.split(".")[0] + ".labels.json")
+
+
+def keymap_key(image_path: Path) -> str:
+    """A key map's id across the corpus: ``"<volume>/<stem>"``.
+
+    Stems repeat — ten volumes have a ``p0`` — so a bare stem cannot name one
+    key map. This matches the ids the labeler and check_truth_labels use.
+    """
+    # <volume>/raw/<stem>.jpg
+    return f"{image_path.parent.parent.name}/{image_path.stem}"
+
+
+def labelled_keymaps(root: Path = Path("data")) -> list[tuple[Path, Path]]:
+    """(image, truth file) for every hand-labelled key map under ``root``.
+
+    Finds ``<volume>/raw/truth/*.labels.json`` at any depth, since volumes may
+    be nested (``data/queens_1950/vol2/raw/``), and pairs each with the key-map
+    image it labels. Truth with no surviving image is skipped.
+    """
+    pairs: list[tuple[Path, Path]] = []
+    for labels_path in sorted(root.glob("**/raw/truth/*.labels.json")):
+        stem = labels_path.name.split(".")[0]
+        raw_dir = labels_path.parent.parent
+        for extension in (".jpg", ".jpeg", ".png"):
+            image = raw_dir / (stem + extension)
+            if image.exists():
+                pairs.append((image, labels_path))
+                break
+    return pairs

--- a/mapsnap/keymap/keymap_patches_test.py
+++ b/mapsnap/keymap/keymap_patches_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 
 from mapsnap.keymap.keymap_patches import (
@@ -85,3 +87,50 @@ def test_build_image_patches_counts_and_labels():
     assert len(patches) == len(labels)
     assert all(p.shape == (64, 64, 3) for p in patches)
     assert labels.count(0) > 0  # some negatives sampled
+
+
+def test_labels_path_for_uses_the_truth_directory():
+    from mapsnap.keymap.keymap_patches import labels_path_for
+
+    assert labels_path_for("data/vol/raw/p0.jpg") == Path(
+        "data/vol/raw/truth/p0.labels.json"
+    )
+    # Compound extensions collapse to the stem, as the labeler writes them.
+    assert labels_path_for("data/vol/raw/p35B.jpeg") == Path(
+        "data/vol/raw/truth/p35B.labels.json"
+    )
+
+
+def test_keymap_key_is_volume_qualified():
+    from mapsnap.keymap.keymap_patches import keymap_key
+
+    # Ten volumes have a "p0", so the stem alone cannot name a key map.
+    assert keymap_key(Path("data/chicago_il_1950_vol_1/raw/p0.jpg")) == (
+        "chicago_il_1950_vol_1/p0"
+    )
+    assert keymap_key(Path("data/los_angeles_ca_1949_vol_14/raw/pa.jpg")) == (
+        "los_angeles_ca_1949_vol_14/pa"
+    )
+
+
+def test_labelled_keymaps_finds_truth_at_any_depth(tmp_path):
+    from mapsnap.keymap.keymap_patches import labelled_keymaps
+
+    def make(volume: str, stem: str, *, image: bool = True) -> None:
+        raw = tmp_path / volume / "raw"
+        (raw / "truth").mkdir(parents=True, exist_ok=True)
+        (raw / "truth" / f"{stem}.labels.json").write_text("{}")
+        if image:
+            (raw / f"{stem}.jpg").write_bytes(b"jpeg")
+
+    make("champaign", "p1")
+    make("queens_1950/vol2", "p0")  # a nested volume
+    make("detroit", "p0", image=False)  # truth whose image is gone
+    pairs = labelled_keymaps(tmp_path)
+    assert [str(i.relative_to(tmp_path)) for i, _ in pairs] == [
+        "champaign/raw/p1.jpg",
+        "queens_1950/vol2/raw/p0.jpg",
+    ]
+    # Each image is paired with the truth file that labels it.
+    for image, labels in pairs:
+        assert labels == image.parent / "truth" / f"{image.stem}.labels.json"

--- a/mapsnap/keymap/train_crnn.py
+++ b/mapsnap/keymap/train_crnn.py
@@ -5,7 +5,7 @@ image's native resolution; see mapsnap.keymap.crnn_model.number_strip) paired wi
 digit string, holds out one whole image for validation, and trains the CRNN with CTC.
 Runs on CPU (the model and data are small, and CTC loss is most portable there).
 
-    uv run python -m mapsnap.keymap.train_crnn --val-image chicago-p0b
+    uv run python -m mapsnap.keymap.train_crnn --val-image chicago_il_1950_vol_1/p0
 """
 
 import argparse
@@ -32,11 +32,12 @@ from mapsnap.keymap.crnn_model import (
 )
 from mapsnap.keymap.keymap_patches import (
     crop_excludes_numbers,
+    keymap_key,
+    labelled_keymaps,
     labels_path_for,
     load_label_points,
     working_scale,
 )
-from mapsnap.utils import image_stem
 
 # Default empty-target negative strips sampled per positive, so the CRNN learns to emit
 # nothing (-> rejected) on the localizer's false positives instead of inventing a number.
@@ -45,19 +46,6 @@ DEFAULT_NEGATIVE_RATIO = 0.5
 # Fraction of negatives drawn from the most colorful (high-saturation) safe locations —
 # the pastel gaps between numbers where the localizer tends to false-positive.
 COLORFUL_FRAC = 0.6
-
-
-def labeled_images(data_dir: Path) -> list[Path]:
-    """Image files in ``data_dir`` that have a sibling .labels.json."""
-    images = []
-    for label_file in sorted(data_dir.glob("*.labels.json")):
-        stem = label_file.name.split(".")[0]
-        for ext in (".jpg", ".jpeg", ".png"):
-            candidate = data_dir / (stem + ext)
-            if candidate.exists():
-                images.append(candidate)
-                break
-    return images
 
 
 def sample_negative_strips(
@@ -193,8 +181,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Train the CRNN page-number recognizer."
     )
-    parser.add_argument("--data-dir", type=Path, default=Path("data/keymaps"))
-    parser.add_argument("--val-image", default="chicago-p0b")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data"),
+        help="Corpus root; truth is found at <volume>/raw/truth/*.labels.json.",
+    )
+    parser.add_argument(
+        "--val-image",
+        default="chicago_il_1950_vol_1/p0",
+        help=(
+            "Key map to hold out, as <volume>/<stem>. A bare stem cannot "
+            "name one key map: ten volumes have a p0."
+        ),
+    )
     parser.add_argument("--epochs", type=int, default=40)
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--lr", type=float, default=1e-3)
@@ -212,11 +212,14 @@ def main() -> None:
     rng = np.random.default_rng(args.seed)
     device = torch.device("cpu")
 
-    images = labeled_images(args.data_dir)
-    val_images = [p for p in images if image_stem(str(p)) == args.val_image]
-    train_images = [p for p in images if image_stem(str(p)) != args.val_image]
+    images = [image for image, _ in labelled_keymaps(args.data_dir)]
+    val_images = [p for p in images if keymap_key(p) == args.val_image]
+    train_images = [p for p in images if keymap_key(p) != args.val_image]
     if not val_images:
-        sys.exit(f"--val-image {args.val_image!r} not found")
+        sys.exit(
+            f"--val-image {args.val_image!r} not found; have "
+            + ", ".join(keymap_key(p) for p in images)
+        )
 
     train_strips, train_texts = build_split(
         train_images, negative_ratio=args.negative_ratio, rng=rng

--- a/mapsnap/keymap/train_number_detector.py
+++ b/mapsnap/keymap/train_number_detector.py
@@ -20,6 +20,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from mapsnap.keymap.keymap_patches import (
     build_image_patches,
+    labelled_keymaps,
     labels_path_for,
     load_label_points,
     scale_points,
@@ -42,19 +43,6 @@ def load_scaled_image(image_path: str, scale: float) -> np.ndarray:
         new_size = (round(rgb.width * scale), round(rgb.height * scale))
         rgb = rgb.resize(new_size, Image.Resampling.LANCZOS)
         return np.asarray(rgb)
-
-
-def labeled_images(data_dir: Path) -> list[Path]:
-    """Image files in ``data_dir`` that have a sibling .labels.json."""
-    images = []
-    for label_file in sorted(data_dir.glob("*.labels.json")):
-        stem = label_file.name.split(".")[0]
-        for ext in (".jpg", ".jpeg", ".png"):
-            candidate = data_dir / (stem + ext)
-            if candidate.exists():
-                images.append(candidate)
-                break
-    return images
 
 
 class PatchDataset(Dataset):
@@ -107,7 +95,12 @@ def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> floa
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train the page-number localizer CNN.")
-    parser.add_argument("--data-dir", type=Path, default=Path("data/keymaps"))
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data"),
+        help="Corpus root; truth is found at <volume>/raw/truth/*.labels.json.",
+    )
     parser.add_argument(
         "--val-image",
         default="chicago-p0b",
@@ -124,7 +117,7 @@ def main() -> None:
     rng = np.random.default_rng(args.seed)
     device = select_device()
 
-    images = labeled_images(args.data_dir)
+    images = [image for image, _ in labelled_keymaps(args.data_dir)]
     val_images = [p for p in images if image_stem(str(p)) == args.val_image]
     train_images = [p for p in images if image_stem(str(p)) != args.val_image]
     if not val_images:

--- a/mapsnap/score.py
+++ b/mapsnap/score.py
@@ -162,23 +162,32 @@ def land_fraction(
 
 
 def volume_page_scores(
-    generated_iiif: Path, *, street_near_m: float = STREET_NEAR_M
+    generated_iiif: Path,
+    *,
+    street_near_m: float = STREET_NEAR_M,
+    truth: Path | None = None,
 ) -> list[PageScore]:
     """Per-truth-page scores for one volume's generated annotation file.
 
     Matching and RMSE come from ``compare_pages`` (identical to ``mapsnap
     compare``, including the skeleton rule); footprints and land fractions are
     computed here from the truth items and the volume's centerlines.
+
+    ``truth`` overrides the volume's own main.iiif.json, so a revised truth set
+    can be scored against the same generated pages as the one it replaces. Note
+    that the truth defines the denominator as well as the per-page RMSE, so two
+    truth sets are only comparable when they cover the same sheets.
     """
     volume = generated_iiif.parent
-    truth_path = volume / "main.iiif.json"
+    truth_path = truth if truth is not None else volume / "main.iiif.json"
     if not truth_path.exists():
-        sys.exit(f"{volume} has no main.iiif.json truth data.")
+        sys.exit(f"No truth data at {truth_path}.")
     centerlines = default_centerlines(volume)
     if centerlines is None:
         sys.exit(f"{volume} has no centerlines.geojson (needed for land weights).")
 
-    rows, missing = compare_pages(truth_path, generated_iiif)
+    # The panels live with the volume, not with whichever truth file is in use.
+    rows, missing = compare_pages(truth_path, generated_iiif, oim_dir=volume / "oim")
     rmse_by_key: dict[str, float | None] = {}
     for row in missing:
         rmse_by_key.setdefault(row["page_key"], None)
@@ -291,9 +300,28 @@ def main() -> None:
         help="Footprint counts as land within this range of a street (default: %(default)s)",
     )
     parser.add_argument(
+        "--truth",
+        metavar="IIIF",
+        type=Path,
+        help=(
+            "Truth AnnotationPage to score against, instead of the "
+            "main.iiif.json in the generated file's own directory. Truth is "
+            "per-volume, so this may only be used with generated file(s) from "
+            "a single volume — handy for measuring what a truth revision moved."
+        ),
+    )
+    parser.add_argument(
         "--csv", metavar="FILE", help="Also write per-page scores to a CSV file"
     )
     args = parser.parse_args()
+
+    if args.truth is not None:
+        volumes = {Path(p).parent for p in args.generated}
+        if len(volumes) > 1:
+            sys.exit(
+                "--truth applies to one volume, but the generated files span "
+                + ", ".join(sorted(str(v) for v in volumes))
+            )
 
     header = (
         f"{'volume':<30} {'pages':>5} {'placed':>6} "
@@ -305,7 +333,9 @@ def main() -> None:
     all_pages: list[tuple[str, PageScore]] = []
     for path in args.generated:
         generated = Path(path)
-        pages = volume_page_scores(generated, street_near_m=args.street_near_m)
+        pages = volume_page_scores(
+            generated, street_near_m=args.street_near_m, truth=args.truth
+        )
         all_pages.extend((generated.parent.name, p) for p in pages)
         s = summarize(pages, good_ft=args.good_ft, disaster_ft=args.disaster_ft)
         print(


### PR DESCRIPTION
Key-map truth data used to live in `data/keymaps/` — a flat scratch directory holding *copies* of key-map images pulled out of their volumes, with `<stem>.labels.json` beside each one. That worked while there were a dozen hand-labelled sheets, but it detaches truth from the volume it describes: the copies drift from the originals (some were quarter-scale, some full), the filenames are ad-hoc (`neworleans1898-p0` for a volume called `new_orleans_la_1896_vol_2`), and nothing can cross-check a label against the pages it is supposed to name.

This moves truth to **`<volume>/raw/truth/<stem>.labels.json`**, beside the full-resolution sheet it labels, and updates everything that reads or writes it. A step towards #156.

## The pieces

**Labeler** (`app/`) serves key maps straight from each volume's `raw/` instead of the copies, and writes truth to `raw/truth/`. Pages are addressed by a volume-qualified id — `queens_1950/vol2/p0` — since stems repeat across volumes, which also means nested volumes work. A page is listed if it has a `keymap.json` sidecar *or* existing truth, so labels written for a sheet whose detection has not been run stay reachable instead of vanishing from the list. The label box also gets width/height sliders: it is a visualization only, never stored, and the fixed 160×107 was wrong for sheets whose numbers are much larger or smaller.

**`mapsnap.keymap.check_truth_labels`** (new) cross-checks hand-labelled truth against the volume's page images, which the old layout could not do at all:

- `UNKNOWN` — a label naming no page image (`"35A?"`, where the labeller marked their own uncertainty)
- `MISSING` — a sheet no truth file labels
- `DUPLICATED` — a label used twice for a sheet that is not split into panels

`UNKNOWN` and `DUPLICATED` are per-file, since each is a slip made on one sheet. `MISSING` is per-volume: LA's `pa`/`pb` and Brooklyn's SW/NE halves divide the sheets between them, so a sheet drawn on one key map is not missing because the other omits it. Split sheets are exempt from the duplicate check — the key map draws one region per panel. Exits non-zero, so it can gate a labelling session.

**`download_loc_iiif`** no longer silently drops canvases. A manifest can concatenate several LOC volumes, each with its own key map at page 0, and both `...-0000` canvases reduce to `p0`: the first wrote `p0.jpg` and the second was skipped as "already done". Colliding keys are now suffixed in manifest order (`p0a`, `p0b`), and a suffix another canvas already owns is skipped, so a manifest holding a real `p0a` plus two `p0`s cannot collide again. Keys that do not collide are untouched, so existing volumes keep their filenames. A new `--pages` flag downloads a named subset, matching either the final key or the base key it came from.

**`mapsnap score --truth IIIF`** scores against an alternate truth AnnotationPage instead of the volume's own `main.iiif.json` — for measuring what a truth revision moved. Restricted to one volume, since truth is per-volume.

**Trainers** discover truth through a shared `labelled_keymaps()` (replacing two copies of the same function) that globs `**/raw/truth/*.labels.json`, so nested volumes are found. `--val-image` now takes a `<volume>/<stem>` key: ten volumes have a `p0`, so a bare stem would have silently held out ten images instead of one. **No models are retrained here.**

## What it surfaced

**Grand Rapids was using the wrong key map.** Its manifest concatenates LOC volumes 07 (sheets 701–729) and 08 (809–846), and the page-0 collision meant only one was ever fetched. The file that had been on disk since ingest is volume **8**'s "KEY MAP NO. 2", covering the 8xx sheets — confirmed by fetching both URLs and matching (MSE 0.0005 against v08, 1.79 against v07). Volume 7's "KEY MAP NO. 1" had never been downloaded, so 28 of the volume's 65 sheets had no key-map coverage at all. Our recorded explanation for Grand Rapids' 5 detections had been a leading-`7` OCR truncation; that was wrong.

**The checker earns its keep on real data.** Asheville: one `"35A?"` (resolvable by elimination — every other member of the 35 family is labelled) and an unlabelled `60` that is plainly printed on the sheet. LA: 68 + 44 apparent misses collapse to **2 genuine** ones under the volume-wide rule, both verified as printed-but-unlabelled. Grand Rapids: one missing sheet and five duplicate labels.

**A scoring bug.** `compare_pages` derived the split-panel directory from the truth file's own parent, so an archived truth set stored under `oim/` sent it looking in `oim/oim/` and every split panel scored as unplaced. It now takes an explicit `oim_dir`, and `score.py` passes the volume's. This understated the *old* New Orleans 1896 truth by 1.1 points — I found it because the first `--truth` comparison reported a suspiciously large gain. With it fixed, the revised NO-1896 truth measures **49.7 → 59.2 (+9.5)**, entirely from 8 mid-tier pages crossing to good, with 83 of 91 pages unchanged and a median RMSE change of 0.0 ft.

## Corpus

Truth discovery now finds **21 key maps / 1,487 labels**, against 18 files in the old flat directory. The new ones are Asheville, LA `pa`/`pb`, and Grand Rapids `p0a`/`p0b`.

Relevant to #156: this corpus contains lettered labels for the first time — Asheville's 22 (`3A`–`3H`, `33A`–`33D`, `35A`–`35F`, `71A`–`71D`) and LA's `1499A`–`1499R`. `train_crnn` still strips them with `isdigit()`, so they would currently train as bare numbers; the data for that decision now exists.

Note `data/` is gitignored, so the data reorganisation itself is not in this diff — only the code that expects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
