### PR TITLE
Replace the page-region runaway guard with a flat 2% of the sheet

### DIFF
--- a/mapsnap/keymap/page_regions.py
+++ b/mapsnap/keymap/page_regions.py
@@ -114,16 +114,17 @@ class RegionParams:
         black line-work is a low-chroma cluster too, so pure-chroma matching would merge it
         into any pale-tint family — and the ink lattice connects the whole map, ballooning
         one region to the full sheet (Hudson p44, 99.8% of the key map).
-    max_region_area_factor: a region whose mask exceeds this multiple of the median seed
-        spacing squared is dropped as a runaway (leaves room for giant waterfront sheets at
-        ~9% of a key map).
-    max_region_sheet_frac: a region covering more than this share of the whole sheet is
-        dropped as a runaway too. The spacing-squared rule alone cannot catch every leak,
-        because seed spacing shrinks as a sheet gets denser: measured over the 25 key maps
-        on hand, the two leaked regions are 192.5x and 59.0x spacing squared while healthy
-        sheets reach 66.7x and 65.0x, so no factor separates them. As a share of the sheet
-        they separate cleanly — 99.9% and 53.7% against a healthy maximum of 11.8% — since
-        a page's footprint is a fixed fraction of the sheet however many pages are on it.
+    max_region_sheet_frac: a region covering more than this share of the sheet is a
+        runaway; the seed retries against its unmerged cluster and is dropped only if that
+        is oversized too. Measured against hand-traced key maps, an ordinary page's
+        footprint is at most 1.7% of its sheet (Brooklyn 1939 v1 p0 and p0b) and 0.8% on a
+        dense one (Kansas City, 129 pages), so 2% clears anything real by ~1.2x. That is a
+        deliberately tight margin: at 2.5% Brooklyn p1's leaked region (2.1%, against a
+        true 0.7%) slipped under and kept costing that page a fit, and no observed region
+        falls between 1.7% and the one known casualty, Hudson p92 at 8.9%. The test is
+        applied to the hole-filled mask, since that is what becomes the polygon: a mask can
+        be thin and still enclose the sheet (an outlined coastline, or the ink lattice
+        tracing every street), and filling it then covers everything.
     """
 
     target_long_side: int = 3000
@@ -142,8 +143,7 @@ class RegionParams:
     family_chroma_distance: float = 12.0
     family_contact_frac: float = 0.10
     family_min_lightness: float = 30.0
-    max_region_area_factor: float = 60.0
-    max_region_sheet_frac: float = 0.25
+    max_region_sheet_frac: float = 0.020
 
 
 def nearest_neighbor_distance(points: list[Point]) -> float:
@@ -613,29 +613,18 @@ def segment_page_regions(
             ):
                 region_masks[index] = piece
 
-    spacing = nearest_neighbor_distance([box_center(box) for box in seeds]) * scale
     sheet_area = float(labels.size)
 
-    def runaway(mask: np.ndarray, filled: np.ndarray) -> bool:
+    def runaway(filled: np.ndarray) -> bool:
         """Whether a region is too big to be one page's footprint.
 
