### PR TITLE
Stop filtering page edges in callers the pipeline does not

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -2603,7 +2603,7 @@ def prepare_label_features(
     min_long_side: float = 250.0,
     min_short_side: float = 60.0,
     min_aspect_ratio: float = 2.0,
-    edge_margin: float = 0.02,
+    edge_margin: float = 0.0,
     high_confidence_size_fraction: float = 0.7,
     keep_labels_on_fill: bool = False,
     collinear_perp_tolerance_px: float = COLLINEAR_PERP_TOLERANCE_PX,
@@ -2783,7 +2783,7 @@ def process_image(
     min_long_side: float = 250.0,
     min_short_side: float = 60.0,
     min_aspect_ratio: float = 2.0,
-    edge_margin: float = 0.02,
+    edge_margin: float = 0.0,
     force_intersection: tuple[int, int] | None = None,
     one_gcp_fits: bool = False,
     debug: bool = False,
@@ -3629,6 +3629,8 @@ def main() -> None:
         "auto_threshold_percentile": args.auto_threshold_percentile,
         "auto_threshold_include_hints": auto_threshold_include_hints,
         "high_confidence_size_fraction": args.high_confidence_size_fraction,
+        "edge_margin": args.edge_margin,
+        "keep_labels_on_fill": args.keep_labels_on_fill,
     }
 
     n_success = 0

--- a/mapsnap/keymap/align_page_region.py
+++ b/mapsnap/keymap/align_page_region.py
@@ -1207,6 +1207,8 @@ def volume_filter_params(volume: Path) -> dict:
         "min_short_side",
         "min_aspect_ratio",
         "high_confidence_size_fraction",
+        "edge_margin",
+        "keep_labels_on_fill",
     )
     for georef_path in sorted(volume.glob("p*.georef.json")):
         parameters = (


### PR DESCRIPTION
`--edge-margin` has defaulted to `0.0` since e5faa6f ("change default flags", June 11), but `prepare_label_features` and `process_image` kept the original `0.02` in their signatures. The value is also never written to a sidecar's `inputs.parameters`, so `volume_filter_params` cannot restore it — which means **every caller that rebuilds the pipeline's filters from a sidecar has been discarding a 2% band around each page that production keeps.** The region placer in `align_page_region` does exactly that.

The labels in that band are the ones naming the streets along a page's edges, which is precisely what a fit wants. Kansas City p547 loses `45TH` this way — confidence 0.55, never consulted, because the label sits 36 px down a 1949 px sheet — and p502 loses `39TH` and `LOCUST`.

This sets the function defaults to `0.0`, matching the CLI, and records `edge_margin` and `keep_labels_on_fill` in `inputs.parameters` so a run that sets either is reproducible instead of silently falling back. Older sidecars omit both and now resolve to the production defaults, which is what they were fit with.

## Audit of the other filters

Four more parameters have signature defaults that disagree with the CLI — `min_confidence` 0.5 vs 0.15, the size floors 250/60 vs auto-computed, `min_aspect_ratio` 2.0 vs 1.0 — but each **is** recorded and restored, so reconstructing callers get production's values. They are latent traps for a caller that forgets to pass `filter_params`, not active bugs. `high_confidence_size_fraction` agrees at 0.7, and `collinear_perp_tolerance_px` has no flag, so it is a genuine constant.

This changes what the region placer sees, so its "streets used" counts have been slightly understated on pages with edge labels.

756 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)