### PR TITLE
Don't let a failed key-map georef take the volume down

### DIFF
--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -314,9 +314,9 @@ def keymap_region_adjacency(
     from shapely.geometry.base import BaseGeometry
     from shapely.ops import unary_union
 
-    from mapsnap.keymap.locate import KeymapLocator
+    from mapsnap.keymap.locate import KeymapLocator, usable_keymaps
 
-    keymaps = sorted((volume / "raw").glob("*.keymap.json"))
+    keymaps = usable_keymaps(volume / "raw")
     if not keymaps:
         return set(), {}
     regions = KeymapLocator.from_keymaps(keymaps).regions_by_number()

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3815,7 +3815,19 @@ def main() -> None:
     # Drop georef files whose fitted scale is a major outlier vs the reference —
     # unless the scale agrees with the pages fitted around it (an intermediate local
     # drawing scale, e.g. a downtown sheet, lands in the gap between outlier bands).
-    if ref_scale_px_per_ft is not None and not args.disable_scale_outlier_check:
+    #
+    # Key-map runs are exempt: index sheets are drawn at whatever scale fits their
+    # coverage, so a volume's city-wide index and its downtown inset differ by design
+    # and share no scale family for family_scale to anchor on. Neither can the
+    # neighbor-corroboration escape save them, since a key-map run georeferences no
+    # ordinary pages to be adjacent to. Atlanta 1911 is the case in point: two index
+    # sheets, and the check dropped the accurate one (28 m median against the pages
+    # that later fit from street OCR) in favour of the 355 m one.
+    if (
+        ref_scale_px_per_ft is not None
+        and not args.disable_scale_outlier_check
+        and not args.geocode_keymaps
+    ):
         centers_by_path = dict(location_records)
         n_dropped = 0
         for img_path, px_per_ft in scale_records:

--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -31,6 +31,7 @@ __all__ = [
     "page_key",
     "page_number",
     "resolve_keymaps",
+    "usable_keymaps",
 ]
 
 
@@ -44,6 +45,21 @@ def keymap_georef_path(keymap_json: Path) -> Path:
     return keymap_json.with_name(
         keymap_json.name.replace(".keymap.json", ".georef.json")
     )
+
+
+def usable_keymaps(directory: Path) -> list[Path]:
+    """Key-map detections files in one directory that a locator can actually load.
+
+    A key map whose own georeferencing failed leaves a bare ``<stem>.keymap.json``
+    beside a ``-misscale``/``-nofit`` sidecar rather than the ``<stem>.georef.json``
+    :func:`KeymapLocator.from_keymap` reads, so it is skipped here instead of
+    raising when the locator gets around to opening it.
+    """
+    return [
+        keymap_json
+        for keymap_json in sorted(directory.glob("*.keymap.json"))
+        if keymap_georef_path(keymap_json).exists()
+    ]
 
 
 def discover_keymaps(image_paths: list[str]) -> list[Path]:
@@ -62,8 +78,8 @@ def discover_keymaps(image_paths: list[str]) -> list[Path]:
                 directories.append(directory)
     found: list[Path] = []
     for directory in directories:
-        for keymap_json in sorted(directory.glob("*.keymap.json")):
-            if keymap_georef_path(keymap_json).exists() and keymap_json not in found:
+        for keymap_json in usable_keymaps(directory):
+            if keymap_json not in found:
                 found.append(keymap_json)
     return found
 

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -12,6 +12,7 @@ from mapsnap.keymap.locate import (
     page_key,
     page_number,
     resolve_keymaps,
+    usable_keymaps,
 )
 
 # A key map georeferenced to an axis-aligned box: 1000x500 px over lon 0..1, lat 2..3
@@ -275,6 +276,19 @@ def make_keymap(directory: Path, stem: str, *, with_georef: bool = True) -> Path
     if with_georef:
         (directory / f"{stem}.georef.json").write_text("{}")
     return keymap
+
+
+def test_usable_keymaps_keeps_only_georeferenced(tmp_path: Path):
+    # Atlanta 1911 has two index sheets and only one georeferenced; the volume
+    # scans that glob raw/*.keymap.json must skip the other, not open a georef
+    # that isn't there.
+    make_keymap(tmp_path, "p0a")
+    make_keymap(tmp_path, "p0b", with_georef=False)
+    assert usable_keymaps(tmp_path) == [tmp_path / "p0a.keymap.json"]
+
+
+def test_usable_keymaps_empty_directory(tmp_path: Path):
+    assert usable_keymaps(tmp_path) == []
 
 
 def test_discover_keymaps_finds_under_raw(tmp_path: Path):

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -41,7 +41,7 @@ from mapsnap.keymap.align_page_region import (
     load_adjacency,
     volume_filter_params,
 )
-from mapsnap.keymap.locate import KeymapLocator
+from mapsnap.keymap.locate import KeymapLocator, usable_keymaps
 from mapsnap.osm_snap import (
     PageContext,
     RotationPrior,
@@ -423,7 +423,7 @@ def load_volume_context(
     if centerlines_path is None:
         sys.exit(f"no centerlines.geojson under {volume}")
     features = json.loads(centerlines_path.read_text())["features"]
-    keymaps = sorted((volume / "raw").glob("*.keymap.json"))
+    keymaps = usable_keymaps(volume / "raw")
     locator = KeymapLocator.from_keymaps(keymaps) if keymaps else None
     _, region_centroids = keymap_region_adjacency(volume)
     residuals = keymap_fit_residuals(units)

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -636,11 +636,8 @@ def cmd_select(args: argparse.Namespace) -> None:
         ctx, _status = build_page_context(vctx, unit)
         if ctx is None:
             continue
-        # The volume's OSM features, as whichever form this checkout's snap wants:
-        # a spatial index where one exists, else the plain feature list.
-        osm_features = getattr(vctx, "feature_index", vctx.features)
-        incumbent = evaluate_pose(ctx, osm_features, incumbent_affine)
-        challenger = evaluate_pose(ctx, osm_features, streets_affine)
+        incumbent = evaluate_pose(ctx, vctx.feature_index, incumbent_affine)
+        challenger = evaluate_pose(ctx, vctx.feature_index, streets_affine)
         if incumbent is None or challenger is None:
             continue
         gap = challenger["verification"] - incumbent["verification"]


### PR DESCRIPTION
Atlanta 1911 has two index sheets, and run-loc crashed on it: the volume scans glob raw/*.keymap.json and hand every hit to KeymapLocator, which opens each one's <stem>.georef.json sibling — a file the key map whose own georeferencing failed does not have. discover_keymaps already screened for that sibling; the two experiment modules globbed directly and did not. Share the rule as usable_keymaps() and use it in both.

That kept the volume running but on the wrong key map, because the failure upstream was itself a false positive. Index sheets are drawn at whatever scale their coverage needs, so a city-wide index and a downtown inset differ by design and share no scale family for family_scale to anchor on; with only the two of them, one is inevitably an outlier, and the neighbor-corroboration escape cannot fire because a key-map run georeferences no ordinary pages to be adjacent to. The check dropped Atlanta's accurate sheet (28 m median against the 40 pages that later fit from street OCR, all within 500 m) and kept the other (355 m median, 19 of 38 within 500 m). Exempt key-map runs, as the location-outlier check below already exempts small samples for the same reason.

Both key maps now georeference, and snap runs the volume end to end: 124 pages, 31 accepted.