-        Two independent caps, measured on different things, because neither catches every
-        leak on its own.
-
-        The spacing-squared cap scales with how densely the sheet is seeded — right for
-        "much bigger than the blocks around it" — and applies to the raw mask, as it
-        always has, so the giant-waterfront regions it was calibrated to allow (~9-11% of
-        a sheet) still pass. It is blind to a sparse sheet whose runaway is a modest
-        multiple of a large spacing: Brooklyn 1939 v1's p0 swallowed 54% of the sheet at
-        only 59x spacing squared, under the 60x cap, while healthy dense sheets reach 67x.
-
-        The sheet-fraction cap catches that, and applies to the *filled* mask, since that
-        is what becomes the polygon. A mask can be thin and still enclose the sheet — an
-        outlined coastline, or the ink lattice tracing every street — and filling it then
-        covers everything, which is how Brooklyn 1906 v6's p0R reached 99.9%.
+        One flat share of the sheet, because a page's footprint is a roughly fixed
+        fraction of its sheet however many pages are drawn on it. The predecessor scaled
+        with the median seed spacing instead, which made it a different rule on every
+        sheet: expressed as a share of the sheet it ranged from 5% to 55%, so a sparse
+        40-seed key map was allowed a region covering half the paper while a dense
+        130-seed one was held to 10%. Both leaks this replaced hid inside that slack.
         """
-        if spacing > 0 and int(mask.sum()) > params.max_region_area_factor * spacing**2:
-            return True
         return int(filled.sum()) > params.max_region_sheet_frac * sheet_area
 
     def fill(mask: np.ndarray) -> np.ndarray:
@@ -644,7 +633,7 @@ def segment_page_regions(
     polygons: dict[int, list[Point]] = {}
     for index, mask in region_masks.items():
         filled = fill(mask)
-        if runaway(mask, filled):
+        if runaway(filled):
             # Runaway region (a family that swallowed a map-spanning tint, or a page
             # number printed in the water with no block of its own): retry with this
             # seed's unmerged cluster, and drop the seed only if that is huge too.
@@ -653,7 +642,7 @@ def segment_page_regions(
                 if unmerged is not None
                 else None
             )
-            if fallback is None or runaway(fallback, fill(fallback)):
+            if fallback is None or runaway(fill(fallback)):
                 continue
             filled = fill(fallback)
         polygon = mask_to_polygon(filled, params.simplify_tolerance)

--- a/mapsnap/keymap/page_regions.py
+++ b/mapsnap/keymap/page_regions.py
@@ -117,6 +117,13 @@ class RegionParams:
     max_region_area_factor: a region whose mask exceeds this multiple of the median seed
         spacing squared is dropped as a runaway (leaves room for giant waterfront sheets at
         ~9% of a key map).
+    max_region_sheet_frac: a region covering more than this share of the whole sheet is
+        dropped as a runaway too. The spacing-squared rule alone cannot catch every leak,
+        because seed spacing shrinks as a sheet gets denser: measured over the 25 key maps
+        on hand, the two leaked regions are 192.5x and 59.0x spacing squared while healthy
+        sheets reach 66.7x and 65.0x, so no factor separates them. As a share of the sheet
+        they separate cleanly — 99.9% and 53.7% against a healthy maximum of 11.8% — since
+        a page's footprint is a fixed fraction of the sheet however many pages are on it.
     """
 
     target_long_side: int = 3000
@@ -136,6 +143,7 @@ class RegionParams:
     family_contact_frac: float = 0.10
     family_min_lightness: float = 30.0
     max_region_area_factor: float = 60.0
+    max_region_sheet_frac: float = 0.25
 
 
 def nearest_neighbor_distance(points: list[Point]) -> float:
