### PR TITLE
Streets-as-constraints georeferencer (issue #168): +1.5 aggregate score

### DIFF
--- a/mapsnap/keymap/align_page_region.py
+++ b/mapsnap/keymap/align_page_region.py
@@ -80,7 +80,7 @@ from mapsnap.keymap.locate import (
     page_number,
 )
 from mapsnap.keymap.page_regions import clean_cluster_mask
-from mapsnap.streets import Block, build_block_index
+from mapsnap.streets import Block, build_block_index, street_name_family
 from mapsnap.utils import FEET_PER_METER, haversine_m
 
 Point = tuple[float, float]
@@ -525,21 +525,35 @@ StreetPose = tuple[
     float, float, float, float
 ]  # (east_m, north_m, psi_deg, log_px_per_m)
 
+
 # Street label centers sit tens of metres off their centerlines (the text box is not on the
 # street line), so the point-to-line *position* is only a weak constraint — deliberately loose
 # here. The label *angle*, by contrast, tracks the street bearing to ~1 degree and is what
 # reliably fixes rotation (including region rotation flips), so it is kept tight.
-SIGMA_LINE_M = 60.0  # street point-to-line distance (loose: label centers are offset)
-SIGMA_ANGLE_DEG = (
-    3.0  # street text-angle vs centerline bearing (tight: the reliable signal)
-)
-SIGMA_CONTAIN_M = 9.144  # 30 ft: region vertex outside the page frame
-SIGMA_CENTROID_M = 152.4  # 500 ft: weak page-center vs region-centroid spring
-SIGMA_LOG_SCALE = 0.05  # tight scale prior: the volume-median scale is accurate (~1%)
-SIGMA_STAMP_M = (
-    6.096  # 20 ft: printed neighbor-number stamp outside its neighbor's region
-)
-STAMP_SLACK_M = 4.572  # 15 ft of free play before a stamp is penalized
+@dataclass(frozen=True)
+class PoseSigmas:
+    """Residual normalizers for :func:`pose_residuals`, one per factor family.
+
+    The defaults are the region-align values (salvaged from the earlier ``factor_place``
+    experiment); other callers vary them — a fit driven by streets alone wants a weaker
+    scale prior, since two parallel streets determine scale from their spacing.
+    """
+
+    line_m: float = (
+        60.0  # street point-to-line distance (loose: label centers are offset)
+    )
+    angle_deg: float = (
+        3.0  # street text-angle vs centerline bearing (the reliable signal)
+    )
+    contain_m: float = 9.144  # 30 ft: region vertex outside the page frame
+    centroid_m: float = 152.4  # 500 ft: weak page-center vs region-centroid spring
+    log_scale: float = 0.05  # scale prior; the volume-median scale is accurate to ~1%
+    stamp_m: float = 6.096  # 20 ft: neighbor-number stamp outside its neighbor's region
+    stamp_slack_m: float = 4.572  # 15 ft of free play before a stamp is penalized
+
+
+DEFAULT_SIGMAS = PoseSigmas()
+
 
 # One matchable street label: page-pixel center, long-axis angle, canonical name, and the
 # street's centerline segments as (start, end) arrays in the local East/North metre frame.
@@ -649,23 +663,88 @@ def street_matches(
         features: list[LabelFeature] = prepare_label_features(
             str(streets_path), block_index, label_size, **filter_params
         )
-    scale_x = size[0] / label_size[0]
-    scale_y = size[1] / label_size[1]
-    # A label read as several distinct streets (VAN BRUNT vs VAN DYKE at one box) is ambiguous:
-    # one candidate is wrong and would drag the fit, so drop it from position constraints (this is
-    # factor_place's unambiguous-only rule). Same-name repeats along a street are kept.
-    names_per_center: dict[Point, set[str]] = {}
+    return constraints_from_features(
+        features,
+        block_index,
+        origin=origin,
+        label_size=label_size,
+        working_size=size,
+    )
+
+
+def constraints_from_features(
+    features: list[LabelFeature],
+    block_index: dict[str, list[Block]],
+    *,
+    origin: Point,
+    label_size: tuple[int, int],
+    working_size: tuple[int, int],
+    merge_families: bool = False,
+    locality: tuple[Point, float] | None = None,
+) -> list[StreetSegments]:
+    """Pair accepted label features with their streets' centerline segments (metres).
+
+    A label read as several distinct streets (VAN BRUNT vs VAN DYKE at one box) is
+    ambiguous: one candidate is wrong and would drag the fit, so it is dropped (this is
+    factor_place's unambiguous-only rule). Same-name repeats along a street are kept.
+
+    ``merge_families`` softens that rule where the candidates are only *variants* of one
+    street — "NORTH/SOUTH/BONNIE BEACH PLACE" (see :func:`street_name_family`) — by
+    unioning their segments into a single constraint instead of discarding the label.
+    Without it a volume whose streets carry direction prefixes loses most of its labels.
+
+    ``locality`` is an optional ``(center, radius_m)`` filter on the *segments*: a merged
+    family can span kilometres, and a distant branch would let the label snap to whichever
+    branch the current pose happens to favour. Keeping only segments near the page's prior
+    location bounds that to the neighborhood the page actually sits in.
+    """
+    scale_x = working_size[0] / label_size[0]
+    scale_y = working_size[1] / label_size[1]
+    names_per_center: dict[Point, list[str]] = {}
     for feature in features:
-        names_per_center.setdefault(feature.center, set()).add(feature.text)
+        names = names_per_center.setdefault(feature.center, [])
+        if feature.text not in names:
+            names.append(feature.text)
+
+    def soup_for(names: list[str]) -> tuple[np.ndarray, np.ndarray]:
+        """Union of the named streets' segments, optionally trimmed to the locality."""
+        starts: list[np.ndarray] = []
+        ends: list[np.ndarray] = []
+        for name in names:
+            blocks = block_index.get(name)
+            if not blocks:
+                continue
+            block_starts, block_ends = street_soup_metres(blocks, origin)
+            if len(block_starts):
+                starts.append(block_starts)
+                ends.append(block_ends)
+        if not starts:
+            return np.zeros((0, 2)), np.zeros((0, 2))
+        all_starts, all_ends = np.vstack(starts), np.vstack(ends)
+        if locality is not None:
+            center, radius_m = locality
+            anchor = np.array(center)
+            midpoints = (all_starts + all_ends) / 2
+            near = np.linalg.norm(midpoints - anchor, axis=1) <= radius_m
+            all_starts, all_ends = all_starts[near], all_ends[near]
+        return all_starts, all_ends
+
     matches: list[StreetSegments] = []
+    seen_centers: set[Point] = set()
     for feature in features:
-        blocks = block_index.get(feature.text)
-        if not blocks or len(names_per_center[feature.center]) > 1:
+        if feature.center in seen_centers:
             continue
-        starts, ends = street_soup_metres(blocks, origin)
-        if len(starts):
-            center = (feature.center[0] * scale_x, feature.center[1] * scale_y)
-            matches.append((center, feature.dir_pix, feature.text, starts, ends))
+        names = names_per_center[feature.center]
+        if len(names) > 1 and (
+            not merge_families or len({street_name_family(n) for n in names}) > 1
+        ):
+            continue
+        starts, ends = soup_for(names)
+        if not len(starts):
+            continue
+        seen_centers.add(feature.center)
+        center = (feature.center[0] * scale_x, feature.center[1] * scale_y)
+        matches.append((center, feature.dir_pix, names[0], starts, ends))
     return matches
 
 
@@ -740,6 +819,7 @@ def pose_residuals(
     region_vertices: np.ndarray,
     size: tuple[int, int],
     prior_log_scale: float,
+    sigmas: PoseSigmas = DEFAULT_SIGMAS,
 ) -> np.ndarray:
     """Normalized residual vector for the 4-DOF street + stamp + region + scale-prior factors."""
     east, north, psi, log_scale = pose
@@ -751,10 +831,10 @@ def pose_residuals(
     for center_px, dir_pix, _name, starts, ends in matches:
         world = pose_world_of(pose, center_px, size)
         distance, bearing = point_to_segments(world, starts, ends)
-        residuals.append(distance / SIGMA_LINE_M)
+        residuals.append(distance / sigmas.line_m)
         text_bearing = (psi + 90 + math.degrees(dir_pix)) % 180
         residuals.append(
-            angle_difference_mod180(text_bearing, bearing) / SIGMA_ANGLE_DEG
+            angle_difference_mod180(text_bearing, bearing) / sigmas.angle_deg
         )
     for pixel, neighbor_region in stamps:
         point = ShapelyPoint(pose_world_of(pose, pixel, size))
@@ -763,16 +843,16 @@ def pose_residuals(
             if neighbor_region.contains(point)
             else neighbor_region.boundary.distance(point)
         )
-        residuals.append(max(0.0, outside - STAMP_SLACK_M) / SIGMA_STAMP_M)
+        residuals.append(max(0.0, outside - sigmas.stamp_slack_m) / sigmas.stamp_m)
     for vertex in region_vertices:
         relative = vertex - center
         along = max(0.0, abs(float(relative @ up)) - half_height)
         across = max(0.0, abs(float(relative @ right)) - half_width)
-        residuals.append(math.hypot(along, across) / SIGMA_CONTAIN_M)
+        residuals.append(math.hypot(along, across) / sigmas.contain_m)
     centroid = region_vertices.mean(axis=0)
-    residuals.append((east - centroid[0]) / SIGMA_CENTROID_M)
-    residuals.append((north - centroid[1]) / SIGMA_CENTROID_M)
-    residuals.append((log_scale - prior_log_scale) / SIGMA_LOG_SCALE)
+    residuals.append((east - centroid[0]) / sigmas.centroid_m)
+    residuals.append((north - centroid[1]) / sigmas.centroid_m)
+    residuals.append((log_scale - prior_log_scale) / sigmas.log_scale)
     return np.array(residuals)
 
 
@@ -809,40 +889,68 @@ def refine_pose_with_streets(
         math.log(scale_px_per_m) if scale_px_per_m is not None else initial[3]
     )
     initial = (initial[0], initial[1], initial[2], prior_log_scale)
+    best_pose = initial
+    best_cost = float("inf")
+    for delta_psi in (0.0, 180.0):
+        start = (initial[0], initial[1], initial[2] + delta_psi, initial[3])
+        solved = solve_pose(
+            start,
+            matches,
+            stamps,
+            region_vertices=region_vertices,
+            size=size,
+            prior_log_scale=prior_log_scale,
+        )
+        if solved is not None and solved[1] < best_cost:
+            best_pose, best_cost = solved[0], solved[1]
+    return best_pose
+
+
+def solve_pose(
+    initial: StreetPose,
+    matches: list[StreetSegments],
+    stamps: list[Stamp],
+    *,
+    region_vertices: np.ndarray,
+    size: tuple[int, int],
+    prior_log_scale: float,
+    sigmas: PoseSigmas = DEFAULT_SIGMAS,
+) -> tuple[StreetPose, float] | None:
+    """One robust least-squares solve from ``initial``; (pose, cost) or None if it fails.
+
+    The single-shot primitive behind :func:`refine_pose_with_streets` and the
+    streets-only solver: no bearing sweep, no re-snapping loop — callers that want
+    several starts call this once per start and keep the best cost.
+    """
     # Bound the log-scale to prior +/- log(4); an unbounded scale can run to overflow, giving
     # non-finite residuals that segfault the MINPACK core (this mirrors factor_place's bounds).
     lower = np.array([-np.inf, -np.inf, -np.inf, prior_log_scale - math.log(4)])
     upper = np.array([np.inf, np.inf, np.inf, prior_log_scale + math.log(4)])
-    best_pose = initial
-    best_cost = float("inf")
-    for delta_psi in (0.0, 180.0):
-        start = np.array([initial[0], initial[1], initial[2] + delta_psi, initial[3]])
-        try:
-            result = least_squares(
-                lambda pose: pose_residuals(
-                    (pose[0], pose[1], pose[2], pose[3]),
-                    matches,
-                    stamps,
-                    region_vertices=region_vertices,
-                    size=size,
-                    prior_log_scale=prior_log_scale,
-                ),
-                start,
-                loss="soft_l1",
-                f_scale=1.0,
-                bounds=(lower, upper),
-            )
-        except (ValueError, np.linalg.LinAlgError):
-            continue
-        if result.cost < best_cost:
-            best_cost = float(result.cost)
-            best_pose = (
-                float(result.x[0]),
-                float(result.x[1]),
-                float(result.x[2]),
-                float(result.x[3]),
-            )
-    return best_pose
+    try:
+        result = least_squares(
+            lambda pose: pose_residuals(
+                (pose[0], pose[1], pose[2], pose[3]),
+                matches,
+                stamps,
+                region_vertices=region_vertices,
+                size=size,
+                prior_log_scale=prior_log_scale,
+                sigmas=sigmas,
+            ),
+            np.array(initial),
+            loss="soft_l1",
+            f_scale=1.0,
+            bounds=(lower, upper),
+        )
+    except (ValueError, np.linalg.LinAlgError):
+        return None
+    pose = (
+        float(result.x[0]),
+        float(result.x[1]),
+        float(result.x[2]),
+        float(result.x[3]),
+    )
+    return pose, float(result.cost)
 
 
 def pose_corners_world(

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -50,8 +50,10 @@ def georef_path_to_page_key(path: str) -> str | None:
 
     Accepts filenames ending in '_p16s.georef.json', '_p16.georef.json',
     '_p16s.gcps.georef.json' (the '.gcps' infix is optional), or the
-    neighbor-fit / OSM-snap variants '_p16.georef-neighbor.json' and
-    '_p16.georef-osm.json'.
+    neighbor-fit / OSM-snap / street-constraint variants
+    '_p16.georef-neighbor.json', '_p16.georef-osm.json' and
+    '_p16.georef-streets.json'. A variant missing from this list is dropped
+    silently -- the glob matches the file but no page key comes out of it.
 
     Any letter page suffix is kept (Sanborn sheets run 'a', 'b', … past the
     directional 's'/'n'/'e'/'w'/'l'/'r' letters), not just a known few — a
@@ -60,7 +62,7 @@ def georef_path_to_page_key(path: str) -> str | None:
     still parse here; drop_redundant_skeletons raises on them rather than guess.
     """
     m = re.search(
-        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor|-osm)?\.json$",
+        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor|-osm|-streets)?\.json$",
         path,
         re.IGNORECASE,
     )

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -307,6 +307,10 @@ def test_georef_path_neighbor_variant():
 def test_georef_path_osm_variant():
     assert georef_path_to_page_key("data/vol/p147.georef-osm.json") == "p147"
     assert georef_path_to_page_key("data/vol/p4l__2.georef-osm.json") == "p4l__2"
+    # A variant absent from the pattern yields no page key, so the glob matches the
+    # file and the annotation silently omits the page -- worth a test per variant.
+    assert georef_path_to_page_key("data/vol/p147.georef-streets.json") == "p147"
+    assert georef_path_to_page_key("data/vol/p4l__2.georef-streets.json") == "p4l__2"
 
 
 def test_georef_path_other_variants_do_not_match():

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -62,7 +62,11 @@ class StreetGates:
     """Every tunable of the streets-only solver, in one sweepable place."""
 
     angle_gate_deg: float = 8.0  # inlier: |label bearing - street bearing| at the pose
-    position_gate_m: float = 80.0  # inlier: label center to street distance (G3)
+    # Inlier: label centre to street distance (G3). Below a downtown block: at 80 m
+    # Nashville's numbered-avenue grid let poses slide half a block and still agree
+    # with every street (five fits over 200 ft); at 50 m those vanish and no genuine
+    # fit is lost -- the inliers of every correct fit measured sit under 46 m.
+    position_gate_m: float = 50.0
     min_inliers: int = 3
     min_inlier_fraction: float = 0.6  # a right pose explains most of what the page says
     min_distinct_streets: int = 3  # two streets determine the pose with no redundancy

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -1,0 +1,537 @@
+"""Georeference a page from street labels as constraints, with no intersection GCPs.
+
+The RANSAC georeferencer needs two detected streets to *cross*, so it can anchor a
+control point. Many pages never produce one: their readable streets run mutually
+parallel, or the crossing falls off the sheet. But a street label still carries two
+usable facts on its own — the label sits on its street (position), and its long axis
+runs along that street (angle). Two distinct parallel streets fix rotation and, from
+their spacing, scale; one crossing street completes the pose. No intersections needed.
+
+This module solves that pose (issue #168). It runs only where the page already has a
+coarse location prior, restricts the street vocabulary to that neighborhood, and is
+built around the fact that **a quarter to a half of the assembled constraints are
+wrong** — renamed streets that match elsewhere in the radius, streets rerouted since
+the survey, and near-square text boxes whose long axis is meaningless. Robustness is
+therefore structural, not incidental:
+
+  * consensus over constraint pairs proposes poses; outliers never enter the fit;
+  * hard angle/position gates decide inliers, tighter than RANSAC's 30 degrees;
+  * a leave-one-out check rejects a pose that rests on a single constraint.
+
+Anti-drift guards (an early version of this idea, in a predecessor repo, drifted by
+re-snapping onto streets that end sooner in OSM than they did on the Sanborn sheet,
+rotating the fit until it was worthless):
+
+  G1  constraints are assembled once, from the prior, and never re-matched at a
+      refined pose — the loop that produced the original drift does not exist here.
+  G2  no endpoint extrapolation: snapping is clipped to the segments that exist, so a
+      street truncated in OSM produces a large residual rather than a plausible one.
+  G3  that residual then fails the hard position gate and the constraint is dropped.
+  G4  exactly one least-squares polish, on a frozen inlier set, and the pose is
+      rejected outright if the polish travels far from the consensus proposal.
+  G5  the scale prior is soft but bounded, so contaminated positions cannot trade
+      themselves into a plausible-looking rescale.
+  G6  rotation seeds come from street-vs-OSM evidence, never a blind sweep: at four
+      to six constraints a sweep finds self-consistent poses tens of degrees from
+      truth (New Orleans 1896 p181 has one at ~30 degrees).
+"""
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from mapsnap.georef_from_labels import LabelFeature
+from mapsnap.keymap.align_page_region import (
+    PoseSigmas,
+    StreetPose,
+    StreetSegments,
+    angle_difference_mod180,
+    constraints_from_features,
+    point_to_segments,
+    pose_world_of,
+    solve_pose,
+)
+from mapsnap.streets import Block
+
+Point = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class StreetGates:
+    """Every tunable of the streets-only solver, in one sweepable place."""
+
+    angle_gate_deg: float = 8.0  # inlier: |label bearing - street bearing| at the pose
+    position_gate_m: float = 80.0  # inlier: label center to street distance (G3)
+    min_inliers: int = 3
+    bearing_diversity_deg: float = 30.0  # two inlier bearings must differ by this much
+    min_aspect: float = 2.0  # near-square boxes carry no usable long axis
+    parallel_tolerance_deg: float = 10.0  # bearings this close count as parallel
+    min_parallel_spacing_m: float = 20.0  # closer than this, spacing cannot fix scale
+    polish_max_move_m: float = 60.0  # G4: polish travel from the consensus proposal
+    polish_max_rot_deg: float = 3.0
+    loo_max_shift_m: float = 30.0  # leave-one-out stability
+    loo_max_rot_deg: float = 2.0
+    radius_slack_m: float = 60.0  # converged center vs the prior location
+    sigma_line_m: float = 60.0  # positions stay loose: label centers sit off the line
+    sigma_angle_deg: float = 3.0  # angles are the reliable signal
+    sigma_log_scale: float = 0.05  # G5: soft scale prior (bounded in solve_pose)
+    sigma_centroid_m: float = 400.0  # the location prior is a neighborhood, not a fix
+
+
+DEFAULT_GATES = StreetGates()
+
+
+@dataclass
+class PriorLocation:
+    """A page's coarse location before any fitting, and where it came from."""
+
+    center: Point  # (lon, lat) frame origin and centroid-spring anchor
+    radius_m: float
+    source: str  # "keymap-exact" | "keymap-family" | "fit-center" | "truth-centroid"
+    centers: list[Point] = field(default_factory=list)  # all centers, for the vocab
+
+    def __post_init__(self) -> None:
+        if not self.centers:
+            self.centers = [self.center]
+
+
+@dataclass
+class ConstraintDiag:
+    """Per-constraint diagnostics at the solved pose (or at drop time)."""
+
+    name: str
+    center_px: tuple[float, float]
+    position_m: float | None = None
+    angle_deg: float | None = None
+    inlier: bool = False
+    dropped: str = ""
+
+
+@dataclass
+class StreetSolveResult:
+    """A streets-only fit, or an abstention with the reason it abstained."""
+
+    pose: StreetPose | None = None
+    abstain: str = ""
+    psi_source: str = ""
+    n_constraints: int = 0
+    n_inliers: int = 0
+    bearing_spread_deg: float = 0.0
+    polish_move_m: float = 0.0
+    polish_rot_deg: float = 0.0
+    loo_max_shift_m: float = 0.0
+    loo_max_rot_deg: float = 0.0
+    scale_source: str = ""
+    diagnostics: list[ConstraintDiag] = field(default_factory=list)
+
+
+def psi_from_theta(theta_deg: float) -> float:
+    """Page-up bearing (StreetPose psi) for an osm_snap rotation prior's theta.
+
+    A pixel delta at page angle ``a`` maps, under a pose with bearing psi, to a world
+    direction whose y-down raster angle is ``a + psi``; osm_snap defines
+    ``theta = page_angle - raster_angle``, so psi is its negation.
+    """
+    return -theta_deg
+
+
+def distinct_lines(
+    starts: np.ndarray,
+    ends: np.ndarray,
+    *,
+    bearing_tolerance_deg: float = 5.0,
+    offset_tolerance_m: float = 15.0,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Collapse a segment soup to the distinct straight lines it lies on.
+
+    A street's segments are mostly collinear, so the soup usually describes one or two
+    lines; the consensus search needs those, not hundreds of near-duplicates. Each line
+    is returned as (point on the line, unit direction).
+    """
+    lines: list[tuple[np.ndarray, np.ndarray]] = []
+    for start, end in zip(starts, ends):
+        delta = end - start
+        length = float(np.linalg.norm(delta))
+        if length < 1e-6:
+            continue
+        direction = delta / length
+        bearing = math.degrees(math.atan2(direction[0], direction[1])) % 180.0
+        for point, existing in lines:
+            existing_bearing = (
+                math.degrees(math.atan2(existing[0], existing[1])) % 180.0
+            )
+            if abs(angle_difference_mod180(bearing, existing_bearing)) > (
+                bearing_tolerance_deg
+            ):
+                continue
+            normal = np.array([existing[1], -existing[0]])
+            if abs(float((start - point) @ normal)) <= offset_tolerance_m:
+                break
+        else:
+            lines.append((start, direction))
+    return lines
+
+
+def constraint_bearing(pose: StreetPose, dir_pix: float) -> float:
+    """The world bearing (mod 180) a label's long axis claims under ``pose``."""
+    return (pose[2] + 90.0 + math.degrees(dir_pix)) % 180.0
+
+
+def residuals_at(
+    pose: StreetPose, constraint: StreetSegments, size: tuple[int, int]
+) -> tuple[float, float]:
+    """(position error in metres, signed angle error in degrees) for one constraint."""
+    center_px, dir_pix, _name, starts, ends = constraint
+    world = pose_world_of(pose, center_px, size)
+    distance, bearing = point_to_segments(world, starts, ends)
+    return distance, angle_difference_mod180(constraint_bearing(pose, dir_pix), bearing)
+
+
+def is_inlier(
+    pose: StreetPose,
+    constraint: StreetSegments,
+    size: tuple[int, int],
+    gates: StreetGates,
+) -> bool:
+    """Whether a constraint agrees with ``pose`` within both hard gates."""
+    position, angle = residuals_at(pose, constraint, size)
+    return position <= gates.position_gate_m and abs(angle) <= gates.angle_gate_deg
+
+
+def bearing_spread(pose: StreetPose, constraints: list[StreetSegments]) -> float:
+    """The largest angular gap (mod 180) between any two constraints' bearings."""
+    bearings = [constraint_bearing(pose, c[1]) for c in constraints]
+    return max(
+        (
+            abs(angle_difference_mod180(a, b))
+            for i, a in enumerate(bearings)
+            for b in bearings[i + 1 :]
+        ),
+        default=0.0,
+    )
+
+
+def scale_candidates(
+    constraints: list[StreetSegments],
+    psi_deg: float,
+    prior_log_scale: float,
+    size: tuple[int, int],
+    gates: StreetGates,
+) -> list[tuple[float, str]]:
+    """Log-scale candidates: the prior, plus one per pair of parallel streets.
+
+    Two labels on distinct parallel streets fix the scale on their own: the pixel
+    distance between them across the streets, over the metre spacing of the streets,
+    is pixels per metre. That is what lets this channel place a page whose scale prior
+    is missing or wrong.
+    """
+    candidates: list[tuple[float, str]] = [(prior_log_scale, "prior")]
+    for i, first in enumerate(constraints):
+        for second in constraints[i + 1 :]:
+            if first[2] == second[2]:
+                continue  # same street: spacing is zero by construction
+            lines_a = distinct_lines(first[3], first[4])
+            lines_b = distinct_lines(second[3], second[4])
+            for point_a, direction_a in lines_a:
+                for point_b, direction_b in lines_b:
+                    bearing_a = math.degrees(math.atan2(*direction_a)) % 180.0
+                    bearing_b = math.degrees(math.atan2(*direction_b)) % 180.0
+                    if (
+                        abs(angle_difference_mod180(bearing_a, bearing_b))
+                        > gates.parallel_tolerance_deg
+                    ):
+                        continue
+                    normal = np.array([direction_a[1], -direction_a[0]])
+                    spacing = abs(float((point_b - point_a) @ normal))
+                    if spacing < gates.min_parallel_spacing_m:
+                        continue
+                    # Pixel separation of the two labels across the street direction,
+                    # measured in the page frame at bearing psi.
+                    pose = (0.0, 0.0, psi_deg, 0.0)
+                    world_a = pose_world_of(pose, first[0], size)
+                    world_b = pose_world_of(pose, second[0], size)
+                    pixel_spacing = abs(float((world_b - world_a) @ normal))
+                    if pixel_spacing < 1e-6:
+                        continue
+                    candidates.append(
+                        (math.log(pixel_spacing / spacing), "parallel-pair")
+                    )
+    return candidates
+
+
+def propose_translation(
+    first: StreetSegments,
+    second: StreetSegments,
+    line_a: tuple[np.ndarray, np.ndarray],
+    line_b: tuple[np.ndarray, np.ndarray],
+    psi_deg: float,
+    log_scale: float,
+    size: tuple[int, int],
+) -> StreetPose | None:
+    """The pose placing two labels exactly on two given (non-parallel) street lines.
+
+    With bearing and scale fixed, a label lying on a known line is one linear equation
+    in the translation; two independent lines determine it outright.
+    """
+    point_a, direction_a = line_a
+    point_b, direction_b = line_b
+    normal_a = np.array([direction_a[1], -direction_a[0]])
+    normal_b = np.array([direction_b[1], -direction_b[0]])
+    matrix = np.array([normal_a, normal_b])
+    if abs(float(np.linalg.det(matrix))) < 1e-6:
+        return None
+    base = (0.0, 0.0, psi_deg, log_scale)
+    offset_a = pose_world_of(base, first[0], size)
+    offset_b = pose_world_of(base, second[0], size)
+    rhs = np.array(
+        [
+            float(normal_a @ (point_a - offset_a)),
+            float(normal_b @ (point_b - offset_b)),
+        ]
+    )
+    try:
+        translation = np.linalg.solve(matrix, rhs)
+    except np.linalg.LinAlgError:
+        return None
+    return (float(translation[0]), float(translation[1]), psi_deg, log_scale)
+
+
+def consensus_pose(
+    constraints: list[StreetSegments],
+    psi_deg: float,
+    log_scales: list[tuple[float, str]],
+    size: tuple[int, int],
+    gates: StreetGates,
+) -> tuple[StreetPose, list[StreetSegments], str] | None:
+    """Best (pose, inliers, scale source) over all constraint-pair/line/scale proposals."""
+    best: tuple[tuple[int, float], StreetPose, list[StreetSegments], str] | None = None
+    lines = [distinct_lines(c[3], c[4]) for c in constraints]
+    for log_scale, scale_source in log_scales:
+        for i, first in enumerate(constraints):
+            for j in range(i + 1, len(constraints)):
+                second = constraints[j]
+                for line_a in lines[i]:
+                    for line_b in lines[j]:
+                        bearing_a = math.degrees(math.atan2(*line_a[1])) % 180.0
+                        bearing_b = math.degrees(math.atan2(*line_b[1])) % 180.0
+                        if (
+                            abs(angle_difference_mod180(bearing_a, bearing_b))
+                            < gates.bearing_diversity_deg
+                        ):
+                            continue
+                        pose = propose_translation(
+                            first, second, line_a, line_b, psi_deg, log_scale, size
+                        )
+                        if pose is None:
+                            continue
+                        inliers = [
+                            c for c in constraints if is_inlier(pose, c, size, gates)
+                        ]
+                        if len(inliers) < gates.min_inliers:
+                            continue
+                        if bearing_spread(pose, inliers) < gates.bearing_diversity_deg:
+                            continue
+                        mean_position = float(
+                            np.mean([residuals_at(pose, c, size)[0] for c in inliers])
+                        )
+                        score = (len(inliers), -mean_position)
+                        if best is None or score > best[0]:
+                            best = (score, pose, inliers, scale_source)
+    if best is None:
+        return None
+    return best[1], best[2], best[3]
+
+
+def synthetic_ring(center_offset: Point = (0.0, 0.0)) -> np.ndarray:
+    """A one-vertex 'region' so pose_residuals' centroid spring anchors on the prior.
+
+    The containment factor is inert for a point at the page center (it is inside the
+    page frame by construction), leaving only the centroid spring — which is exactly
+    the location prior this channel is given.
+    """
+    return np.array([[center_offset[0], center_offset[1]]])
+
+
+def solve_streets_pose(
+    constraints: list[StreetSegments],
+    *,
+    size: tuple[int, int],
+    prior_log_scale: float,
+    psi_priors: list[tuple[float, str]],
+    gates: StreetGates = DEFAULT_GATES,
+    prior_radius_m: float = 0.0,
+) -> StreetSolveResult:
+    """Fit a 4-DOF pose from street constraints alone, or abstain with a reason.
+
+    ``psi_priors`` are (bearing, source) seeds in StreetPose degrees — evidence, never
+    a sweep (G6). ``constraints`` must already be restricted to the page's
+    neighborhood and expressed in a metre frame whose origin is the prior location.
+    """
+    result = StreetSolveResult(n_constraints=len(constraints))
+    if not psi_priors:
+        result.abstain = "no-rotation-prior"
+        return result
+    if len(constraints) < gates.min_inliers:
+        result.abstain = "too-few-constraints"
+        return result
+
+    sigmas = PoseSigmas(
+        line_m=gates.sigma_line_m,
+        angle_deg=gates.sigma_angle_deg,
+        log_scale=gates.sigma_log_scale,
+        # Weak on purpose: the prior says which neighborhood, not where in it. The
+        # hard radius gate below is what bounds the answer.
+        centroid_m=max(gates.sigma_centroid_m, prior_radius_m),
+    )
+    ring = synthetic_ring()
+    best: tuple[tuple[int, float], StreetSolveResult] | None = None
+
+    for psi, psi_source in psi_priors:
+        proposal = consensus_pose(
+            constraints,
+            psi,
+            scale_candidates(constraints, psi, prior_log_scale, size, gates),
+            size,
+            gates,
+        )
+        if proposal is None:
+            continue
+        seed, inliers, scale_source = proposal
+        polished = solve_pose(
+            seed,
+            inliers,
+            [],
+            region_vertices=ring,
+            size=size,
+            prior_log_scale=prior_log_scale,
+            sigmas=sigmas,
+        )
+        if polished is None:
+            continue
+        pose = polished[0]
+        move = math.hypot(pose[0] - seed[0], pose[1] - seed[1])
+        rotation = abs(angle_difference_mod180(pose[2], seed[2]))
+        attempt = StreetSolveResult(
+            psi_source=psi_source,
+            n_constraints=len(constraints),
+            scale_source=scale_source,
+            polish_move_m=move,
+            polish_rot_deg=rotation,
+        )
+        if move > gates.polish_max_move_m or rotation > gates.polish_max_rot_deg:
+            attempt.abstain = "polish-runaway"
+        elif not all(is_inlier(pose, c, size, gates) for c in inliers):
+            # G4: an inlier that no longer agrees means the polish moved onto a
+            # different interpretation; re-solving on the survivors is the drift loop.
+            attempt.abstain = "polish-lost-inliers"
+        elif prior_radius_m and math.hypot(pose[0], pose[1]) > (
+            prior_radius_m + gates.radius_slack_m
+        ):
+            attempt.abstain = "outside-prior-radius"
+        else:
+            spread = bearing_spread(pose, inliers)
+            shift, rotate = (
+                leave_one_out_spread(pose, inliers, size, prior_log_scale, sigmas, ring)
+                if len(inliers) > gates.min_inliers
+                else (0.0, 0.0)
+            )
+            attempt.bearing_spread_deg = spread
+            attempt.loo_max_shift_m = shift
+            attempt.loo_max_rot_deg = rotate
+            if shift > gates.loo_max_shift_m or rotate > gates.loo_max_rot_deg:
+                attempt.abstain = "unstable-leave-one-out"
+            else:
+                attempt.pose = pose
+                attempt.n_inliers = len(inliers)
+        attempt.diagnostics = [
+            ConstraintDiag(
+                name=c[2],
+                center_px=c[0],
+                position_m=residuals_at(pose, c, size)[0],
+                angle_deg=residuals_at(pose, c, size)[1],
+                inlier=c in inliers,
+            )
+            for c in constraints
+        ]
+        score = (len(inliers) if attempt.pose else 0, -move)
+        if best is None or score > best[0]:
+            best = (score, attempt)
+
+    if best is None:
+        result.abstain = "no-consensus"
+        return result
+    return best[1]
+
+
+def leave_one_out_spread(
+    pose: StreetPose,
+    inliers: list[StreetSegments],
+    size: tuple[int, int],
+    prior_log_scale: float,
+    sigmas: PoseSigmas,
+    ring: np.ndarray,
+) -> tuple[float, float]:
+    """(max centre shift, max rotation change) when each inlier is dropped in turn.
+
+    A pose that moves when one constraint leaves is resting on that constraint; with a
+    quarter of constraints wrong, that is the shape a wrong fit takes. Callers only
+    apply this where the inliers are redundant: a minimum-size set determines the pose
+    exactly, so every member is load-bearing and the check carries no information.
+    """
+    max_shift = 0.0
+    max_rotation = 0.0
+    for index in range(len(inliers)):
+        remaining = inliers[:index] + inliers[index + 1 :]
+        if len(remaining) < 2:
+            continue
+        refit = solve_pose(
+            pose,
+            remaining,
+            [],
+            region_vertices=ring,
+            size=size,
+            prior_log_scale=prior_log_scale,
+            sigmas=sigmas,
+        )
+        if refit is None:
+            continue
+        candidate = refit[0]
+        max_shift = max(
+            max_shift, math.hypot(candidate[0] - pose[0], candidate[1] - pose[1])
+        )
+        max_rotation = max(
+            max_rotation, abs(angle_difference_mod180(candidate[2], pose[2]))
+        )
+    return max_shift, max_rotation
+
+
+def assemble_constraints(
+    features: list[LabelFeature],
+    block_index: dict[str, list[Block]],
+    *,
+    prior: PriorLocation,
+    label_size: tuple[int, int],
+    working_size: tuple[int, int],
+    gates: StreetGates = DEFAULT_GATES,
+) -> list[StreetSegments]:
+    """Street constraints for a page: family-merged, locality-trimmed, aspect-filtered.
+
+    Near-square label boxes are dropped here: their long axis is set by the box, not
+    the text, so their angle — this channel's most trusted signal — is noise.
+    """
+    usable = [
+        feature
+        for feature in features
+        if feature.short_side <= 0
+        or feature.long_side / feature.short_side >= gates.min_aspect
+    ]
+    return constraints_from_features(
+        usable,
+        block_index,
+        origin=prior.center,
+        label_size=label_size,
+        working_size=working_size,
+        merge_families=True,
+        locality=((0.0, 0.0), prior.radius_m + gates.position_gate_m),
+    )

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -77,6 +77,8 @@ class StreetGates:
     sigma_angle_deg: float = 3.0  # angles are the reliable signal
     sigma_log_scale: float = 0.05  # G5: soft scale prior (bounded in solve_pose)
     sigma_centroid_m: float = 400.0  # the location prior is a neighborhood, not a fix
+    max_psi_seeds: int = 8  # bearing clusters tried per page (evidence, not a sweep)
+    max_scale_seeds: int = 5  # distinct scale proposals tried per bearing
 
 
 DEFAULT_GATES = StreetGates()
@@ -173,6 +175,55 @@ def distinct_lines(
     return lines
 
 
+def wrap_degrees(value: float) -> float:
+    """An angle folded into (-180, 180]."""
+    return (value + 180.0) % 360.0 - 180.0
+
+
+def circular_mean_deg(angles: list[float]) -> float:
+    """Mean of full-circle angles, in [0, 360)."""
+    x = float(np.mean([math.cos(math.radians(a)) for a in angles]))
+    y = float(np.mean([math.sin(math.radians(a)) for a in angles]))
+    return math.degrees(math.atan2(y, x)) % 360.0
+
+
+def psi_votes(
+    constraints: list[StreetSegments], gates: StreetGates = DEFAULT_GATES
+) -> list[tuple[float, str]]:
+    """Page bearings implied by the constraints themselves, most-supported first.
+
+    Every constraint votes: its label's long axis runs along its street, so each
+    straight line in that street's soup implies psi = bearing - 90 - label angle (and
+    the 180-degree flip). A correct constraint votes for the true bearing; wrong ones
+    scatter, so the largest cluster is the page's rotation. This is the same evidence
+    ``osm_snap.label_osm_rotations`` uses, but read off the locality-trimmed soup each
+    constraint actually carries, which matters where a street curves away from the
+    prior — the tangent a kilometre off is not the tangent under the label.
+    """
+    votes: list[float] = []
+    for _center, dir_pix, _name, starts, ends in constraints:
+        for _point, direction in distinct_lines(starts, ends):
+            bearing = math.degrees(math.atan2(direction[0], direction[1])) % 180.0
+            base = (bearing - 90.0 - math.degrees(dir_pix)) % 360.0
+            # A street's bearing is undirected, so each vote admits both page-up
+            # senses; the pose's own bearing is not (the page has a top), so the two
+            # stay separate candidates rather than averaging into a meaningless middle.
+            votes.extend((base, (base + 180.0) % 360.0))
+    clusters: list[list[float]] = []
+    for vote in sorted(votes):
+        for cluster in clusters:
+            if abs(wrap_degrees(vote - cluster[0])) <= 2.0:
+                cluster.append(vote)
+                break
+        else:
+            clusters.append([vote])
+    clusters.sort(key=len, reverse=True)
+    return [
+        (circular_mean_deg(cluster), "constraint-vote")
+        for cluster in clusters[: gates.max_psi_seeds]
+    ]
+
+
 def constraint_bearing(pose: StreetPose, dir_pix: float) -> float:
     """The world bearing (mod 180) a label's long axis claims under ``pose``."""
     return (pose[2] + 90.0 + math.degrees(dir_pix)) % 180.0
@@ -214,6 +265,7 @@ def bearing_spread(pose: StreetPose, constraints: list[StreetSegments]) -> float
 
 def scale_candidates(
     constraints: list[StreetSegments],
+    lines: list[list[tuple[np.ndarray, np.ndarray]]],
     psi_deg: float,
     prior_log_scale: float,
     size: tuple[int, int],
@@ -228,13 +280,12 @@ def scale_candidates(
     """
     candidates: list[tuple[float, str]] = [(prior_log_scale, "prior")]
     for i, first in enumerate(constraints):
-        for second in constraints[i + 1 :]:
+        for j in range(i + 1, len(constraints)):
+            second = constraints[j]
             if first[2] == second[2]:
                 continue  # same street: spacing is zero by construction
-            lines_a = distinct_lines(first[3], first[4])
-            lines_b = distinct_lines(second[3], second[4])
-            for point_a, direction_a in lines_a:
-                for point_b, direction_b in lines_b:
+            for point_a, direction_a in lines[i]:
+                for point_b, direction_b in lines[j]:
                     bearing_a = math.degrees(math.atan2(*direction_a)) % 180.0
                     bearing_b = math.degrees(math.atan2(*direction_b)) % 180.0
                     if (
@@ -257,7 +308,20 @@ def scale_candidates(
                     candidates.append(
                         (math.log(pixel_spacing / spacing), "parallel-pair")
                     )
-    return candidates
+    return dedupe_scales(candidates, gates.max_scale_seeds)
+
+
+def dedupe_scales(
+    candidates: list[tuple[float, str]], cap: int
+) -> list[tuple[float, str]]:
+    """Collapse log-scale proposals that agree within a percent, keeping the first."""
+    kept: list[tuple[float, str]] = []
+    for value, source in candidates:
+        if all(abs(value - existing) > 0.01 for existing, _ in kept):
+            kept.append((value, source))
+        if len(kept) >= cap:
+            break
+    return kept
 
 
 def propose_translation(
@@ -303,10 +367,12 @@ def consensus_pose(
     log_scales: list[tuple[float, str]],
     size: tuple[int, int],
     gates: StreetGates,
+    lines: list[list[tuple[np.ndarray, np.ndarray]]] | None = None,
 ) -> tuple[StreetPose, list[StreetSegments], str] | None:
     """Best (pose, inliers, scale source) over all constraint-pair/line/scale proposals."""
     best: tuple[tuple[int, float], StreetPose, list[StreetSegments], str] | None = None
-    lines = [distinct_lines(c[3], c[4]) for c in constraints]
+    if lines is None:
+        lines = [distinct_lines(c[3], c[4]) for c in constraints]
     for log_scale, scale_source in log_scales:
         for i, first in enumerate(constraints):
             for j in range(i + 1, len(constraints)):
@@ -386,14 +452,18 @@ def solve_streets_pose(
     )
     ring = synthetic_ring()
     best: tuple[tuple[int, float], StreetSolveResult] | None = None
+    # Segment soups collapse to a handful of straight lines; computing that once per
+    # page (not per bearing seed, per pair) is what keeps the search tractable.
+    lines = [distinct_lines(c[3], c[4]) for c in constraints]
 
-    for psi, psi_source in psi_priors:
+    for psi, psi_source in psi_priors[: gates.max_psi_seeds]:
         proposal = consensus_pose(
             constraints,
             psi,
-            scale_candidates(constraints, psi, prior_log_scale, size, gates),
+            scale_candidates(constraints, lines, psi, prior_log_scale, size, gates),
             size,
             gates,
+            lines,
         )
         if proposal is None:
             continue
@@ -433,7 +503,10 @@ def solve_streets_pose(
             spread = bearing_spread(pose, inliers)
             shift, rotate = (
                 leave_one_out_spread(pose, inliers, size, prior_log_scale, sigmas, ring)
-                if len(inliers) > gates.min_inliers
+                # Needs real redundancy: dropping one of four leaves an exactly
+                # determined three, which moves for sound reasons, so the check would
+                # reject good fits (LA p1467 at 34 ft) rather than fragile ones.
+                if len(inliers) >= gates.min_inliers + 2
                 else (0.0, 0.0)
             )
             attempt.bearing_spread_deg = spread

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -93,11 +93,12 @@ class StreetGates:
     max_proposals: int = 6  # distinct placements polished per bearing, best cost wins
     # A street whose OSM data stops short of the label still constrains it: the label
     # sits on the street's line, and the sheet simply drew more of the street than
-    # today's data holds. Terminal ends are extended this far so that shortfall is not
-    # read as position error. project_to_polyline allows 500 ft for the same reason;
-    # here that much lets an over-extended street claim labels it should not, and 80 m
-    # measured best (swept against sigma_line over twenty diagnosed pages).
-    terminal_extrapolation_m: float = 80.0
+    # today's data holds -- on Detroit's east side, hundreds of metres more, since the
+    # streets themselves are gone. The allowance is therefore generous and the position
+    # gate does the rejecting: a label that still does not fit is an outlier, which is
+    # the honest test. Detroit p5's labels sit 1-5 m from their streets' lines and 170
+    # to 400 m past where OSM stops drawing them (282 ft -> 17 ft at this distance).
+    terminal_extrapolation_m: float = 500.0
 
 
 DEFAULT_GATES = StreetGates()

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -49,6 +49,7 @@ from mapsnap.keymap.align_page_region import (
     angle_difference_mod180,
     constraints_from_features,
     point_to_segments,
+    pose_residuals,
     pose_world_of,
     solve_pose,
 )
@@ -79,12 +80,24 @@ class StreetGates:
     loo_max_shift_m: float = 30.0  # leave-one-out stability
     loo_max_rot_deg: float = 2.0
     radius_slack_m: float = 60.0  # converged center vs the prior location
-    sigma_line_m: float = 60.0  # positions stay loose: label centers sit off the line
+    # Positions are trustworthy once a street that stops short is no longer read as a
+    # position error (see extend_terminal_segments): a correct page's labels sit 1-3 m
+    # from their centerlines, so the 60 m inherited from the region placer -- where a
+    # label really does sit off the line -- let the fit trade position away for angle.
+    sigma_line_m: float = 15.0
     sigma_angle_deg: float = 3.0  # angles are the reliable signal
     sigma_log_scale: float = 0.05  # G5: soft scale prior (bounded in solve_pose)
     sigma_centroid_m: float = 400.0  # the location prior is a neighborhood, not a fix
     max_psi_seeds: int = 8  # bearing clusters tried per page (evidence, not a sweep)
     max_scale_seeds: int = 5  # distinct scale proposals tried per bearing
+    max_proposals: int = 6  # distinct placements polished per bearing, best cost wins
+    # A street whose OSM data stops short of the label still constrains it: the label
+    # sits on the street's line, and the sheet simply drew more of the street than
+    # today's data holds. Terminal ends are extended this far so that shortfall is not
+    # read as position error. project_to_polyline allows 500 ft for the same reason;
+    # here that much lets an over-extended street claim labels it should not, and 80 m
+    # measured best (swept against sigma_line over twenty diagnosed pages).
+    terminal_extrapolation_m: float = 80.0
 
 
 DEFAULT_GATES = StreetGates()
@@ -131,6 +144,7 @@ class StreetSolveResult:
     loo_max_shift_m: float = 0.0
     loo_max_rot_deg: float = 0.0
     scale_source: str = ""
+    cost: float = 0.0  # the soft_l1 objective at this pose, over every constraint
     diagnostics: list[ConstraintDiag] = field(default_factory=list)
 
 
@@ -228,6 +242,42 @@ def psi_votes(
         (circular_mean_deg(cluster), "constraint-vote")
         for cluster in clusters[: gates.max_psi_seeds]
     ]
+
+
+def extend_terminal_segments(
+    starts: np.ndarray, ends: np.ndarray, distance_m: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extend a polyline's open ends outward, leaving interior joins untouched.
+
+    New Orleans p181 shows why: SOUTH MIRO's label sits 0.3 m from its street's line
+    but 49 m past where OSM stops drawing it, and measuring to the segment reads that
+    shortfall as a 49 m position error. Left alone the solver moves the page to
+    "fix" it, which is how a fit ends up translated off a set of otherwise perfect
+    constraints. Only ends that no other segment touches are extended, so a street
+    that genuinely turns is not straightened.
+    """
+    if not len(starts) or distance_m <= 0:
+        return starts, ends
+    counts: dict[tuple[float, float], int] = {}
+    for point in np.vstack([starts, ends]):
+        key = (round(float(point[0]), 2), round(float(point[1]), 2))
+        counts[key] = counts.get(key, 0) + 1
+
+    def is_open(point: np.ndarray) -> bool:
+        return counts.get((round(float(point[0]), 2), round(float(point[1]), 2)), 0) < 2
+
+    new_starts, new_ends = starts.copy(), ends.copy()
+    for i, (start, end) in enumerate(zip(starts, ends)):
+        delta = end - start
+        length = float(np.linalg.norm(delta))
+        if length < 1e-6:
+            continue
+        unit = delta / length
+        if is_open(start):
+            new_starts[i] = start - unit * distance_m
+        if is_open(end):
+            new_ends[i] = end + unit * distance_m
+    return new_starts, new_ends
 
 
 def constraint_bearing(pose: StreetPose, dir_pix: float) -> float:
@@ -372,16 +422,22 @@ def propose_translation(
     return (float(translation[0]), float(translation[1]), psi_deg, log_scale)
 
 
-def consensus_pose(
+def consensus_poses(
     constraints: list[StreetSegments],
     psi_deg: float,
     log_scales: list[tuple[float, str]],
     size: tuple[int, int],
     gates: StreetGates,
     lines: list[list[tuple[np.ndarray, np.ndarray]]] | None = None,
-) -> tuple[StreetPose, list[StreetSegments], str] | None:
-    """Best (pose, inliers, scale source) over all constraint-pair/line/scale proposals."""
-    best: tuple[tuple[int, float], StreetPose, list[StreetSegments], str] | None = None
+) -> list[tuple[StreetPose, list[StreetSegments], str]]:
+    """The most-supported distinct proposals over all pair/line/scale combinations.
+
+    Several are kept, not one: inlier count alone picks the wrong pose where a
+    block-over placement admits one more marginal constraint than the right placement
+    does (Kansas City p502 -- four against truth's three). The caller polishes each
+    and decides on the fitted objective, which is the thing actually being minimized.
+    """
+    scored: list[tuple[tuple[int, float], StreetPose, list[StreetSegments], str]] = []
     if lines is None:
         lines = [distinct_lines(c[3], c[4]) for c in constraints]
     for log_scale, scale_source in log_scales:
@@ -418,12 +474,32 @@ def consensus_pose(
                         mean_position = float(
                             np.mean([residuals_at(pose, c, size)[0] for c in inliers])
                         )
-                        score = (len(inliers), -mean_position)
-                        if best is None or score > best[0]:
-                            best = (score, pose, inliers, scale_source)
-    if best is None:
-        return None
-    return best[1], best[2], best[3]
+                        scored.append(
+                            (
+                                (len(inliers), -mean_position),
+                                pose,
+                                inliers,
+                                scale_source,
+                            )
+                        )
+    scored.sort(key=lambda entry: entry[0], reverse=True)
+    kept: list[tuple[StreetPose, list[StreetSegments], str]] = []
+    for _score, pose, inliers, scale_source in scored:
+        if any(
+            math.hypot(pose[0] - other[0][0], pose[1] - other[0][1]) < 20.0
+            and abs(pose[3] - other[0][3]) < 0.01
+            for other in kept
+        ):
+            continue  # the same placement reached from another pair
+        kept.append((pose, inliers, scale_source))
+        if len(kept) >= gates.max_proposals:
+            break
+    return kept
+
+
+def soft_l1_cost(residuals: np.ndarray) -> float:
+    """scipy's soft_l1 cost for a residual vector (f_scale=1), so poses compare."""
+    return float(0.5 * np.sum(2.0 * (np.sqrt(1.0 + residuals**2) - 1.0)))
 
 
 def synthetic_ring(center_offset: Point = (0.0, 0.0)) -> np.ndarray:
@@ -474,7 +550,7 @@ def solve_streets_pose(
     lines = [distinct_lines(c[3], c[4]) for c in constraints]
 
     for psi, psi_source in psi_priors[: gates.max_psi_seeds]:
-        proposal = consensus_pose(
+        proposals = consensus_poses(
             constraints,
             psi,
             scale_candidates(constraints, lines, psi, prior_log_scale, size, gates),
@@ -482,71 +558,85 @@ def solve_streets_pose(
             gates,
             lines,
         )
-        if proposal is None:
-            continue
-        seed, inliers, scale_source = proposal
-        polished = solve_pose(
-            seed,
-            inliers,
-            [],
-            region_vertices=ring,
-            size=size,
-            prior_log_scale=prior_log_scale,
-            sigmas=sigmas,
-        )
-        if polished is None:
-            continue
-        pose = polished[0]
-        move = math.hypot(pose[0] - seed[0], pose[1] - seed[1])
-        rotation = abs(angle_difference_mod180(pose[2], seed[2]))
-        attempt = StreetSolveResult(
-            psi_source=psi_source,
-            n_constraints=len(constraints),
-            scale_source=scale_source,
-            polish_move_m=move,
-            polish_rot_deg=rotation,
-        )
-        if move > gates.polish_max_move_m or rotation > gates.polish_max_rot_deg:
-            attempt.abstain = "polish-runaway"
-        elif not all(is_inlier(pose, c, size, gates) for c in inliers):
-            # G4: an inlier that no longer agrees means the polish moved onto a
-            # different interpretation; re-solving on the survivors is the drift loop.
-            attempt.abstain = "polish-lost-inliers"
-        elif prior_radius_m and math.hypot(pose[0], pose[1]) > (
-            prior_radius_m + gates.radius_slack_m
-        ):
-            attempt.abstain = "outside-prior-radius"
-        else:
-            spread = bearing_spread(pose, inliers)
-            shift, rotate = (
-                leave_one_out_spread(pose, inliers, size, prior_log_scale, sigmas, ring)
-                # Needs real redundancy: dropping one of four leaves an exactly
-                # determined three, which moves for sound reasons, so the check would
-                # reject good fits (LA p1467 at 34 ft) rather than fragile ones.
-                if len(inliers) >= gates.min_inliers + 2
-                else (0.0, 0.0)
+        for seed, inliers, scale_source in proposals:
+            polished = solve_pose(
+                seed,
+                inliers,
+                [],
+                region_vertices=ring,
+                size=size,
+                prior_log_scale=prior_log_scale,
+                sigmas=sigmas,
             )
-            attempt.bearing_spread_deg = spread
-            attempt.loo_max_shift_m = shift
-            attempt.loo_max_rot_deg = rotate
-            if shift > gates.loo_max_shift_m or rotate > gates.loo_max_rot_deg:
-                attempt.abstain = "unstable-leave-one-out"
+            if polished is None:
+                continue
+            pose = polished[0]
+            move = math.hypot(pose[0] - seed[0], pose[1] - seed[1])
+            rotation = abs(angle_difference_mod180(pose[2], seed[2]))
+            attempt = StreetSolveResult(
+                psi_source=psi_source,
+                n_constraints=len(constraints),
+                scale_source=scale_source,
+                polish_move_m=move,
+                polish_rot_deg=rotation,
+            )
+            if move > gates.polish_max_move_m or rotation > gates.polish_max_rot_deg:
+                attempt.abstain = "polish-runaway"
+            elif not all(is_inlier(pose, c, size, gates) for c in inliers):
+                # G4: an inlier that no longer agrees means the polish moved onto a
+                # different interpretation; re-solving on the survivors is the drift loop.
+                attempt.abstain = "polish-lost-inliers"
+            elif prior_radius_m and math.hypot(pose[0], pose[1]) > (
+                prior_radius_m + gates.radius_slack_m
+            ):
+                attempt.abstain = "outside-prior-radius"
             else:
-                attempt.pose = pose
-                attempt.n_inliers = len(inliers)
-        attempt.diagnostics = [
-            ConstraintDiag(
-                name=c[2],
-                center_px=c[0],
-                position_m=residuals_at(pose, c, size)[0],
-                angle_deg=residuals_at(pose, c, size)[1],
-                inlier=c in inliers,
+                spread = bearing_spread(pose, inliers)
+                shift, rotate = (
+                    leave_one_out_spread(
+                        pose, inliers, size, prior_log_scale, sigmas, ring
+                    )
+                    # Needs real redundancy: dropping one of four leaves an exactly
+                    # determined three, which moves for sound reasons, so the check would
+                    # reject good fits (LA p1467 at 34 ft) rather than fragile ones.
+                    if len(inliers) >= gates.min_inliers + 2
+                    else (0.0, 0.0)
+                )
+                attempt.bearing_spread_deg = spread
+                attempt.loo_max_shift_m = shift
+                attempt.loo_max_rot_deg = rotate
+                if shift > gates.loo_max_shift_m or rotate > gates.loo_max_rot_deg:
+                    attempt.abstain = "unstable-leave-one-out"
+                else:
+                    attempt.pose = pose
+                    attempt.n_inliers = len(inliers)
+            attempt.diagnostics = [
+                ConstraintDiag(
+                    name=c[2],
+                    center_px=c[0],
+                    position_m=residuals_at(pose, c, size)[0],
+                    angle_deg=residuals_at(pose, c, size)[1],
+                    inlier=c in inliers,
+                )
+                for c in constraints
+            ]
+            # Decide on the objective being minimized, over every constraint. Inlier
+            # count picks whichever placement admits one more marginal street, which
+            # is how p502 landed a block from a pose this objective scores better.
+            attempt.cost = soft_l1_cost(
+                pose_residuals(
+                    pose,
+                    constraints,
+                    [],
+                    region_vertices=ring,
+                    size=size,
+                    prior_log_scale=prior_log_scale,
+                    sigmas=sigmas,
+                )
             )
-            for c in constraints
-        ]
-        score = (len(inliers) if attempt.pose else 0, -move)
-        if best is None or score > best[0]:
-            best = (score, attempt)
+            score = (1 if attempt.pose else 0, -attempt.cost)
+            if best is None or score > best[0]:
+                best = (score, attempt)
 
     if best is None:
         result.abstain = "no-consensus"
@@ -603,6 +693,7 @@ def assemble_constraints(
     prior: PriorLocation,
     label_size: tuple[int, int],
     working_size: tuple[int, int],
+    scale_px_per_m: float,
     gates: StreetGates = DEFAULT_GATES,
 ) -> list[StreetSegments]:
     """Street constraints for a page: family-merged, locality-trimmed, aspect-filtered.
@@ -616,12 +707,28 @@ def assemble_constraints(
         if feature.short_side <= 0
         or feature.long_side / feature.short_side >= gates.min_aspect
     ]
-    return constraints_from_features(
+    constraints = constraints_from_features(
         usable,
         block_index,
         origin=prior.center,
         label_size=label_size,
         working_size=working_size,
         merge_families=True,
-        locality=((0.0, 0.0), prior.radius_m + gates.position_gate_m),
+        # Wide enough that a street crossing the page is never cut mid-page: the trim
+        # exists to keep a distant branch of a merged family from capturing a label,
+        # not to truncate the page's own streets.
+        locality=(
+            (0.0, 0.0),
+            prior.radius_m
+            + math.hypot(*working_size) / 2.0 / max(scale_px_per_m, 1e-6),
+        ),
     )
+    return [
+        (
+            center,
+            dir_pix,
+            name,
+            *extend_terminal_segments(starts, ends, gates.terminal_extrapolation_m),
+        )
+        for center, dir_pix, name, starts, ends in constraints
+    ]

--- a/mapsnap/street_solve.py
+++ b/mapsnap/street_solve.py
@@ -52,7 +52,7 @@ from mapsnap.keymap.align_page_region import (
     pose_world_of,
     solve_pose,
 )
-from mapsnap.streets import Block
+from mapsnap.streets import Block, street_name_family
 
 Point = tuple[float, float]
 
@@ -64,6 +64,8 @@ class StreetGates:
     angle_gate_deg: float = 8.0  # inlier: |label bearing - street bearing| at the pose
     position_gate_m: float = 80.0  # inlier: label center to street distance (G3)
     min_inliers: int = 3
+    min_inlier_fraction: float = 0.6  # a right pose explains most of what the page says
+    min_distinct_streets: int = 3  # two streets determine the pose with no redundancy
     bearing_diversity_deg: float = 30.0  # two inlier bearings must differ by this much
     min_aspect: float = 2.0  # near-square boxes carry no usable long axis
     parallel_tolerance_deg: float = 10.0  # bearings this close count as parallel
@@ -250,6 +252,11 @@ def is_inlier(
     return position <= gates.position_gate_m and abs(angle) <= gates.angle_gate_deg
 
 
+def distinct_streets(constraints: list[StreetSegments]) -> int:
+    """How many different streets a constraint set speaks for (variants count once)."""
+    return len({street_name_family(c[2]) for c in constraints})
+
+
 def bearing_spread(pose: StreetPose, constraints: list[StreetSegments]) -> float:
     """The largest angular gap (mod 180) between any two constraints' bearings."""
     bearings = [constraint_bearing(pose, c[1]) for c in constraints]
@@ -395,6 +402,12 @@ def consensus_pose(
                             c for c in constraints if is_inlier(pose, c, size, gates)
                         ]
                         if len(inliers) < gates.min_inliers:
+                            continue
+                        if len(inliers) < gates.min_inlier_fraction * len(constraints):
+                            # Kansas City p576 slid a block on two streets while four
+                            # others disagreed; a correct pose explains most of them.
+                            continue
+                        if distinct_streets(inliers) < gates.min_distinct_streets:
                             continue
                         if bearing_spread(pose, inliers) < gates.bearing_diversity_deg:
                             continue

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -1,0 +1,452 @@
+"""Truth-aware harness for the streets-only georeferencer (issue #168).
+
+Runs :mod:`mapsnap.street_solve` over a volume's pages and scores the result against
+the human georeferencing, beside the RANSAC fit the pipeline produced for the same
+page. The question it answers is narrow and deliberately isolated from the rest of the
+pipeline: *given a coarse location, do street constraints alone place a page better
+than intersection-GCP RANSAC does?* Nothing here writes production sidecars.
+
+Each page gets a location prior from the first rung that applies, recorded per page so
+a reader can tell what the fit was given:
+
+  keymap-exact    the key map places this page key on its own (the normal case)
+  keymap-family   only the page's stem family is placed; usable when those centers
+                  are tight, useless when they are a whole lettered family apart
+  fit-center      the existing RANSAC fit's own centre — truth-free, and the honest
+                  fallback for pages whose key-map prior is degenerate
+  truth-centroid  the truth footprint's centre; an experiment-only ceiling, never
+                  mixed into the headline comparison
+
+    uv run python -m mapsnap.street_solve_experiment candidates data/los_angeles_ca_1949_vol_14
+    uv run python -m mapsnap.street_solve_experiment report data/*/
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from mapsnap.compare_iiif_georef import (
+    annotation_transform_type,
+    extract_gcps,
+    fit_transform,
+)
+from mapsnap.edge_join_experiment import (
+    PageUnit,
+    TruthFit,
+    grid_rmse_ft_between,
+    load_page_units,
+    load_truth_units,
+    scale_affine_to_local,
+)
+from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
+from mapsnap.keymap.align_page_region import (
+    pose_corners_world,
+    volume_filter_params,
+    volume_median_scale_px_per_m,
+)
+from mapsnap.keymap.locate import KeymapLocator, discover_keymaps
+from mapsnap.osm_snap import dedupe_thetas, label_osm_rotations
+from mapsnap.street_solve import (
+    PriorLocation,
+    StreetGates,
+    StreetSolveResult,
+    assemble_constraints,
+    psi_from_theta,
+    psi_votes,
+    solve_streets_pose,
+)
+from mapsnap.streets import build_block_index
+
+ARTIFACT_DIR = "artifacts/street_solve"
+# A stem family whose centers span more than this is not a location (LA's 1499 family
+# covers twenty blocks); such a page falls through to the next prior rung.
+MAX_FAMILY_SPREAD_M = 400.0
+
+
+def family_spread_m(centers: list[tuple[float, float]]) -> float:
+    """Largest distance between any two key-map centers, in metres."""
+    if len(centers) < 2:
+        return 0.0
+    kx = 111_320.0 * math.cos(math.radians(centers[0][1]))
+    points = [((lon * kx), lat * 110_540.0) for lon, lat in centers]
+    return max(math.dist(a, b) for i, a in enumerate(points) for b in points[i + 1 :])
+
+
+def page_prior(
+    unit: PageUnit,
+    locator: KeymapLocator | None,
+    *,
+    allow_truth: bool = False,
+) -> PriorLocation | None:
+    """The best available coarse location for a page, by the prior ladder."""
+    if locator is not None:
+        key = unit.stem[1:].upper()
+        exact = locator.locations.get(key)
+        if exact:
+            center = (
+                sum(c[0] for c in exact) / len(exact),
+                sum(c[1] for c in exact) / len(exact),
+            )
+            return PriorLocation(center, locator.radius_m, "keymap-exact", list(exact))
+        family = locator.centers_for(key)
+        if family and family_spread_m(family) <= MAX_FAMILY_SPREAD_M:
+            center = (
+                sum(c[0] for c in family) / len(family),
+                sum(c[1] for c in family) / len(family),
+            )
+            return PriorLocation(
+                center, locator.radius_m, "keymap-family", list(family)
+            )
+    radius = locator.radius_m if locator is not None else 500.0
+    if unit.gen_affine is not None:
+        lon, lat = unit.gen_affine @ np.array(
+            [unit.width / 2.0, unit.height / 2.0, 1.0]
+        )
+        return PriorLocation((float(lon), float(lat)), radius, "fit-center")
+    if allow_truth and unit.truth is not None:
+        lon, lat = unit.truth.affine_local @ np.array(
+            [unit.width / 2.0, unit.height / 2.0, 1.0]
+        )
+        return PriorLocation((float(lon), float(lat)), radius, "truth-centroid")
+    return None
+
+
+def page_features(
+    volume: Path,
+    unit: PageUnit,
+    prior: PriorLocation,
+    centerlines: list[dict],
+    filter_params: dict,
+) -> tuple[list[LabelFeature], dict, tuple[int, int]] | None:
+    """(features, block index, label frame) for a page, restricted to its prior.
+
+    The vocabulary is the streets near the prior only — no rectangle or volume-wide
+    fallback, which is the whole point of running this channel on a located page.
+    """
+    streets_path = volume / f"{unit.stem}.streets.json"
+    if not streets_path.exists():
+        return None
+    # A one-page locator over the prior's centers: reuses the same radius search the
+    # pipeline uses, without needing the page to be in the real key map.
+    near = KeymapLocator(
+        {"1": list(prior.centers)}, prior.radius_m
+    ).restricted_features("1", centerlines)
+    if not near:
+        return None
+    block_index = build_block_index({"type": "FeatureCollection", "features": near})
+    doc = json.loads(streets_path.read_text())
+    label_size = (int(doc["width"]), int(doc["height"]))
+    sink = io.StringIO()
+    with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+        features = prepare_label_features(
+            str(streets_path), block_index, label_size, **filter_params
+        )
+    return features, block_index, label_size
+
+
+def psi_priors_for(
+    features: list[LabelFeature], block_index: dict, prior: PriorLocation
+) -> list[tuple[float, str]]:
+    """Evidence-seeded page bearings, best rung first (never a blind sweep, see G6)."""
+    rotations = dedupe_thetas(label_osm_rotations(features, block_index, prior.center))
+    return [(psi_from_theta(r.theta_deg), r.source) for r in rotations]
+
+
+def solve_page(
+    volume: Path,
+    unit: PageUnit,
+    locator: KeymapLocator | None,
+    centerlines: list[dict],
+    filter_params: dict,
+    scale_px_per_m: float | None,
+    gates: StreetGates,
+    *,
+    allow_truth_prior: bool = False,
+) -> dict:
+    """One page's streets-only fit, scored against truth and against RANSAC."""
+    record: dict = {
+        "stem": unit.stem,
+        "fit_state": unit.fit_state,
+        "ransac_rmse_ft": unit.rmse_ft,
+        "ransac_inlier_intersections": unit.inlier_intersections,
+        "ransac_inlier_streets": unit.inlier_streets,
+        "has_truth": unit.truth is not None,
+    }
+    prior = page_prior(unit, locator, allow_truth=allow_truth_prior)
+    if prior is None:
+        record["status"] = "no-prior"
+        return record
+    record["prior_source"] = prior.source
+    record["prior_radius_m"] = round(prior.radius_m, 1)
+
+    prepared = page_features(volume, unit, prior, centerlines, filter_params)
+    if prepared is None:
+        record["status"] = "no-vocabulary"
+        return record
+    features, block_index, label_size = prepared
+    size = (unit.width, unit.height)
+    constraints = assemble_constraints(
+        features,
+        block_index,
+        prior=prior,
+        label_size=label_size,
+        working_size=size,
+        gates=gates,
+    )
+    record["n_constraints"] = len(constraints)
+    record["constraint_names"] = sorted({c[2] for c in constraints})
+
+    # Constraint votes first (they read the tangent under each label), then the
+    # osm_snap rungs, which see streets the constraint set may have dropped.
+    psi_priors = psi_votes(constraints, gates) + psi_priors_for(
+        features, block_index, prior
+    )
+    record["n_psi_priors"] = len(psi_priors)
+    prior_log_scale = math.log(scale_px_per_m) if scale_px_per_m else 0.0
+    result: StreetSolveResult = solve_streets_pose(
+        constraints,
+        size=size,
+        prior_log_scale=prior_log_scale,
+        psi_priors=psi_priors,
+        gates=gates,
+        prior_radius_m=prior.radius_m,
+    )
+    record["psi_source"] = result.psi_source
+    record["scale_source"] = result.scale_source
+    record["n_inliers"] = result.n_inliers
+    record["bearing_spread_deg"] = round(result.bearing_spread_deg, 1)
+    record["diagnostics"] = [
+        {
+            "name": d.name,
+            "position_m": None if d.position_m is None else round(d.position_m, 1),
+            "angle_deg": None if d.angle_deg is None else round(d.angle_deg, 2),
+            "inlier": d.inlier,
+        }
+        for d in result.diagnostics
+    ]
+    if result.pose is None:
+        record["status"] = f"abstain-{result.abstain}"
+        return record
+
+    record["status"] = "posed"
+    record["pose"] = [round(v, 6) for v in result.pose]
+    corners = pose_corners_world(result.pose, size, prior.center)
+    record["corners"] = corners
+    affine = corners_to_affine(corners, size)
+    record["street_scale_px_per_m"] = round(math.exp(result.pose[3]), 4)
+    if unit.truth is not None:
+        record["street_rmse_ft"] = round(
+            grid_rmse_ft_between(
+                affine, unit.truth.affine_local, unit.width, unit.height
+            ),
+            1,
+        )
+    return record
+
+
+def corners_to_affine(corners: list[list[float]], size: tuple[int, int]) -> np.ndarray:
+    """Local-pixel affine from TL/TR/BR/BL world corners (the quad is a parallelogram)."""
+    top_left = np.array(corners[0], dtype=float)
+    top_right = np.array(corners[1], dtype=float)
+    bottom_left = np.array(corners[3], dtype=float)
+    width, height = size
+    column_x = (top_right - top_left) / width
+    column_y = (bottom_left - top_left) / height
+    return np.array(
+        [
+            [column_x[0], column_y[0], top_left[0]],
+            [column_x[1], column_y[1], top_left[1]],
+        ]
+    )
+
+
+def attach_case_folded_truth(volume: Path, units: list[PageUnit]) -> int:
+    """Attach truth to pages whose truth key differs from the jpg stem only in case.
+
+    Lettered pages are written ``p1499J`` in the truth annotations and ``p1499j`` on
+    disk, so an exact-key lookup silently leaves them unscored — and unscored pages
+    would quietly vanish from a head-to-head comparison. Returns how many were fixed.
+    """
+    truth_by_key, _ = load_truth_units(volume)
+    folded = {key.lower(): item for key, item in truth_by_key.items()}
+    fixed = 0
+    for unit in units:
+        if unit.truth is not None:
+            continue
+        item = folded.get(unit.stem.lower())
+        if item is None:
+            continue
+        source = item["target"]["source"]
+        affine_full = fit_transform(extract_gcps(item), annotation_transform_type(item))
+        unit.truth = TruthFit(
+            affine_local=scale_affine_to_local(
+                affine_full, source["width"], unit.width
+            ),
+            gcp_count=len(extract_gcps(item)),
+            transform_type=annotation_transform_type(item),
+        )
+        if unit.gen_affine is not None:
+            unit.rmse_ft = grid_rmse_ft_between(
+                unit.truth.affine_local, unit.gen_affine, unit.width, unit.height
+            )
+        fixed += 1
+    return fixed
+
+
+def volume_context(volume: Path):
+    """(locator, centerlines, filter params, volume scale) for a volume."""
+    keymaps = discover_keymaps([str(volume / "p1.jpg")])
+    locator = KeymapLocator.from_keymaps(keymaps) if keymaps else None
+    centerlines_path = volume / "centerlines.geojson"
+    centerlines = (
+        json.loads(centerlines_path.read_text())["features"]
+        if centerlines_path.exists()
+        else []
+    )
+    return (
+        locator,
+        centerlines,
+        volume_filter_params(volume),
+        volume_median_scale_px_per_m(volume),
+    )
+
+
+def cmd_candidates(args: argparse.Namespace) -> None:
+    """Solve every eligible page of a volume and write candidates.jsonl."""
+    volume = Path(args.volume)
+    locator, centerlines, filter_params, scale = volume_context(volume)
+    if not centerlines:
+        sys.exit(f"{volume} has no centerlines.geojson")
+    wanted = set(args.pages.split(",")) if args.pages else None
+    units = load_page_units(volume)
+    fixed = attach_case_folded_truth(volume, units)
+    if fixed:
+        print(f"attached truth to {fixed} case-mismatched page(s)", file=sys.stderr)
+    gates = StreetGates(**parse_gate_overrides(args.gates))
+    records = []
+    for unit in units:
+        if wanted is not None and unit.stem not in wanted:
+            continue
+        record = solve_page(
+            volume,
+            unit,
+            locator,
+            centerlines,
+            filter_params,
+            scale,
+            gates,
+            allow_truth_prior=args.truth_prior,
+        )
+        records.append(record)
+        print(
+            f"{unit.stem:<10} {record.get('status', '?'):<26} "
+            f"prior={record.get('prior_source', '-'):<14} "
+            f"constraints={record.get('n_constraints', 0):<3} "
+            f"inliers={record.get('n_inliers', 0):<3} "
+            f"streets={format_ft(record.get('street_rmse_ft'))} "
+            f"ransac={format_ft(record.get('ransac_rmse_ft'))}",
+            flush=True,
+        )
+    out_dir = volume / ARTIFACT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "candidates.jsonl"
+    out_path.write_text("".join(json.dumps(r) + "\n" for r in records))
+    print(f"\nwrote {out_path} ({len(records)} pages)")
+
+
+def format_ft(value: float | None) -> str:
+    """A right-aligned RMSE cell, or a dash when the page has no such fit."""
+    return "     -" if value is None else f"{value:6.0f}"
+
+
+def parse_gate_overrides(text: str | None) -> dict:
+    """``angle_gate_deg=6,position_gate_m=60`` -> kwargs for StreetGates."""
+    if not text:
+        return {}
+    overrides = {}
+    for part in text.split(","):
+        key, _, value = part.partition("=")
+        overrides[key.strip()] = float(value)
+    return overrides
+
+
+def cmd_report(args: argparse.Namespace) -> None:
+    """Head-to-head table: streets-only vs RANSAC, per volume and aggregate."""
+    rows: list[dict] = []
+    for volume_arg in args.volumes:
+        path = Path(volume_arg) / ARTIFACT_DIR / "candidates.jsonl"
+        if not path.exists():
+            print(f"skip {volume_arg}: no candidates.jsonl", file=sys.stderr)
+            continue
+        for line in path.read_text().splitlines():
+            record = json.loads(line)
+            record["volume"] = Path(volume_arg).name
+            rows.append(record)
+    if not rows:
+        sys.exit("no candidate records; run `candidates` first")
+
+    posed = [r for r in rows if r.get("status") == "posed"]
+    comparable = [
+        r
+        for r in posed
+        if r.get("street_rmse_ft") is not None and r.get("ransac_rmse_ft") is not None
+    ]
+    print(f"{len(rows)} pages, {len(posed)} posed, {len(comparable)} comparable\n")
+    print(f"{'page':<22} {'prior':<14} {'streets':>8} {'ransac':>8} {'delta':>8}")
+    for record in sorted(
+        comparable, key=lambda r: r["ransac_rmse_ft"] - r["street_rmse_ft"]
+    ):
+        delta = record["ransac_rmse_ft"] - record["street_rmse_ft"]
+        print(
+            f"{record['volume'][:12]}/{record['stem']:<9} "
+            f"{record.get('prior_source', '-'):<14} "
+            f"{record['street_rmse_ft']:8.0f} {record['ransac_rmse_ft']:8.0f} "
+            f"{delta:+8.0f}"
+        )
+    wins = sum(1 for r in comparable if r["street_rmse_ft"] < r["ransac_rmse_ft"] - 5)
+    losses = sum(1 for r in comparable if r["street_rmse_ft"] > r["ransac_rmse_ft"] + 5)
+    print(
+        f"\nstreets better on {wins}, worse on {losses}, "
+        f"within 5 ft on {len(comparable) - wins - losses}"
+    )
+    print("\nabstentions:")
+    reasons: dict[str, int] = {}
+    for record in rows:
+        status = record.get("status", "?")
+        if status != "posed":
+            reasons[status] = reasons.get(status, 0) + 1
+    for reason, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+        print(f"  {reason:<32} {count}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    candidates = sub.add_parser("candidates", help="Solve a volume's pages.")
+    candidates.add_argument("volume")
+    candidates.add_argument("--pages", help="Comma-separated stems (default: all).")
+    candidates.add_argument("--gates", help="Overrides, e.g. 'angle_gate_deg=6'.")
+    candidates.add_argument(
+        "--truth-prior",
+        action="store_true",
+        help="Allow the truth-centroid prior rung (experiment ceiling only).",
+    )
+    candidates.set_defaults(func=cmd_candidates)
+
+    report = sub.add_parser("report", help="Head-to-head vs RANSAC.")
+    report.add_argument("volumes", nargs="+")
+    report.set_defaults(func=cmd_report)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -27,6 +27,7 @@ import io
 import json
 import math
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import numpy as np
@@ -47,6 +48,7 @@ from mapsnap.edge_join_experiment import (
 )
 from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
 from mapsnap.keymap.align_page_region import (
+    angle_difference_mod180,
     pose_corners_world,
     pose_world_of,
     volume_filter_params,
@@ -311,6 +313,7 @@ def street_records(
     origin: tuple[float, float],
     gates: StreetGates,
     label_scale: tuple[float, float],
+    raw_soups: dict | None = None,
 ) -> list[dict]:
     """Every considered detection under a pose, in the .georef.json street schema.
 
@@ -336,26 +339,62 @@ def street_records(
         snap_lon, snap_lat = unproject(
             float(snapped[0]), float(snapped[1]), origin[0], origin[1]
         )
-        records.append(
-            {
-                "street": name,
-                "x": round(center_px[0] / label_scale[0]),
-                "y": round(center_px[1] / label_scale[1]),
-                "lat": round(lat, 7),
-                "lon": round(lon, 7),
-                "dir_x": round(math.cos(dir_pix), 6),
-                "dir_y": round(math.sin(dir_pix), 6),
-                "dir_lon": round((tip_lon - lon) / norm, 6),
-                "dir_lat": round((tip_lat - lat) / norm, 6),
-                "inlier": position_m <= gates.position_gate_m
-                and abs(angle_deg) <= gates.angle_gate_deg,
-                "position_m": round(position_m, 1),
-                "angle_deg": round(angle_deg, 2),
-                "snap_lon": round(snap_lon, 7),
-                "snap_lat": round(snap_lat, 7),
-            }
-        )
+        record = {
+            "street": name,
+            "x": round(center_px[0] / label_scale[0]),
+            "y": round(center_px[1] / label_scale[1]),
+            "lat": round(lat, 7),
+            "lon": round(lon, 7),
+            "dir_x": round(math.cos(dir_pix), 6),
+            "dir_y": round(math.sin(dir_pix), 6),
+            "dir_lon": round((tip_lon - lon) / norm, 6),
+            "dir_lat": round((tip_lat - lat) / norm, 6),
+            "inlier": position_m <= gates.position_gate_m
+            and abs(angle_deg) <= gates.angle_gate_deg,
+            "position_m": round(position_m, 1),
+            "angle_deg": round(angle_deg, 2),
+            "snap_lon": round(snap_lon, 7),
+            "snap_lat": round(snap_lat, 7),
+        }
+        if raw_soups is not None:
+            record.update(extension_diagnostics(raw_soups.get(name), world, position_m))
+        records.append(record)
     return records
+
+
+def extension_diagnostics(
+    raw: tuple[np.ndarray, np.ndarray] | None, world: np.ndarray, used_m: float
+) -> dict:
+    """How much this constraint leaned on the terminal extension, and whether it should.
+
+    ``distance_to_drawn_m`` is the distance to the street as OSM actually draws it, so
+    the gap against the reported distance is what extending the open end bought.
+    ``local_bend_deg`` is the widest bearing disagreement among the drawn segments
+    within 100 m of that nearest point: a street that is turning there is one whose
+    straight continuation is a guess, which is the case a fixed allowance cannot see.
+    """
+    if raw is None or not len(raw[0]):
+        return {}
+    starts, ends = raw
+    delta = ends - starts
+    length_sq = (delta * delta).sum(axis=1)
+    t = np.clip(
+        ((world - starts) * delta).sum(axis=1) / np.maximum(length_sq, 1e-9), 0, 1
+    )
+    projected = starts + t[:, None] * delta
+    distances = np.linalg.norm(world - projected, axis=1)
+    nearest = int(distances.argmin())
+    near = np.linalg.norm(projected - projected[nearest], axis=1) <= 100.0
+    bearings = np.degrees(np.arctan2(delta[near, 0], delta[near, 1])) % 180.0
+    bend = 0.0
+    for i, first in enumerate(bearings):
+        for second in bearings[i + 1 :]:
+            bend = max(bend, abs(angle_difference_mod180(float(first), float(second))))
+    return {
+        "distance_to_drawn_m": round(float(distances[nearest]), 1),
+        "extension_gain_m": round(float(distances[nearest]) - round(used_m, 1), 1),
+        "local_bend_deg": round(bend, 1),
+    }
 
 
 def nearest_point_on(point, starts, ends):
@@ -411,6 +450,7 @@ def write_georef_streets(
     label_size: tuple[int, int],
     suffix: str,
     extra: dict,
+    raw_soups: dict | None = None,
 ) -> Path:
     """Write one <stem>.georef-streets*.json in the pipeline's sidecar schema."""
     size = (unit.width, unit.height)
@@ -420,7 +460,7 @@ def write_georef_streets(
         "height": label_size[1],
         "corners": pose_corners_world(pose, size, prior.center),
         "streets": street_records(
-            constraints, pose, size, prior.center, gates, label_scale
+            constraints, pose, size, prior.center, gates, label_scale, raw_soups
         ),
         "intersections": [],
         "keymap": {
@@ -598,6 +638,18 @@ def cmd_materialize(args: argparse.Namespace) -> None:
             scale_px_per_m=scale or 1.0,
             gates=gates,
         )
+        # The same constraints without the terminal extension, so each record can say
+        # what the extension bought and whether the street bends where it was applied.
+        drawn = assemble_constraints(
+            features,
+            block_index,
+            prior=prior,
+            label_size=label_size,
+            working_size=size,
+            scale_px_per_m=scale or 1.0,
+            gates=StreetGates(**{**asdict(gates), "terminal_extrapolation_m": 0.0}),
+        )
+        raw_soups = {c[2]: (c[3], c[4]) for c in drawn}
         psi_priors = psi_votes(constraints, gates) + psi_priors_for(
             features, block_index, prior
         )
@@ -635,7 +687,7 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                     result.pose,
                     gates,
                     label_size,
-                    "streets",
+                    args.suffix,
                     {
                         "pose": [round(v, 6) for v in result.pose],
                         "psi_source": result.psi_source,
@@ -647,6 +699,7 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                             None if unit.rmse_ft is None else round(unit.rmse_ft, 1)
                         ),
                     },
+                    raw_soups,
                 )
             )
         else:
@@ -662,13 +715,14 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                     truth_pose,
                     gates,
                     label_size,
-                    "streets-truth",
+                    f"{args.suffix}-truth",
                     {
                         "pose": [round(v, 6) for v in truth_pose],
                         "source": "truth",
                         "n_constraints": len(constraints),
                         "note": "detections scored against the human georeference",
                     },
+                    raw_soups,
                 )
             )
         for path in written:
@@ -697,6 +751,11 @@ def main() -> None:
     materialize.add_argument("--pages", required=True)
     materialize.add_argument("--gates")
     materialize.add_argument("--truth-prior", action="store_true")
+    materialize.add_argument(
+        "--suffix",
+        default="streets",
+        help="Sidecar suffix: <stem>.georef-<suffix>.json (default: %(default)s).",
+    )
     materialize.set_defaults(func=cmd_materialize)
 
     report = sub.add_parser("report", help="Head-to-head vs RANSAC.")

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -57,6 +57,7 @@ from mapsnap.keymap.align_page_region import (
 from mapsnap.keymap.fit_keymap import project, unproject
 from mapsnap.keymap.locate import KeymapLocator, discover_keymaps
 from mapsnap.osm_snap import dedupe_thetas, label_osm_rotations
+from mapsnap.road_model import page_world_affine
 from mapsnap.street_solve import (
     PriorLocation,
     StreetGates,
@@ -559,6 +560,135 @@ def parse_gate_overrides(text: str | None) -> dict:
     return overrides
 
 
+# Two poses closer than this are not a disagreement worth refereeing.
+DISAGREE_FT = 25.0
+# The streets pose is adopted only when the referee prefers it by more than this.
+# Swept over all 123 production-incumbent disagreements: every threshold loses
+# zero pages and creates zero disasters, so this only trades how much upside is
+# taken; 0.2 sits in the middle of a flat plateau at ~95% precision.
+ADOPT_GAP = 0.2
+
+
+def incumbent_pose(volume: Path, unit: PageUnit) -> tuple[np.ndarray | None, str]:
+    """(affine, source) of the pose the pipeline publishes for a page.
+
+    Snap's sidecar takes priority in the production glob, so on a page it acted on
+    that -- not the RANSAC fit -- is what a challenger has to beat.
+    """
+    osm_path = volume / f"{unit.stem}.georef-osm.json"
+    if osm_path.exists():
+        try:
+            return page_world_affine(json.loads(osm_path.read_text())), "snap"
+        except (KeyError, TypeError, ValueError):
+            pass
+    return unit.gen_affine, "ransac"
+
+
+def cmd_select(args: argparse.Namespace) -> None:
+    """Adopt the streets pose where an independent referee prefers it.
+
+    Neither channel can say which of the two is right -- their agreement is a coin
+    flip and neither ranks its own fits. `osm_snap.evaluate_pose` can: it scores any
+    pose by road-skeleton chamfer against OSM plus name alignment, evidence derived
+    from neither channel's fitting criterion. Both poses are scored by identical
+    features, and the streets pose is written only when the referee prefers it by
+    ADOPT_GAP. Measured over every disagreement in the twelve truth volumes, that
+    picks the closer pose 86% of the time and never costs a page its <=25 ft
+    placement.
+    """
+    from mapsnap.osm_snap import evaluate_pose
+    from mapsnap.osm_snap_experiment import build_page_context, load_volume_context
+
+    volume = Path(args.volume)
+    locator, centerlines, filter_params, scale = volume_context(volume)
+    gates = StreetGates(**parse_gate_overrides(args.gates))
+    units = load_page_units(volume)
+    attach_case_folded_truth(volume, units)
+    posed = {}
+    path = volume / ARTIFACT_DIR / "candidates.jsonl"
+    if path.exists():
+        for line in path.read_text().splitlines():
+            record = json.loads(line)
+            if record.get("status") == "posed" and record.get("corners"):
+                posed[record["stem"]] = record
+    if not posed:
+        sys.exit(f"no posed candidates in {path}; run `candidates` first")
+
+    for stale in volume.glob("p*.georef-streets.json"):
+        stale.unlink()  # this command owns them; never leave a previous run's pick
+
+    vctx = load_volume_context(volume, units)
+    adopted = 0
+    for unit in units:
+        record = posed.get(unit.stem)
+        if record is None:
+            continue
+        incumbent_affine, source = incumbent_pose(volume, unit)
+        if incumbent_affine is None:
+            continue
+        size = (unit.width, unit.height)
+        streets_affine = corners_to_affine(record["corners"], size)
+        apart = grid_rmse_ft_between(
+            streets_affine, incumbent_affine, unit.width, unit.height
+        )
+        if apart < DISAGREE_FT:
+            continue
+        ctx, _status = build_page_context(vctx, unit)
+        if ctx is None:
+            continue
+        incumbent = evaluate_pose(ctx, vctx.feature_index, incumbent_affine)
+        challenger = evaluate_pose(ctx, vctx.feature_index, streets_affine)
+        if incumbent is None or challenger is None:
+            continue
+        gap = challenger["verification"] - incumbent["verification"]
+        if gap <= args.adopt_gap:
+            continue
+        prior = page_prior(unit, locator)
+        if prior is None:
+            continue
+        prepared = page_features(volume, unit, prior, centerlines, filter_params)
+        if prepared is None:
+            continue
+        features, block_index, label_size = prepared
+        constraints = assemble_constraints(
+            features,
+            block_index,
+            prior=prior,
+            label_size=label_size,
+            working_size=size,
+            scale_px_per_m=scale or 1.0,
+            gates=gates,
+        )
+        write_georef_streets(
+            volume,
+            unit,
+            prior,
+            constraints,
+            tuple(record["pose"]),
+            gates,
+            label_size,
+            "streets",
+            {
+                "pose": record["pose"],
+                "adopted_over": source,
+                "verification": {
+                    "streets": round(challenger["verification"], 4),
+                    "incumbent": round(incumbent["verification"], 4),
+                    "gap": round(gap, 4),
+                },
+                "disagreement_ft": round(apart, 1),
+                "rmse_ft": record.get("street_rmse_ft"),
+            },
+        )
+        adopted += 1
+        print(
+            f"{unit.stem:<10} adopted over {source:<6} gap {gap:+.3f} "
+            f"(apart {apart:.0f} ft)",
+            flush=True,
+        )
+    print(f"\n{adopted} page(s) adopted in {volume.name}")
+
+
 def cmd_report(args: argparse.Namespace) -> None:
     """Head-to-head table: streets-only vs RANSAC, per volume and aggregate."""
     rows: list[dict] = []
@@ -757,6 +887,19 @@ def main() -> None:
         help="Sidecar suffix: <stem>.georef-<suffix>.json (default: %(default)s).",
     )
     materialize.set_defaults(func=cmd_materialize)
+
+    select = sub.add_parser(
+        "select", help="Adopt the streets pose where the referee prefers it."
+    )
+    select.add_argument("volume")
+    select.add_argument("--gates")
+    select.add_argument(
+        "--adopt-gap",
+        type=float,
+        default=ADOPT_GAP,
+        help="Verification margin the streets pose must win by (default: %(default)s).",
+    )
+    select.set_defaults(func=cmd_select)
 
     report = sub.add_parser("report", help="Head-to-head vs RANSAC.")
     report.add_argument("volumes", nargs="+")

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -636,8 +636,11 @@ def cmd_select(args: argparse.Namespace) -> None:
         ctx, _status = build_page_context(vctx, unit)
         if ctx is None:
             continue
-        incumbent = evaluate_pose(ctx, vctx.feature_index, incumbent_affine)
-        challenger = evaluate_pose(ctx, vctx.feature_index, streets_affine)
+        # The volume's OSM features, as whichever form this checkout's snap wants:
+        # a spatial index where one exists, else the plain feature list.
+        osm_features = getattr(vctx, "feature_index", vctx.features)
+        incumbent = evaluate_pose(ctx, osm_features, incumbent_affine)
+        challenger = evaluate_pose(ctx, osm_features, streets_affine)
         if incumbent is None or challenger is None:
             continue
         gap = challenger["verification"] - incumbent["verification"]

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -201,6 +201,7 @@ def solve_page(
         prior=prior,
         label_size=label_size,
         working_size=size,
+        scale_px_per_m=scale_px_per_m or 1.0,
         gates=gates,
     )
     record["n_constraints"] = len(constraints)
@@ -594,6 +595,7 @@ def cmd_materialize(args: argparse.Namespace) -> None:
             prior=prior,
             label_size=label_size,
             working_size=size,
+            scale_px_per_m=scale or 1.0,
             gates=gates,
         )
         psi_priors = psi_votes(constraints, gates) + psi_priors_for(

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -35,6 +35,7 @@ from mapsnap.compare_iiif_georef import (
     annotation_transform_type,
     extract_gcps,
     fit_transform,
+    truth_polygons_by_page,
 )
 from mapsnap.edge_join_experiment import (
     PageUnit,
@@ -47,9 +48,11 @@ from mapsnap.edge_join_experiment import (
 from mapsnap.georef_from_labels import LabelFeature, prepare_label_features
 from mapsnap.keymap.align_page_region import (
     pose_corners_world,
+    pose_world_of,
     volume_filter_params,
     volume_median_scale_px_per_m,
 )
+from mapsnap.keymap.fit_keymap import project, unproject
 from mapsnap.keymap.locate import KeymapLocator, discover_keymaps
 from mapsnap.osm_snap import dedupe_thetas, label_osm_rotations
 from mapsnap.street_solve import (
@@ -59,6 +62,7 @@ from mapsnap.street_solve import (
     assemble_constraints,
     psi_from_theta,
     psi_votes,
+    residuals_at,
     solve_streets_pose,
 )
 from mapsnap.streets import build_block_index
@@ -299,6 +303,144 @@ def attach_case_folded_truth(volume: Path, units: list[PageUnit]) -> int:
     return fixed
 
 
+def street_records(
+    constraints: list,
+    pose,
+    size: tuple[int, int],
+    origin: tuple[float, float],
+    gates: StreetGates,
+    label_scale: tuple[float, float],
+) -> list[dict]:
+    """Every considered detection under a pose, in the .georef.json street schema.
+
+    Adds the diagnostics this channel turns on — the distance and angle to the
+    matched centerline, and the point it snapped to — so the debugger can draw the
+    residual that decided inlier or outlier.
+    """
+    records = []
+    for constraint in constraints:
+        center_px, dir_pix, name, starts, ends = constraint
+        position_m, angle_deg = residuals_at(pose, constraint, size)
+        world = pose_world_of(pose, center_px, size)
+        lon, lat = unproject(float(world[0]), float(world[1]), origin[0], origin[1])
+        step = 20.0
+        tip_px = (
+            center_px[0] + step * math.cos(dir_pix),
+            center_px[1] + step * math.sin(dir_pix),
+        )
+        tip = pose_world_of(pose, tip_px, size)
+        tip_lon, tip_lat = unproject(float(tip[0]), float(tip[1]), origin[0], origin[1])
+        norm = math.hypot(tip_lon - lon, tip_lat - lat) or 1.0
+        snapped = nearest_point_on(world, starts, ends)
+        snap_lon, snap_lat = unproject(
+            float(snapped[0]), float(snapped[1]), origin[0], origin[1]
+        )
+        records.append(
+            {
+                "street": name,
+                "x": round(center_px[0] / label_scale[0]),
+                "y": round(center_px[1] / label_scale[1]),
+                "lat": round(lat, 7),
+                "lon": round(lon, 7),
+                "dir_x": round(math.cos(dir_pix), 6),
+                "dir_y": round(math.sin(dir_pix), 6),
+                "dir_lon": round((tip_lon - lon) / norm, 6),
+                "dir_lat": round((tip_lat - lat) / norm, 6),
+                "inlier": position_m <= gates.position_gate_m
+                and abs(angle_deg) <= gates.angle_gate_deg,
+                "position_m": round(position_m, 1),
+                "angle_deg": round(angle_deg, 2),
+                "snap_lon": round(snap_lon, 7),
+                "snap_lat": round(snap_lat, 7),
+            }
+        )
+    return records
+
+
+def nearest_point_on(point, starts, ends):
+    """The closest point to ``point`` on a segment soup (metre frame)."""
+    delta = ends - starts
+    length_sq = (delta * delta).sum(axis=1)
+    t = np.clip(
+        ((point - starts) * delta).sum(axis=1) / np.maximum(length_sq, 1e-9), 0, 1
+    )
+    projected = starts + t[:, None] * delta
+    return projected[int(np.linalg.norm(point - projected, axis=1).argmin())]
+
+
+def truth_pose_for(unit: PageUnit, origin: tuple[float, float]):
+    """The truth transform expressed as a StreetPose in the prior's metre frame."""
+    if unit.truth is None:
+        return None
+    affine = unit.truth.affine_local
+
+    def world(px: float, py: float):
+        lon, lat = affine @ np.array([px, py, 1.0])
+        return np.array(project(float(lon), float(lat), origin[0], origin[1]))
+
+    center = world(unit.width / 2, unit.height / 2)
+    up = world(unit.width / 2, unit.height / 2 - 1.0) - center
+    psi = math.degrees(math.atan2(up[0], up[1]))
+    return (
+        float(center[0]),
+        float(center[1]),
+        psi,
+        math.log(1.0 / float(np.linalg.norm(up))),
+    )
+
+
+def truth_rings(volume: Path, unit: PageUnit) -> list | None:
+    """The page's human footprint ring(s) as [lon, lat] lists, if truth exists."""
+    truth_path = volume / "main.iiif.json"
+    if not truth_path.exists():
+        return None
+    polygons = truth_polygons_by_page(truth_path).get(unit.number)
+    if not polygons:
+        return None
+    return [[[float(x), float(y)] for x, y in ring] for ring in polygons]
+
+
+def write_georef_streets(
+    volume: Path,
+    unit: PageUnit,
+    prior: PriorLocation,
+    constraints: list,
+    pose,
+    gates: StreetGates,
+    label_size: tuple[int, int],
+    suffix: str,
+    extra: dict,
+) -> Path:
+    """Write one <stem>.georef-streets*.json in the pipeline's sidecar schema."""
+    size = (unit.width, unit.height)
+    label_scale = (size[0] / label_size[0], size[1] / label_size[1])
+    doc = {
+        "width": label_size[0],
+        "height": label_size[1],
+        "corners": pose_corners_world(pose, size, prior.center),
+        "streets": street_records(
+            constraints, pose, size, prior.center, gates, label_scale
+        ),
+        "intersections": [],
+        "keymap": {
+            "lat": round(prior.center[1], 7),
+            "lon": round(prior.center[0], 7),
+            "radius_m": round(prior.radius_m, 1),
+            "centers": [[round(c[0], 7), round(c[1], 7)] for c in prior.centers],
+            "source": prior.source,
+        },
+        "street_solve": extra,
+    }
+    rings = truth_rings(volume, unit)
+    if rings:
+        # The human footprint, so one file shows where the page belongs beside where
+        # this fit put it.
+        doc["truth"] = rings
+    path = volume / f"{unit.stem}.georef-{suffix}.json"
+    path.write_text(json.dumps(doc, indent=2) + "\n")
+    return path
+
+
 def volume_context(volume: Path):
     """(locator, centerlines, filter params, volume scale) for a volume."""
     keymaps = discover_keymaps([str(volume / "p1.jpg")])
@@ -425,6 +567,112 @@ def cmd_report(args: argparse.Namespace) -> None:
         print(f"  {reason:<32} {count}")
 
 
+def cmd_materialize(args: argparse.Namespace) -> None:
+    """Write .georef-streets.json (and the truth-pose twin) for chosen pages."""
+    volume = Path(args.volume)
+    locator, centerlines, filter_params, scale = volume_context(volume)
+    gates = StreetGates(**parse_gate_overrides(args.gates))
+    units = load_page_units(volume)
+    attach_case_folded_truth(volume, units)
+    wanted = set(args.pages.split(","))
+    for unit in units:
+        if unit.stem not in wanted:
+            continue
+        prior = page_prior(unit, locator, allow_truth=args.truth_prior)
+        if prior is None:
+            print(f"{unit.stem}: no prior", file=sys.stderr)
+            continue
+        prepared = page_features(volume, unit, prior, centerlines, filter_params)
+        if prepared is None:
+            print(f"{unit.stem}: no vocabulary", file=sys.stderr)
+            continue
+        features, block_index, label_size = prepared
+        size = (unit.width, unit.height)
+        constraints = assemble_constraints(
+            features,
+            block_index,
+            prior=prior,
+            label_size=label_size,
+            working_size=size,
+            gates=gates,
+        )
+        psi_priors = psi_votes(constraints, gates) + psi_priors_for(
+            features, block_index, prior
+        )
+        result = solve_streets_pose(
+            constraints,
+            size=size,
+            prior_log_scale=math.log(scale) if scale else 0.0,
+            psi_priors=psi_priors,
+            gates=gates,
+            prior_radius_m=prior.radius_m,
+        )
+        written = []
+        if result.pose is not None:
+            rmse = (
+                round(
+                    grid_rmse_ft_between(
+                        corners_to_affine(
+                            pose_corners_world(result.pose, size, prior.center), size
+                        ),
+                        unit.truth.affine_local,
+                        unit.width,
+                        unit.height,
+                    ),
+                    1,
+                )
+                if unit.truth is not None
+                else None
+            )
+            written.append(
+                write_georef_streets(
+                    volume,
+                    unit,
+                    prior,
+                    constraints,
+                    result.pose,
+                    gates,
+                    label_size,
+                    "streets",
+                    {
+                        "pose": [round(v, 6) for v in result.pose],
+                        "psi_source": result.psi_source,
+                        "scale_source": result.scale_source,
+                        "n_inliers": result.n_inliers,
+                        "n_constraints": len(constraints),
+                        "rmse_ft": rmse,
+                        "ransac_rmse_ft": (
+                            None if unit.rmse_ft is None else round(unit.rmse_ft, 1)
+                        ),
+                    },
+                )
+            )
+        else:
+            print(f"{unit.stem}: abstained ({result.abstain})", file=sys.stderr)
+        truth_pose = truth_pose_for(unit, prior.center)
+        if truth_pose is not None:
+            written.append(
+                write_georef_streets(
+                    volume,
+                    unit,
+                    prior,
+                    constraints,
+                    truth_pose,
+                    gates,
+                    label_size,
+                    "streets-truth",
+                    {
+                        "pose": [round(v, 6) for v in truth_pose],
+                        "source": "truth",
+                        "n_constraints": len(constraints),
+                        "note": "detections scored against the human georeference",
+                    },
+                )
+            )
+        for path in written:
+            print(path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     sub = parser.add_subparsers(dest="command", required=True)
@@ -439,6 +687,15 @@ def main() -> None:
         help="Allow the truth-centroid prior rung (experiment ceiling only).",
     )
     candidates.set_defaults(func=cmd_candidates)
+
+    materialize = sub.add_parser(
+        "materialize", help="Write .georef-streets.json sidecars for chosen pages."
+    )
+    materialize.add_argument("volume")
+    materialize.add_argument("--pages", required=True)
+    materialize.add_argument("--gates")
+    materialize.add_argument("--truth-prior", action="store_true")
+    materialize.set_defaults(func=cmd_materialize)
 
     report = sub.add_parser("report", help="Head-to-head vs RANSAC.")
     report.add_argument("volumes", nargs="+")

--- a/mapsnap/street_solve_test.py
+++ b/mapsnap/street_solve_test.py
@@ -9,8 +9,9 @@ from mapsnap.keymap.align_page_region import (
 from mapsnap.street_solve import (
     StreetGates,
     bearing_spread,
-    consensus_pose,
+    consensus_poses,
     distinct_lines,
+    extend_terminal_segments,
     psi_from_theta,
     psi_votes,
     residuals_at,
@@ -233,16 +234,16 @@ def test_bearing_spread_measures_the_widest_pair():
     assert 85.0 < spread <= 90.0
 
 
-def test_consensus_returns_none_without_a_diverse_pair():
+def test_consensus_returns_nothing_without_a_diverse_pair():
     parallel = [
         constraint_for(TRUE_POSE, "A", (200.0, 300.0), 25.0),
         constraint_for(TRUE_POSE, "B", (500.0, 300.0), 25.0),
     ]
     assert (
-        consensus_pose(
+        consensus_poses(
             parallel, TRUE_POSE[2], [(LOG_SCALE, "prior")], SIZE, StreetGates()
         )
-        is None
+        == []
     )
 
 
@@ -306,3 +307,34 @@ def test_abstains_when_only_two_streets_support_the_pose():
         psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
     )
     assert result.pose is None and result.abstain == "no-consensus"
+
+
+def test_extends_only_the_open_ends_of_a_polyline():
+    starts, ends = street_along((0.0, 0.0), 0.0, length_m=600.0)
+    before = float(np.sum(np.linalg.norm(ends - starts, axis=1)))
+    new_starts, new_ends = extend_terminal_segments(starts, ends, 80.0)
+    after = float(np.sum(np.linalg.norm(new_ends - new_starts, axis=1)))
+    # Both ends grow by the allowance; the interior joins are untouched.
+    assert abs((after - before) - 160.0) < 1e-6
+    assert np.allclose(new_starts[1:], starts[1:])
+    assert np.allclose(new_ends[:-1], ends[:-1])
+
+
+def test_street_ending_short_still_constrains_the_page():
+    # New Orleans p181's SOUTH MIRO: the label sits on the street's line but 49 m
+    # past where OSM stops drawing it. Without the allowance that reads as a 49 m
+    # position error, and the solver moves the page to "fix" it.
+    world = pose_world_of(TRUE_POSE, (500.0, 200.0), SIZE)
+    starts, ends = street_along((world[0], world[1] - 90.0), 0.0, length_m=100.0)
+    stub = (
+        (500.0, 200.0),
+        math.radians((0.0 - TRUE_POSE[2] - 90.0) % 180.0),
+        "SHORT",
+        starts,
+        ends,
+    )
+    before, _ = residuals_at(TRUE_POSE, stub, SIZE)
+    extended = (*stub[:3], *extend_terminal_segments(starts, ends, 80.0))
+    after, _ = residuals_at(TRUE_POSE, extended, SIZE)
+    assert before > 35.0  # measured to the polyline's end
+    assert after < 1.0  # measured across to its line, where the label actually sits

--- a/mapsnap/street_solve_test.py
+++ b/mapsnap/street_solve_test.py
@@ -268,3 +268,41 @@ def test_psi_votes_outvote_a_single_wrong_street():
     planted[-1] = (planted[-1][0], math.radians(0.0), "ROGUE", *planted[-1][3:])
     votes = psi_votes(planted)
     assert any(abs(v - TRUE_POSE[2]) < 1.0 for v, _ in votes[:2])
+
+
+def test_abstains_when_most_constraints_disagree():
+    # Kansas City p576: a pose that satisfied two streets while four others said no,
+    # 1080 ft from truth. Explaining half the page is not enough.
+    disagreeing = scene() + [
+        constraint_for(
+            TRUE_POSE,
+            f"OTHER{i}",
+            (200.0 + 90 * i, 250.0),
+            25.0,
+            offset_m=(260.0 + 40 * i, 190.0),
+        )
+        for i in range(4)
+    ]
+    result = solve_streets_pose(
+        disagreeing,
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is None, f"posed with {result.n_inliers}/{len(disagreeing)}"
+
+
+def test_abstains_when_only_two_streets_support_the_pose():
+    # Two streets fix the pose exactly, leaving nothing to check it against.
+    two_streets = [
+        constraint_for(TRUE_POSE, "FIRST", (250.0, 400.0), 25.0),
+        constraint_for(TRUE_POSE, "FIRST", (250.0, 600.0), 25.0),
+        constraint_for(TRUE_POSE, "CROSS", (500.0, 1100.0), 115.0),
+    ]
+    result = solve_streets_pose(
+        two_streets,
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is None and result.abstain == "no-consensus"

--- a/mapsnap/street_solve_test.py
+++ b/mapsnap/street_solve_test.py
@@ -1,0 +1,250 @@
+import math
+
+import numpy as np
+
+from mapsnap.keymap.align_page_region import (
+    init_pose_from_model,
+    pose_world_of,
+)
+from mapsnap.street_solve import (
+    StreetGates,
+    bearing_spread,
+    consensus_pose,
+    distinct_lines,
+    psi_from_theta,
+    residuals_at,
+    solve_streets_pose,
+)
+
+SIZE = (1000, 1400)
+SCALE = 2.0  # pixels per metre
+LOG_SCALE = math.log(SCALE)
+
+
+def street_along(
+    point_m: tuple[float, float], bearing_deg: float, length_m: float = 600.0
+) -> tuple[np.ndarray, np.ndarray]:
+    """A straight street's segment soup, centred on a point, at a world bearing."""
+    direction = np.array(
+        [math.sin(math.radians(bearing_deg)), math.cos(math.radians(bearing_deg))]
+    )
+    center = np.array(point_m)
+    steps = np.linspace(-length_m / 2, length_m / 2, 13)
+    points = center + steps[:, None] * direction
+    return points[:-1], points[1:]
+
+
+def constraint_for(
+    pose, name: str, pixel: tuple[float, float], bearing_deg: float, offset_m=(0.0, 0.0)
+):
+    """A constraint whose street passes through the pixel's true world position.
+
+    ``offset_m`` displaces the street from that position, so a test can plant a
+    constraint that the pose cannot satisfy.
+    """
+    world = pose_world_of(pose, pixel, SIZE)
+    starts, ends = street_along(
+        (world[0] + offset_m[0], world[1] + offset_m[1]), bearing_deg
+    )
+    dir_pix = math.radians((bearing_deg - pose[2] - 90.0) % 180.0)
+    return (pixel, dir_pix, name, starts, ends)
+
+
+TRUE_POSE = (120.0, -80.0, 25.0, LOG_SCALE)
+
+
+def scene(pose=TRUE_POSE):
+    """Two parallel streets (bearing 25) plus one crossing street (bearing 115)."""
+    return [
+        constraint_for(pose, "FIRST", (250.0, 400.0), 25.0),
+        constraint_for(pose, "SECOND", (750.0, 400.0), 25.0),
+        constraint_for(pose, "CROSS", (500.0, 1100.0), 115.0),
+    ]
+
+
+def test_psi_from_theta_matches_pose_convention():
+    # A pixel delta maps to a raster-frame angle of page_angle + psi, so theta negates.
+    for psi in (0.0, 25.0, -70.0, 170.0):
+        pose = (0.0, 0.0, psi, LOG_SCALE)
+        start = pose_world_of(pose, (500.0, 700.0), SIZE)
+        end = pose_world_of(pose, (600.0, 700.0), SIZE)  # page angle 0
+        raster = math.degrees(math.atan2(-(end[1] - start[1]), end[0] - start[0]))
+        theta = 0.0 - raster
+        assert abs((psi_from_theta(theta) - psi + 180) % 360 - 180) < 1e-6
+
+
+def test_psi_matches_init_pose_from_model():
+    # The same bearing convention the region placer derives from its similarity model.
+    for psi in (0.0, 40.0, -110.0):
+        pose = (0.0, 0.0, psi, LOG_SCALE)
+        center = pose_world_of(pose, (SIZE[0] / 2, SIZE[1] / 2), SIZE)
+        up = pose_world_of(pose, (SIZE[0] / 2, SIZE[1] / 2 - 1.0), SIZE)
+        model_psi = math.degrees(math.atan2(up[0] - center[0], up[1] - center[1]))
+        assert abs((model_psi - psi + 180) % 360 - 180) < 1e-6
+
+
+def test_distinct_lines_collapses_a_straight_street():
+    starts, ends = street_along((0.0, 0.0), 40.0)
+    assert len(starts) == 12
+    assert len(distinct_lines(starts, ends)) == 1
+
+
+def test_recovers_pose_from_two_parallels_and_a_crossing():
+    result = solve_streets_pose(
+        scene(),
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is not None, result.abstain
+    assert result.n_inliers == 3
+    assert (
+        math.hypot(result.pose[0] - TRUE_POSE[0], result.pose[1] - TRUE_POSE[1]) < 5.0
+    )
+    assert abs(result.pose[2] - TRUE_POSE[2]) < 0.5
+
+
+def test_scale_recovered_from_parallel_spacing_without_a_good_prior():
+    # The prior is off by 40% and effectively unweighted: the two parallel streets'
+    # spacing has to carry the scale on its own, which is the claim in issue #168.
+    result = solve_streets_pose(
+        scene(),
+        size=SIZE,
+        prior_log_scale=LOG_SCALE + math.log(1.4),
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+        gates=StreetGates(sigma_log_scale=5.0),
+    )
+    assert result.pose is not None, result.abstain
+    assert result.scale_source == "parallel-pair"
+    assert abs(result.pose[3] - LOG_SCALE) < 0.05
+
+
+def test_scale_prior_strength_trades_against_the_streets():
+    # With a tight prior the same scene keeps the (wrong) prior scale: the sigma is a
+    # real knob, not decoration -- the harness sweeps it.
+    tight = solve_streets_pose(
+        scene(),
+        size=SIZE,
+        prior_log_scale=LOG_SCALE + math.log(1.4),
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+        gates=StreetGates(sigma_log_scale=0.01),
+    )
+    assert tight.pose is not None, tight.abstain
+    assert abs(tight.pose[3] - (LOG_SCALE + math.log(1.4))) < 0.05
+
+
+def test_rejects_a_wrong_street_a_kilometre_away():
+    # LA p1499J's BROOKLYN PLACE: right name, renamed street, matched 1 km off.
+    planted = scene() + [
+        constraint_for(
+            TRUE_POSE, "RENAMED", (500.0, 700.0), 60.0, offset_m=(900.0, 500.0)
+        )
+    ]
+    result = solve_streets_pose(
+        planted,
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is not None, result.abstain
+    assert result.n_inliers == 3
+    dropped = [d for d in result.diagnostics if not d.inlier]
+    assert [d.name for d in dropped] == ["RENAMED"]
+    assert dropped[0].position_m is not None and dropped[0].position_m > 500.0
+
+
+def test_rejects_a_rerouted_street_whose_angle_disagrees():
+    # Kansas City's GILLHAM: the street is there, but its drawn geometry is not OSM's.
+    planted = scene() + [
+        constraint_for(TRUE_POSE, "REROUTED", (300.0, 900.0), 25.0 + 40.0)
+    ]
+    planted[-1] = (planted[-1][0], math.radians(0.0), "REROUTED", *planted[-1][3:])
+    result = solve_streets_pose(
+        planted,
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is not None, result.abstain
+    assert "REROUTED" not in [d.name for d in result.diagnostics if d.inlier]
+
+
+def test_abstains_without_a_rotation_prior():
+    result = solve_streets_pose(
+        scene(), size=SIZE, prior_log_scale=LOG_SCALE, psi_priors=[]
+    )
+    assert result.pose is None and result.abstain == "no-rotation-prior"
+
+
+def test_abstains_with_too_few_constraints():
+    result = solve_streets_pose(
+        scene()[:2],
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is None and result.abstain == "too-few-constraints"
+
+
+def test_abstains_when_every_street_is_parallel():
+    # Three parallels leave the along-street translation free: no diverse pair exists.
+    parallel = [
+        constraint_for(TRUE_POSE, "A", (200.0, 300.0), 25.0),
+        constraint_for(TRUE_POSE, "B", (500.0, 300.0), 25.0),
+        constraint_for(TRUE_POSE, "C", (800.0, 300.0), 25.0),
+    ]
+    result = solve_streets_pose(
+        parallel,
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+    )
+    assert result.pose is None and result.abstain == "no-consensus"
+
+
+def test_abstains_outside_the_prior_radius():
+    result = solve_streets_pose(
+        scene(),
+        size=SIZE,
+        prior_log_scale=LOG_SCALE,
+        psi_priors=[(TRUE_POSE[2], "label-pair-exact")],
+        prior_radius_m=50.0,  # the true centre sits ~144 m from the prior
+    )
+    assert result.pose is None and result.abstain == "outside-prior-radius"
+
+
+def test_truncated_street_produces_a_large_residual_not_a_plausible_one():
+    # G2/G3: OSM keeps only a stub of a street the sheet drew in full. Snapping is
+    # clipped to the stub, so the label lands far from it and the gate drops it.
+    stub_pose = TRUE_POSE
+    world = pose_world_of(stub_pose, (500.0, 200.0), SIZE)
+    starts, ends = street_along((world[0], world[1] + 400.0), 25.0, length_m=40.0)
+    truncated = ((500.0, 200.0), math.radians(0.0), "STUB", starts, ends)
+    position, _angle = residuals_at(stub_pose, truncated, SIZE)
+    assert position > 300.0
+    gates = StreetGates()
+    assert position > gates.position_gate_m
+
+
+def test_bearing_spread_measures_the_widest_pair():
+    poses = scene()
+    spread = bearing_spread(TRUE_POSE, poses)
+    assert 85.0 < spread <= 90.0
+
+
+def test_consensus_returns_none_without_a_diverse_pair():
+    parallel = [
+        constraint_for(TRUE_POSE, "A", (200.0, 300.0), 25.0),
+        constraint_for(TRUE_POSE, "B", (500.0, 300.0), 25.0),
+    ]
+    assert (
+        consensus_pose(
+            parallel, TRUE_POSE[2], [(LOG_SCALE, "prior")], SIZE, StreetGates()
+        )
+        is None
+    )
+
+
+def test_init_pose_from_model_is_importable_for_convention_checks():
+    # Guards the refactor: the region placer's seed helper stays public.
+    assert callable(init_pose_from_model)

--- a/mapsnap/street_solve_test.py
+++ b/mapsnap/street_solve_test.py
@@ -12,6 +12,7 @@ from mapsnap.street_solve import (
     consensus_pose,
     distinct_lines,
     psi_from_theta,
+    psi_votes,
     residuals_at,
     solve_streets_pose,
 )
@@ -248,3 +249,22 @@ def test_consensus_returns_none_without_a_diverse_pair():
 def test_init_pose_from_model_is_importable_for_convention_checks():
     # Guards the refactor: the region placer's seed helper stays public.
     assert callable(init_pose_from_model)
+
+
+def test_psi_votes_finds_the_true_bearing():
+    # Every correct constraint votes for the page's bearing; the flip is a separate
+    # candidate rather than being averaged in (they differ by 180, not by noise).
+    votes = psi_votes(scene())
+    assert votes, "no bearing votes"
+    best = votes[0][0]
+    assert min(abs(best - TRUE_POSE[2]), abs(best - (TRUE_POSE[2] + 180))) < 1.0
+    assert any(abs(v - TRUE_POSE[2]) < 1.0 for v, _ in votes)
+
+
+def test_psi_votes_outvote_a_single_wrong_street():
+    # Three streets agree on the bearing, one rogue is 30 degrees off: the majority
+    # cluster wins, and the rogue survives only as a lower-ranked seed.
+    planted = scene() + [constraint_for(TRUE_POSE, "ROGUE", (400.0, 800.0), 55.0)]
+    planted[-1] = (planted[-1][0], math.radians(0.0), "ROGUE", *planted[-1][3:])
+    votes = psi_votes(planted)
+    assert any(abs(v - TRUE_POSE[2]) < 1.0 for v, _ in votes[:2])

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -280,6 +280,22 @@ def street_base_name(name: str) -> str:
     return name
 
 
+def street_name_family(name: str) -> str:
+    """The distinctive core a street's name variants share.
+
+    Strips a leading or trailing directional word and a trailing type word, so
+    "NORTH BONNIE BEACH PLACE", "SOUTH BONNIE BEACH PLACE" and "BONNIE BEACH PLACE"
+    all reduce to "BONNIE BEACH". Variants that reduce alike are halves or renamings
+    of one street; variants that do not (VAN BRUNT vs VAN DYKE) are different streets.
+    """
+    words = street_base_name(name).split()
+    if len(words) > 1 and words[0] in DIRECTIONAL_SUFFIXES:
+        words = words[1:]
+    if len(words) > 1 and words[-1] in STREET_TYPES:
+        words = words[:-1]
+    return " ".join(words)
+
+
 def is_number_only(text: str) -> bool:
     """Return True if text contains no alphabetic characters (e.g. block numbers)."""
     return not bool(re.search(r"[a-zA-Z]", text))


### PR DESCRIPTION
Fits a page from street labels treated as position+angle constraints against their named OSM polylines, with no intersection GCPs — issue #168's idea. Two distinct parallel streets fix rotation and, from their spacing, scale; one crossing street completes the pose.

**Measured on the twelve truth volumes: aggregate score 73.1 → 74.6 (+1.5), no volume regressing, disasters down from 3.2% to 2.8% of land.**

| volume | before | after |
|---|---|---|
| los_angeles_ca_1949_vol_14 | 78.1 | **82.6** |
| kansas_city_mo_1951_vol_4 | 67.8 | **70.7** |
| new_orleans_la_1896_vol_2 | 67.3 | **69.7** |
| grand_rapids_mi_1953_vol7 | 66.6 | 67.7 |
| brooklyn_ny_1939_vol_1 | 79.1 | 80.1 |
| washington_dc_1916_vol_2 | 78.4 | 79.3 |
| the other six | — | unchanged |
| **aggregate** | **73.1** | **74.6** |

Only eleven pages are adopted, but they are land-heavy — two LA pages carry +4.5 on their own.

## The solver

`mapsnap/street_solve.py` plus a truth-aware harness (`candidates | select | report | materialize`) and 22 synthetic tests. It reuses the region placer's math through three behavior-preserving extractions in `align_page_region.py` (`PoseSigmas`, `solve_pose`, `constraints_from_features`), so none of it is reimplemented.

It runs only where a page has a coarse location prior, restricts the vocabulary to that neighborhood, and is built around the measured fact that **a quarter to a half of assembled constraints are wrong** — renamed streets matching elsewhere, streets rerouted since the survey, near-square text boxes whose long axis is meaningless. Poses come from consensus over constraint pairs, inliers from hard angle/position gates, and a pose resting on a single constraint is rejected. Six anti-drift guards are enumerated in the module docstring; the re-snapping loop that made a predecessor version of this idea drift does not exist here by construction.

## What the pages taught it

- **A street whose OSM data stops short is not a misplaced page.** New Orleans p181's SOUTH MIRO sits **0.3 m from its street's line and 49 m past the end of it** — OSM draws less than the 1896 sheet did. Measuring point-to-segment charged that shortfall as position error, error *largest at the true pose*, so the solver slid pages away from truth to reduce it. Extending open polyline ends fixed p181 96 → 11 ft, KC p502 93 → 13 ft, Chicago p70w 376 → 11 ft.
- **ψ is mod-360, not mod-180** — the page has a top. Clustering bearings mod-180 averaged 25° and 205° into a meaningless 115°, which alone was the difference between LA p1499J abstaining and placing at 15 ft.
- **The unambiguous-only rule discarded same-street variants**: on p1499J every multi-candidate label was direction-prefix aliasing of one street, and merging them took constraint recall from 4 to 13.
- **Leave-one-out needs real redundancy** — at four inliers, dropping one leaves an exactly determined three that moves for sound reasons.

## Why it needs a referee, and which one works

On its own the channel is a coin flip against the incumbent: medians 13 ft vs 13 ft, head-to-head 162/150/400 across 712 pages. Worse, **nothing derived from the two channels can tell which is right** — their agreement predicts correctness at 50–52% across every disagreement band, and the solver cannot rank its own fits (inlier fraction is uninformative). An oracle that applies it only where the incumbent is bad is worth +81 pages, but the oracle needs truth.

`osm_snap.evaluate_pose` is the one signal derived from neither: road-skeleton chamfer against OSM plus name alignment. Scoring both poses with identical features picks the closer one **104 of 123 times (85%)**, and symmetrically — 79% when it prefers the street pose, 86% when it keeps the incumbent. `select` writes a sidecar only where it prefers the street pose by `ADOPT_GAP`.

The gate is forgiving: **every threshold from 0.05 up loses zero pages and creates zero disasters**, so it only trades how much upside is taken. 0.2 ships (91% precision).

Two things worth knowing for anyone extending this:

- **The incumbent is what the pipeline publishes, snap's sidecar included** — not the RANSAC fit beneath it. Snap already replaces that pose on 90 of the 155 RANSAC-vs-streets disagreements, so judging against RANSAC measures a fight production is not having and roughly triples the apparent headroom.
- **The existing 0.1 incumbent-verification gate is wrong for this challenger.** Where the incumbent is "defensible" (≥0.1), the street pose is closer only 19% of the time; the head-to-head gap is the signal, not a floor on the incumbent.

## Notes

`make_iiif_georef`'s page-key pattern needed `-streets` added: an unlisted variant produces no page key, so the glob matches the file and the annotation is silently short. Eleven adopted poses vanished that way and scored exactly as the baseline, which reads like a no-op rather than a bug. There is now a test per variant.

Measurements assume #176 (the edge-margin fix) — without it this channel silently drops a 2% band of page-edge labels that production keeps. Independent of #174; the referee call reads whichever feature form that branch has left in place.

778 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
