### PR TITLE
Show unfit (non-truth) pages, filter keymaps

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -77,14 +77,21 @@ export interface AdjacencyTruthTarget {
 export type AdjacencyLabelsResponse = LabelsWriteRequest | { exists: false };
 
 /**
- * Response of GET /iiif-api/failed-georefs — page stem → failure kind.
+ * Response of GET /iiif-api/failed-georefs — a volume's page files.
  *
- * Maps each page that has a failed-georef sidecar (`<stem>.georef-<kind>.json`,
+ * `failed` maps each page that has a failed-georef sidecar (`<stem>.georef-<kind>.json`,
  * e.g. `p1452.georef-nofit.json`) to its kind ("nofit", "1gcp", "misscale", …),
  * so the volume viewer can link a not-georeferenced page to that debug file.
+ *
+ * `pages` is every page-image stem in the volume, split sheets represented by their
+ * panels. A volume with no truth annotation has no other way to know which pages
+ * exist, so this is what the viewer subtracts the fitted pages from to list the
+ * un-fit ones. Optional so a client talking to an older server degrades to listing
+ * none rather than failing.
  */
 export interface FailedGeorefsResponse {
   failed: Record<string, string>;
+  pages?: string[];
 }
 
 /** One key-map sheet in a volume's `raw/` directory and which sidecars it has. */

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -25,6 +25,7 @@ import {
   parseCompareTxt,
   parseMissingTruthKeys,
 } from './compareTxt.ts';
+import { volumePages } from './adjacencyTruth.ts';
 
 const require = createRequire(import.meta.url);
 const iiif = require('express-iiif').default;
@@ -202,9 +203,11 @@ export function registerIiifApi(
     }
   });
 
-  // Page stems with a failed-georef sidecar in a volume, and each one's kind, so
-  // the viewer can link an un-georeferenced page to its georef-<kind>.json file.
-  // ?volume=<dir> → { failed: { "p1452": "nofit", "p1427": "misscale" } }.
+  // A volume's page files: every page-image stem, plus the ones with a failed-georef
+  // sidecar and that sidecar's kind, so the viewer can link an un-georeferenced page to
+  // its georef-<kind>.json file and — for a volume with no truth annotation — work out
+  // which pages went unplaced at all. ?volume=<dir> →
+  // { pages: ["p1", …], failed: { "p1452": "nofit", "p1427": "misscale" } }.
   router.get('/iiif-api/failed-georefs', async (_params, request) => {
     const { volume } = request.query;
     if (!isSafeName(volume)) {
@@ -224,7 +227,9 @@ export function registerIiifApi(
         failed[match[1]] = match[2].toLowerCase();
       }
     }
-    return { failed };
+    // volumePages drops a split sheet in favour of its panels, so a sheet whose panels
+    // all fitted is not reported as an unplaced page.
+    return { failed, pages: await volumePages(dataDir, volume) };
   });
 
   // A volume's key-map sheets and which visualization sidecars each has, so the viewer can link

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -198,6 +198,7 @@ export function App() {
     minShortSide: 20,
     minLongSide: 20,
     showIgnored: false,
+    text: '',
   });
 
   const prevObjectUrlRef = useRef<string | null>(null);
