### PR TITLE
Ignore a key map that re-indexes another sheet's pages

### DIFF
--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -12,24 +12,42 @@ import itertools
 import json
 import math
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
 
 from mapsnap.feature_index import FeatureIndex
-from mapsnap.keymap.fit_keymap import key_stem, load_detections, page_key, page_number
+from mapsnap.keymap.fit_keymap import (
+    key_stem,
+    load_detections,
+    page_key,
+    page_number,
+    volume_page_keys,
+)
 
 Point = tuple[float, float]
 
 M_PER_DEG_LAT = 110540.0
 M_PER_DEG_LON_EQUATOR = 111320.0
 
+# Two key maps that index this much of the smaller one's page set are indexing the
+# same volume rather than complementary parts of it. Measured across the seven
+# multi-key-map volumes on hand, the complementary pairs (left/right or north/south
+# halves) share 3-20% of their keys, and the one redundant pair shares 83%.
+REDUNDANT_KEY_OVERLAP = 0.5
+# How much more of a redundant sheet's page set must be foreign to this volume before
+# the other sheet is preferred. Atlanta's multi-volume index reads 48% pages this
+# volume does not have against its counterpart's 0%; no other sheet exceeds 29%.
+FOREIGN_KEY_GAP = 0.2
+
 __all__ = [
     "KeymapLocator",
     "discover_keymaps",
     "page_key",
     "page_number",
+    "redundant_keymaps",
     "resolve_keymaps",
     "usable_keymaps",
 ]
@@ -60,6 +78,57 @@ def usable_keymaps(directory: Path) -> list[Path]:
         for keymap_json in sorted(directory.glob("*.keymap.json"))
         if keymap_georef_path(keymap_json).exists()
     ]
+
+
+def foreign_key_fraction(keys: set[str], volume_keys: set[str]) -> float:
+    """Share of a key map's page numbers that are not pages of this volume."""
+    if not keys:
+        return 0.0
+    return sum(1 for key in keys if key.upper() not in volume_keys) / len(keys)
+
+
+def redundant_keymaps(key_sets: list[set[str]], volume_keys: set[str]) -> set[int]:
+    """Indices of key maps to ignore as redundant duplicates of a better sheet.
+
+    A volume with several key maps normally has *complementary* ones — left/right or
+    north/south halves that each index their own pages. Two sheets that index largely
+    the *same* pages are a different situation: one of them is a multi-volume index,
+    covering this volume plus others, and every page it shares gets a second search
+    centre that may be far from the first. Atlanta 1911 is the case in point: its
+    city-wide sheet placed pages a median 779 m from where they actually fit, against
+    26 m for the volume's own sheet, and dropping it gained eight pages.
+
+    Redundancy alone does not say which sheet to keep — the two disagree, but nothing
+    local says who is right. What does is that a multi-volume index reads page numbers
+    this volume does not have: 48% of Atlanta's foreign against 0% for its counterpart.
+    So a sheet is dropped only when it both duplicates another's page set and is the
+    more foreign of the two by :data:`FOREIGN_KEY_GAP`; ties keep everything.
+
+    Note that *disagreement* deliberately plays no part. Complementary sheets disagree
+    far more than the redundant pair does (5.2 km and 7.4 km medians against Atlanta's
+    445 m), because their handful of shared keys are misreads on opposite sides of a
+    city — so gating on it would reject exactly the wrong sheets.
+
+    Returns an empty set when the volume's page keys are unknown: with nothing to call
+    foreign, there is no evidence to act on.
+    """
+    if not volume_keys:
+        return set()
+    foreign = [foreign_key_fraction(keys, volume_keys) for keys in key_sets]
+    drop: set[int] = set()
+    for i, j in itertools.combinations(range(len(key_sets)), 2):
+        if i in drop or j in drop:
+            continue
+        smaller = min(len(key_sets[i]), len(key_sets[j]))
+        if not smaller:
+            continue
+        if len(key_sets[i] & key_sets[j]) / smaller < REDUNDANT_KEY_OVERLAP:
+            continue  # complementary sheets; both are needed
+        if foreign[i] - foreign[j] >= FOREIGN_KEY_GAP:
+            drop.add(i)
+        elif foreign[j] - foreign[i] >= FOREIGN_KEY_GAP:
+            drop.add(j)
+    return drop
 
 
 def discover_keymaps(image_paths: list[str]) -> list[Path]:
