### PR TITLE
Adjacency-truth labeler in the debugger app

### DIFF
--- a/app/adjacency.html
+++ b/app/adjacency.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Adjacency Labeler</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/adjacency-main.tsx"></script>
+  </body>
+</html>

--- a/app/server/adjacencyRoutes.ts
+++ b/app/server/adjacencyRoutes.ts
@@ -1,0 +1,80 @@
+/**
+ * Typed JSON API for the adjacency-truth labeler (`/api/adjacency-*`).
+ *
+ * Page images are not served here: the labeler loads them through the static
+ * `data/` route (the Vite serveDataDir plugin in development, express.static
+ * in production), which both resolve `data/<volume>/<stem>.jpg` relative to
+ * the app base.
+ */
+
+import { HTTPError, type TypedRouter } from 'crosswalk';
+import type { API } from './api.ts';
+import {
+  findVolumes,
+  isSafePage,
+  isSafeVolume,
+  readTruth,
+  volumePages,
+  writePageTruth,
+} from './adjacencyTruth.ts';
+import type { ImageInfo } from '../src/keymap/types.ts';
+
+/** Register the adjacency-truth endpoints on the shared crosswalk router. */
+export function registerAdjacencyTruthApi(
+  router: TypedRouter<API>,
+  dataDir: string,
+): void {
+  // Volumes that have labelable pages, with their labelling progress.
+  router.get('/api/adjacency-volumes', async () => {
+    const volumes = [];
+    for (const name of await findVolumes(dataDir)) {
+      const pages = await volumePages(dataDir, name);
+      if (!pages.length) continue;
+      const truth = await readTruth(dataDir, name);
+      const labeled = pages.filter((p) => truth[p]?.labels?.length).length;
+      volumes.push({ name, pageCount: pages.length, labeledPages: labeled });
+    }
+    return { volumes };
+  });
+
+  // One volume's pages, each with its current label count.
+  router.get('/api/adjacency-pages', async (_params, request) => {
+    const { volume } = request.query;
+    if (!isSafeVolume(volume)) {
+      throw new HTTPError(400, `invalid volume: ${volume}`);
+    }
+    const truth = await readTruth(dataDir, volume);
+    const pages: ImageInfo[] = (await volumePages(dataDir, volume)).map(
+      (stem) => {
+        const labels = truth[stem]?.labels ?? [];
+        const withText = labels.filter((l) => l.text.trim()).length;
+        return { name: stem, withText, withoutText: labels.length - withText };
+      },
+    );
+    return { pages };
+  });
+
+  // Read one page's labels, or report that none exist yet.
+  router.get('/api/adjacency-labels', async (_params, request) => {
+    const { volume, page } = request.query;
+    if (!isSafeVolume(volume) || !isSafePage(page)) {
+      throw new HTTPError(400, `invalid target: ${volume}/${page}`);
+    }
+    const entry = (await readTruth(dataDir, volume))[page];
+    return entry ?? { exists: false };
+  });
+
+  // Write one page's labels into the volume's adjacency-truth.json.
+  router.put('/api/adjacency-labels', async (_params, body, request) => {
+    const { volume, page } = request.query;
+    if (!isSafeVolume(volume) || !isSafePage(page)) {
+      throw new HTTPError(400, `invalid target: ${volume}/${page}`);
+    }
+    await writePageTruth(dataDir, volume, page, {
+      width: body.width,
+      height: body.height,
+      labels: body.labels,
+    });
+    return { ok: true };
+  });
+}