@@ -593,6 +594,9 @@ export function App() {
         intersections={intersections}
         filteredDetections={
           mode === 'adjacency' ? adjacencyDetections : filteredDetections
+        }
+        detectionCount={
+          mode === 'adjacency' ? adjacencyDetections.length : detections.length
         }
         panels={panels}
         panelLabels={panelLabels}

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -31,6 +31,8 @@ interface ImageColumnProps {
   streets: Street[];
   intersections: IntersectionPoint[];
   filteredDetections: IndexedDetection[];
+  /** Detections before any filtering, for the "showing N of M" readout. */
+  detectionCount: number;
   panels: PanelPolygon[];
   panelLabels?: string[];
   boxes: IndexedBox[];
@@ -68,6 +70,7 @@ export function ImageColumn(props: ImageColumnProps) {
     streets,
     intersections,
     filteredDetections,
+    detectionCount,
     panels,
     panelLabels,
     boxes,
@@ -253,6 +256,27 @@ export function ImageColumn(props: ImageColumnProps) {
 
       {streetsMode && (
         <div id="detection-filters">
+          <div className="filter-row">
+            <label htmlFor="filter-text">
+              Text{' '}
+              {filters.text.trim() !== '' && (
+                <span>
+                  {filteredDetections.length} of {detectionCount}
+                </span>
+              )}
+            </label>
+            <input
+              type="search"
+              id="filter-text"
+              placeholder="e.g. 6, 7"
+              title={
+                'Show only detections whose text matches. Terms match whole words, ' +
+                'so "6" finds page 6 but not 16 or 60; separate alternatives with commas.'
+              }
+              value={filters.text}
+              onChange={(e) => setFilters({ ...filters, text: e.target.value })}
+            />
+          </div>
           <div className="filter-row">
             <label htmlFor="filter-confidence">
               Min confidence: <span>{filters.minConfidence.toFixed(3)}</span>

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import type { KeymapInfo } from '../../server/api';
 import type { SkippedItem } from '../../server/iiifAnnotations';
 import type { PageCompareStats } from '../iiif/compare';
-import type { PageGeo } from '../iiif/pages';
+import { hasFootprint, type PageGeo } from '../iiif/pages';
 
 interface InfoPanelProps {
   /** All pages in the loaded annotation, or [] before one is loaded. */
@@ -145,14 +145,20 @@ export function InfoPanel(props: InfoPanelProps) {
             <>
               <dt>Status</dt>
               <dd>not georeferenced</dd>
-              <dt>Truth scale</dt>
-              <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
-              <dt>Truth rotation</dt>
-              <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
-              <dt>Size</dt>
-              <dd>
-                {selectedPage.width} × {selectedPage.height} px
-              </dd>
+              {/* Everything below comes from the page's truth georeference. A volume
+                  without truth knows only that the page exists and was not placed. */}
+              {hasFootprint(selectedPage) && (
+                <>
+                  <dt>Truth scale</dt>
+                  <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
+                  <dt>Truth rotation</dt>
+                  <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
+                  <dt>Size</dt>
+                  <dd>
+                    {selectedPage.width} × {selectedPage.height} px
+                  </dd>
+                </>
+              )}
             </>
           ) : (
             <>

--- a/app/src/components/PageList.tsx
+++ b/app/src/components/PageList.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 
 import { rmseBucket, type PageCompareStats } from '../iiif/compare';
-import type { PageGeo } from '../iiif/pages';
+import { hasFootprint, type PageGeo } from '../iiif/pages';
 
 interface PageListProps {
   pages: PageGeo[];
@@ -49,10 +49,12 @@ function sortValue(
       return undefined; // handled by natural key comparison
     case 'rmse':
       return stats?.rmseFt;
+    // Undefined for a footprint-less miss so it sinks under these sorts with the
+    // other valueless rows instead of sorting as a real 0.
     case 'rot':
-      return page.rotationDegrees;
+      return hasFootprint(page) ? page.rotationDegrees : undefined;
     case 'scale':
-      return page.scalePixelsPerFoot;
+      return hasFootprint(page) ? page.scalePixelsPerFoot : undefined;
     case 'rotErr':
       return stats ? Math.abs(stats.rotationErrorDegrees) : undefined;
     case 'scaleErr':
@@ -223,9 +225,16 @@ export function PageList(props: PageListProps) {
                     )}
                   </td>
                 )}
-                <td className="numeric">{page.rotationDegrees.toFixed(1)}°</td>
+                {/* Rotation and scale come from a georeference. A miss known only by
+                    name (a volume with no truth) has none, so 0.0°/0.00 would be a
+                    reading rather than a blank. */}
                 <td className="numeric">
-                  {page.scalePixelsPerFoot.toFixed(2)}
+                  {hasFootprint(page)
+                    ? `${page.rotationDegrees.toFixed(1)}°`
+                    : ''}
+                </td>
+                <td className="numeric">
+                  {hasFootprint(page) ? page.scalePixelsPerFoot.toFixed(2) : ''}
                 </td>
                 {hasTruth && (
                   <td className="numeric">

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -4,7 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { WarpedMapLayer } from '@allmaps/maplibre';
 import type { FeatureCollection } from 'geojson';
 import { pointInPolygon } from '../geometry';
-import type { PageGeo } from '../iiif/pages';
+import { hasFootprint, type PageGeo } from '../iiif/pages';
 import type { AdjacencyClaim } from '../iiif/adjacency';
 
 interface VolumeMapProps {
@@ -455,7 +455,8 @@ export function VolumeMap(props: VolumeMapProps) {
         ? undefined
         : (pages.find((p) => p.itemIndex === selectedItemIndex) ??
           missingPages.find((p) => p.itemIndex === selectedItemIndex));
-    if (!page) {
+    // Nothing to outline for a miss known only by name (a truth-less volume's).
+    if (!page || !hasFootprint(page)) {
       source?.setData(EMPTY_FEATURES);
       return;
     }
@@ -581,11 +582,15 @@ export function VolumeMap(props: VolumeMapProps) {
     }
     source.setData({
       type: 'FeatureCollection',
-      features: missingPages.map((page): FeatureCollection['features'][0] => ({
-        type: 'Feature',
-        properties: { itemIndex: page.itemIndex },
-        geometry: { type: 'Polygon', coordinates: [page.clipRing] },
-      })),
+      // A truth-less volume's misses are known only by name, so they have no
+      // footprint to outline — they are listed but never drawn.
+      features: missingPages
+        .filter(hasFootprint)
+        .map((page): FeatureCollection['features'][0] => ({
+          type: 'Feature',
+          properties: { itemIndex: page.itemIndex },
+          geometry: { type: 'Polygon', coordinates: [page.clipRing] },
+        })),
     });
   }, [missingPages, showMissing, mapReady]);
 

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -15,16 +15,20 @@ import type { AdjacencyData } from '../types';
 import {
   fetchAdjacency,
   fetchCompare,
-  fetchFailedGeorefs,
   fetchKeymaps,
   fetchRewrittenAnnotation,
+  fetchVolumePageFiles,
   fetchVolumes,
 } from '../iiif/api';
 import type { KeymapInfo } from '../../server/api';
 import { isTypingTarget } from '../keyboard';
 import { fetchVolumeNotes } from '../notes/api';
 import { adjacencyClaimFeatures } from '../iiif/adjacency';
-import { missingTruthPages, pagesFromAnnotation } from '../iiif/pages';
+import {
+  missingTruthPages,
+  pagesFromAnnotation,
+  unfittedPages,
+} from '../iiif/pages';
 import { InfoPanel } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
@@ -119,6 +123,9 @@ export function VolumeViewer() {
   const [failedGeorefs, setFailedGeorefs] = useState<Map<string, string>>(
     new Map(),
   );
+  // Every page-image stem in the selected volume; the un-fit list for a volume with
+  // no truth annotation is these minus the ones the run placed.
+  const [volumeStems, setVolumeStems] = useState<string[]>([]);
   // The selected volume's key-map sheets (raw/*.keymap.json), for the info-panel links.
   const [keymaps, setKeymaps] = useState<KeymapInfo[]>([]);
 
@@ -211,12 +218,16 @@ export function VolumeViewer() {
       .catch(() => {
         if (!cancelled) setNotes(new Map());
       });
-    fetchFailedGeorefs(volumeName)
-      .then((map) => {
-        if (!cancelled) setFailedGeorefs(map);
+    fetchVolumePageFiles(volumeName)
+      .then(({ stems, failed }) => {
+        if (cancelled) return;
+        setFailedGeorefs(failed);
+        setVolumeStems(stems);
       })
       .catch(() => {
-        if (!cancelled) setFailedGeorefs(new Map());
+        if (cancelled) return;
+        setFailedGeorefs(new Map());
+        setVolumeStems([]);
       });
     setAdjacencyData(null);
     fetchAdjacency(volumeName)
@@ -266,10 +277,16 @@ export function VolumeViewer() {
         : null,
     [compareRows, pages],
   );
-  // Truth pages the run never georeferenced, shown as "missing" rows/footprints.
+  // Pages the run never georeferenced, shown as "missing" rows (and footprints where
+  // truth gives one). With truth the misses come from the comparison, which decides
+  // them per truth page; without it there is nothing to compare against, so they are
+  // the volume's page images minus the ones the annotation placed.
   const missingPages = useMemo(
-    () => (truthPages ? missingTruthPages(truthPages, compareMissing) : []),
-    [truthPages, compareMissing],
+    () =>
+      truthPages
+        ? missingTruthPages(truthPages, compareMissing)
+        : unfittedPages(pages, volumeStems),
+    [truthPages, compareMissing, pages, volumeStems],
   );
 
   // Adjacency claim boxes, mapped into geo through each page's georeference: the fitted pages,

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -5,6 +5,7 @@ import {
   FILL_YELLOW_HUE_BAND,
   filterDetections,
   isOnBuildingFill,
+  matchesTextQuery,
   previewOrientation,
 } from './detections';
 import type { Detection } from './types';
@@ -122,6 +123,7 @@ describe('filterDetections', () => {
       minShortSide: 0,
       minLongSide: 0,
       showIgnored: true,
+      text: '',
     });
     expect(result.map((r) => r.i)).toEqual([0, 1, 2]);
   });
@@ -132,6 +134,7 @@ describe('filterDetections', () => {
       minShortSide: 20,
       minLongSide: 50,
       showIgnored: true,
+      text: '',
     });
     expect(result.map((r) => r.i)).toEqual([1, 2]);
   });
@@ -142,6 +145,7 @@ describe('filterDetections', () => {
       minShortSide: 0,
       minLongSide: 0,
       showIgnored: false,
+      text: '',
     });
     expect(hidden.map((r) => r.i)).toEqual([0, 1]);
   });
@@ -240,5 +244,50 @@ describe('isOnBuildingFill', () => {
     expect(isOnBuildingFill(withBackground(low))).toBe(false);
     expect(isOnBuildingFill(withBackground(high))).toBe(false);
     expect(isOnBuildingFill(withBackground(low - 0.1))).toBe(true);
+  });
+});
+
+describe('matchesTextQuery', () => {
+  it('matches everything when the query is empty or blank', () => {
+    expect(matchesTextQuery('ELLIOTT ST', '')).toBe(true);
+    expect(matchesTextQuery('ELLIOTT ST', '   ')).toBe(true);
+  });
+
+  it('matches a page number without matching numbers that contain it', () => {
+    // The motivating case: finding page 6 among a key map's 201 reads, where a
+    // substring match would also return 16, 60 and 63.
+    expect(matchesTextQuery('6', '6')).toBe(true);
+    expect(matchesTextQuery('16', '6')).toBe(false);
+    expect(matchesTextQuery('60', '6')).toBe(false);
+    expect(matchesTextQuery('63', '6')).toBe(false);
+  });
+
+  it('treats a letter suffix as part of the page key', () => {
+    // 6S is a different sheet from 6.
+    expect(matchesTextQuery('6S', '6')).toBe(false);
+    expect(matchesTextQuery('6S', '6S')).toBe(true);
+  });
+
+  it('matches a word inside a longer street name', () => {
+    expect(matchesTextQuery('ELLIOTT ST', 'ELLIOTT')).toBe(true);
+    expect(matchesTextQuery('ELLIOTT ST', 'ST')).toBe(true);
+    expect(matchesTextQuery('ELLIOTTS', 'ELLIOTT')).toBe(false);
+  });
+
+  it('ignores case', () => {
+    expect(matchesTextQuery('ELLIOTT ST', 'elliott')).toBe(true);
+  });
+
+  it('ORs comma-separated terms and ignores the spacing', () => {
+    expect(matchesTextQuery('7', '6, 7')).toBe(true);
+    expect(matchesTextQuery('6', '6,7')).toBe(true);
+    expect(matchesTextQuery('8', '6, 7')).toBe(false);
+    // Trailing separators and stray blanks must not turn into a match-nothing term.
+    expect(matchesTextQuery('8', '6, ,')).toBe(false);
+  });
+
+  it('treats regex metacharacters literally', () => {
+    expect(matchesTextQuery('6', '.')).toBe(false);
+    expect(matchesTextQuery('N. MAIN', '.')).toBe(true);
   });
 });

--- a/app/src/detections.ts
+++ b/app/src/detections.ts
@@ -6,6 +6,8 @@ export interface DetectionFilters {
   minShortSide: number;
   minLongSide: number;
   showIgnored: boolean;
+  /** Text query; empty shows everything. See {@link matchesTextQuery}. */
+  text: string;
 }
 
 /** A detection paired with its index in the original, unfiltered list. */
@@ -85,8 +87,40 @@ export function filterDetections(
         det.confidence >= filters.minConfidence &&
         det.short_side >= filters.minShortSide &&
         det.long_side >= filters.minLongSide &&
-        (!det.ignore || filters.showIgnored),
+        (!det.ignore || filters.showIgnored) &&
+        matchesTextQuery(det.text, filters.text),
     );
+}
+
+// Escape a query term for use inside a RegExp.
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Whether a detection's text satisfies a filter query.
+ *
+ * Terms match on **word boundaries**, not as bare substrings, because the query that
+ * matters most on a key map is a page number: searching a sheet's 201 reads for "6"
+ * has to find page 6 without also returning 16, 60 and 63. The same rule still lets
+ * "ELLIOTT" find "ELLIOTT ST", since the boundary falls at the space.
+ *
+ * Comma-separated terms are OR-ed ("6, 7" shows both pages), and matching ignores
+ * case. An empty (or whitespace-only) query matches everything.
+ */
+export function matchesTextQuery(text: string, query: string): boolean {
+  const terms = query
+    .split(',')
+    .map((term) => term.trim())
+    .filter(Boolean);
+  if (terms.length === 0) return true;
+  return terms.some((term) => {
+    // \b only sits between a word and a non-word character, so a term that starts or
+    // ends with punctuation would never match beside one. Anchor those edges loosely.
+    const start = /^\w/.test(term) ? '\\b' : '';
+    const end = /\w$/.test(term) ? '\\b' : '';
+    return new RegExp(`${start}${escapeRegExp(term)}${end}`, 'i').test(text);
+  });
 }
 
 /**

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -26,17 +26,27 @@ export function fetchRewrittenAnnotation(
   return api.get('/iiif-api/annotation')(null, { path });
 }
 
+/** A volume's page-image stems, and which of them have a failed-georef sidecar. */
+export interface VolumePageFiles {
+  /** Every page-image stem, split sheets represented by their panels. */
+  stems: string[];
+  /** Page stem → failure kind ("nofit", "1gcp", …), for linking to the georef view. */
+  failed: Map<string, string>;
+}
+
 /**
- * Fetch a volume's failed-georef sidecars as a page-stem → failure-kind map
- * (e.g. "p1452" → "nofit"), for linking un-georeferenced pages to the georef view.
+ * Fetch a volume's page files: the stems on disk plus the failed-georef sidecars.
+ *
+ * An older server omits `pages`; the stems then come back empty, which costs the
+ * un-fit listing on truth-less volumes rather than taking the viewer down.
  */
-export async function fetchFailedGeorefs(
+export async function fetchVolumePageFiles(
   volume: string,
-): Promise<Map<string, string>> {
-  const { failed } = await api.get('/iiif-api/failed-georefs')(null, {
+): Promise<VolumePageFiles> {
+  const { failed, pages } = await api.get('/iiif-api/failed-georefs')(null, {
     volume,
   });
-  return new Map(Object.entries(failed));
+  return { stems: pages ?? [], failed: new Map(Object.entries(failed)) };
 }
 
 /**

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import type { GeorefAnnotationPage } from '../../server/iiifAnnotations';
 import {
   bearingDegrees,
+  hasFootprint,
   missingTruthPages,
   pagesFromAnnotation,
+  unfittedPages,
   svgPolygonPoints,
   type PageGeo,
 } from './pages';
@@ -269,5 +271,47 @@ describe('missingTruthPages resilience', () => {
     // An older server, or a compare sidecar predating the field: no misses beats a
     // crashed page.
     expect(missingTruthPages([pageGeo('p1', 0)], undefined)).toEqual([]);
+  });
+});
+
+describe('unfittedPages', () => {
+  it('lists the volume page images the run never placed', () => {
+    const fit = [pageGeo('p1', 0), pageGeo('p3', 1)];
+    const missing = unfittedPages(fit, ['p1', 'p2', 'p3', 'p4']);
+    expect(missing.map((p) => p.stem)).toEqual(['p2', 'p4']);
+    // Negative ids, matching missingTruthPages, keep these out of the fit id space.
+    expect(missing.map((p) => p.itemIndex)).toEqual([-1, -2]);
+  });
+
+  it('carries no footprint, since nothing says where the page belongs', () => {
+    const [missing] = unfittedPages([], ['p7']);
+    expect(missing && hasFootprint(missing)).toBe(false);
+  });
+
+  it('treats a placed panel as placed and its unplaced sibling as missing', () => {
+    const fit = [pageGeo('p90__1', 0)];
+    expect(
+      unfittedPages(fit, ['p90__1', 'p90__2', 'p90__3']).map((p) => p.stem),
+    ).toEqual(['p90__2', 'p90__3']);
+  });
+
+  it('splits a panel stem into its page key and index', () => {
+    const [missing] = unfittedPages([], ['p90__2']);
+    expect(missing?.pageKey).toBe('p90');
+    expect(missing?.splitIndex).toBe(2);
+  });
+
+  it('leaves splitIndex null for a whole sheet', () => {
+    expect(unfittedPages([], ['p12'])[0]?.splitIndex).toBeNull();
+  });
+
+  it('matches placed stems case-insensitively', () => {
+    // p1499J in the annotation, p1499j on disk: one page, not a miss.
+    expect(unfittedPages([pageGeo('p1499J', 0)], ['p1499j'])).toEqual([]);
+  });
+
+  it('reports nothing when the server sent no page list', () => {
+    // An older server omits `pages`; losing the listing beats a crashed page.
+    expect(unfittedPages([pageGeo('p1', 0)], [])).toEqual([]);
   });
 });

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -216,6 +216,57 @@ export function missingTruthPages(
   return missing;
 }
 
+/** Whether a missing-page row knows where on earth its page belongs. */
+export function hasFootprint(page: PageGeo): boolean {
+  return page.clipRing.length >= 3 || page.rectRing.length >= 3;
+}
+
+/**
+ * Un-fit pages of a volume that has no truth annotation, from the stems on disk.
+ *
+ * With truth, a miss is a truth page the run failed to place and its footprint is
+ * known. Without truth there is nothing to compare against, so a miss is simply a
+ * page image the annotation never placed — which is still worth listing, since it is
+ * the only signal a truth-less volume gives about what is not working. These rows
+ * carry no geometry (see {@link hasFootprint}): they appear in the page list, but
+ * there is nowhere on the map to draw them.
+ *
+ * Negative `itemIndex` selection ids keep these clear of the fitted pages' array
+ * indices, matching {@link missingTruthPages}.
+ */
+export function unfittedPages(
+  fitPages: PageGeo[],
+  volumeStems: readonly string[],
+): PageGeo[] {
+  const placed = new Set(fitPages.map((page) => page.stem.toLowerCase()));
+  const missing: PageGeo[] = [];
+  for (const stem of volumeStems) {
+    if (placed.has(stem.toLowerCase())) continue;
+    const [pageKey = stem, panel] = stem.split('__');
+    missing.push({
+      itemIndex: -(missing.length + 1),
+      pageKey,
+      splitIndex: panel === undefined ? null : Number(panel),
+      stem,
+      width: 0,
+      height: 0,
+      corners: [
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+      ],
+      rectRing: [],
+      clipRing: [],
+      scalePixelsPerFoot: 0,
+      rotationDegrees: 0,
+      gcps: [],
+      transformationType: '',
+    });
+  }
+  return missing;
+}
+
 // Close a ring in place if its last point differs from its first.
 function closedRing(ring: [number, number][]): [number, number][] {
   if (ring.length === 0) return ring;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -64,6 +64,13 @@
   flex: 1;
 }
 
+.filter-row input[type='search'] {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  padding: 2px 6px;
+}
+
 .image-wrapper {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
This makes it easier to figure out where the three "6" detections are on the Atlanta keymap, for example.