@@ -323,9 +392,31 @@ class KeymapLocator:
 
         A page key is placed by whichever key map(s) detect it (locations are unioned), and
         the fallback rectangle is the union of all the key maps' rectangles. The radius is the
-        median of the per-key-map estimates unless overridden.
+        median of the per-key-map estimates unless overridden. Sheets that
+        :func:`redundant_keymaps` rejects are left out of the union entirely.
         """
+        # Imported here, as volume_pages_for does, to keep the pipeline module out of
+        # this one's import graph.
+        from mapsnap.keymap.pipeline import keymap_volume_dir
+
         locators = [cls.from_keymap(path) for path in keymap_jsons]
+        volume_keys = (
+            volume_page_keys(keymap_volume_dir(keymap_jsons[0]))
+            if keymap_jsons
+            else set()
+        )
+        for index in sorted(
+            redundant_keymaps([set(loc.locations) for loc in locators], volume_keys),
+            reverse=True,
+        ):
+            print(
+                f"Ignoring key map {keymap_jsons[index].name}: it indexes the same pages "
+                "as another sheet in this volume, and more of its page numbers are "
+                "foreign to this volume.",
+                file=sys.stderr,
+            )
+            del locators[index]
+            del keymap_jsons[index]
         locations: dict[str, list[Point]] = {}
         rectangles: list[list[Point]] = []
         regions: dict[str, list[list[Point]]] = {}

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -11,6 +11,7 @@ from mapsnap.keymap.locate import (
     meters_between,
     page_key,
     page_number,
+    redundant_keymaps,
     resolve_keymaps,
     usable_keymaps,
 )
@@ -335,3 +336,53 @@ def test_resolve_keymaps_explicit_wins_over_discovery(tmp_path: Path):
 def test_resolve_keymaps_falls_back_to_discovery(tmp_path: Path):
     keymap = make_keymap(tmp_path / "raw", "p0")
     assert resolve_keymaps(None, False, [str(tmp_path / "p5.jpg")]) == [keymap]
+
+
+# Volume pages 1-20, as volume_page_keys reports them.
+VOLUME_KEYS = {str(n) for n in range(1, 21)}
+
+
+def test_redundant_keymaps_drops_the_more_foreign_of_two_duplicates():
+    # Atlanta's shape: both sheets index this volume's pages, but one is a
+    # multi-volume index that also carries page numbers from other volumes.
+    own = {"1", "2", "3", "4", "5", "6"}
+    multi = {"1", "2", "3", "4", "5", "6", "154", "823", "7217", "195"}
+    assert redundant_keymaps([own, multi], VOLUME_KEYS) == {1}
+    assert redundant_keymaps([multi, own], VOLUME_KEYS) == {0}
+
+
+def test_redundant_keymaps_keeps_complementary_halves():
+    # The healthy multi-key-map shape: each sheet indexes its own half, so neither
+    # is redundant however different their page counts or foreign-key rates.
+    left = {"1", "2", "3", "4", "5"}
+    right = {"11", "12", "13", "14", "15", "99"}
+    assert redundant_keymaps([left, right], VOLUME_KEYS) == set()
+
+
+def test_redundant_keymaps_keeps_duplicates_that_look_equally_good():
+    # Redundancy alone is not grounds to drop: with nothing to separate them, a
+    # wrong guess would cost half the volume's placements.
+    a = {"1", "2", "3", "4", "5", "6"}
+    b = {"1", "2", "3", "4", "5", "7"}
+    assert redundant_keymaps([a, b], VOLUME_KEYS) == set()
+
+
+def test_redundant_keymaps_needs_the_volume_page_set():
+    # Without it nothing can be called foreign, so there is no evidence to act on.
+    own = {"1", "2", "3", "4", "5", "6"}
+    multi = own | {"154", "823", "7217"}
+    assert redundant_keymaps([own, multi], set()) == set()
+
+
+def test_redundant_keymaps_handles_a_single_or_empty_sheet():
+    assert redundant_keymaps([{"1", "2"}], VOLUME_KEYS) == set()
+    assert redundant_keymaps([], VOLUME_KEYS) == set()
+    assert redundant_keymaps([set(), {"1", "2"}], VOLUME_KEYS) == set()
+
+
+def test_redundant_keymaps_drops_only_one_of_three_duplicates():
+    # Two good sheets and one multi-volume index: the index goes, both others stay.
+    a = {"1", "2", "3", "4", "5", "6"}
+    b = {"1", "2", "3", "4", "5", "6"}
+    multi = a | {"154", "823", "7217", "911"}
+    assert redundant_keymaps([a, b, multi], VOLUME_KEYS) == {2}


### PR DESCRIPTION
Atlanta 1911 ships two index sheets. One indexes this volume; the other is a **multi-volume index** covering this volume and three others. Its extra page numbers give the recognizer chances to misread — three separate "6" placements, and a "195" from another volume snapped onto this volume's "19S". Since `from_keymaps` unions locations per key, every page both sheets named got a second search centre, and the vocabulary restriction had to span both neighbourhoods. That is precisely the ambiguity the restriction exists to remove.

Scored against the pages that georeference independently, the multi-volume sheet places them a **median 779 m** from where they actually fit, against **26 m** for the volume's own sheet. Hiding it by hand and re-running took Atlanta from **63 to 71 of 111 pages with no losses**. This rule makes that decision automatically.

## Two simpler rules, rejected against the data

**Containment — never fires.** "Keep the sheet contained inside the other" does nothing on any volume, Atlanta included: its smaller sheet (area 0.0044 vs 0.0116) pokes outside the larger on two edges.

**Preferring the smaller sheet — actively harmful.** The other five multi-key-map volumes pair *complementary* left/right or north/south halves at near-identical areas (Brooklyn 0.00136 vs 0.00136, LA 0.00176 vs 0.00170). Dropping the smaller would discard half of each volume's placements.

## What actually separates the two situations

Complementary sheets index *different* pages. A multi-volume index re-indexes the *same* ones.

| volume | key overlap | worse sheet's median miss |
|---|---|---|
| **Atlanta 1911** | **83%** | **779 m** |
| LA 1949 v14 | 20% | 32 m |
| Brooklyn 1939 v2 | 14% | 41 m |
| Brooklyn 1939 v1 | 12% | 43 m |
| Grand Rapids 1953 | 4% | 112 m |
| Brooklyn 1906 v6 | 3% | 50 m |

Redundancy alone does not say which sheet to keep, and **the obvious tiebreak points backwards**: complementary sheets disagree about their shared keys far *more* than the redundant pair does — 5.2 km and 7.4 km medians against Atlanta's 445 m — because their handful of shared keys are misreads on opposite sides of a city. Gating on disagreement would reject exactly the wrong sheets.

What does separate them is that a multi-volume index reads page numbers this volume does not have: **48% foreign for Atlanta's, against 0% for its counterpart**, where no other sheet exceeds 29%.

## The rule

`redundant_keymaps()` ignores a sheet only when it **both** duplicates another's page set (≥50% of the smaller key set) **and** is the more foreign of the two by ≥20 points. It runs in `KeymapLocator.from_keymaps`, which every consumer funnels through — `ocr`, `georef`, `snap`, the street solver — and logs what it ignored and why.

Every uncertain case falls back to today's behaviour rather than risking half a volume: ties keep everything, and so does an unknown volume page set.

**Verified over all 20 volumes: it drops nothing as they stand**, and drops `p0a` when Atlanta's is restored to the candidate list. Six unit tests cover the Atlanta shape, complementary halves, the ambiguous tie, the missing-page-set case, and a three-sheet volume.

## Caveat

Both thresholds are calibrated on a **single positive example**. The margins are wide (83% vs 20% overlap; 48% vs 29% foreign) and every failure mode I could construct degrades to "keep everything" — but the second volume showing this pattern is the real test of the numbers. `raw/disabled/` remains the manual override, since `usable_keymaps` only globs `raw/*.keymap.json`.

802 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
