### PR TITLE
Repair conflicted key-map reads with CTC-margin evidence

### DIFF
--- a/mapsnap/keymap/crnn_model.py
+++ b/mapsnap/keymap/crnn_model.py
@@ -53,6 +53,40 @@ def ctc_greedy_decode(indices: list[int]) -> str:
     return "".join(out)
 
 
+def ctc_log_likelihood(log_probs: np.ndarray, digits: str) -> float:
+    """Log P(digit string | window) under the standard CTC forward algorithm.
+
+    ``log_probs`` is a (T, classes) slice of the CRNN's output (blank at index
+    0, digit d at index d+1). Unlike the greedy decode, this scores an
+    *arbitrary* digit string against the window, so competing page numbers can
+    be compared on likelihood — the evidence behind the conflict-repair pass.
+    """
+    labels = [int(c) + 1 for c in digits]
+    extended = [BLANK_INDEX]
+    for label in labels:
+        extended.extend((label, BLANK_INDEX))
+    T, n = log_probs.shape[0], len(extended)
+    NEG = -1e30
+    alpha = np.full(n, NEG)
+    alpha[0] = log_probs[0, extended[0]]
+    if n > 1:
+        alpha[1] = log_probs[0, extended[1]]
+    for t in range(1, T):
+        previous = alpha
+        alpha = np.full(n, NEG)
+        for s in range(n):
+            best = previous[s]
+            if s >= 1:
+                best = np.logaddexp(best, previous[s - 1])
+            if s >= 2 and extended[s] != BLANK_INDEX and extended[s] != extended[s - 2]:
+                best = np.logaddexp(best, previous[s - 2])
+            alpha[s] = best + log_probs[t, extended[s]]
+    result = alpha[n - 1]
+    if n > 1:
+        result = np.logaddexp(result, alpha[n - 2])
+    return float(result)
+
+
 def strip_crop_box(
     width: int,
     height: int,

--- a/mapsnap/keymap/crnn_model_test.py
+++ b/mapsnap/keymap/crnn_model_test.py
@@ -8,6 +8,7 @@ from mapsnap.keymap.crnn_model import (
     build_crnn,
     central_group,
     ctc_greedy_decode,
+    ctc_log_likelihood,
     decode_batch,
     encode_text,
     greedy_paths,
@@ -117,3 +118,23 @@ def test_ink_row_center_is_robust_to_speckle():
 
 def test_ink_row_center_empty():
     assert ink_row_center(np.zeros(48)) is None
+
+
+def test_ctc_log_likelihood_prefers_the_emitted_digit():
+    # Synthetic window: blank, strong "5" (index 6), blank.
+    log_probs = np.full((3, 11), -10.0)
+    log_probs[0, 0] = -0.01
+    log_probs[1, 6] = -0.01
+    log_probs[2, 0] = -0.01
+    assert ctc_log_likelihood(log_probs, "5") > ctc_log_likelihood(log_probs, "4")
+    # A two-digit string cannot be emitted in this window without a big penalty.
+    assert ctc_log_likelihood(log_probs, "5") > ctc_log_likelihood(log_probs, "55")
+
+
+def test_ctc_log_likelihood_two_digits():
+    # "47": 4 fires at t0-1, 7 at t3-4, blank between.
+    log_probs = np.full((5, 11), -12.0)
+    for t_step, idx in ((0, 5), (1, 5), (2, 0), (3, 8), (4, 8)):
+        log_probs[t_step, idx] = -0.01
+    assert ctc_log_likelihood(log_probs, "47") > ctc_log_likelihood(log_probs, "4")
+    assert ctc_log_likelihood(log_probs, "47") > ctc_log_likelihood(log_probs, "48")

--- a/mapsnap/keymap/detect_numbers_crnn.py
+++ b/mapsnap/keymap/detect_numbers_crnn.py
@@ -36,6 +36,7 @@ from mapsnap.keymap.crnn_model import (
     build_crnn,
     central_group,
     ctc_greedy_decode,
+    ctc_log_likelihood,
     eval_transform,
     greedy_paths,
     locate_number,
@@ -251,6 +252,199 @@ def choose_duplicate_reread(
     return max(different, key=lambda r: r[2])
 
 
+# Conflict-repair gates (measured on the 23-sheet truth corpus, 2026-07-28: +19
+# key-correct, zero regressions; each gate is load-bearing — see the PR).
+REPAIR_FLOOR = -1.5  # min margin for adopting a missing page
+ADOPT_DELTA = 1.0  # adopted margin must come within this of the read's own margin
+SPATIAL_NEIGHBORS = 4  # nearest detections consulted for the plausibility gate
+SPATIAL_GATE = 6.0  # adopted stem within this multiple of the median neighbor delta
+WINDOW_PAD = 2  # timesteps of context around the central group when scoring
+
+
+@torch.no_grad()
+def stem_margins(
+    image: np.ndarray,
+    center: tuple[float, float],
+    factor: float,
+    crnn: torch.nn.Module,
+    device,
+    stems: list[str],
+) -> dict[str, float]:
+    """CTC-margin score per digit stem for the crop(s) around ``center``.
+
+    Each stem is scored in the central-group window of the wide strip and both
+    narrow re-read strips: margin = log P(stem | window) minus the window's
+    best-path log-probability, so scores compare across windows; a stem's
+    margin is its best across the windows. ~0 means the stem explains the ink
+    as well as anything can; strongly negative means it does not fit.
+    """
+    cx, cy = center
+    margins: dict[str, float] = {}
+    for half_w in (None, *REREAD_HALF_WIDTHS_WORKING):
+        kwargs = {} if half_w is None else {"half_w_working": half_w}
+        strip = number_strip(image, cx, cy, factor, **kwargs)
+        tensor = cast(torch.Tensor, eval_transform()(strip)).unsqueeze(0).to(device)
+        log_probs = crnn(tensor)[:, 0, :].cpu().numpy().astype(np.float64)
+        path = log_probs.argmax(axis=1).tolist()
+        group = central_group(path)
+        if group is None:
+            continue
+        t0 = max(0, group[0] - WINDOW_PAD)
+        t1 = min(len(path) - 1, group[1] + WINDOW_PAD)
+        window = log_probs[t0 : t1 + 1]
+        best_path = float(window.max(axis=1).sum())
+        for stem in stems:
+            margin = ctc_log_likelihood(window, stem) - best_path
+            if stem not in margins or margin > margins[stem]:
+                margins[stem] = margin
+    return margins
+
+
+def plan_repairs(
+    texts: list[str],
+    centers: list[tuple[float, float]],
+    margins: list[dict[str, float]],
+    pages: list[str],
+) -> list[tuple[int, str]]:
+    """Which detections to relabel to which missing pages (pure decision logic).
+
+    A detection is suspect when its text duplicates another detection's (the
+    weakest-margin instances of the group) or is no page key at all. Each
+    suspect adopts the best-margin *missing* page that clears every gate:
+    margin above REPAIR_FLOOR, within ADOPT_DELTA of the read's own margin (a
+    read that strongly IS its text stays a duplicate — one instance is right),
+    a different digit stem (same-stem alternatives score identically, so there
+    is no evidence to move on), and a stem plausible among the spatial
+    neighbors' stems. Returns (index, new text) pairs.
+    """
+    valid = set(pages)
+    stems_in_vocab = {key_stem(p) for p in pages}
+
+    def own_margin(i: int) -> float:
+        return margins[i].get(key_stem(texts[i]), -1e9)
+
+    # Spatial context: median |stem delta| between nearby detections.
+    def neighbor_stems(i: int) -> list[int]:
+        distances = sorted(
+            (
+                (centers[j][0] - centers[i][0]) ** 2
+                + (centers[j][1] - centers[i][1]) ** 2,
+                j,
+            )
+            for j in range(len(texts))
+            if j != i
+        )
+        stems = []
+        for _, j in distances[:SPATIAL_NEIGHBORS]:
+            stem = key_stem(texts[j])
+            if stem.isdigit():
+                stems.append(int(stem))
+        return stems
+
+    deltas = []
+    for i in range(len(texts)):
+        stem = key_stem(texts[i])
+        if not stem.isdigit():
+            continue
+        deltas.extend(abs(int(stem) - n) for n in neighbor_stems(i))
+    median_delta = max(1.0, float(np.median(deltas))) if deltas else 1.0
+
+    def spatially_ok(i: int, page: str) -> bool:
+        stems = neighbor_stems(i)
+        if not stems:
+            return True
+        return (
+            abs(int(key_stem(page)) - float(np.median(stems)))
+            <= SPATIAL_GATE * median_delta
+        )
+
+    counts = Counter(texts)
+    missing = [p for p in pages if counts[p] == 0]
+    groups: dict[str, list[int]] = {}
+    for i, text in enumerate(texts):
+        groups.setdefault(text, []).append(i)
+
+    repairs: list[tuple[int, str]] = []
+    for text, members in sorted(groups.items()):
+        if text not in valid and key_stem(text) not in stems_in_vocab:
+            suspects = members  # not a page key: every instance is suspect
+        elif len(members) > 1 and text in valid:
+            keeper = max(members, key=own_margin)
+            suspects = [i for i in members if i != keeper]
+        else:
+            continue
+        for i in suspects:
+            options = [
+                (margins[i].get(key_stem(page), -1e9), page)
+                for page in missing
+                if key_stem(page) != key_stem(text)
+                and margins[i].get(key_stem(page), -1e9) > REPAIR_FLOOR
+                and spatially_ok(i, page)
+            ]
+            if not options:
+                continue
+            best_margin, best_page = max(options)
+            if text in valid and best_margin < own_margin(i) - ADOPT_DELTA:
+                continue
+            repairs.append((i, best_page))
+            missing.remove(best_page)
+    return repairs
+
+
+def repair_conflicts(
+    image: np.ndarray,
+    crnn: torch.nn.Module,
+    device,
+    found: list[tuple[list[list[int]], str, float]],
+    *,
+    factor: float,
+    pages: list[str],
+    image_name: str,
+) -> list[tuple[list[list[int]], str, float]]:
+    """Relabel duplicated / invalid reads to missing pages by CTC-margin evidence.
+
+    Runs after resolve_duplicate_labels: that pass relabels only when two
+    narrow re-reads agree, which misses conflicts whose evidence sits in the
+    wide window (KC's 478 read as a duplicate '470': narrow crops disagree,
+    but '478' is the wide window's best interpretation by a wide margin).
+    This pass scores every still-missing page's stem directly against the
+    CRNN's own likelihoods and adopts under plan_repairs' gates.
+    """
+    if not found:
+        return found
+    texts = [text for _, text, _ in found]
+    centers = [
+        (sum(p[0] for p in poly) / len(poly), sum(p[1] for p in poly) / len(poly))
+        for poly, _, _ in found
+    ]
+    counts = Counter(texts)
+    valid = set(pages)
+    stems_in_vocab = {key_stem(p) for p in pages}
+
+    # Margins are only needed for detections in a conflicted group.
+    def conflicted(text: str) -> bool:
+        if text not in valid and key_stem(text) not in stems_in_vocab:
+            return True
+        return counts[text] > 1 and text in valid
+
+    stems = sorted({key_stem(p) for p in pages})
+    margins: list[dict[str, float]] = [
+        stem_margins(image, centers[i], factor, crnn, device, stems)
+        if conflicted(texts[i])
+        else {}
+        for i in range(len(found))
+    ]
+    repaired = list(found)
+    for i, new_text in plan_repairs(texts, centers, margins, pages):
+        polygon, old_text, confidence = found[i]
+        print(
+            f"{image_name}: conflict repair {old_text!r} -> {new_text!r}",
+            file=sys.stderr,
+        )
+        repaired[i] = (polygon, new_text, confidence)
+    return repaired
+
+
 def resolve_duplicate_labels(
     image: np.ndarray,
     crnn: torch.nn.Module,
@@ -301,12 +495,14 @@ def detect_and_read(
     nms_dist: float,
     pages: list[str],
     disable_reread: bool = False,
+    disable_repair: bool = False,
 ) -> list[dict]:
     """CNN-localize then CRNN-read one image; write <stem>.keymap.json.
 
     ``disable_reread`` turns off the tight-crop re-reads (the narrow-detection
-    minimum-width re-read and the duplicate-label re-read; an ablation switch for
-    measuring those steps' effect); they are on by default.
+    minimum-width re-read and the duplicate-label re-read) and ``disable_repair``
+    the CTC-margin conflict repair — ablation switches for measuring those
+    steps' effect; all are on by default.
     """
     image = np.asarray(Image.open(image_path).convert("RGB"))
     height, width = image.shape[:2]
@@ -378,6 +574,19 @@ def detect_and_read(
             image_name=Path(image_path).name,
         )
 
+    # Remaining duplicated or invalid reads: adopt a missing page when the CRNN's
+    # own likelihoods say it is the better interpretation (see repair_conflicts).
+    if valid_pages and not disable_repair:
+        found = repair_conflicts(
+            image,
+            crnn,
+            device,
+            found,
+            factor=factor,
+            pages=pages,
+            image_name=Path(image_path).name,
+        )
+
     detections = [
         detection_record(cast(list, polygon), text, confidence)
         for polygon, text, confidence in found
@@ -426,6 +635,11 @@ def main() -> None:
         action="store_true",
         help="Turn off the narrow-detection and duplicate-label re-reads (ablation).",
     )
+    parser.add_argument(
+        "--disable-repair",
+        action="store_true",
+        help="Turn off the CTC-margin conflict repair of duplicated/invalid reads (ablation).",
+    )
     args = parser.parse_args()
 
     device = select_device()
@@ -457,6 +671,7 @@ def main() -> None:
             nms_dist=args.nms_dist,
             pages=pages,
             disable_reread=args.disable_reread,
+            disable_repair=args.disable_repair,
         )
 
 

--- a/mapsnap/keymap/detect_numbers_crnn_test.py
+++ b/mapsnap/keymap/detect_numbers_crnn_test.py
@@ -2,6 +2,7 @@ from mapsnap.keymap.detect_numbers_crnn import (
     choose_duplicate_reread,
     choose_reread,
     levenshtein,
+    plan_repairs,
     snap_to_pages,
     volume_pages_for,
 )
@@ -143,3 +144,80 @@ def test_volume_pages_for_derives_from_raw_parent(tmp_path):
     # page 0 (the key map itself) is excluded; letters kept; splits collapse
     assert volume_pages_for(str(volume / "raw" / "p0.jpg")) == ["1", "6", "35A", "35B"]
     assert volume_pages_for(str(volume / "p0.jpg")) == ["1", "6", "35A", "35B"]
+
+
+# plan_repairs — the CTC-margin conflict-repair decision logic ------------------------------
+
+# A 3x3 grid of consecutive pages; margins default to "reads as its own text".
+GRID_PAGES = [str(n) for n in range(470, 479)]
+
+
+def grid(texts, margin_overrides=None):
+    centers = [(100.0 * (i % 3), 100.0 * (i // 3)) for i in range(len(texts))]
+    margins = []
+    for i, text in enumerate(texts):
+        m = {text: 0.0} if text.isdigit() else {}
+        m.update((margin_overrides or {}).get(i, {}))
+        margins.append(m)
+    return texts, centers, margins
+
+
+def test_plan_repairs_duplicate_loser_adopts_missing_page():
+    # The KC scenario: two '470' reads; the one at 478's spot scores '478' best.
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "470"],
+        {8: {"470": -2.2, "478": 0.59}},
+    )
+    assert plan_repairs(texts, centers, margins, GRID_PAGES) == [(8, "478")]
+
+
+def test_plan_repairs_keeper_is_best_own_margin():
+    # The stronger '470' stays; the weaker one moves.
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "470"],
+        {0: {"470": -2.2, "478": 0.5}, 8: {"470": 0.1}},
+    )
+    assert plan_repairs(texts, centers, margins, GRID_PAGES) == [(0, "478")]
+
+
+def test_plan_repairs_respects_adopt_delta():
+    # The loser reads solidly as its own text and no missing page comes close.
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "470"],
+        {8: {"470": 0.0, "478": -1.4}},
+    )
+    assert plan_repairs(texts, centers, margins, GRID_PAGES) == []
+
+
+def test_plan_repairs_floor_blocks_weak_adoptions():
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "470"],
+        {8: {"470": -5.0, "478": -2.0}},
+    )
+    assert plan_repairs(texts, centers, margins, GRID_PAGES) == []
+
+
+def test_plan_repairs_never_same_stem():
+    # '35' duplicated with lettered variants missing: same stem, no evidence.
+    pages = ["35", "35A", "35B", "36", "37"]
+    texts, centers, margins = grid(["35", "36", "37", "35"], {3: {"35": 0.0}})
+    assert plan_repairs(texts, centers, margins, pages) == []
+
+
+def test_plan_repairs_out_of_vocab_read_is_suspect():
+    # '81' is no page key on a 470-478 sheet; it adopts the strong missing page.
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "81"],
+        {8: {"478": 0.3, "81": 0.9}},
+    )
+    assert plan_repairs(texts, centers, margins, GRID_PAGES) == [(8, "478")]
+
+
+def test_plan_repairs_spatial_gate_blocks_distant_stems():
+    # Neighbors sit near 470; a missing page numerically far away is implausible.
+    pages = [*GRID_PAGES, "600"]
+    texts, centers, margins = grid(
+        ["470", "471", "472", "473", "474", "475", "476", "477", "470"],
+        {8: {"470": -2.2, "600": 0.9}},
+    )
+    assert plan_repairs(texts, centers, margins, pages) == []