--- a/app/server/adjacencyTruth.test.ts
+++ b/app/server/adjacencyTruth.test.ts
@@ -1,0 +1,108 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  findVolumes,
+  isSafePage,
+  isSafeVolume,
+  pageSortKey,
+  readTruth,
+  truthPath,
+  volumePages,
+  writePageTruth,
+} from './adjacencyTruth.ts';
+
+let dataDir: string;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'adjacency-truth-'));
+  const write = async (relative: string, contents = 'jpeg') => {
+    const path = join(dataDir, relative);
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, contents);
+  };
+  // A plain volume with whole sheets, a split panel, and non-page files.
+  for (const name of ['p1.jpg', 'p2.jpg', 'p10.jpg', 'p33B.jpg', 'p6__1.jpg']) {
+    await write(`champaign/${name}`);
+  }
+  await write('champaign/raw/p0.jpg'); // raw/ must not be listed as a volume
+  await write('champaign/manifest.json', '{}');
+  // A nested volume.
+  await write('queens_1950/vol2/p0.jpg');
+  await write('queens_1950/vol2/p5.jpg');
+  // A directory with no pages at all.
+  await write('loc/readme.txt', 'x');
+});
+
+describe('discovery', () => {
+  it('finds plain and nested volumes, not their subdirectories', async () => {
+    expect(await findVolumes(dataDir)).toEqual([
+      'champaign',
+      'queens_1950/vol2',
+    ]);
+  });
+
+  it('lists whole-sheet stems in natural order, excluding split panels', async () => {
+    expect(await volumePages(dataDir, 'champaign')).toEqual([
+      'p1',
+      'p2',
+      'p10',
+      'p33B',
+    ]);
+  });
+});
+
+describe('validation', () => {
+  it('accepts real names and rejects traversal', () => {
+    expect(isSafeVolume('champaign')).toBe(true);
+    expect(isSafeVolume('queens_1950/vol2')).toBe(true);
+    for (const bad of ['', '..', 'a/../b', 'a/b/c', 'a\\b', '/abs']) {
+      expect(isSafeVolume(bad)).toBe(false);
+    }
+    expect(isSafePage('p12')).toBe(true);
+    expect(isSafePage('p33B')).toBe(true);
+    for (const bad of ['p6__1', '12', 'p12/x', '..', 'adjacency-truth']) {
+      expect(isSafePage(bad)).toBe(false);
+    }
+  });
+
+  it('natural sort puts p2 before p10', () => {
+    const stems = ['p10', 'p2', 'p33B', 'p33A'];
+    stems.sort((a, b) => {
+      const [na, sa] = pageSortKey(a);
+      const [nb, sb] = pageSortKey(b);
+      return na - nb || sa.localeCompare(sb);
+    });
+    expect(stems).toEqual(['p2', 'p10', 'p33A', 'p33B']);
+  });
+});
+
+describe('truth round-trip', () => {
+  it('reads empty for a volume with no truth file', async () => {
+    expect(await readTruth(dataDir, 'champaign')).toEqual({});
+  });
+
+  it('writes one page without disturbing others, in natural order', async () => {
+    const entry = (text: string) => ({
+      width: 1665,
+      height: 2018,
+      labels: [{ x: 10, y: 20, text }],
+    });
+    await writePageTruth(dataDir, 'champaign', 'p10', entry('11'));
+    await writePageTruth(dataDir, 'champaign', 'p2', entry('3'));
+    const pages = await readTruth(dataDir, 'champaign');
+    expect(Object.keys(pages)).toEqual(['p2', 'p10']); // natural order on disk
+    expect(pages['p10']!.labels[0]!.text).toBe('11');
+    // Overwriting one page keeps the other.
+    await writePageTruth(dataDir, 'champaign', 'p2', entry('4'));
+    const after = await readTruth(dataDir, 'champaign');
+    expect(after['p2']!.labels[0]!.text).toBe('4');
+    expect(after['p10']!.labels[0]!.text).toBe('11');
+    // The file itself lives beside the volume's pages.
+    const raw = JSON.parse(
+      await readFile(truthPath(dataDir, 'champaign'), 'utf8'),
+    );
+    expect(Object.keys(raw.pages)).toEqual(['p2', 'p10']);
+  });
+});

