### PR TITLE
Volume viewer: take the missing pages from the comparison

### DIFF
--- a/app/server/compareTxt.ts
+++ b/app/server/compareTxt.ts
@@ -30,6 +30,12 @@ export interface ComparePageStats {
 /** Response of GET /iiif-api/compare — paired-page stats plus the table's summary footer. */
 export interface CompareResponse {
   pages: ComparePageStats[];
+  /**
+   * Truth page keys the run never placed — the table's `(no fit)` rows, at the
+   * granularity the comparison itself counts, so the viewer's missing rows and the
+   * "N/M pages georeferenced" line always agree.
+   */
+  missing: string[];
   /** The summary block below the table ("N/M = …% pages georeferenced", RMSE stats, …); "" if none. */
   footer: string;
 }
@@ -37,6 +43,15 @@ export interface CompareResponse {
 // Whether a line is a header/rule row of the compare table (not a data row).
 function isSeparator(line: string): boolean {
   return /^-{3,}$/.test(line.trim());
+}
+
+/** The truth page key of a `(no fit)` row, or null for any other line. */
+export function parseMissingRow(line: string): string | null {
+  const trailing = line.match(/\s+\(no fit\)\s*$/);
+  if (!trailing) return null;
+  const tokens = line.slice(0, trailing.index).trim().split(/\s+/);
+  const key = tokens[0];
+  return key && !isSeparator(key) ? key : null;
 }
 
 // Parse one data row; returns null for `(no fit)` (truth-only) rows and unparseable lines.
@@ -89,9 +104,8 @@ function parseRow(line: string): ComparePageStats | null {
 /**
  * Parse a `mapsnap compare` table, returning the paired pages' error stats.
  *
- * Returns [] when the text is not a compare table (e.g. an unrelated `.txt`). Only rows with a
- * fit are returned; `(no fit)` truth-only rows are dropped (the viewer sources missing pages
- * from the truth annotation instead).
+ * Returns [] when the text is not a compare table (e.g. an unrelated `.txt`).
+ * `(no fit)` truth-only rows are reported separately by {@link parseMissingTruthKeys}.
  */
 export function parseCompareTxt(text: string): ComparePageStats[] {
   const lines = text.split('\n');
@@ -108,6 +122,30 @@ export function parseCompareTxt(text: string): ComparePageStats[] {
     if (row) pages.push(row);
   }
   return pages;
+}
+
+/**
+ * Truth page keys the run never placed: the table's `(no fit)` rows, in table order.
+ *
+ * The comparison already decides this — including which truth split a generated page
+ * matched — so the viewer reads it rather than re-deriving coverage from the two
+ * annotations, which is how its missing rows drifted from the "N/M pages
+ * georeferenced" line the same file reports.
+ */
+export function parseMissingTruthKeys(text: string): string[] {
+  const lines = text.split('\n');
+  const header = lines.find((line) => line.trim() !== '');
+  if (!header || !header.includes('rmse_ft')) return [];
+  const start = lines.findIndex(isSeparator);
+  if (start < 0) return [];
+  const keys: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (isSeparator(line)) break;
+    const key = parseMissingRow(line);
+    if (key) keys.push(key);
+  }
+  return keys;
 }
 
 /**

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -20,7 +20,11 @@ import {
   type VolumeInfo,
 } from './iiifAnnotations.ts';
 import { jpegDimensions } from './jpegDimensions.ts';
-import { parseCompareFooter, parseCompareTxt } from './compareTxt.ts';
+import {
+  parseCompareFooter,
+  parseCompareTxt,
+  parseMissingTruthKeys,
+} from './compareTxt.ts';
 
 const require = createRequire(import.meta.url);
 const iiif = require('express-iiif').default;
@@ -170,9 +174,13 @@ export function registerIiifApi(
     );
     try {
       const text = await readFile(txtPath, 'utf8');
-      return { pages: parseCompareTxt(text), footer: parseCompareFooter(text) };
+      return {
+        pages: parseCompareTxt(text),
+        missing: parseMissingTruthKeys(text),
+        footer: parseCompareFooter(text),
+      };
     } catch {
-      return { pages: [], footer: '' };
+      return { pages: [], missing: [], footer: '' };
     }
   });
 

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -104,6 +104,9 @@ export function VolumeViewer() {
   const [compareRows, setCompareRows] = useState<ComparePageStats[] | null>(
     null,
   );
+  // Truth page keys the compare table marks `(no fit)` — the misses it counts, which is
+  // what the missing rows show, so the two never disagree.
+  const [compareMissing, setCompareMissing] = useState<string[]>([]);
   // The compare table's summary footer ("N/M pages georeferenced", RMSE stats), or "" if none.
   const [compareFooter, setCompareFooter] = useState<string>('');
   // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
@@ -148,13 +151,16 @@ export function VolumeViewer() {
     setCompareRows(null);
     setCompareFooter('');
     fetchCompare(selectedPath)
-      .then(({ pages, footer }) => {
+      .then(({ pages, missing, footer }) => {
         if (cancelled) return;
         setCompareRows(pages);
+        setCompareMissing(missing);
         setCompareFooter(footer);
       })
       .catch(() => {
-        if (!cancelled) setCompareRows([]);
+        if (cancelled) return;
+        setCompareRows([]);
+        setCompareMissing([]);
       });
 
     // Truth annotation, rewritten into the same local pixel frame, for the missing-page
@@ -262,8 +268,8 @@ export function VolumeViewer() {
   );
   // Truth pages the run never georeferenced, shown as "missing" rows/footprints.
   const missingPages = useMemo(
-    () => (truthPages ? missingTruthPages(pages, truthPages) : []),
-    [pages, truthPages],
+    () => (truthPages ? missingTruthPages(truthPages, compareMissing) : []),
+    [truthPages, compareMissing],
   );
 
   // Adjacency claim boxes, mapped into geo through each page's georeference: the fitted pages,

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -154,7 +154,7 @@ export function VolumeViewer() {
       .then(({ pages, missing, footer }) => {
         if (cancelled) return;
         setCompareRows(pages);
-        setCompareMissing(missing);
+        setCompareMissing(missing ?? []);
         setCompareFooter(footer);
       })
       .catch(() => {

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -263,3 +263,11 @@ describe('missingTruthPages', () => {
     expect(missingTruthPages([pageGeo('p1', 0)], [])).toEqual([]);
   });
 });
+
+describe('missingTruthPages resilience', () => {
+  it('reports nothing when the response carries no missing field', () => {
+    // An older server, or a compare sidecar predating the field: no misses beats a
+    // crashed page.
+    expect(missingTruthPages([pageGeo('p1', 0)], undefined)).toEqual([]);
+  });
+});

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -212,31 +212,54 @@ describe('pagesFromAnnotation', () => {
   });
 });
 
-// A stand-in PageGeo carrying only the fields missingTruthPages reads.
-function pageGeo(pageKey: string, itemIndex: number): PageGeo {
-  return { pageKey, itemIndex } as PageGeo;
+// A stand-in PageGeo carrying the fields missingTruthPages reads.
+function pageGeo(stem: string, itemIndex: number): PageGeo {
+  return {
+    stem,
+    pageKey: stem.split('__')[0]!,
+    itemIndex,
+  } as PageGeo;
 }
 
 describe('missingTruthPages', () => {
-  it('returns truth pages absent from the fit, with negative ids', () => {
-    const fit = [pageGeo('p1', 0), pageGeo('p2', 1)];
+  it('selects the truth pages the comparison marked as unplaced', () => {
     const truth = [pageGeo('p1', 0), pageGeo('p2', 1), pageGeo('p3', 2)];
-    const missing = missingTruthPages(fit, truth);
-    expect(missing.map((p) => p.pageKey)).toEqual(['p3']);
+    const missing = missingTruthPages(truth, ['p3']);
+    expect(missing.map((p) => p.stem)).toEqual(['p3']);
     // Negative id keeps it out of the fit pages' itemIndex space.
     expect(missing[0]!.itemIndex).toBe(-1);
   });
 
-  it('dedupes a split parent that appears once per truth panel', () => {
-    const fit = [pageGeo('p1', 0)];
-    const truth = [pageGeo('p9', 5), pageGeo('p9', 6), pageGeo('p10', 7)];
-    const missing = missingTruthPages(fit, truth);
-    expect(missing.map((p) => p.pageKey)).toEqual(['p9', 'p10']);
+  it('lists each unplaced panel of a sheet under its own stem', () => {
+    // Hudson: both p92 panels are unplaced. The old parent-key rule collapsed them
+    // into one row called "p92", hiding p92__1 -- the largest single miss there is.
+    const truth = [
+      pageGeo('p92__1', 5),
+      pageGeo('p92__2', 6),
+      pageGeo('p91', 7),
+    ];
+    const missing = missingTruthPages(truth, ['p92__1', 'p92__2']);
+    expect(missing.map((p) => p.stem)).toEqual(['p92__1', 'p92__2']);
     expect(missing.map((p) => p.itemIndex)).toEqual([-1, -2]);
   });
 
-  it('returns nothing when every truth page was fitted', () => {
-    const fit = [pageGeo('p1', 0), pageGeo('p2', 1)];
-    expect(missingTruthPages(fit, [pageGeo('p1', 0)])).toEqual([]);
+  it('keeps a panel whose sibling was placed', () => {
+    // Champaign: p4__1 is placed and p4__2 is not. Keying on the parent page counted
+    // the whole sheet as present, so the volume showed no misses against four reported.
+    const truth = [pageGeo('p4__1', 0), pageGeo('p4__2', 1)];
+    expect(missingTruthPages(truth, ['p4__2']).map((p) => p.stem)).toEqual([
+      'p4__2',
+    ]);
+  });
+
+  it('matches keys case-insensitively', () => {
+    // Lettered pages are p1499J in the annotations and p1499j on disk.
+    expect(
+      missingTruthPages([pageGeo('p1499j', 0)], ['p1499J']).map((p) => p.stem),
+    ).toEqual(['p1499j']);
+  });
+
+  it('returns nothing when the comparison reports no misses', () => {
+    expect(missingTruthPages([pageGeo('p1', 0)], [])).toEqual([]);
   });
 });

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -203,9 +203,11 @@ function gcpPoints(features: GcpFeature[]): PageGcp[] {
  */
 export function missingTruthPages(
   truthPages: PageGeo[],
-  missingKeys: readonly string[],
+  missingKeys: readonly string[] | undefined,
 ): PageGeo[] {
-  const wanted = new Set(missingKeys.map((key) => key.toLowerCase()));
+  // A compare sidecar written before this field existed, or a server still serving
+  // the older response, simply reports no misses rather than taking the page down.
+  const wanted = new Set((missingKeys ?? []).map((key) => key.toLowerCase()));
   const missing: PageGeo[] = [];
   for (const truthPage of truthPages) {
     if (!wanted.has(truthPage.stem.toLowerCase())) continue;

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -12,7 +12,11 @@ import type {
   GeorefAnnotationPage,
   GcpFeature,
 } from '../../server/iiifAnnotations';
-import { computeCorners, projectThroughCorners } from '../geometry';
+import {
+  computeCorners,
+  pointInPolygon,
+  projectThroughCorners,
+} from '../geometry';
 import type { Corners, Street } from '../types';
 
 const FEET_PER_METER = 3.28084;
@@ -185,32 +189,27 @@ function gcpPoints(features: GcpFeature[]): PageGcp[] {
 }
 
 /**
- * Truth pages that the loaded run never georeferenced, ready to show as
- * "missing" rows and footprints.
+ * Truth pages the loaded run never placed, ready to show as "missing" rows and
+ * footprints.
  *
- * A truth page is missing when its page key is absent from the fitted pages.
- * Results are deduped by page key (a split parent has one truth item per panel;
- * we keep the first) and given negative `itemIndex` selection ids so they never
- * collide with the fitted pages' array indices.
+ * `missingKeys` comes from the compare sidecar's `(no fit)` rows, so this list is the
+ * one the "N/M pages georeferenced" line counts — including split panels, which is
+ * what the previous parent-key rule hid: a page whose sibling panel was fitted showed
+ * no miss at all (Champaign reported four while showing none), and several missing
+ * panels of one sheet collapsed into a single parent row (Hudson's p92__1, the largest
+ * single miss in the corpus, was invisible).
+ *
+ * Negative `itemIndex` selection ids keep these clear of the fitted pages' array indices.
  */
 export function missingTruthPages(
-  fitPages: PageGeo[],
   truthPages: PageGeo[],
+  missingKeys: readonly string[],
 ): PageGeo[] {
-  const fitKeys = new Set(fitPages.map((page) => page.pageKey));
-  const seen = new Set<string>();
+  const wanted = new Set(missingKeys.map((key) => key.toLowerCase()));
   const missing: PageGeo[] = [];
   for (const truthPage of truthPages) {
-    if (fitKeys.has(truthPage.pageKey) || seen.has(truthPage.pageKey)) continue;
-    seen.add(truthPage.pageKey);
-    // The whole page is missing (no panel was fitted), so label it by the parent
-    // key rather than the first truth panel's split stem.
-    missing.push({
-      ...truthPage,
-      itemIndex: -(missing.length + 1),
-      splitIndex: null,
-      stem: truthPage.pageKey,
-    });
+    if (!wanted.has(truthPage.stem.toLowerCase())) continue;
+    missing.push({ ...truthPage, itemIndex: -(missing.length + 1) });
   }
   return missing;
 }


### PR DESCRIPTION
The pages list and the "N/M pages georeferenced" line in the same volume disagreed, because they counted different things. The list keyed on the **parent page**, so a sheet with any one panel placed showed no miss at all — Champaign reported four losses while listing none — and several missing panels of one sheet collapsed into a single parent row, which is how Hudson's `p92__1`, the largest single miss across the twelve truth volumes, stayed invisible.

The comparison already decides this per truth page, including which truth split a generated page matched, so the viewer now reads its `(no fit)` rows (`parseMissingTruthKeys`, surfaced through the existing `/iiif-api/compare` route) instead of re-deriving coverage from the two annotations. Both numbers come from one source and cannot drift apart again.

Verified against the sidecars, each volume matching its own footer:

| volume | missing rows | footer |
|---|---|---|
| Champaign | 4 | 4 total losses |
| Hudson | 25, incl. `p92__1` and `p92__2` separately | 25 total losses |
| Los Angeles | 6 | 6 total losses |
| Kansas City | 14 | 14 total losses |

I first tried recomputing coverage client-side and got Champaign to 3 — `p13__1` looked 89% covered on the ground while the comparison correctly counts it a loss, since the generated panel covers a different piece of paper. Deferring to the pipeline avoids that whole class of disagreement.

Missing rows now keep their own stems, so they sort naturally beside their siblings and select correctly, and the footprints drawn under "Show missing pages" come from each panel's own truth georeference rather than the parent's.

The second commit is a guard: an API server started before the `missing` field existed returns the older shape, and destructuring it took the whole page down on load. It now reports no misses instead.

132 app tests, tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)