### PR DESCRIPTION
Adds a conflict-repair pass to the key-map reader: when a page number is read twice, or read as something that is no page key at all, the CRNN's own likelihoods decide which still-missing page the suspect detection actually shows.

## Why the existing gate misses these

`resolve_duplicate_labels` relabels a duplicate only when **both narrow re-reads agree**. Kansas City's 478 is the canonical failure: its narrow crops disagree (`'71'` vs `'47'`), so the gate refuses and the sheet keeps a second `'470'` — even though `'478'` is the *wide* window's outright best interpretation (CTC margin 0.59 vs −2.23 for `'470'`, i.e. rank 1). The decisive evidence sits in a window the agreement gate never scores. That misread put p470's key-map location 961m from truth and cost KC 2.9 points in the last pipeline rerun.

## Mechanism

- `ctc_log_likelihood` (new in `crnn_model`): the standard CTC forward algorithm, so an *arbitrary* digit string can be scored against a window — not just the greedy decode.
- `stem_margins` scores every candidate stem in the central-group window of the wide strip and both narrow strips, as a margin against each window's own best path, taking the best across windows. Only conflicted detections are scored, so the added compute is small.
- `plan_repairs` (pure decision logic, unit-tested): suspects are duplicate-losers (weakest own-margin instances) and reads that are no page key. Each adopts the best-margin **missing** page that clears four gates — margin floor (−1.5), within `ADOPT_DELTA` (1.0) of the read's own margin, **never a same-stem target** (`'7'` vs `'7S'` score identically, so there is no evidence to move on), and spatial plausibility against neighboring stems.
- `--disable-repair` ablates the pass.

