### PR TITLE
Adjacency labeler: label split panels instead of the sheets they split

### DIFF
--- a/app/server/adjacencyRoutes.ts
+++ b/app/server/adjacencyRoutes.ts
@@ -13,11 +13,20 @@ import {
   findVolumes,
   isSafePage,
   isSafeVolume,
+  isSupersededSheet,
   readTruth,
   volumePages,
   writePageTruth,
 } from './adjacencyTruth.ts';
+import type { AdjacencyPageTruth } from './adjacencyTruth.ts';
 import type { ImageInfo } from '../src/keymap/types.ts';
+
+/** Stems that already carry labels, so a split sheet's own labels stay reachable. */
+function labeledStems(truth: Record<string, AdjacencyPageTruth>): Set<string> {
+  return new Set(
+    Object.keys(truth).filter((stem) => truth[stem]?.labels?.length),
+  );
+}
 
 /** Register the adjacency-truth endpoints on the shared crosswalk router. */
 export function registerAdjacencyTruthApi(
@@ -28,9 +37,9 @@ export function registerAdjacencyTruthApi(
   router.get('/api/adjacency-volumes', async () => {
     const volumes = [];
     for (const name of await findVolumes(dataDir)) {
-      const pages = await volumePages(dataDir, name);
-      if (!pages.length) continue;
       const truth = await readTruth(dataDir, name);
+      const pages = await volumePages(dataDir, name, labeledStems(truth));
+      if (!pages.length) continue;
       const labeled = pages.filter((p) => truth[p]?.labels?.length).length;
       volumes.push({ name, pageCount: pages.length, labeledPages: labeled });
     }
@@ -44,13 +53,17 @@ export function registerAdjacencyTruthApi(
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
     const truth = await readTruth(dataDir, volume);
-    const pages: ImageInfo[] = (await volumePages(dataDir, volume)).map(
-      (stem) => {
-        const labels = truth[stem]?.labels ?? [];
-        const withText = labels.filter((l) => l.text.trim()).length;
-        return { name: stem, withText, withoutText: labels.length - withText };
-      },
-    );
+    const stems = await volumePages(dataDir, volume, labeledStems(truth));
+    const pages: ImageInfo[] = stems.map((stem) => {
+      const labels = truth[stem]?.labels ?? [];
+      const withText = labels.filter((l) => l.text.trim()).length;
+      return {
+        name: stem,
+        withText,
+        withoutText: labels.length - withText,
+        supersededBySplit: isSupersededSheet(stem, stems) || undefined,
+      };
+    });
     return { pages };
   });
 

--- a/app/server/adjacencyTruth.test.ts
+++ b/app/server/adjacencyTruth.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
+  comparePages,
   findVolumes,
   isSafePage,
   isSafeVolume,
-  pageSortKey,
+  isSupersededSheet,
+  panelParent,
   readTruth,
   truthPath,
   volumePages,
@@ -22,8 +24,18 @@ beforeAll(async () => {
     await mkdir(join(path, '..'), { recursive: true });
     await writeFile(path, contents);
   };
-  // A plain volume with whole sheets, a split panel, and non-page files.
-  for (const name of ['p1.jpg', 'p2.jpg', 'p10.jpg', 'p33B.jpg', 'p6__1.jpg']) {
+  // A plain volume with whole sheets, a split sheet (p6 + its panels), an
+  // orphan panel whose sheet is not on disk, and non-page files.
+  for (const name of [
+    'p1.jpg',
+    'p2.jpg',
+    'p10.jpg',
+    'p33B.jpg',
+    'p6.jpg',
+    'p6__1.jpg',
+    'p6__2.jpg',
+    'p7__1.jpg',
+  ]) {
     await write(`champaign/${name}`);
   }
   await write('champaign/raw/p0.jpg'); // raw/ must not be listed as a volume
@@ -43,10 +55,34 @@ describe('discovery', () => {
     ]);
   });
 
-  it('lists whole-sheet stems in natural order, excluding split panels', async () => {
+  it('keeps a superseded sheet listed when it still carries labels', async () => {
+    // p6 is split, but its own labels must stay reachable in the UI.
+    expect(await volumePages(dataDir, 'champaign', new Set(['p6']))).toEqual([
+      'p1',
+      'p2',
+      'p6',
+      'p6__1',
+      'p6__2',
+      'p7__1',
+      'p10',
+      'p33B',
+    ]);
+  });
+
+  it('flags a sheet whose panels supersede it', async () => {
+    const pages = await volumePages(dataDir, 'champaign', new Set(['p6']));
+    expect(isSupersededSheet('p6', pages)).toBe(true);
+    expect(isSupersededSheet('p1', pages)).toBe(false);
+    expect(isSupersededSheet('p6__1', pages)).toBe(false);
+  });
+
+  it('lists panels instead of the sheets they split, in natural order', async () => {
     expect(await volumePages(dataDir, 'champaign')).toEqual([
       'p1',
       'p2',
+      'p6__1', // p6 itself is not offered: its panels supersede it
+      'p6__2',
+      'p7__1', // a panel whose sheet is absent still stands on its own
       'p10',
       'p33B',
     ]);
@@ -62,19 +98,29 @@ describe('validation', () => {
     }
     expect(isSafePage('p12')).toBe(true);
     expect(isSafePage('p33B')).toBe(true);
-    for (const bad of ['p6__1', '12', 'p12/x', '..', 'adjacency-truth']) {
+    expect(isSafePage('p12__1')).toBe(true);
+    for (const bad of [
+      '12',
+      'p12/x',
+      '..',
+      'adjacency-truth',
+      'p12__',
+      'p12__x',
+    ]) {
       expect(isSafePage(bad)).toBe(false);
     }
   });
 
-  it('natural sort puts p2 before p10', () => {
-    const stems = ['p10', 'p2', 'p33B', 'p33A'];
-    stems.sort((a, b) => {
-      const [na, sa] = pageSortKey(a);
-      const [nb, sb] = pageSortKey(b);
-      return na - nb || sa.localeCompare(sb);
-    });
-    expect(stems).toEqual(['p2', 'p10', 'p33A', 'p33B']);
+  it('natural sort orders numbers, suffixes, then panels', () => {
+    const stems = ['p10', 'p2', 'p33B', 'p33A', 'p10__2', 'p10__1'];
+    stems.sort(comparePages);
+    expect(stems).toEqual(['p2', 'p10', 'p10__1', 'p10__2', 'p33A', 'p33B']);
+  });
+
+  it('panelParent strips a panel index and leaves sheets alone', () => {
+    expect(panelParent('p1401__2')).toBe('p1401');
+    expect(panelParent('p1401')).toBe('p1401');
+    expect(panelParent('p33B')).toBe('p33B');
   });
 });
 

--- a/app/server/adjacencyTruth.ts
+++ b/app/server/adjacencyTruth.ts
@@ -10,6 +10,11 @@
  *   { "pages": { "p12": { "width": 1665, "height": 2018,
  *                          "labels": [{"x":…, "y":…, "text": "13"}] } } }
  *
+ * A sheet that has been split into panels is labelled panel by panel, so its
+ * keys are the panel stems (`p1401__1`, `p1401__2`) and the composite sheet is
+ * not offered: the pipeline georeferences panels, and a printed neighbor number
+ * along a panel's edge describes that panel's neighborhood, not the sheet's.
+ *
  * Coordinates are in the pixel frame of the volume-root page image (the 25%
  * scan the debugger displays), recorded by each entry's width/height.
  */
@@ -17,8 +22,8 @@
 import { readFile, readdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 
-/** A whole-sheet page image at the volume root: p12, p33B, p101w — not splits. */
-const PAGE_IMAGE = /^p\d+[A-Za-z]{0,2}\.jpe?g$/;
+/** A page image at the volume root: a whole sheet (p12, p33B, p101w) or a panel (p12__1). */
+const PAGE_IMAGE = /^p\d+[A-Za-z]{0,2}(?:__\d+)?\.jpe?g$/;
 
 /** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
 const MAX_VOLUME_DEPTH = 2;
@@ -49,15 +54,29 @@ export function isSafeVolume(volume: string): boolean {
   );
 }
 
-/** Reject a page stem that is not a plain whole-sheet stem. */
+/** Reject a page stem that is not a whole-sheet stem or a split panel. */
 export function isSafePage(stem: string): boolean {
-  return /^p\d+[A-Za-z]{0,2}$/.test(stem);
+  return /^p\d+[A-Za-z]{0,2}(?:__\d+)?$/.test(stem);
 }
 
-/** Natural sort key for page stems, so p2 sorts before p10. */
-export function pageSortKey(stem: string): [number, string] {
-  const match = /^p(\d+)([A-Za-z]*)$/.exec(stem);
-  return match ? [Number(match[1]), match[2]] : [Number.MAX_SAFE_INTEGER, stem];
+/** Natural sort key for a page stem: number, letter suffix, then panel index. */
+export function pageSortKey(stem: string): [number, string, number] {
+  const match = /^p(\d+)([A-Za-z]*)(?:__(\d+))?$/.exec(stem);
+  if (!match) return [Number.MAX_SAFE_INTEGER, stem, 0];
+  return [Number(match[1]), match[2]!, match[3] ? Number(match[3]) : 0];
+}
+
+/** Compare page stems in natural order: p2 < p10 < p10__1 < p10__2 < p33A. */
+export function comparePages(a: string, b: string): number {
+  const [numberA, suffixA, panelA] = pageSortKey(a);
+  const [numberB, suffixB, panelB] = pageSortKey(b);
+  return numberA - numberB || suffixA.localeCompare(suffixB) || panelA - panelB;
+}
+
+/** The sheet a stem belongs to: a panel's parent (`p12__1` -> `p12`), else itself. */
+export function panelParent(stem: string): string {
+  const separator = stem.indexOf('__');
+  return separator === -1 ? stem : stem.slice(0, separator);
 }
 
 /** Path of a volume's adjacency truth file. */
@@ -90,11 +109,7 @@ export async function writePageTruth(
   // Stable natural page order keeps the file diff-friendly across sessions.
   const sorted = Object.fromEntries(
     Object.keys(pages)
-      .sort((a, b) => {
-        const [na, sa] = pageSortKey(a);
-        const [nb, sb] = pageSortKey(b);
-        return na - nb || sa.localeCompare(sb);
-      })
+      .sort(comparePages)
       .map((key) => [key, pages[key]]),
   );
   await writeFile(
@@ -103,10 +118,20 @@ export async function writePageTruth(
   );
 }
 
-/** Whole-sheet page stems of a volume, naturally sorted. */
+/**
+ * Labelable page stems of a volume, naturally sorted.
+ *
+ * A sheet that has been split contributes its panels *instead of* itself, since
+ * the panels are what carry a page's printed neighbor numbers into the
+ * pipeline; a sheet with no panels on disk contributes itself. `keep` names
+ * stems to list even when their panels supersede them — the caller passes the
+ * sheets that already carry truth labels, so hand-made labels never vanish
+ * from the UI when a sheet is split (they sort just above their panels).
+ */
 export async function volumePages(
   dataDir: string,
   volume: string,
+  keep: ReadonlySet<string> = new Set(),
 ): Promise<string[]> {
   let files: string[];
   try {
@@ -114,14 +139,23 @@ export async function volumePages(
   } catch {
     return [];
   }
-  return files
+  const stems = files
     .filter((file) => PAGE_IMAGE.test(file))
-    .map((file) => file.replace(/\.jpe?g$/, ''))
-    .sort((a, b) => {
-      const [na, sa] = pageSortKey(a);
-      const [nb, sb] = pageSortKey(b);
-      return na - nb || sa.localeCompare(sb);
-    });
+    .map((file) => file.replace(/\.jpe?g$/, ''));
+  const split = new Set(
+    stems.filter((stem) => stem.includes('__')).map(panelParent),
+  );
+  return stems
+    .filter((stem) => stem.includes('__') || !split.has(stem) || keep.has(stem))
+    .sort(comparePages);
+}
+
+/** Whether a stem names a sheet that the volume has split into panels. */
+export function isSupersededSheet(stem: string, pages: string[]): boolean {
+  return (
+    !stem.includes('__') &&
+    pages.some((p) => panelParent(p) === stem && p !== stem)
+  );
 }
 
 /**

--- a/app/src/keymap/ImageList.tsx
+++ b/app/src/keymap/ImageList.tsx
@@ -8,6 +8,17 @@ interface ImageListProps {
   heading?: string;
 }
 
+/** Hover text: why a page is listed, when it is not listed for the usual reason. */
+function pageTitle(info: ImageInfo): string {
+  if (info.hasKeymap === false) {
+    return `${info.name} (no keymap.json; listed because it has truth labels)`;
+  }
+  if (info.supersededBySplit) {
+    return `${info.name} (split into panels; listed because it still has labels of its own)`;
+  }
+  return info.name;
+}
+
 /** Left-column list of available key map pages, with their label counts. */
 export function ImageList(props: ImageListProps) {
   const { images, selectedName, onSelect, heading = 'Key maps' } = props;
@@ -20,15 +31,13 @@ export function ImageList(props: ImageListProps) {
             key={info.name}
             className={info.name === selectedName ? 'selected' : undefined}
             onClick={() => onSelect(info.name)}
-            title={
-              info.hasKeymap === false
-                ? `${info.name} (no keymap.json; listed because it has truth labels)`
-                : info.name
-            }
+            title={pageTitle(info)}
           >
             <span
               className={
-                info.hasKeymap === false ? 'image-name no-keymap' : 'image-name'
+                info.hasKeymap === false || info.supersededBySplit
+                  ? 'image-name listed-for-labels'
+                  : 'image-name'
               }
             >
               {info.name}

--- a/app/src/keymap/keymap.css
+++ b/app/src/keymap/keymap.css
@@ -58,7 +58,9 @@
 }
 
 /* Listed for its truth labels alone: no keymap.json marks it as a key map. */
-.image-list .image-name.no-keymap {
+/* A page listed only because it carries truth labels: no keymap.json of its
+   own, or a sheet whose panels supersede it. */
+.image-list .image-name.listed-for-labels {
   color: #777;
   font-style: italic;
 }

--- a/app/src/keymap/types.ts
+++ b/app/src/keymap/types.ts
@@ -31,4 +31,7 @@ export interface ImageInfo {
   /** Whether the page has a keymap.json sidecar (vs. being listed for its truth).
    * Absent for lists where the notion does not apply (adjacency pages). */
   hasKeymap?: boolean;
+  /** Whether this sheet has been split into panels and is listed only because
+   * it still carries labels of its own (adjacency pages). */
+  supersededBySplit?: boolean;
 }


### PR DESCRIPTION
A sheet split into panels is what the pipeline georeferences, and a printed neighbor number along a panel's edge describes that panel's neighborhood, not the composite sheet's. The labeler now offers `p1401__1`/`p1401__2` rather than `p1401`. Panels sort after their sheet number (`p10 < p10__1 < p10__2 < p33A`) and get their own truth keys.

A split sheet that already carries labels stays listed — italic, with a tooltip explaining why — so hand-made truth never silently disappears. Three sheets were labelled before their panels existed: Hudson `p1` and `p86`, and LA `p1408`.

132 app tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)