### PR TITLE
Speed up the snap channel (issue #155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The four arguments here are:
   - `mapsnap iiif`: produces a IIIF Georeference Extension with clipping masks. You can find examples of these in the `gallery` directory. View them on Allmaps.
   - `mapsnap compare`: compares the generated IIIF file with the human-generated one from OIM, producing a report on the accuracy of the fit.
 
-`mapsnap ocr` is typically the slowest step. The first `mapsnap snap` run on a volume also takes a while (road-UNet inference plus grid matching, roughly 10–30 minutes); its candidates are cached and later runs take seconds. The other steps under `mapsnap fit` run relatively quickly. You can run `mapsnap fit` yourself to experiment.
+`mapsnap ocr` is typically the slowest step. The first `mapsnap snap` run on a volume also takes a while (road-UNet inference plus grid matching); its candidates are cached and later runs take seconds. Both `georef` and `snap` fit one page at a time and take `--num-workers N` to spread that across processes (default 1); `mapsnap fit` passes the flag to both. Each snap worker rebuilds the volume's street index, so budget roughly a gigabyte of memory apiece on a large volume. The other steps under `mapsnap fit` run relatively quickly. You can run `mapsnap fit` yourself to experiment.
 
 The end result is a IIIF file pointing at Library of Congress imagery that you can view in Allmaps, along with a text file comparing Mapsnap's results against OIM's.
 

--- a/mapsnap/edge_join.py
+++ b/mapsnap/edge_join.py
@@ -292,6 +292,13 @@ def chamfer_refine(
     homogeneous = np.column_stack([points_page, np.ones(len(points_page))])
 
     height, width = distance_m.shape
+    # sample() is the matcher's hottest loop — least_squares evaluates the
+    # residuals ~115 times per candidate, and a volume runs ~200 candidates per
+    # page. Gathering from a flat view off one precomputed corner offset costs
+    # about half what four 2D fancy-index gathers do. The bilinear expression
+    # below keeps the original operand order and association, so every value it
+    # produces is bit-for-bit what the four-gather form produced.
+    flat_distance = distance_m.reshape(-1)
 
     def sample(pts: np.ndarray) -> np.ndarray:
         x = np.clip(pts[:, 0], 0, width - 1.001)
@@ -300,11 +307,14 @@ def chamfer_refine(
         y0 = y.astype(int)
         fx = x - x0
         fy = y - y0
+        corner = y0 * width + x0
+        one_minus_fx = 1 - fx
+        one_minus_fy = 1 - fy
         d = (
-            distance_m[y0, x0] * (1 - fx) * (1 - fy)
-            + distance_m[y0, x0 + 1] * fx * (1 - fy)
-            + distance_m[y0 + 1, x0] * (1 - fx) * fy
-            + distance_m[y0 + 1, x0 + 1] * fx * fy
+            flat_distance[corner] * one_minus_fx * one_minus_fy
+            + flat_distance[corner + 1] * fx * one_minus_fy
+            + flat_distance[corner + width] * one_minus_fx * fy
+            + flat_distance[corner + width + 1] * fx * fy
         )
         return d
 

--- a/mapsnap/edge_join.py
+++ b/mapsnap/edge_join.py
@@ -158,15 +158,22 @@ def rotation_candidates(
     target_prob: np.ndarray,
     jitter_deg: tuple[float, ...] = (0.0,),
     fixed_valid: np.ndarray | None = None,
+    *,
+    target_dir: float | None = None,
 ) -> list[float]:
     """cv2-convention rotations aligning the target's road grid to the frame's.
 
     The array-frame rotation mapping target directions onto fixed directions is
     fixed_dir - target_dir (mod 90); cv2.getRotationMatrix2D uses the opposite
     sign, so candidates are -(delta) + k*90 (+ jitter) for k in 0..3.
+
+    ``target_dir`` supplies an already-measured target orientation — the same
+    target is often swept against several frames, and the measurement depends
+    only on the target.
     """
     fixed_dir = dominant_orientation_deg(fixed_prob, fixed_valid)
-    target_dir = dominant_orientation_deg(target_prob)
+    if target_dir is None:
+        target_dir = dominant_orientation_deg(target_prob)
     delta = fixed_dir - target_dir
     return [
         (-delta + 90.0 * k + j + 180.0) % 360.0 - 180.0

--- a/mapsnap/feature_index.py
+++ b/mapsnap/feature_index.py
@@ -1,0 +1,116 @@
+"""Spatial index over GeoJSON features, so "what's near here" stops being a linear scan.
+
+A volume's centerlines.geojson runs to hundreds of thousands of features (Los
+Angeles county: 201k). Consumers that repeatedly ask for the features near a
+point or a frame — the OSM rasterizer's per-frame bbox cull, the key map's
+per-page vocabulary restriction — used to walk the entire list per query, which
+costs 0.5-2 s each and dominated their runtime.
+
+The index is a pure *cull*: every query returns a superset of the features whose
+geometry could satisfy the caller's own (exact, unchanged) test, in the original
+feature order. Callers keep their test and their answers, and only stop paying
+for the features that could never have passed it.
+"""
+
+import math
+
+import numpy as np
+import shapely
+from shapely.strtree import STRtree
+
+Bounds = tuple[float, float, float, float]  # (min_lon, max_lon, min_lat, max_lat)
+
+M_PER_DEG_LAT = 110540.0
+M_PER_DEG_LON_EQUATOR = 111320.0
+
+
+def geometry_bbox(geometry: dict) -> Bounds | None:
+    """(min_lon, max_lon, min_lat, max_lat) of a geometry's vertices, or None if it has none."""
+    kind = geometry.get("type")
+    coordinates = geometry.get("coordinates")
+    if not coordinates:
+        return None
+    if kind == "Point":
+        points = [coordinates]
+    elif kind in ("LineString", "MultiPoint"):
+        points = coordinates
+    elif kind in ("MultiLineString", "Polygon"):
+        points = [point for part in coordinates for point in part]
+    elif kind == "MultiPolygon":
+        points = [point for part in coordinates for ring in part for point in ring]
+    else:
+        return None
+    if not points:
+        return None
+    lons = [point[0] for point in points]
+    lats = [point[1] for point in points]
+    return min(lons), max(lons), min(lats), max(lats)
+
+
+def point_bounds(point: tuple[float, float], radius_m: float) -> Bounds:
+    """The lon/lat box of everything within ``radius_m`` of a lon/lat point.
+
+    Sized with the same equirectangular scales the exact distance tests use (see
+    :func:`mapsnap.keymap.locate.segment_point_distance_m`), so nothing genuinely
+    within the radius can fall outside the box.
+    """
+    lon, lat = point
+    d_lat = radius_m / M_PER_DEG_LAT
+    d_lon = radius_m / max(M_PER_DEG_LON_EQUATOR * math.cos(math.radians(lat)), 1e-6)
+    return (lon - d_lon, lon + d_lon, lat - d_lat, lat + d_lat)
+
+
+class FeatureIndex:
+    """An STRtree over GeoJSON features' bounding boxes; build one per feature list."""
+
+    def __init__(self, features: list[dict]) -> None:
+        self.features = features
+        min_lons: list[float] = []
+        min_lats: list[float] = []
+        max_lons: list[float] = []
+        max_lats: list[float] = []
+        # Features with no usable geometry stay out of the tree: they can never
+        # be near anything, and every caller already skips them.
+        self.positions: list[int] = []
+        for position, feature in enumerate(features):
+            bbox = geometry_bbox(feature.get("geometry") or {})
+            if bbox is None:
+                continue
+            self.positions.append(position)
+            min_lons.append(bbox[0])
+            max_lons.append(bbox[1])
+            min_lats.append(bbox[2])
+            max_lats.append(bbox[3])
+        self.tree = STRtree(
+            shapely.box(
+                np.array(min_lons),
+                np.array(min_lats),
+                np.array(max_lons),
+                np.array(max_lats),
+            )
+        )
+
+    def near_bboxes(self, boxes: list[Bounds]) -> list[dict]:
+        """Features whose bounding box touches any of the lon/lat boxes, in feature order."""
+        if not boxes or not self.positions:
+            return []
+        query = shapely.box(
+            np.array([b[0] for b in boxes]),
+            np.array([b[2] for b in boxes]),
+            np.array([b[1] for b in boxes]),
+            np.array([b[3] for b in boxes]),
+        )
+        # A multi-geometry query returns (query index, tree index) pairs; only
+        # the tree side matters, deduped since a feature can hit several boxes.
+        hits = sorted(set(self.tree.query(query)[1].tolist()))
+        return [self.features[self.positions[i]] for i in hits]
+
+    def near_bbox(self, bounds: Bounds) -> list[dict]:
+        """Features whose bounding box touches the lon/lat box, in feature order."""
+        return self.near_bboxes([bounds])
+
+    def near_points(
+        self, points: list[tuple[float, float]], radius_m: float
+    ) -> list[dict]:
+        """Features whose bounding box comes within ``radius_m`` of any lon/lat point."""
+        return self.near_bboxes([point_bounds(point, radius_m) for point in points])

--- a/mapsnap/feature_index_test.py
+++ b/mapsnap/feature_index_test.py
@@ -1,0 +1,127 @@
+"""Tests for the GeoJSON feature spatial index.
+
+The index only ever *culls*, so the property that matters is that it never drops
+a feature an exhaustive scan would have kept — every test below compares against
+the brute-force answer rather than asserting an exact hit count.
+"""
+
+import math
+
+from mapsnap.feature_index import (
+    M_PER_DEG_LAT,
+    Bounds,
+    FeatureIndex,
+    geometry_bbox,
+    point_bounds,
+)
+
+LON0, LAT0 = -74.0, 40.0
+KX = 111_320.0 * math.cos(math.radians(LAT0))
+
+
+def line(name: str, points: list[tuple[float, float]]) -> dict:
+    """A LineString feature from (lon, lat) degree offsets about the test origin."""
+    return {
+        "properties": {"street_name": name},
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[LON0 + dx, LAT0 + dy] for dx, dy in points],
+        },
+    }
+
+
+def scan_bbox(features: list[dict], bounds: Bounds) -> list[dict]:
+    """Brute-force: features with any vertex inside the lon/lat box."""
+    min_lon, max_lon, min_lat, max_lat = bounds
+    return [
+        feature
+        for feature in features
+        if any(
+            min_lon <= lon <= max_lon and min_lat <= lat <= max_lat
+            for lon, lat in feature["geometry"]["coordinates"]
+        )
+    ]
+
+
+def test_geometry_bbox_covers_every_geometry_kind() -> None:
+    assert geometry_bbox({"type": "Point", "coordinates": [1.0, 2.0]}) == (
+        1.0,
+        1.0,
+        2.0,
+        2.0,
+    )
+    assert geometry_bbox(
+        {"type": "LineString", "coordinates": [[1.0, 2.0], [-1.0, 5.0]]}
+    ) == (-1.0, 1.0, 2.0, 5.0)
+    assert geometry_bbox(
+        {
+            "type": "MultiLineString",
+            "coordinates": [[[1.0, 2.0], [3.0, 2.0]], [[0.0, 9.0], [0.0, 8.0]]],
+        }
+    ) == (0.0, 3.0, 2.0, 9.0)
+    assert geometry_bbox(
+        {"type": "Polygon", "coordinates": [[[0.0, 0.0], [2.0, 0.0], [2.0, 3.0]]]}
+    ) == (0.0, 2.0, 0.0, 3.0)
+    assert geometry_bbox({"type": "LineString", "coordinates": []}) is None
+    assert geometry_bbox({}) is None
+
+
+def test_near_bbox_matches_a_full_scan() -> None:
+    features = [
+        line("A", [(0.00, 0.00), (0.00, 0.02)]),
+        line("B", [(0.01, 0.01), (0.02, 0.01)]),
+        line("C", [(0.50, 0.50), (0.51, 0.51)]),
+    ]
+    index = FeatureIndex(features)
+    bounds = (LON0 - 0.005, LON0 + 0.005, LAT0 - 0.005, LAT0 + 0.005)
+    assert index.near_bbox(bounds) == scan_bbox(features, bounds)
+    far = (LON0 + 10.0, LON0 + 11.0, LAT0, LAT0 + 1.0)
+    assert index.near_bbox(far) == []
+
+
+def test_near_bbox_keeps_a_long_line_with_no_vertex_inside() -> None:
+    """A street crossing the box without a vertex in it must survive the cull."""
+    through = line("THROUGH", [(-1.0, 0.0), (1.0, 0.0)])
+    index = FeatureIndex([through])
+    bounds = (LON0 - 0.001, LON0 + 0.001, LAT0 - 0.001, LAT0 + 0.001)
+    assert index.near_bbox(bounds) == [through]
+    assert scan_bbox([through], bounds) == []  # the exact vertex test would miss it
+
+
+def test_results_come_back_in_feature_order() -> None:
+    features = [line(str(i), [(0.0, 0.0), (0.001, 0.001)]) for i in range(5)]
+    index = FeatureIndex(features)
+    hit = index.near_bbox((LON0 - 1, LON0 + 1, LAT0 - 1, LAT0 + 1))
+    assert [f["properties"]["street_name"] for f in hit] == ["0", "1", "2", "3", "4"]
+
+
+def test_features_without_geometry_are_skipped() -> None:
+    features = [
+        {"properties": {"street_name": "NO GEOM"}},
+        line("REAL", [(0.0, 0.0), (0.001, 0.0)]),
+    ]
+    index = FeatureIndex(features)
+    hit = index.near_bbox((LON0 - 1, LON0 + 1, LAT0 - 1, LAT0 + 1))
+    assert [f["properties"]["street_name"] for f in hit] == ["REAL"]
+
+
+def test_empty_index_answers_without_error() -> None:
+    assert FeatureIndex([]).near_bbox((0.0, 1.0, 0.0, 1.0)) == []
+
+
+def test_point_bounds_reaches_the_radius_in_both_axes() -> None:
+    min_lon, max_lon, min_lat, max_lat = point_bounds((LON0, LAT0), 100.0)
+    assert abs((max_lat - LAT0) * M_PER_DEG_LAT - 100.0) < 1e-6
+    assert abs((max_lon - LON0) * KX - 100.0) < 1e-6
+    # Longitude degrees are worth less than latitude degrees away from the
+    # equator, so the box must be wider than it is tall.
+    assert (max_lon - min_lon) > (max_lat - min_lat)
+
+
+def test_near_points_unions_the_query_points() -> None:
+    near_a = line("A", [(0.0, 0.0), (0.0005, 0.0)])
+    near_b = line("B", [(0.5, 0.0), (0.5005, 0.0)])
+    far = line("FAR", [(9.0, 0.0), (9.0005, 0.0)])
+    index = FeatureIndex([near_a, near_b, far])
+    hit = index.near_points([(LON0, LAT0), (LON0 + 0.5, LAT0)], 200.0)
+    assert [f["properties"]["street_name"] for f in hit] == ["A", "B"]

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -11,6 +11,20 @@ from mapsnap import experiments
 from mapsnap.utils import default_centerlines, list_pages, run_cmd
 
 
+def worker_flag(georef_extra: list[str]) -> list[str]:
+    """The ``--num-workers N`` pair out of the georef passthrough, or nothing.
+
+    Accepts either spelling argparse does (``--num-workers 4`` or
+    ``--num-workers=4``) and normalizes to the two-token form.
+    """
+    for i, token in enumerate(georef_extra):
+        if token == "--num-workers" and i + 1 < len(georef_extra):
+            return [token, georef_extra[i + 1]]
+        if token.startswith("--num-workers="):
+            return ["--num-workers", token.split("=", 1)[1]]
+    return []
+
+
 def find_centerlines(dir_path: Path) -> Path:
     """Return the centerlines GeoJSON, checking dir then parent dir."""
     centerlines = default_centerlines(dir_path)
@@ -133,7 +147,9 @@ def main() -> None:
     # OSM contradicts, refine mid-tier fits. Its pN.georef-osm.json sidecars
     # take priority in the hybrid glob below.
     if not args.no_snap:
-        run_cmd(["mapsnap", "snap", str(dir_path)])
+        # Both passes are per-page and CPU-bound, so one --num-workers governs
+        # both; the rest of the georef passthrough is georef-only.
+        run_cmd(["mapsnap", "snap", str(dir_path), *worker_flag(georef_extra)])
 
     output_iiif = dir_path / f"{run_id}.iiif.json"
     # Pass the glob as a literal string; make_iiif_georef does its own glob

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -1,0 +1,21 @@
+"""Tests for the `mapsnap fit` driver's flag handling."""
+
+from mapsnap.fit import worker_flag
+
+
+def test_worker_flag_extracts_both_spellings():
+    assert worker_flag(["--num-workers", "4"]) == ["--num-workers", "4"]
+    assert worker_flag(["--num-workers=4"]) == ["--num-workers", "4"]
+    # Found among other georef-only passthrough flags.
+    assert worker_flag(["--debug", "--num-workers", "2", "--affine"]) == [
+        "--num-workers",
+        "2",
+    ]
+
+
+def test_worker_flag_absent_or_malformed_yields_nothing():
+    assert worker_flag([]) == []
+    assert worker_flag(["--debug", "--affine"]) == []
+    # A trailing --num-workers with no value: leave it to georef's parser to
+    # reject rather than forwarding half a flag.
+    assert worker_flag(["--debug", "--num-workers"]) == []

--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mapsnap.feature_index import FeatureIndex
 from mapsnap.keymap.fit_keymap import key_stem, load_detections, page_key, page_number
 
 Point = tuple[float, float]
@@ -263,6 +264,19 @@ class KeymapLocator:
     # Page key -> world (lon, lat) rings of the colored block(s) drawn around that number
     # on the key map (from page_regions segmentation) — the page's approximate ground footprint.
     regions: dict[str, list[list[Point]]] = field(default_factory=dict)
+    # Spatial index over the last feature list the cull methods were handed, kept
+    # because callers pass the same volume-wide centerlines list once per page and
+    # rebuilding the tree every time would cost what the scan it replaces cost. The
+    # strong reference keeps that list alive, so its identity can never be reused.
+    index_cache: tuple[list[dict], FeatureIndex] | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def feature_index(self, features: list[dict]) -> FeatureIndex:
+        """Spatial index over ``features``, reused across calls with the same list."""
+        if self.index_cache is None or self.index_cache[0] is not features:
+            self.index_cache = (features, FeatureIndex(features))
+        return self.index_cache[1]
 
     @classmethod
     def from_keymap(
@@ -413,7 +427,7 @@ class KeymapLocator:
             )
         return [
             feature
-            for feature in features
+            for feature in self.feature_index(features).near_bboxes(boxes)
             if any(
                 min_lon <= lon <= max_lon and min_lat <= lat <= max_lat
                 for (min_lon, max_lon, min_lat, max_lat) in boxes
@@ -433,7 +447,7 @@ class KeymapLocator:
         if not centers:
             return None
         kept = []
-        for feature in features:
+        for feature in self.feature_index(features).near_points(centers, self.radius_m):
             segments = geometry_segments(feature.get("geometry", {}))
             if any(
                 segment_point_distance_m(segment, center) <= self.radius_m

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -102,6 +102,18 @@ def test_restricted_features_keeps_through_street_with_no_vertex_inside():
     assert kept is not None and [f["id"] for f in kept] == ["through"]
 
 
+def test_feature_index_is_cached_per_feature_list():
+    """The cull's index is reused for the same list and rebuilt for a different one."""
+    locator = KeymapLocator(locations={"61": [(0.0, 0.0)]}, radius_m=150.0)
+    features = [{"geometry": {"type": "Point", "coordinates": [0.0, 0.0]}, "id": "a"}]
+    first = locator.feature_index(features)
+    assert locator.feature_index(features) is first
+    other = [{"geometry": {"type": "Point", "coordinates": [1.0, 1.0]}, "id": "b"}]
+    rebuilt = locator.feature_index(other)
+    assert rebuilt is not first
+    assert [f["id"] for f in rebuilt.near_bbox((0.9, 1.1, 0.9, 1.1))] == ["b"]
+
+
 def test_located_keys_and_page_keys():
     locator = KeymapLocator(
         locations={"1": [(0.0, 0.0)], "61": [(1.0, 1.0)]}, radius_m=100.0

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -31,6 +31,7 @@ from mapsnap.edge_join import (
     FrameSpec,
     JoinCandidate,
     MatchParams,
+    dominant_orientation_deg,
     match_at_rotation,
     pose_ncc,
     refine_and_rank,
@@ -164,6 +165,27 @@ class PageContext:
     keymap_regions: list[list[list[float]]] | None = None  # world rings
     label_features: list[LabelFeature] | None = None
     block_index: dict[str, list[Block]] | None = None
+    # Memos of the maps derived from `prob`. The road skeleton (a Zhang
+    # thinning pass) is needed by both evaluate_pose and snap_page, and the
+    # dominant road orientation is re-derived once per search center. Each is a
+    # pure function of `prob`, so a reuse is identical to a recompute.
+    road_points_cache: dict[tuple[float, int], np.ndarray] = field(
+        default_factory=dict, repr=False
+    )
+    orientation_cache: float | None = field(default=None, repr=False)
+
+    def road_points(self, params: MatchParams) -> np.ndarray:
+        """The page's road-skeleton points (x, y in page pixels), thinned once per page."""
+        key = (params.mask_threshold, params.mask_min_area)
+        if key not in self.road_points_cache:
+            self.road_points_cache[key] = skeleton_points(self.prob, *key)
+        return self.road_points_cache[key]
+
+    def road_orientation_deg(self) -> float:
+        """The page's dominant road direction folded to [0, 90), measured once per page."""
+        if self.orientation_cache is None:
+            self.orientation_cache = dominant_orientation_deg(self.prob)
+        return self.orientation_cache
 
 
 def frame_around(
@@ -630,7 +652,7 @@ def evaluate_pose(
         return None
     distance = osm_distance_m(skeleton, res)
     pose = frame.page_to_raster_affine(world_affine)
-    points = skeleton_points(ctx.prob, params.mask_threshold, params.mask_min_area)
+    points = ctx.road_points(params)
     if len(points) < 10:
         return None
     if len(points) > 3000:
@@ -694,7 +716,7 @@ def snap_page(
     if params.min_overlap_m2 > 0.5 * page_area_m2:
         params = dataclasses.replace(params, min_overlap_m2=0.5 * page_area_m2)
     half_m = ctx.radius_m + page_diag_m / 2 + 100.0
-    points = skeleton_points(ctx.prob, params.mask_threshold, params.mask_min_area)
+    points = ctx.road_points(params)
     sigma_px = max(params.blur_sigma_m / res, 0.5)
     border_px = max(1, round(REFINE_SHIFT_MAX_M / res))
     page_center = np.array([ctx.width / 2.0, ctx.height / 2.0, 1.0])
@@ -719,7 +741,11 @@ def snap_page(
         # theta set is never empty and covers any 180-flip a prior missed.
         thetas = dedupe_thetas(ctx.rotation_priors)
         for theta in rotation_candidates(
-            osm_prob, ctx.prob, params.jitter_deg, fixed_valid=valid
+            osm_prob,
+            ctx.prob,
+            params.jitter_deg,
+            fixed_valid=valid,
+            target_dir=ctx.road_orientation_deg(),
         ):
             if not any(
                 abs(wrap_deg(theta - k.theta_deg)) <= THETA_DEDUPE_DEG for k in thetas

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -55,6 +55,15 @@ CONTAINMENT_BUFFER_M = 60.0
 RADIUS_SLACK_M = 60.0  # post-refinement slack on the center-distance gate
 THETA_DEDUPE_DEG = 3.0
 MAX_PRIOR_THETAS = 8
+# Rotation-prior confidence, for skipping the rest of the ladder. A
+# label-pair-exact rung is ONE label pair's reading of the page rotation, not
+# the page's: a page usually carries several, and a mis-OCR'd or mis-matched
+# label makes its pair disagree with the rest. Several that all agree is
+# independent corroboration; one on its own is a hypothesis (see
+# confident_theta_deg).
+CONFIDENT_MIN_RUNGS = 2
+CONFIDENT_AGREE_DEG = 8.0
+CONFIDENT_WINDOW_DEG = 12.0
 MERGE_SEPARATION_M = 60.0  # candidates closer than this are the same lock
 CALIBRATED_RADIUS_MARGIN_M = 100.0
 CALIBRATED_RADIUS_MIN_M = 150.0
@@ -310,6 +319,27 @@ def dedupe_thetas(
         if len(kept) >= cap:
             break
     return kept
+
+
+def confident_theta_deg(priors: list[RotationPrior]) -> float | None:
+    """The rotation the page's label pairs unanimously imply, or None.
+
+    Each "label-pair-exact" rung comes from one pair of OCR'd labels on
+    distinct streets, and the ladder normally carries several — a page with
+    four usable labels emits up to six pairs. When they all agree, each pair
+    independently corroborates the others (a mis-read label, or one matched to
+    the wrong street, throws its pairs off by tens of degrees), and no other
+    rung has ever out-scored them in the corpus, so the search can drop the
+    rest of the ladder. A lone rung is just a hypothesis and gets no such
+    trust: pruning to the first rung of a page whose pairs disagree costs real
+    placements (issue #155).
+    """
+    exact = [p.theta_deg for p in priors if p.source == "label-pair-exact"]
+    if len(exact) < CONFIDENT_MIN_RUNGS:
+        return None
+    if max(abs(wrap_deg(theta - exact[0])) for theta in exact) > CONFIDENT_AGREE_DEG:
+        return None
+    return exact[0]
 
 
 def cluster_rotation(
@@ -689,6 +719,47 @@ def evaluate_pose(
     return evaluation
 
 
+def frame_thetas(
+    ctx: PageContext,
+    confident_deg: float | None,
+    fixed: tuple[np.ndarray, np.ndarray],
+    params: MatchParams,
+) -> list[RotationPrior]:
+    """The rotation ladder to sweep against one OSM frame (prob, valid).
+
+    Every theta here costs a full masked NCC pass plus params.top_k chamfer
+    refinements, and the refinements are where the matcher spends most of its
+    time — so when the label pairs unanimously pin the rotation, the ladder
+    collapses to a window around them and the mask-mod-90 sweep (four more
+    rotations) is skipped. Without that corroboration the priors are deduped
+    and the sweep is appended, so the set is never empty and always covers a
+    180-flip a prior missed.
+    """
+    if confident_deg is not None:
+        return dedupe_thetas(
+            [
+                prior
+                for prior in ctx.rotation_priors
+                if abs(wrap_deg(prior.theta_deg - confident_deg))
+                <= CONFIDENT_WINDOW_DEG
+            ]
+        )
+    osm_prob, valid = fixed
+    thetas = dedupe_thetas(ctx.rotation_priors)
+    for theta in rotation_candidates(
+        osm_prob,
+        ctx.prob,
+        params.jitter_deg,
+        fixed_valid=valid,
+        target_dir=ctx.road_orientation_deg(),
+    ):
+        if not any(
+            abs(wrap_deg(theta - k.theta_deg)) <= THETA_DEDUPE_DEG for k in thetas
+        ):
+            thetas.append(RotationPrior(theta, 4.0, "mask-mod90"))
+    return thetas
+
+
 def snap_page(
     ctx: PageContext,
     features: FeatureIndex,
@@ -720,6 +791,7 @@ def snap_page(
     sigma_px = max(params.blur_sigma_m / res, 0.5)
     border_px = max(1, round(REFINE_SHIFT_MAX_M / res))
     page_center = np.array([ctx.width / 2.0, ctx.height / 2.0, 1.0])
+    confident = confident_theta_deg(ctx.rotation_priors)
 
     collected: list[SnapCandidate] = []
     for center in ctx.search_centers:
@@ -737,20 +809,7 @@ def snap_page(
         search_center = frame.lonlat_to_raster(*center)
         search_radius_px = ctx.radius_m / res
 
-        # The prior ladder, plus the mask-mod-90 sweep — always appended so the
-        # theta set is never empty and covers any 180-flip a prior missed.
-        thetas = dedupe_thetas(ctx.rotation_priors)
-        for theta in rotation_candidates(
-            osm_prob,
-            ctx.prob,
-            params.jitter_deg,
-            fixed_valid=valid,
-            target_dir=ctx.road_orientation_deg(),
-        ):
-            if not any(
-                abs(wrap_deg(theta - k.theta_deg)) <= THETA_DEDUPE_DEG for k in thetas
-            ):
-                thetas.append(RotationPrior(theta, 4.0, "mask-mod90"))
+        thetas = frame_thetas(ctx, confident, (osm_prob, valid), params)
 
         candidates: list[JoinCandidate] = []
         provenance: dict[int, tuple[RotationPrior, ScalePrior]] = {}

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -37,6 +37,7 @@ from mapsnap.edge_join import (
     rotation_candidates,
     skeleton_points,
 )
+from mapsnap.feature_index import FeatureIndex
 from mapsnap.georef_from_labels import LabelFeature, project_to_polyline
 from mapsnap.streets import Block, street_base_name
 from mapsnap.utils import haversine_m
@@ -194,7 +195,7 @@ def frame_bounds_lonlat(frame: FrameSpec) -> tuple[float, float, float, float]:
 
 
 def osm_rasters(
-    frame: FrameSpec, features: list[dict], *, width_m: float = OSM_WIDTH_M
+    frame: FrameSpec, features: FeatureIndex, *, width_m: float = OSM_WIDTH_M
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """(prob, valid, skeleton) rasters of OSM centerlines in the frame.
 
@@ -203,14 +204,19 @@ def osm_rasters(
     same polylines at 1 px: the exact centerline (no thinning needed), which
     the chamfer distance transform is built from. valid is all-true — OSM
     knowledge covers the whole frame, unlike an edge-join anchor page.
+
+    The index pre-culls to the features whose bounding box reaches the frame;
+    the per-line bbox test below still runs on every one of them, so what gets
+    drawn is exactly what a scan of the whole volume would draw.
     """
     rows, cols = frame.shape
     prob = np.zeros((rows, cols), np.float32)
     skeleton = np.zeros((rows, cols), np.uint8)
-    min_lon, max_lon, min_lat, max_lat = frame_bounds_lonlat(frame)
+    bounds = frame_bounds_lonlat(frame)
+    min_lon, max_lon, min_lat, max_lat = bounds
     kx, ky = frame.metre_scales()
     thickness = max(2, round(width_m / frame.res_m))
-    for feature in features:
+    for feature in features.near_bbox(bounds):
         geometry = feature.get("geometry") or {}
         if geometry.get("type") == "LineString":
             lines = [geometry["coordinates"]]
@@ -589,7 +595,7 @@ def region_containment_frac(
 
 def evaluate_pose(
     ctx: PageContext,
-    features: list[dict],
+    features: FeatureIndex,
     world_affine: np.ndarray,
     params: MatchParams = OSM_MATCH_PARAMS,
 ) -> dict | None:
@@ -663,7 +669,7 @@ def evaluate_pose(
 
 def snap_page(
     ctx: PageContext,
-    features: list[dict],
+    features: FeatureIndex,
     params: MatchParams = OSM_MATCH_PARAMS,
 ) -> list[SnapCandidate]:
     """Candidate placements of a page against OSM around its keymap location.

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -16,9 +16,11 @@ import contextlib
 import io
 import json
 import math
+import multiprocessing
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import cv2
 import numpy as np
@@ -801,6 +803,37 @@ def ensure_probs(volume: Path, stems: list[str]) -> None:
     print(f"  inferred {len(missing)} P(road) maps")
 
 
+# Module-level state populated by init_worker and read by snap_one_page. Each
+# multiprocessing worker gets its own copy; at --num-workers=1 the main process
+# fills it directly instead of spawning a pool.
+worker_state: dict[str, Any] = {}
+
+
+def init_worker(volume: Path, vctx: VolumeContext | None = None) -> None:
+    """Give this process the volume context snap_one_page reads.
+
+    A pool worker receives only the volume path and rebuilds the context
+    itself: the centerlines run to hundreds of thousands of features and
+    pickling them to every worker costs far more than re-reading the file
+    (~1 s), and the rebuild is deterministic — it reads the same sidecars. The
+    sequential path passes the context the caller already built.
+    """
+    context = load_volume_context(volume) if vctx is None else vctx
+    worker_state["vctx"] = context
+    worker_state["units"] = {
+        unit.stem: unit for unit in list(context.units) + list(context.panel_units)
+    }
+
+
+def snap_one_page(stem: str) -> tuple[str, dict]:
+    """Generate one page's candidates record from worker_state.
+
+    Runs the same way whether dispatched to a pool worker or called directly,
+    so a page's record is identical either way.
+    """
+    return stem, page_record(worker_state["vctx"], worker_state["units"][stem])
+
+
 def cmd_candidates(
     volume: Path,
     pages: list[str] | None,
@@ -808,6 +841,8 @@ def cmd_candidates(
     limit: int | None,
     recompute: bool,
     vis: bool,
+    *,
+    num_workers: int = 1,
 ) -> None:
     """Generate candidates.jsonl for the volume's rescue targets."""
     out_dir = artifacts_dir(volume)
@@ -868,25 +903,25 @@ def cmd_candidates(
     vis_dir = out_dir / "vis"
     if vis:
         vis_dir.mkdir(exist_ok=True)
-    done = 0
-    for unit in targets:
-        cached = existing.get(unit.stem)
-        if (
-            cached is not None
-            and not recompute
-            and not pages
-            and candidates_record_fresh(
-                cached, unit, georef_variant_mtime(volume, unit.stem)
-            )
-        ):
-            continue
-        record = page_record(vctx, unit)
-        existing[unit.stem] = record
-        done += 1
+    stale = [
+        unit
+        for unit in targets
+        if recompute
+        or pages
+        or (cached := existing.get(unit.stem)) is None
+        or not candidates_record_fresh(
+            cached, unit, georef_variant_mtime(volume, unit.stem)
+        )
+    ]
+    by_stem = {unit.stem: unit for unit in targets}
+
+    def record_done(stem: str, record: dict) -> None:
+        """Log one finished page, draw its contact sheet, and checkpoint the file."""
+        existing[stem] = record
         best = (record.get("candidates") or [{}])[0]
         rmse = best.get("rmse_ft")
         print(
-            f"  {unit.stem:<8} {record['status']:<14}"
+            f"  {stem:<8} {record['status']:<14}"
             f" cands={len(record.get('candidates', []))}"
             + (f" best_rmse={rmse:.0f}ft" if rmse is not None else "")
             + (
@@ -896,12 +931,29 @@ def cmd_candidates(
             )
         )
         if vis and record.get("candidates"):
-            write_contact_sheet(vctx, unit, record, vis_dir)
+            write_contact_sheet(vctx, by_stem[stem], record, vis_dir)
         # Rewrite after every page so an interrupted run keeps its progress.
         with out_path.open("w") as handle:
-            for stem in sorted(existing):
-                handle.write(json.dumps(existing[stem]) + "\n")
-    print(f"{done} pages computed; {len(existing)} total in {out_path}")
+            for target in sorted(existing):
+                handle.write(json.dumps(existing[target]) + "\n")
+
+    if num_workers > 1 and len(stale) > 1:
+        # Matching is independent per page and CPU-bound. Workers rebuild the
+        # volume context from disk rather than receive it pickled, so start-up
+        # costs about a second each; results are consumed as they land so the
+        # checkpoint file keeps pace with an interrupted run.
+        with multiprocessing.Pool(
+            num_workers, initializer=init_worker, initargs=(volume,)
+        ) as pool:
+            for stem, record in pool.imap_unordered(
+                snap_one_page, [unit.stem for unit in stale]
+            ):
+                record_done(stem, record)
+    else:
+        init_worker(volume, vctx)
+        for unit in stale:
+            record_done(*snap_one_page(unit.stem))
+    print(f"{len(stale)} pages computed; {len(existing)} total in {out_path}")
 
 
 def load_candidates(volume: Path) -> list[dict]:
@@ -2541,6 +2593,13 @@ def main() -> None:
     p_cand.add_argument("--limit", type=int, default=None)
     p_cand.add_argument("--recompute", action="store_true")
     p_cand.add_argument("--no-vis", action="store_true", help="skip contact sheets")
+    p_cand.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help="worker processes for the per-page matching pass (default: %(default)s)",
+    )
 
     p_rep = sub.add_parser("report", help="ranking diagnostics vs truth")
     p_rep.add_argument("volume", type=Path, nargs="+")
@@ -2603,6 +2662,7 @@ def main() -> None:
             args.limit,
             args.recompute,
             vis=not args.no_vis,
+            num_workers=args.num_workers,
         )
     elif args.command == "report":
         if args.sweep_refine:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -32,6 +32,7 @@ from mapsnap.edge_join_experiment import (
     load_prob,
     volume_median_scale,
 )
+from mapsnap.feature_index import FeatureIndex
 from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
 from mapsnap.keymap.align_page_region import (
     image_neighbor_directions,
@@ -72,6 +73,7 @@ class VolumeContext:
     units: list[PageUnit]
     panel_units: list[PageUnit]
     features: list[dict]
+    feature_index: FeatureIndex  # the same features, spatially indexed
     locator: KeymapLocator | None
     volume_m_per_px: float
     adjacency: dict
@@ -430,6 +432,7 @@ def load_volume_context(
         units=units,
         panel_units=load_panel_units(volume),
         features=features,
+        feature_index=FeatureIndex(features),
         locator=locator,
         volume_m_per_px=volume_median_scale(units),
         adjacency=load_adjacency(volume),
@@ -720,7 +723,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # Arbitration head-to-head: score the incumbent RANSAC pose with the
         # same evidence the challenger candidates carry.
-        incumbent = evaluate_pose(ctx, vctx.features, unit.gen_affine)
+        incumbent = evaluate_pose(ctx, vctx.feature_index, unit.gen_affine)
         if incumbent is not None:
             incumbent["world_affine"] = [
                 [float(v) for v in row] for row in unit.gen_affine
@@ -729,7 +732,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
             if unit.rmse_ft is not None:
                 incumbent["rmse_ft"] = round(unit.rmse_ft, 1)
             record["incumbent"] = incumbent
-    candidates = snap_page(ctx, vctx.features)
+    candidates = snap_page(ctx, vctx.feature_index)
     if not candidates:
         record["status"] = "no_candidates"
         return record
@@ -757,7 +760,7 @@ def write_contact_sheet(
         center = (candidate["center"][0], candidate["center"][1])
         diag_m = math.hypot(unit.width, unit.height) * candidate["scale_m_per_px"] / 2
         frame = frame_around(center, half_m=diag_m + 100.0)
-        osm_prob, _, _ = osm_rasters(frame, vctx.features)
+        osm_prob, _, _ = osm_rasters(frame, vctx.feature_index)
         pose = frame.page_to_raster_affine(world)
         warped = cv2.warpAffine(prob, pose, (frame.shape[1], frame.shape[0]))
         rgb = np.zeros((*frame.shape, 3), np.uint8)

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -5,20 +5,27 @@ RANSAC fit — the riskiest action in the pipeline — so their gates are pinned
 here with the failure modes that motivated them (see the osm-snap PR).
 """
 
+import dataclasses
+
 import numpy as np
 
+from mapsnap import osm_snap_experiment
 from mapsnap.edge_join_experiment import PageUnit
+from mapsnap.feature_index import FeatureIndex
 from mapsnap.osm_snap_experiment import (
     SNAP_LOG_BEGIN,
     SNAP_LOG_END,
+    VolumeContext,
     append_snap_logs,
     arbitrate_challenge,
     candidates_record_fresh,
     canonicalize_refine_keys,
+    init_worker,
     refine_adopt_set,
     refine_adoption,
     refine_eligible_features,
     refine_rule_outcome,
+    snap_one_page,
 )
 
 # A page-local degree scale of ~0.6 m/px at the test latitude.
@@ -250,6 +257,42 @@ def test_candidates_record_fresh_tracks_fit_changes():
             {**base, "status": status}, make_unit("fitted"), 111
         )
     assert candidates_record_fresh({**base, "status": "ok"}, make_unit("fitted"), 111)
+
+
+def test_init_worker_indexes_pages_and_panels(monkeypatch, tmp_path):
+    """snap_one_page must reach panels too, and never rebuild a context it was given."""
+    panel = dataclasses.replace(make_unit("nofit"), stem="p1__1")
+    context = VolumeContext(
+        volume=tmp_path,
+        units=[make_unit("fitted")],
+        panel_units=[panel],
+        features=[],
+        feature_index=FeatureIndex([]),
+        locator=None,
+        volume_m_per_px=0.6,
+        adjacency={},
+        region_centroids={},
+        filter_params={},
+        radius_m=150.0,
+        radius_source="calibrated",
+        median_theta_deg=None,
+    )
+
+    def fail(_volume):
+        raise AssertionError("a supplied context must not be rebuilt")
+
+    monkeypatch.setattr(osm_snap_experiment, "load_volume_context", fail)
+    init_worker(tmp_path, context)
+    assert set(osm_snap_experiment.worker_state["units"]) == {"p1", "p1__1"}
+
+    seen = []
+    monkeypatch.setattr(
+        osm_snap_experiment,
+        "page_record",
+        lambda vctx, unit: seen.append(unit.stem) or {"target": unit.stem},
+    )
+    assert snap_one_page("p1__1") == ("p1__1", {"target": "p1__1"})
+    assert seen == ["p1__1"]
 
 
 def test_append_snap_logs_is_idempotent(tmp_path):

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -24,8 +24,10 @@ from mapsnap.osm_snap import (
     affine_theta_deg,
     calibrated_radius_m,
     cluster_rotation,
+    confident_theta_deg,
     dedupe_thetas,
     frame_around,
+    frame_thetas,
     label_osm_rotations,
     merge_candidates,
     name_alignment,
@@ -158,6 +160,75 @@ def test_dedupe_thetas_keeps_first_of_near_duplicates() -> None:
         "label-osm-mod180",
         "mask-mod90",
     ]
+
+
+def test_confident_theta_needs_agreeing_label_pairs() -> None:
+    def exact(theta: float) -> RotationPrior:
+        return RotationPrior(theta, 4.0, "label-pair-exact")
+
+    # A lone pair is a hypothesis, not corroboration.
+    assert confident_theta_deg([exact(20.0)]) is None
+    # Two pairs that agree pin the rotation.
+    assert confident_theta_deg([exact(20.0), exact(23.0)]) == 20.0
+    # One dissenting pair means the matcher still has to arbitrate.
+    assert confident_theta_deg([exact(20.0), exact(23.0), exact(-60.0)]) is None
+    # Other rungs never confer confidence, however many agree.
+    assert (
+        confident_theta_deg(
+            [
+                RotationPrior(20.0, 6.0, "ransac-neighbor"),
+                RotationPrior(20.5, 12.0, "adjacency-keymap"),
+                RotationPrior(20.0, 4.0, "label-osm-mod180"),
+            ]
+        )
+        is None
+    )
+    # Agreement is measured mod 360: a pair reading -179 and one reading 179
+    # are 2 degrees apart, not 358.
+    assert confident_theta_deg([exact(179.0), exact(-179.0)]) == 179.0
+
+
+def test_frame_thetas_prunes_only_under_confidence() -> None:
+    page, _, _ = make_world_and_page(25.0)
+    frame = frame_around((LON0, LAT0), half_m=1200.0)
+    osm_prob, valid, _ = osm_rasters(frame, grid_index())
+    params = MatchParams(mask_min_area=200)
+
+    def context(priors: list[RotationPrior]) -> PageContext:
+        return PageContext(
+            stem="p1",
+            number=1,
+            width=300,
+            height=420,
+            prob=page,
+            search_centers=[(LON0, LAT0)],
+            radius_m=300.0,
+            rotation_priors=priors,
+            scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
+        )
+
+    agreeing = [
+        RotationPrior(25.0, 4.0, "label-pair-exact"),
+        RotationPrior(26.0, 4.0, "label-pair-exact"),
+        RotationPrior(-70.0, 12.0, "adjacency-keymap"),
+    ]
+    ctx = context(agreeing)
+    pruned = frame_thetas(ctx, confident_theta_deg(agreeing), (osm_prob, valid), params)
+    assert [p.source for p in pruned] == ["label-pair-exact"]
+
+    # The same ladder with the pairs disagreeing keeps everything and appends
+    # the mask sweep.
+    disagreeing = [
+        RotationPrior(25.0, 4.0, "label-pair-exact"),
+        RotationPrior(-40.0, 4.0, "label-pair-exact"),
+        RotationPrior(-70.0, 12.0, "adjacency-keymap"),
+    ]
+    ctx = context(disagreeing)
+    full = frame_thetas(
+        ctx, confident_theta_deg(disagreeing), (osm_prob, valid), params
+    )
+    assert len(full) > len(pruned)
+    assert "mask-mod90" in {p.source for p in full}
 
 
 def test_cluster_rotation_rejects_outlier() -> None:

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -328,6 +328,44 @@ def affine_corner_error_m(a: np.ndarray, b: np.ndarray, size: tuple[int, int]) -
     return worst
 
 
+def test_page_context_memos_match_a_fresh_computation() -> None:
+    """The per-page memos must answer exactly what recomputing would."""
+    from mapsnap.edge_join import dominant_orientation_deg, skeleton_points
+
+    page, _, _ = make_world_and_page(25.0)
+    ctx = PageContext(
+        stem="p1",
+        number=1,
+        width=300,
+        height=420,
+        prob=page,
+        search_centers=[(LON0, LAT0)],
+        radius_m=300.0,
+        rotation_priors=[],
+        scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
+    )
+    params = MatchParams(mask_min_area=200)
+    expected = skeleton_points(page, params.mask_threshold, params.mask_min_area)
+    assert np.array_equal(ctx.road_points(params), expected)
+    assert ctx.road_points(params) is ctx.road_points(params)  # memoized
+    # A different mask setting is a different question, not a cache hit.
+    coarse = MatchParams(mask_min_area=5000)
+    assert ctx.road_points(coarse) is not ctx.road_points(params)
+    assert ctx.road_orientation_deg() == dominant_orientation_deg(page)
+
+
+def test_rotation_candidates_target_dir_matches_measuring_it() -> None:
+    from mapsnap.edge_join import dominant_orientation_deg, rotation_candidates
+
+    page, _, _ = make_world_and_page(25.0)
+    frame = frame_around((LON0, LAT0), half_m=1200.0)
+    world_prob, _, _ = osm_rasters(frame, grid_index())
+    supplied = rotation_candidates(
+        world_prob, page, target_dir=dominant_orientation_deg(page)
+    )
+    assert supplied == rotation_candidates(world_prob, page)
+
+
 def test_snap_recovers_synthetic_pose() -> None:
     theta_true = 25.0
     page, truth_affine, center = make_world_and_page(theta_true)

--- a/mapsnap/osm_snap_test.py
+++ b/mapsnap/osm_snap_test.py
@@ -12,6 +12,7 @@ import cv2
 import numpy as np
 
 from mapsnap.edge_join import MatchParams
+from mapsnap.feature_index import FeatureIndex
 from mapsnap.georef_from_labels import LabelFeature
 from mapsnap.osm_snap import (
     CHAMFER_CLAMP_M,
@@ -78,6 +79,11 @@ def grid_features() -> list[dict]:
     return features
 
 
+def grid_index() -> FeatureIndex:
+    """The synthetic grid, spatially indexed as the matcher consumes it."""
+    return FeatureIndex(grid_features())
+
+
 def extract_page(
     world: np.ndarray, pose: np.ndarray, size: tuple[int, int]
 ) -> np.ndarray:
@@ -110,7 +116,9 @@ def test_frame_roundtrip() -> None:
 
 def test_osm_raster_geometry() -> None:
     frame = frame_around((LON0, LAT0), half_m=200.0)
-    prob, valid, skeleton = osm_rasters(frame, [street("A", [(0, -300), (0, 300)])])
+    prob, valid, skeleton = osm_rasters(
+        frame, FeatureIndex([street("A", [(0, -300), (0, 300)])])
+    )
     assert valid.all()
     rows, cols = frame.shape
     center_col = cols // 2
@@ -292,7 +300,7 @@ def make_world_and_page(
 ) -> tuple[np.ndarray, np.ndarray, tuple[float, float]]:
     """(page P(road), truth page->lonlat affine, page-center lonlat)."""
     world_frame = frame_around((LON0, LAT0), half_m=1200.0)
-    world_prob, _, _ = osm_rasters(world_frame, grid_features())
+    world_prob, _, _ = osm_rasters(world_frame, grid_index())
     width, height = page_size
     center_m = (20.0, 30.0)  # metres east/north of the origin
     center_px = world_frame.lonlat_to_raster(*lonlat(*center_m))
@@ -341,7 +349,7 @@ def test_snap_recovers_synthetic_pose() -> None:
     params = MatchParams(
         min_overlap_m2=30_000.0, max_overlap_frac=1.0, top_k=8, mask_min_area=200
     )
-    candidates = snap_page(ctx, grid_features(), params)
+    candidates = snap_page(ctx, grid_index(), params)
     assert candidates, "the matcher must produce candidates"
     best = candidates[0]
     assert best.plausible
@@ -369,7 +377,7 @@ def test_snap_flipped_prior_recovered_by_mask_sweep() -> None:
     params = MatchParams(
         min_overlap_m2=30_000.0, max_overlap_frac=1.0, top_k=8, mask_min_area=200
     )
-    candidates = snap_page(ctx, grid_features(), params)
+    candidates = snap_page(ctx, grid_index(), params)
     assert candidates
     best = candidates[0]
     assert abs(wrap_deg(best.theta_deg - theta_true)) < 1.5
@@ -391,10 +399,10 @@ def test_evaluate_pose_truth_beats_shifted() -> None:
         rotation_priors=[],
         scale_priors=[ScalePrior(1.0, 0.05, "volume-median")],
     )
-    good = evaluate_pose(ctx, grid_features(), truth_affine)
+    good = evaluate_pose(ctx, grid_index(), truth_affine)
     shifted_affine = truth_affine.copy()
     shifted_affine[0, 2] += 60.0 / KX  # slide 60 m east
-    bad = evaluate_pose(ctx, grid_features(), shifted_affine)
+    bad = evaluate_pose(ctx, grid_index(), shifted_affine)
     assert good is not None and bad is not None
     assert good["verification"] > bad["verification"]
     assert good["inlier_frac"] > bad["inlier_frac"]

--- a/mapsnap/snap.py
+++ b/mapsnap/snap.py
@@ -59,6 +59,18 @@ def main() -> None:
         action="store_true",
         help="Ignore cached candidates and re-match every target page.",
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Number of worker processes for the per-page matching pass "
+            "(default: %(default)s, sequential). Matching is CPU-bound and "
+            "independent per page; each worker rebuilds the volume context, "
+            "so expect about a gigabyte of memory apiece on a large volume."
+        ),
+    )
     args = parser.parse_args()
 
     # The production gates are frozen alongside the selection code (see the
@@ -81,6 +93,7 @@ def main() -> None:
         limit=None,
         recompute=args.recompute,
         vis=False,
+        num_workers=args.num_workers,
     )
     cmd_select(
         args.dir,


### PR DESCRIPTION
`mapsnap snap` cost about 2.5 hours over Los Angeles — far more than OCR or georef — and issue #155 set a target of roughly 20 s/page down to 2–4 s/page. This is the profiling and the five changes that came out of it, plus the ideas the measurements rejected.

**The target was not met, and the profiling says why.** Ideas 1–3 in the issue were expected to be pure optimizations worth 2–3×. Two of them were, and are byte-identical; the third is destructive as specified and its safe form has a ~1.4% ceiling on LA. What remains is chamfer refinement, which is irreducible per candidate — so the last commit parallelizes instead (idea 4). Idea 5 (batched GPU FFT) was not attempted.

## Where the time actually went

Profiling six LA pages against a 201,645-feature centerline file — 91 s under cProfile, 67.8 s unprofiled:

| | share |
|---|---|
| chamfer refinement (`least_squares` + residuals) | 41.7 s |
| key map's per-page vocabulary restriction | 15.6 s |
| OSM rasterization | 12.7 s |
| FFT correlation | 9.1 s |

`segment_point_distance_m` alone was called 8,893,981 times.

**A caveat on that sample, found later.** Those six pages are the *first* three fitted and three rescue pages, which are the cheap ones. A full 112-target LA pass measured unpruned pages at **92.5 s/page**, and the whole volume at ~100 minutes in the verification harness. Every ratio below is measured on matched page sets and holds; the absolute "s/page" figures from the six-page benchmark do not generalize to the volume.

## What shipped

**Cull centerlines with an STRtree, not a linear scan.** Two separate passes walked all 201k features — once per search frame, once per page for the key map's vocabulary restriction. A shared `FeatureIndex` answers both as a pure *cull*: every query returns a superset of what the caller's own unchanged exact test would accept, in feature order, so callers keep their test and their answers. Index build is 0.33 s for the whole LA file. `osm_rasters` over the benchmark frames went **8.51 s → 0.02 s**, and those six pages went **11.3 → 8.3 s/page** with byte-identical output. Because `restricted_features` also gates `ocr` and `georef`, those passes get it for free. Correctness checked against brute force on 19 DC pages (0 mismatches, identical objects in identical order) plus `rectangle_features` (an identical 8,876-feature list).

**Derive each page's skeleton and orientation once.** A Zhang thinning pass ran in both `evaluate_pose` and `snap_page`, and the dominant-orientation Sobel pass ran once per search center. `PageContext` memoizes both: **9 → 6 thinnings and 26 → 13 orientation passes** on the benchmark, byte-identical. The wall-clock effect (~1%) is inside this machine's noise — the evidence is the work-unit counts, not the clock.

**Prune the theta ladder only when the label pairs are unanimous.** See the rejected-ideas section for why the issue's version is not safe. What ships requires **≥2 `label-pair-exact` rungs agreeing within 8°**, then collapses the ladder to a 12° window and skips the mask-mod-90 sweep. On the pages it fires, the matcher does **2.5× less work — 54 → 22 NCC passes and 432 → 176 chamfer refinements** over six matched LA pages, with rank-1 rmse identical on all six (same-page wall clock 16.0 → 11.4 s, noisy at this size).

Verified on two full volumes. DC: 56 of 143 pages pruned, 54 of 56 keep an identical rank-1 rmse, and re-running the production selection leaves the truth-graded totals unchanged at **85 placements / 84 ≤25 ft / 0 ≥200 ft** (p156 improves 17.6 → 10.6 ft, p210 slips 12.2 → 12.7 ft, one more page is accepted). LA: 48 of 112 pruned, 41 good→good, 3 disaster→disaster, no regressions.

**The volume-level ceiling is low and volume-dependent — ~14% on DC, ~1.4% on LA.** The pages it fires on are also the cheap ones: LA's 48 pruned pages were 85 s of a 6008 s run. A page is expensive precisely *because* its priors disagree, and that is exactly the page this gate refuses to prune.

**Halve the cost of the chamfer distance sampler.** `edge_join.sample()` is the matcher's hottest loop — `least_squares` evaluates the residuals ~115 times per candidate, ~200 candidates per page, 145,589 calls over the benchmark and ~18% of the profile. Gathering the four bilinear corners from a flat view off one precomputed offset, instead of four 2D fancy-index gathers, takes it **78 → 45 µs** at 2,600 points. The expression preserves operand order and association, so it is bit-for-bit identical by construction — confirmed end to end by 63 LA pages re-matching their cached records byte-for-byte. End-to-end this bounds at ~7–8%, which is **inferred from the profile share, not measured**: the heavy-page A/B timed out at 10 minutes for three pages.

**Fit pages in parallel behind `--num-workers`** (default 1, which spawns no pool at all), on the same pattern `georef_from_labels` uses: module-level `worker_state`, an `init_worker` that fills it, and a `snap_one_page` that runs identically in a pool worker or the main process. One deliberate deviation — georef pickles its feature list to every worker through `initargs`; snap workers receive only the volume path and rebuild the context themselves, since re-reading the file costs ~1 s against far more to pickle 201k features. DC 8 pages: **37.7 s → 18.8 s at 4 workers (2.01×)**, records identical 8/8. `mapsnap fit` now forwards the flag to `snap` as well as `georef`, since snap is the slower of the two passes.

## What was tried and rejected

**Idea 1 as specified in the issue — harmful, measured.** The proposal was to collapse the ladder whenever a confident directed prior exists. Re-running the 31 pages that would change: **30 got worse and 28 lost a ≤25 ft placement** (Grand Rapids p810 6.3 → 2051 ft, KC p523 7.4 → 5717 ft, DC p195 4.2 → 1078 ft). The reason is that a `label-pair-exact` rung is *one pair* of OCR'd labels' reading of the rotation, emitted once per pair — a page with four usable labels emits up to six, they frequently disagree, and pruning to the first is arbitrary. Unanimity across pairs is what turns the rung into corroboration.

**Idea 2 as specified — unsound, not a measurement question.** Sharing the OSM raster between `evaluate_pose` and `snap_page` cannot work: their frames can never coincide (the search frame spans `radius_m` + the page diagonal, the incumbent's only the diagonal), and widening the incumbent's frame shifts the raster lattice under it, moving the very chamfer and correlation scores the arbitration and refinement gates read. After the STRtree cull a frame costs ~1 ms, so there was nothing left there to win anyway. What *was* genuinely duplicated — the page skeleton and orientation — is what that commit fixes instead.

**`transformed()`, the other half of the chamfer inner loop.** At 32 µs it is larger than `sample()` after the rewrite. Explicit-column and split-column formulations are 2.5–4.5× faster but **not bit-identical** — BLAS uses FMA for the 2-element dot product and numpy does not. `np.dot`, preallocated `out=`, and a homogeneous `(N,3)@(3,2)` form are all bit-identical but no faster. Left alone.

**Pinning BLAS to one thread per worker.** Expected to help, since 4 workers only reached 2.01× on a 4-P-core machine. Measured **1.82×** — no better, so the machinery was left out. The limiter is that the sequential baseline is already partly threaded through numpy and OpenCV.

**Cascading the chamfer refinement — refuted, measured.** `refine_and_rank` refines *every* one of a page's ~200 candidates before sorting, so refining only the best N by the NCC score the matcher has already computed would cut the dominant cost — and unlike the theta gate, cut it on the expensive pages rather than the cheap ones. The cost premise holds. Instrumenting `refine_and_rank` over 109 pages in three volumes puts refinement at **63–70% of `snap_page`'s wall clock**, with the NCC search at 22–28%. The ranking premise does not. The candidate that ends up rank-1 sits at a median pre-refinement NCC rank of 0–1, but a p90 of 9 on LA, 11 on Kansas City and 32 on Champaign, with maxima of **175, 37 and 63**. There is no shallow cutoff: N=32 still drops the winner on 3 of 60 LA pages and 3 of 24 Champaign pages, to save roughly a quarter of the wall clock. That is the same trade idea 1 was rejected for. Worth recording how the estimate went wrong — a first pass over the cached records suggested the winner was nearly always in the top 8, but `candidates.jsonl` stores only the 8 *survivors*, not the ~200 refined, and that understated the tail by an order of magnitude.

**A cheap-chamfer prescreen instead of NCC — a far better ranker, but its own cost eats the win.** Separating aliased peaks from the true lock is exactly what refinement does, so the prescreen should use the same objective, just cheaper: `chamfer_refine` caps at `max_points=3000`, and a 400-point pass optimizes the identical function. As a ranker it is dramatically better — the winner's p90 rank falls from 9 to **1** on LA (max 175 → 47) and from 32 to **2** on Champaign (max 63 → 4). But the cheap pass costs **27% (LA) / 20% (Champaign) of the full refinement**, not the ~13% the point ratio implies, because `least_squares` carries real per-call overhead that does not scale down with the point count. The best honest setting — full-refining the top 16 on LA — comes to 55% of today's refinement work, about a **31% wall-clock saving, and still loses the winner on 1 of 60 pages**; Champaign's top 8 keeps 24 of 24 for ~42%. Parked rather than pursued: it is a pure speed play carrying a nonzero score risk, and its safety claim would have to come from a truth-graded re-run, not from rank preservation.

## Caveats worth knowing

- **`--num-workers > 1` breaks byte-comparison of `candidates.jsonl`.** `name.hits[].text` is nondeterministic across processes: `canonical_street_matches` iterates a `set` and `sorted(key=len)` cannot break the tie between equal-length variants ("THIRD STREET NORTHWEST" / "SOUTHWEST"). It flips with `PYTHONHASHSEED`. Every score is identical; only that diagnostic field moves. This is pre-existing, and it cost real debugging time here.
- **Budget roughly a gigabyte per worker** on a large volume. Extrapolated from a 984 MB single-process RSS, not a controlled per-worker measurement.
- **`candidates.jsonl` is an incremental cache**, so a volume's file can mix code versions and calibrated radii. DC's baseline and one LA record were stale; re-run a control at the base commit (a `git worktree` plus a symlink to `data/` works) before calling a diff a regression.
- **The theta gate deviates from the issue's "no observable diff" constraint by design.** It changes the candidate list on 39–43% of pages; it is verified truth-neutral, not byte-neutral. The other three algorithmic commits are byte-identical.

772 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