## Results (23 truth key maps, 1,609 hand labels)

Metric: key-correct — the detection text equals the disk page key at the truth label's location.

| sheet | truth | before | after | Δ |
|---|---|---|---|---|
| san_francisco p0 | 114 | 106 | 113 | **+7** |
| kansas_city p0 | 129 | 116 | 122 | **+6** |
| grand_rapids p0b | 47 | 17 | 22 | **+5** |
| hudson p0 | 93 | 79 | 81 | +2 |
| los_angeles pb | 76 | 50 | 52 | +2 |
| chicago p0 | 112 | 99 | 100 | +1 |
| grand_rapids p0a | 35 | 18 | 19 | +1 |
| los_angeles pa | 49 | 38 | 39 | +1 |
| nashville p0 | 68 | 47 | 48 | +1 |
| new_orleans_1896 p0 | 90 | 88 | 89 | +1 |
| new_orleans_1951 p0 | 106 | 103 | 104 | +1 |
| washington_dc p1b | 128 | 121 | 122 | +1 |
| 11 other sheets | 562 | 481 | 481 | — |
| **total** | **1609** | **1363 (84.7%)** | **1392 (86.5%)** | **+29** |

**12 sheets improved, 0 regressed.** 65 repairs fired across the corpus. Valid-but-wrong keys — the class that corrupts locator locations — drop 49 → 45. KC's `'470'` at 478's location now reads `'478'`, along with five of its six other known misreads (`'2'→524`, `'4'→464`, `'5'→550`, `'5235'→535`, `'55'→551`).

Verified by running the detector twice per sheet (`--disable-repair` for the before arm) with identical models, then scoring both against hand truth. 756 tests including synthetic CTC-forward cases and seven `plan_repairs` gate tests (one reproducing the KC scenario exactly); pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)