@@ -606,21 +614,48 @@ def segment_page_regions(
                 region_masks[index] = piece
 
     spacing = nearest_neighbor_distance([box_center(box) for box in seeds]) * scale
-    max_region_area = params.max_region_area_factor * spacing**2
+    sheet_area = float(labels.size)
+
+    def runaway(mask: np.ndarray, filled: np.ndarray) -> bool:
+        """Whether a region is too big to be one page's footprint.
+
+        Two independent caps, measured on different things, because neither catches every
+        leak on its own.
+
+        The spacing-squared cap scales with how densely the sheet is seeded — right for
+        "much bigger than the blocks around it" — and applies to the raw mask, as it
+        always has, so the giant-waterfront regions it was calibrated to allow (~9-11% of
+        a sheet) still pass. It is blind to a sparse sheet whose runaway is a modest
+        multiple of a large spacing: Brooklyn 1939 v1's p0 swallowed 54% of the sheet at
+        only 59x spacing squared, under the 60x cap, while healthy dense sheets reach 67x.
+
+        The sheet-fraction cap catches that, and applies to the *filled* mask, since that
+        is what becomes the polygon. A mask can be thin and still enclose the sheet — an
+        outlined coastline, or the ink lattice tracing every street — and filling it then
+        covers everything, which is how Brooklyn 1906 v6's p0R reached 99.9%.
+        """
+        if spacing > 0 and int(mask.sum()) > params.max_region_area_factor * spacing**2:
+            return True
+        return int(filled.sum()) > params.max_region_sheet_frac * sheet_area
+
+    def fill(mask: np.ndarray) -> np.ndarray:
+        return ndi.binary_fill_holes(mask)  # type: ignore[return-value]
+
     polygons: dict[int, list[Point]] = {}
     for index, mask in region_masks.items():
-        if spacing > 0 and int(mask.sum()) > max_region_area:
-            # Runaway region (a family that swallowed a map-spanning tint): retry with
-            # this seed's unmerged cluster, and drop the seed only if that is huge too.
+        filled = fill(mask)
+        if runaway(mask, filled):
+            # Runaway region (a family that swallowed a map-spanning tint, or a page
+            # number printed in the water with no block of its own): retry with this
+            # seed's unmerged cluster, and drop the seed only if that is huge too.
             fallback = (
                 single_seed_region(*unmerged, scaled_boxes[index], params)
                 if unmerged is not None
                 else None
             )
-            if fallback is None or int(fallback.sum()) > max_region_area:
+            if fallback is None or runaway(fallback, fill(fallback)):
                 continue
-            mask = fallback
-        filled: np.ndarray = ndi.binary_fill_holes(mask)  # type: ignore[assignment]
+            filled = fill(fallback)
         polygon = mask_to_polygon(filled, params.simplify_tolerance)
         if len(polygon) >= 3:
             polygons[index] = [

--- a/mapsnap/keymap/page_regions_test.py
+++ b/mapsnap/keymap/page_regions_test.py
@@ -140,7 +140,7 @@ def test_segment_page_regions_two_blocks_and_background_discard():
     rgb = np.full((80, 80, 3), 0.85, dtype=np.float64)
     rgb[30:50, 15:30] = [0.8, 0.1, 0.1]  # red block
     rgb[30:50, 50:65] = [0.1, 0.1, 0.8]  # blue block
-    params = RegionParams(n_clusters=3)
+    params = RegionParams(n_clusters=3, max_region_sheet_frac=1.0)
     seeds = [
         (18.0, 35.0, 27.0, 45.0),  # on the red block
         (53.0, 35.0, 62.0, 45.0),  # on the blue block
@@ -157,7 +157,9 @@ def test_segment_page_regions_splits_shared_block():
     # region swallowing the other.
     rgb = np.full((60, 120, 3), 0.85, dtype=np.float64)
     rgb[20:45, 15:105] = [0.8, 0.1, 0.1]  # a single wide red block
-    params = RegionParams(n_clusters=3, cluster_open_radius=0)
+    params = RegionParams(
+        n_clusters=3, cluster_open_radius=0, max_region_sheet_frac=1.0
+    )
     seeds = [(25.0, 28.0, 33.0, 36.0), (87.0, 28.0, 95.0, 36.0)]
     polygons = segment_page_regions(rgb, seeds, params)
     assert set(polygons) == {0, 1}
@@ -257,10 +259,32 @@ def test_segment_page_regions_pale_block_near_paper():
     rgb[30:50, 20:40] = [0.80, 0.78, 0.72]  # pale tan block, close to the 0.85 paper
     rgb[30:50, 55:75] = [0.1, 0.1, 0.8]  # one saturated block (so k-means has a job)
     seeds = [(25.0, 35.0, 34.0, 45.0), (60.0, 35.0, 69.0, 45.0)]
-    params = RegionParams(n_clusters=2, palette_dedup_distance=4.0)
+    params = RegionParams(
+        n_clusters=2, palette_dedup_distance=4.0, max_region_sheet_frac=1.0
+    )
     seeded = segment_page_regions(rgb, seeds, params)
     assert set(seeded) == {0, 1}  # the pale block is found
     globally = segment_page_regions(
-        rgb, seeds, RegionParams(n_clusters=2, use_global_kmeans=True)
+        rgb,
+        seeds,
+        RegionParams(n_clusters=2, use_global_kmeans=True, max_region_sheet_frac=1.0),
     )
     assert 0 not in globally  # plain k=2 merges the pale block into paper and drops it
+
+
+def test_segment_page_regions_drops_a_runaway_region():
+    """A region covering far more of the sheet than a page's footprint is dropped."""
+    # One block over a quarter of the sheet — well past the 2.5% a real page occupies,
+    # but still a minority of the image so it stays a foreground cluster rather than
+    # becoming the background one.
+    rgb = np.full((80, 80, 3), 0.85, dtype=np.float64)
+    rgb[20:60, 20:60] = [0.8, 0.1, 0.1]
+    seeds = [(36.0, 36.0, 44.0, 44.0)]
+    capped = segment_page_regions(
+        rgb, seeds, RegionParams(n_clusters=3, max_region_sheet_frac=0.025)
+    )
+    assert capped == {}
+    uncapped = segment_page_regions(
+        rgb, seeds, RegionParams(n_clusters=3, max_region_sheet_frac=1.0)
+    )
+    assert set(uncapped) == {0}


### PR DESCRIPTION
A page region is one page's drawn footprint on the index sheet — a small patch. On some sheets one region instead covers a large share of the paper, and everything downstream inherits it, because a region's area is read as the page's drawing scale: a swallowed panel mimics a half-scale sheet. Brooklyn 1939 v1's p1 is the case in point, snapped to the half rung at **1061 ft**.

`page_regions` already had a runaway guard. It missed these, and this replaces it with a single cap: **a region covering more than 2% of the sheet**, measured on the hole-filled mask.

## The old guard was not one rule

The cap was `max_region_area_factor` (60) × median seed spacing², which scales with how densely a sheet is seeded. Expressed as a share of the sheet, across the 25 key maps on hand:

| sheet | seeds | 60 × spacing² as % of sheet |
|---|---|---|
| Brooklyn 1939 v1 p0 | 40 | **55%** |
| Brooklyn 1939 v2 p0b | 31 | 51% |
| Brooklyn 1906 p0L | 50 | 33% |
| Hudson p0 | 90 | 14% |
| Kansas City p0__1 | 130 | 10% |
| DC p1b | 133 | 9% |
| Grand Rapids p0a | 30 | 5% |

It spans **5% to 55%** — a sparse sheet was allowed a region covering half the paper while a dense one was held to 10%. Both leaks hid in that slack: Brooklyn's 54% region registered as "only" 59× spacing², *under* the 60× cap.

## Hand truth corrected the calibration

An earlier revision of this PR added a second cap alongside the first and deliberately preserved Kansas City's 11.3% region as a "giant waterfront region". Hand-traced key maps show that was wrong on both counts. **KC page 504's true footprint is 0.219%** — the detector had it 52× too large — and Kansas City has no waterfront. New Orleans 1951's 11.8% region is likewise a leak (p519, truly 0.26%).

Those were two of the three "healthy" data points behind the claim that no spacing² factor could separate leaks from real regions. The comparison class was itself defective, so the claim — and the two-caps-measuring-different-things design built on it — does not survive.

What the truth actually shows, across five hand-traced sheets: an ordinary page's footprint is **at most 1.7%** of its sheet (Brooklyn p0 1.68%, p0b 1.71%) and **0.8%** on a dense one (Kansas City, 129 pages). The one known outlier is **Hudson p92 at 8.9%**, and nothing observed falls between 1.7% and it.

## Results

Truth-graded against the hand-traced sheets:

| sheet | before | after |
|---|---|---|
| Kansas City p0__1 | IoU 0.466, self-overlap 2.3%, largest 11.30% | **IoU 0.483**, self-overlap 0.8%, largest 2.05% |
| Brooklyn p0 | IoU 0.623, largest 7.71% | **IoU 0.654**, largest 0.81% for p1 |
| Brooklyn p0b | IoU 0.835 | **0.835 — byte-identical** |
| New Orleans p0__2 | p519 at 11.77% | **0.24%** against a true 0.26% |
| Brooklyn 1906 p0R | largest 99.9%, 125% covered | **0.8%**, 25% covered |

End to end, re-running `mapsnap fit` on Brooklyn 1939 v1 through georef → snap → street solver → iiif → compare:

| | ≤25 ft | ≥200 ft | score (%≤25 − %≥200) | p1 |
|---|---|---|---|---|
| baseline | 47/55 | 3 | +80.0 | 1061 ft |
| **this PR** | **48/55** | **1** | **+85.5** | **28 ft** |

p1 goes from disaster to a near-miss, and only p50 remains a disaster.

## Why 2% and not 2.5%

2.5% was the first choice and it achieved **nothing** on Brooklyn — that volume scored exactly as it did before the change. Brooklyn p1's leaked region is **2.10%**, just under the cap.

At 2%, p1's region is not simply discarded: the seed retries against its unmerged cluster and lands at **0.81%** against a true 0.712%, so the page gets a *correct* region rather than none. That fallback is why the tighter cap adds information instead of removing it. 2% is also better on every truth sheet independently (Brooklyn p0 0.635 → 0.654, KC 0.476 → 0.483, p0b unchanged).

The margin over the largest real region measured is **~1.2×**, which is tight on five sheets. It is a deliberate trade: a genuine 2.2% region on a future volume would be rescued to its unmerged cluster or dropped. Nothing observed lives in that band.

## Caveats

- **Hudson p92 (8.9%) is dropped.** A known, accepted casualty — the next largest region on that sheet is 1.7%.
- **This is a guardrail, not a fix.** Kansas City's median region IoU is 0.425 whatever the cap: that sheet's foxing (the same block printed in slightly different shades) fragments the colour clustering, and no threshold touches it. Brooklyn p0's largest surviving region is still ~2× its true size.
- **Brooklyn p57's 1706 → 13 ft is not attributable to this change.** It appears under some region sets and not others via snap's containment gate, so it is incidental rather than a benefit of the cap.
- The synthetic unit fixtures are two-page sheets whose blocks are 5–31% of the image, so they now set the cap aside explicitly rather than silently depending on a real-sheet threshold. A new test locks in the drop-and-retry behaviour.

803 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