--- a/app/server/adjacencyTruth.ts
+++ b/app/server/adjacencyTruth.ts
@@ -1,0 +1,156 @@
+/**
+ * Storage and discovery for hand-labelled adjacency truth.
+ *
+ * Sanborn sheets print the numbers of neighboring pages along their edges; the
+ * adjacency labeler records those printed labels as (x, y, text) points, page
+ * by page. Truth for a whole volume lives in one
+ * ``<volume>/adjacency-truth.json`` — a sibling of the pipeline's
+ * ``adjacency.json`` — keyed by page stem:
+ *
+ *   { "pages": { "p12": { "width": 1665, "height": 2018,
+ *                          "labels": [{"x":…, "y":…, "text": "13"}] } } }
+ *
+ * Coordinates are in the pixel frame of the volume-root page image (the 25%
+ * scan the debugger displays), recorded by each entry's width/height.
+ */
+
+import { readFile, readdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+/** A whole-sheet page image at the volume root: p12, p33B, p101w — not splits. */
+const PAGE_IMAGE = /^p\d+[A-Za-z]{0,2}\.jpe?g$/;
+
+/** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
+const MAX_VOLUME_DEPTH = 2;
+
+/** One volume that has labelable pages. */
+export interface AdjacencyVolume {
+  /** Volume directory relative to the data dir, e.g. "queens_1950/vol2". */
+  name: string;
+  pageCount: number;
+  /** Pages with at least one adjacency-truth label. */
+  labeledPages: number;
+}
+
+/** A page entry in a volume's adjacency-truth.json. */
+export interface AdjacencyPageTruth {
+  width: number;
+  height: number;
+  labels: { x: number; y: number; text: string }[];
+}
+
+/** Reject a volume path that could escape the data directory. */
+export function isSafeVolume(volume: string): boolean {
+  const parts = volume.split('/');
+  if (parts.length < 1 || parts.length > MAX_VOLUME_DEPTH) return false;
+  return parts.every(
+    (part) =>
+      part !== '' && part !== '.' && part !== '..' && !part.includes('\\'),
+  );
+}
+
+/** Reject a page stem that is not a plain whole-sheet stem. */
+export function isSafePage(stem: string): boolean {
+  return /^p\d+[A-Za-z]{0,2}$/.test(stem);
+}
+
+/** Natural sort key for page stems, so p2 sorts before p10. */
+export function pageSortKey(stem: string): [number, string] {
+  const match = /^p(\d+)([A-Za-z]*)$/.exec(stem);
+  return match ? [Number(match[1]), match[2]] : [Number.MAX_SAFE_INTEGER, stem];
+}
+
+/** Path of a volume's adjacency truth file. */
+export function truthPath(dataDir: string, volume: string): string {
+  return join(dataDir, volume, 'adjacency-truth.json');
+}
+
+/** Read a volume's truth file; an empty mapping when it does not exist. */
+export async function readTruth(
+  dataDir: string,
+  volume: string,
+): Promise<Record<string, AdjacencyPageTruth>> {
+  try {
+    const doc = JSON.parse(await readFile(truthPath(dataDir, volume), 'utf8'));
+    return doc.pages ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** Write one page's labels into the volume's truth file (read-modify-write). */
+export async function writePageTruth(
+  dataDir: string,
+  volume: string,
+  page: string,
+  entry: AdjacencyPageTruth,
+): Promise<void> {
+  const pages = await readTruth(dataDir, volume);
+  pages[page] = entry;
+  // Stable natural page order keeps the file diff-friendly across sessions.
+  const sorted = Object.fromEntries(
+    Object.keys(pages)
+      .sort((a, b) => {
+        const [na, sa] = pageSortKey(a);
+        const [nb, sb] = pageSortKey(b);
+        return na - nb || sa.localeCompare(sb);
+      })
+      .map((key) => [key, pages[key]]),
+  );
+  await writeFile(
+    truthPath(dataDir, volume),
+    JSON.stringify({ pages: sorted }, null, 2) + '\n',
+  );
+}
+
+/** Whole-sheet page stems of a volume, naturally sorted. */
+export async function volumePages(
+  dataDir: string,
+  volume: string,
+): Promise<string[]> {
+  let files: string[];
+  try {
+    files = await readdir(join(dataDir, volume));
+  } catch {
+    return [];
+  }
+  return files
+    .filter((file) => PAGE_IMAGE.test(file))
+    .map((file) => file.replace(/\.jpe?g$/, ''))
+    .sort((a, b) => {
+      const [na, sa] = pageSortKey(a);
+      const [nb, sb] = pageSortKey(b);
+      return na - nb || sa.localeCompare(sb);
+    });
+}
+
+/**
+ * Volumes (relative to `dataDir`) that have whole-sheet page images.
+ *
+ * Descends at most {@link MAX_VOLUME_DEPTH} levels and stops at the first
+ * page-bearing directory on each branch, so a volume's own subdirectories
+ * (`raw/`, `oim/`, …) are never listed as volumes themselves.
+ */
+export async function findVolumes(
+  dataDir: string,
+  relative = '',
+  depth = 0,
+): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(join(dataDir, relative), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  if (relative && entries.some((e) => e.isFile() && PAGE_IMAGE.test(e.name))) {
+    return [relative];
+  }
+  if (depth >= MAX_VOLUME_DEPTH) return [];
+  const volumes: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+    const path = relative ? `${relative}/${entry.name}` : entry.name;
+    volumes.push(...(await findVolumes(dataDir, path, depth + 1)));
+  }
+  return volumes.sort();
+}

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -57,6 +57,25 @@ export interface VolumeQuery {
   volume: string;
 }
 
+/** Response of GET /api/adjacency-volumes. */
+export interface AdjacencyVolumesResponse {
+  volumes: { name: string; pageCount: number; labeledPages: number }[];
+}
+
+/** Response of GET /api/adjacency-pages. */
+export interface AdjacencyPagesResponse {
+  pages: ImageInfo[];
+}
+
+/** Query naming one page of one volume for adjacency truth. */
+export interface AdjacencyTruthTarget {
+  volume: string;
+  page: string;
+}
+
+/** GET /api/adjacency-labels — the page's entry, or a marker that none exists. */
+export type AdjacencyLabelsResponse = LabelsWriteRequest | { exists: false };
+
 /**
  * Response of GET /iiif-api/failed-georefs — page stem → failure kind.
  *
@@ -135,6 +154,20 @@ export interface API {
   '/api/labels': {
     get: GetEndpoint<LabelsResponse, KeymapTarget>;
     put: Endpoint<LabelsWriteRequest, LabelsWriteResponse, KeymapTarget>;
+  };
+  '/api/adjacency-volumes': {
+    get: GetEndpoint<AdjacencyVolumesResponse>;
+  };
+  '/api/adjacency-pages': {
+    get: GetEndpoint<AdjacencyPagesResponse, VolumeQuery>;
+  };
+  '/api/adjacency-labels': {
+    get: GetEndpoint<AdjacencyLabelsResponse, AdjacencyTruthTarget>;
+    put: Endpoint<
+      LabelsWriteRequest,
+      LabelsWriteResponse,
+      AdjacencyTruthTarget
+    >;
   };
   '/notes-api/notes': {
     get: GetEndpoint<NotesResponse, VolumeQuery>;

--- a/app/server/keymapPages.test.ts
+++ b/app/server/keymapPages.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   findKeymapPages,
-  readLabelCount,
+  readLabelCounts,
   resolveKeymapPage,
 } from './keymapPages.ts';
 
@@ -97,14 +97,20 @@ describe('resolveKeymapPage', () => {
   });
 });
 
-describe('readLabelCount', () => {
-  it('counts labels, and reports null when there is no sidecar', async () => {
+describe('readLabelCounts', () => {
+  it('splits counts by entered text, zeros when there is no sidecar', async () => {
+    // p1's fixture has three labels with no text entered.
     expect(
-      await readLabelCount(join(dataDir, 'champaign/raw/truth/p1.labels.json')),
-    ).toBe(3);
+      await readLabelCounts(
+        join(dataDir, 'champaign/raw/truth/p1.labels.json'),
+      ),
+    ).toEqual({ withText: 0, withoutText: 3 });
     expect(
-      await readLabelCount(join(dataDir, 'detroit/raw/truth/p0.labels.json')),
-    ).toBe(0);
-    expect(await readLabelCount(join(dataDir, 'nope.labels.json'))).toBeNull();
+      await readLabelCounts(join(dataDir, 'detroit/raw/truth/p0.labels.json')),
+    ).toEqual({ withText: 0, withoutText: 0 });
+    expect(await readLabelCounts(join(dataDir, 'nope.labels.json'))).toEqual({
+      withText: 0,
+      withoutText: 0,
+    });
   });
 });

--- a/app/server/keymapPages.ts
+++ b/app/server/keymapPages.ts
@@ -169,14 +169,21 @@ export async function resolveKeymapPage(
   return pageFor(volume, rawDir, new Set(rawFiles), stem);
 }
 
-/** Number of labels in a page's truth sidecar, or null when it has none. */
-export async function readLabelCount(
+/** Label counts in a page's truth sidecar, split by whether text was entered.
+
+Zeros when the sidecar is missing or unreadable — visually equivalent, since
+a zero count draws no badge. */
+export async function readLabelCounts(
   labelsPath: string,
-): Promise<number | null> {
+): Promise<{ withText: number; withoutText: number }> {
   try {
     const data = JSON.parse(await readFile(labelsPath, 'utf8'));
-    return Array.isArray(data.labels) ? data.labels.length : 0;
+    const labels: { text?: unknown }[] = Array.isArray(data.labels)
+      ? data.labels
+      : [];
+    const withText = labels.filter((l) => String(l.text ?? '').trim()).length;
+    return { withText, withoutText: labels.length - withText };
   } catch {
-    return null; // missing or unreadable sidecar
+    return { withText: 0, withoutText: 0 };
   }
 }

--- a/app/server/keymapRoutes.ts
+++ b/app/server/keymapRoutes.ts
@@ -16,7 +16,7 @@ import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API, KeymapImagesResponse } from './api.ts';
 import {
   findKeymapPages,
-  readLabelCount,
+  readLabelCounts,
   resolveKeymapPage,
 } from './keymapPages.ts';
 import type { ImageInfo } from '../src/keymap/types.ts';
@@ -46,7 +46,7 @@ export function registerKeymapApi(
     const images: ImageInfo[] = await Promise.all(
       pages.map(async (page) => ({
         name: page.id,
-        labelCount: await readLabelCount(page.labelsPath),
+        ...(await readLabelCounts(page.labelsPath)),
         hasKeymap: page.hasKeymap,
       })),
     );

--- a/app/server/main.ts
+++ b/app/server/main.ts
@@ -20,6 +20,7 @@ import express from 'express';
 import { TypedRouter } from 'crosswalk';
 import type { API } from './api.ts';
 import { registerIiifApi, registerIiifImages } from './iiifRoutes.ts';
+import { registerAdjacencyTruthApi } from './adjacencyRoutes.ts';
 import { registerKeymapApi, registerKeymapImages } from './keymapRoutes.ts';
 import { registerNotesApi } from './notesRoutes.ts';
 
@@ -48,6 +49,7 @@ registerKeymapImages(app, dataDir);
 const router = new TypedRouter<API>(app);
 registerIiifApi(router, dataDir);
 registerKeymapApi(router, dataDir);
+registerAdjacencyTruthApi(router, dataDir);
 registerNotesApi(router, dataDir);
 
 // Serve the data directory under the app base so `?files=data/...` deep links

--- a/app/src/adjacency-main.tsx
+++ b/app/src/adjacency-main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AdjacencyApp } from './adjacency/AdjacencyApp';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('missing #root element');
+createRoot(root).render(
+  <StrictMode>
+    <AdjacencyApp />
+  </StrictMode>,
+);

--- a/app/src/adjacency/AdjacencyApp.tsx
+++ b/app/src/adjacency/AdjacencyApp.tsx
@@ -1,30 +1,46 @@
 import { useEffect, useRef, useState } from 'react';
-import './keymap.css';
+import '../keymap/keymap.css';
 import { pointInPolygon } from '../geometry';
+import { isTypingTarget } from '../keyboard';
 import { useElementSize } from '../hooks/useElementSize';
 import { loadImage } from '../loadImage';
-import { fetchImages, fetchLabels, imageUrl, saveLabels } from './api';
+import { BoxSizeControls } from '../keymap/BoxSizeControls';
+import { ImageList } from '../keymap/ImageList';
+import { LabelsOverlay } from '../keymap/LabelsOverlay';
+import { LabelsTable } from '../keymap/LabelsTable';
+import { createLabelsJson, labelBox } from '../keymap/labels';
+import type { ImageInfo, Label } from '../keymap/types';
 import {
-  createLabelsJson,
-  labelBox,
-  DEFAULT_BOX_HEIGHT,
-  DEFAULT_BOX_WIDTH,
-} from './labels';
-import { BoxSizeControls } from './BoxSizeControls';
-import { ImageList } from './ImageList';
-import { LabelsOverlay } from './LabelsOverlay';
-import { LabelsTable } from './LabelsTable';
-import type { ImageInfo, Label } from './types';
+  fetchLabels,
+  fetchPages,
+  fetchVolumes,
+  pageImageUrl,
+  saveLabels,
+} from './api';
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
 /**
- * Key map truth-data labeler: pick an image, click to drop labels, type the
- * text for each, and have the labels.json sidecar saved automatically.
+ * Default label-box size for adjacency labels, in image pixels. The volume-root
+ * pages are 25%-scale scans and the printed neighbor numbers along sheet edges
+ * are small, so the box starts at half the key-map default; the sliders adjust
+ * it live.
  */
-export function KeymapApp() {
-  const [images, setImages] = useState<ImageInfo[]>([]);
-  const [selectedName, setSelectedName] = useState<string | null>(null);
+const ADJACENCY_BOX_WIDTH = 80;
+const ADJACENCY_BOX_HEIGHT = 54;
+
+/**
+ * Adjacency truth labeler: pick a volume, pick a page, click the centers of
+ * the printed neighbor-page numbers along its edges, and type each number's
+ * text. Labels save automatically to the volume's adjacency-truth.json.
+ */
+export function AdjacencyApp() {
+  const [volumes, setVolumes] = useState<
+    { name: string; pageCount: number; labeledPages: number }[]
+  >([]);
+  const [volume, setVolume] = useState<string | null>(null);
+  const [pages, setPages] = useState<ImageInfo[]>([]);
+  const [selectedPage, setSelectedPage] = useState<string | null>(null);
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
   const [imageWidth, setImageWidth] = useState(0);
   const [imageHeight, setImageHeight] = useState(0);
@@ -32,62 +48,78 @@ export function KeymapApp() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [showOnlyUnlabeled, setShowOnlyUnlabeled] = useState(false);
-  // Visualization only: the box drawn around each label point and cropped for
-  // its preview. Kept across image selections so the size a sheet's numbers
-  // want is set once, not per page.
-  const [boxWidth, setBoxWidth] = useState(DEFAULT_BOX_WIDTH);
-  const [boxHeight, setBoxHeight] = useState(DEFAULT_BOX_HEIGHT);
+  const [boxWidth, setBoxWidth] = useState(ADJACENCY_BOX_WIDTH);
+  const [boxHeight, setBoxHeight] = useState(ADJACENCY_BOX_HEIGHT);
 
   const [imgRef, imgSize] = useElementSize<HTMLImageElement>();
   // Only persist labels that changed via user edits, not freshly loaded ones.
   const dirtyRef = useRef(false);
-  // Mirror of `labels` so click handlers always see the latest list, even when
-  // several edits happen before React re-renders.
+  // Mirror of `labels` so click handlers always see the latest list.
   const labelsRef = useRef<Label[]>([]);
 
-  // Load the list of available images once.
+  // Load the volume list once.
   useEffect(() => {
-    fetchImages().then(setImages).catch(console.error);
+    fetchVolumes().then(setVolumes).catch(console.error);
   }, []);
 
-  // Load the selected image and its existing labels.
+  // Load the selected volume's page list.
   useEffect(() => {
-    if (!selectedName) return;
+    if (!volume) return;
+    let cancelled = false;
+    setPages([]);
+    setSelectedPage(null);
+    fetchPages(volume)
+      .then((next) => {
+        if (!cancelled) setPages(next);
+      })
+      .catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, [volume]);
+
+  // Load the selected page's image and existing labels.
+  useEffect(() => {
+    if (!volume || !selectedPage) return;
     let cancelled = false;
     dirtyRef.current = false;
     setSelectedIndex(null);
     setSaveStatus('idle');
-    Promise.all([loadImage(imageUrl(selectedName)), fetchLabels(selectedName)])
-      .then(([el, sidecar]) => {
+    Promise.all([
+      loadImage(pageImageUrl(volume, selectedPage)),
+      fetchLabels(volume, selectedPage),
+    ])
+      .then(([el, entry]) => {
         if (cancelled) return;
         setImageEl(el);
-        setImageWidth(sidecar?.width ?? el.naturalWidth);
-        setImageHeight(sidecar?.height ?? el.naturalHeight);
+        setImageWidth(entry?.width ?? el.naturalWidth);
+        setImageHeight(entry?.height ?? el.naturalHeight);
         dirtyRef.current = false;
-        labelsRef.current = sidecar?.labels ?? [];
+        labelsRef.current = entry?.labels ?? [];
         setLabels(labelsRef.current);
       })
       .catch(console.error);
     return () => {
       cancelled = true;
     };
-  }, [selectedName]);
+  }, [volume, selectedPage]);
 
-  // Persist edits to the sidecar (debounced). Skipped for freshly loaded data.
+  // Persist edits (debounced). Skipped for freshly loaded data.
   useEffect(() => {
-    if (!dirtyRef.current || !selectedName) return;
+    if (!dirtyRef.current || !volume || !selectedPage) return;
     const handle = setTimeout(async () => {
       setSaveStatus('saving');
       try {
         await saveLabels(
-          selectedName,
+          volume,
+          selectedPage,
           createLabelsJson(imageWidth, imageHeight, labels),
         );
         setSaveStatus('saved');
         const withText = labels.filter((l) => l.text.trim()).length;
-        setImages((prev) =>
+        setPages((prev) =>
           prev.map((info) =>
-            info.name === selectedName
+            info.name === selectedPage
               ? { ...info, withText, withoutText: labels.length - withText }
               : info,
           ),
@@ -98,9 +130,42 @@ export function KeymapApp() {
       }
     }, 500);
     return () => clearTimeout(handle);
-  }, [labels, selectedName, imageWidth, imageHeight]);
+  }, [labels, volume, selectedPage, imageWidth, imageHeight]);
 
-  // Apply a user edit to the labels and mark them dirty so they get saved.
+  // Step to an adjacent page in the list, clamped at the ends.
+  function stepPage(delta: number): void {
+    if (!pages.length) return;
+    const index = pages.findIndex((info) => info.name === selectedPage);
+    const next =
+      index === -1
+        ? delta > 0
+          ? 0
+          : pages.length - 1
+        : Math.min(pages.length - 1, Math.max(0, index + delta));
+    setSelectedPage(pages[next]!.name);
+  }
+  const pageIndex = pages.findIndex((info) => info.name === selectedPage);
+  const hasNextPage = pageIndex !== -1 && pageIndex < pages.length - 1;
+
+  // n/j and p/k step through the page list while no text field is focused.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isTypingTarget(e.target) || e.metaKey || e.ctrlKey || e.altKey)
+        return;
+      const delta =
+        e.key === 'n' || e.key === 'j'
+          ? 1
+          : e.key === 'p' || e.key === 'k'
+            ? -1
+            : 0;
+      if (!delta) return;
+      e.preventDefault();
+      stepPage(delta);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  });
+
   function editLabels(next: Label[]): void {
     dirtyRef.current = true;
     labelsRef.current = next;
@@ -109,7 +174,7 @@ export function KeymapApp() {
 
   // Add a label at the click point, or select an existing one if clicked.
   function handleImageClick(e: React.MouseEvent): void {
-    if (!selectedName || !imgSize.width || !imgSize.height) return;
+    if (!selectedPage || !imgSize.width || !imgSize.height) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const x = ((e.clientX - rect.left) * imageWidth) / imgSize.width;
     const y = ((e.clientY - rect.top) * imageHeight) / imgSize.height;
@@ -151,14 +216,29 @@ export function KeymapApp() {
 
   return (
     <div className="keymap-container">
-      <ImageList
-        images={images}
-        selectedName={selectedName}
-        onSelect={setSelectedName}
-      />
+      <div className="image-list-column">
+        <select
+          className="volume-select"
+          value={volume ?? ''}
+          onChange={(e) => setVolume(e.target.value || null)}
+        >
+          <option value="">Select a volume…</option>
+          {volumes.map((v) => (
+            <option key={v.name} value={v.name}>
+              {v.name} ({v.labeledPages}/{v.pageCount})
+            </option>
+          ))}
+        </select>
+        <ImageList
+          heading="Pages"
+          images={pages}
+          selectedName={selectedPage}
+          onSelect={setSelectedPage}
+        />
+      </div>
 
       <div className="keymap-center">
-        {selectedName ? (
+        {volume && selectedPage ? (
           <div
             className="image-wrapper"
             style={{ cursor: 'crosshair' }}
@@ -166,7 +246,7 @@ export function KeymapApp() {
           >
             <img
               ref={imgRef}
-              src={imageUrl(selectedName)}
+              src={pageImageUrl(volume, selectedPage)}
               className="keymap-image"
               style={
                 imageWidth && imageHeight
@@ -186,13 +266,17 @@ export function KeymapApp() {
             />
           </div>
         ) : (
-          <div className="keymap-empty">Select a key map to begin labeling</div>
+          <div className="keymap-empty">
+            {volume
+              ? 'Select a page to label its printed neighbor numbers'
+              : 'Select a volume to begin'}
+          </div>
         )}
       </div>
 
       <div className="keymap-right">
         <div className="keymap-status">
-          {selectedName && (
+          {selectedPage && (
             <>
               <span>{labels.length} labels</span>
               <span className={`save-status save-${saveStatus}`}>
@@ -225,6 +309,7 @@ export function KeymapApp() {
           onSelect={setSelectedIndex}
           onChangeText={handleChangeText}
           onDelete={handleDelete}
+          onNextPage={hasNextPage ? () => stepPage(1) : undefined}
         />
       </div>
     </div>

--- a/app/src/adjacency/AdjacencyApp.tsx
+++ b/app/src/adjacency/AdjacencyApp.tsx
@@ -148,6 +148,36 @@ export function AdjacencyApp() {
     return () => clearTimeout(handle);
   }, [labels, volume, selectedPage, imageWidth, imageHeight]);
 
+  // Save any pending (debounced, not-yet-fired) edit for the current page NOW.
+  // Leaving the page cancels the debounce timer and the load effect clears the
+  // dirty flag, so without this an edit made within the debounce window of a
+  // page switch would be silently dropped.
+  function flushPendingSave(): void {
+    if (!dirtyRef.current || !volume || !selectedPage) return;
+    dirtyRef.current = false;
+    const snapshot = labelsRef.current;
+    const withText = snapshot.filter((l) => l.text.trim()).length;
+    const page = selectedPage;
+    setPages((prev) =>
+      prev.map((info) =>
+        info.name === page
+          ? { ...info, withText, withoutText: snapshot.length - withText }
+          : info,
+      ),
+    );
+    saveLabels(
+      volume,
+      page,
+      createLabelsJson(imageWidth, imageHeight, snapshot),
+    ).catch(console.error);
+  }
+
+  // Select a page, saving the current page's pending edits first.
+  function selectPage(name: string): void {
+    flushPendingSave();
+    setSelectedPage(name);
+  }
+
   // Step to an adjacent page in the list, clamped at the ends.
   function stepPage(delta: number): void {
     if (!pages.length) return;
@@ -158,7 +188,7 @@ export function AdjacencyApp() {
           ? 0
           : pages.length - 1
         : Math.min(pages.length - 1, Math.max(0, index + delta));
-    setSelectedPage(pages[next]!.name);
+    selectPage(pages[next]!.name);
   }
   const pageIndex = pages.findIndex((info) => info.name === selectedPage);
   const hasNextPage = pageIndex !== -1 && pageIndex < pages.length - 1;
@@ -236,7 +266,10 @@ export function AdjacencyApp() {
         <select
           className="volume-select"
           value={volume ?? ''}
-          onChange={(e) => setVolume(e.target.value || null)}
+          onChange={(e) => {
+            flushPendingSave();
+            setVolume(e.target.value || null);
+          }}
         >
           <option value="">Select a volume…</option>
           {volumes.map((v) => (
@@ -249,7 +282,7 @@ export function AdjacencyApp() {
           heading="Pages"
           images={pages}
           selectedName={selectedPage}
-          onSelect={setSelectedPage}
+          onSelect={selectPage}
         />
       </div>
 

--- a/app/src/adjacency/AdjacencyApp.tsx
+++ b/app/src/adjacency/AdjacencyApp.tsx
@@ -56,6 +56,11 @@ export function AdjacencyApp() {
   const dirtyRef = useRef(false);
   // Mirror of `labels` so click handlers always see the latest list.
   const labelsRef = useRef<Label[]>([]);
+  // Set by the "Next page" button so the incoming page's first text box takes
+  // focus once its rows render — finishing a page is then tab+enter+type.
+  // Deliberately NOT set by the n/p/j/k shortcuts: moving focus into a text
+  // box would swallow the next keypress as typed text.
+  const focusFirstOnLoadRef = useRef(false);
 
   // Load the volume list once.
   useEffect(() => {
@@ -97,6 +102,17 @@ export function AdjacencyApp() {
         dirtyRef.current = false;
         labelsRef.current = entry?.labels ?? [];
         setLabels(labelsRef.current);
+        if (focusFirstOnLoadRef.current) {
+          focusFirstOnLoadRef.current = false;
+          // After React commits the new rows; the top row is the newest label.
+          requestAnimationFrame(() => {
+            document
+              .querySelector<HTMLInputElement>(
+                '#detections-table input.label-text-input',
+              )
+              ?.focus();
+          });
+        }
       })
       .catch(console.error);
     return () => {
@@ -309,7 +325,14 @@ export function AdjacencyApp() {
           onSelect={setSelectedIndex}
           onChangeText={handleChangeText}
           onDelete={handleDelete}
-          onNextPage={hasNextPage ? () => stepPage(1) : undefined}
+          onNextPage={
+            hasNextPage
+              ? () => {
+                  focusFirstOnLoadRef.current = true;
+                  stepPage(1);
+                }
+              : undefined
+          }
         />
       </div>
     </div>

--- a/app/src/adjacency/api.ts
+++ b/app/src/adjacency/api.ts
@@ -1,0 +1,48 @@
+import { typedApi } from 'crosswalk';
+import { jsonFetch } from '../apiFetch';
+import type { API, AdjacencyVolumesResponse } from '../../server/api';
+import type { ImageInfo, LabelsWriteRequest } from '../keymap/types';
+
+const api = typedApi<API>({ fetch: jsonFetch });
+
+/**
+ * URL of a volume-root page image, served by the static data route (the Vite
+ * serveDataDir plugin in development, express.static in production). Relative
+ * to the app base, so it works at /mapsnap/adjacency.html in both.
+ */
+export function pageImageUrl(volume: string, page: string): string {
+  const path = volume.split('/').map(encodeURIComponent).join('/');
+  return `data/${path}/${encodeURIComponent(page)}.jpg`;
+}
+
+/** Fetch the volumes that have labelable pages, with labelling progress. */
+export async function fetchVolumes(): Promise<
+  AdjacencyVolumesResponse['volumes']
+> {
+  const { volumes } = await api.get('/api/adjacency-volumes')();
+  return volumes;
+}
+
+/** Fetch one volume's pages with their label counts. */
+export async function fetchPages(volume: string): Promise<ImageInfo[]> {
+  const { pages } = await api.get('/api/adjacency-pages')(null, { volume });
+  return pages;
+}
+
+/** Fetch a page's adjacency labels, or null if none exist yet. */
+export async function fetchLabels(
+  volume: string,
+  page: string,
+): Promise<LabelsWriteRequest | null> {
+  const data = await api.get('/api/adjacency-labels')(null, { volume, page });
+  return 'exists' in data ? null : data;
+}
+
+/** Write a page's adjacency labels. */
+export async function saveLabels(
+  volume: string,
+  page: string,
+  data: LabelsWriteRequest,
+): Promise<void> {
+  await api.put('/api/adjacency-labels')({}, data, { volume, page });
+}

--- a/app/src/keymap/ImageList.tsx
+++ b/app/src/keymap/ImageList.tsx
@@ -4,14 +4,16 @@ interface ImageListProps {
   images: ImageInfo[];
   selectedName: string | null;
   onSelect: (name: string) => void;
+  /** Column heading; the adjacency labeler reuses this list for volume pages. */
+  heading?: string;
 }
 
 /** Left-column list of available key map pages, with their label counts. */
 export function ImageList(props: ImageListProps) {
-  const { images, selectedName, onSelect } = props;
+  const { images, selectedName, onSelect, heading = 'Key maps' } = props;
   return (
     <div className="image-list">
-      <h2>Key maps</h2>
+      <h2>{heading}</h2>
       <ul>
         {images.map((info) => (
           <li
@@ -19,18 +21,30 @@ export function ImageList(props: ImageListProps) {
             className={info.name === selectedName ? 'selected' : undefined}
             onClick={() => onSelect(info.name)}
             title={
-              info.hasKeymap
-                ? info.name
-                : `${info.name} (no keymap.json; listed because it has truth labels)`
+              info.hasKeymap === false
+                ? `${info.name} (no keymap.json; listed because it has truth labels)`
+                : info.name
             }
           >
             <span
-              className={info.hasKeymap ? 'image-name' : 'image-name no-keymap'}
+              className={
+                info.hasKeymap === false ? 'image-name no-keymap' : 'image-name'
+              }
             >
               {info.name}
             </span>
-            {info.labelCount !== null && (
-              <span className="label-count">{info.labelCount}</span>
+            {info.withText > 0 && (
+              <span className="label-count" title="labels with text">
+                {info.withText}
+              </span>
+            )}
+            {info.withoutText > 0 && (
+              <span
+                className="label-count label-count-empty"
+                title="labels without text"
+              >
+                {info.withoutText}
+              </span>
             )}
           </li>
         ))}

--- a/app/src/keymap/LabelsTable.tsx
+++ b/app/src/keymap/LabelsTable.tsx
@@ -12,6 +12,12 @@ interface LabelsTableProps {
   onSelect: (index: number) => void;
   onChangeText: (index: number, text: string) => void;
   onDelete: (index: number) => void;
+  /**
+   * When set, renders a "Next page" button after the table. It is the next
+   * element in tab order after the last text box (delete buttons are
+   * tab-skipped), so finishing the last label is tab+enter to the next page.
+   */
+  onNextPage?: () => void;
 }
 
 /**
@@ -33,6 +39,7 @@ export function LabelsTable(props: LabelsTableProps) {
     onSelect,
     onChangeText,
     onDelete,
+    onNextPage,
   } = props;
 
   const rows = labels
@@ -100,6 +107,11 @@ export function LabelsTable(props: LabelsTableProps) {
           ))}
         </tbody>
       </table>
+      {onNextPage && (
+        <button type="button" className="next-page-button" onClick={onNextPage}>
+          Next page ▸
+        </button>
+      )}
     </div>
   );
 }

--- a/app/src/keymap/keymap.css
+++ b/app/src/keymap/keymap.css
@@ -72,6 +72,11 @@
   font-size: 11px;
 }
 
+/* Labels still awaiting text. */
+.image-list .label-count-empty {
+  background: #f57c00;
+}
+
 .keymap-center {
   flex: 1;
   min-width: 0;
@@ -201,4 +206,51 @@
 
 .label-delete:hover {
   color: #8e0000;
+}
+
+/* Adjacency labeler: volume dropdown stacked above the page list. */
+.image-list-column {
+  position: sticky;
+  top: 16px;
+  flex-shrink: 0;
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - 32px);
+}
+
+.image-list-column .image-list {
+  position: static;
+  top: auto;
+  width: auto;
+  overflow-y: auto;
+}
+
+.volume-select {
+  font-family: sans-serif;
+  font-size: 13px;
+  padding: 6px;
+}
+
+/* "Next page" affordance below the label table: the tab stop after the last
+   text box, so finishing a page is tab+enter. */
+.next-page-button {
+  margin-top: 10px;
+  width: 100%;
+  padding: 7px 0;
+  font-family: sans-serif;
+  font-size: 13px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f7f7f7;
+  cursor: pointer;
+}
+
+.next-page-button:hover {
+  background: #eee;
+}
+
+.next-page-button:focus-visible {
+  outline: 2px solid #1e88e5;
 }

--- a/app/src/keymap/types.ts
+++ b/app/src/keymap/types.ts
@@ -24,8 +24,11 @@ export type LabelsWriteRequest = Omit<LabelsJson, 'image'>;
 export interface ImageInfo {
   /** Page id: volume path and stem, e.g. "queens_1950/vol2/p0". */
   name: string;
-  /** Number of labels in the sidecar, or null if no sidecar exists yet. */
-  labelCount: number | null;
-  /** Whether the page has a keymap.json sidecar (vs. being listed for its truth). */
-  hasKeymap: boolean;
+  /** Labels whose text has been entered (blue badge; hidden when zero). */
+  withText: number;
+  /** Labels still awaiting text (orange badge; hidden when zero). */
+  withoutText: number;
+  /** Whether the page has a keymap.json sidecar (vs. being listed for its truth).
+   * Absent for lists where the notion does not apply (adjacency pages). */
+  hasKeymap?: boolean;
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
       input: {
         main: 'index.html',
         keymap: 'keymap.html',
+        adjacency: 'adjacency.html',
       },
     },
   },


### PR DESCRIPTION
Adds a truth-labeling mode for printed adjacent-sheet numbers, reusing the key-map labeler's components. Pick a volume, pick a page, click the centers of the printed neighbor numbers along its edges, and type each number — labels save automatically to the volume's `adjacency-truth.json` (a sibling of the pipeline's `adjacency.json`, keyed by page stem, coordinates in the volume-root image frame).

- **Server**: typed crosswalk API (`/api/adjacency-volumes|pages|labels`) with volume/page-stem validation, natural page sort, and read-modify-write into one truth file per volume. Page images are served through the existing static `data/` route.
- **App**: volume selector with labeling progress, pages list, click-to-place labels with size-slider preview boxes, n/p/j/k page paging, a "Next page" button reachable by tab+enter that focuses the next page's first text box, and per-page blue/orange counts (labels with/without text) shared with the key-map labeler.
- **Saves**: debounced, with an immediate flush before any page/volume switch so edits made inside the debounce window are never dropped.

First use: complete truth for Hudson Co. (92 pages, 463 printed references). Grading against it showed the mutual-edge detector at 100% pair precision / 74% recall of mutually-printed pairs, and validated the OIM-footprint proxy in `score_adjacency.py` (its verdicts matched hand truth on all 165 detector edges; its recall denominator overcounts by ~13% from corner contacts sheets don't print).

🤖 Generated with [Claude Code](https://claude.com/claude-code)