### PR TITLE
Pick the key-map segmentation scale per sheet, preferring the finest that works

### DIFF
--- a/mapsnap/keymap/keymap_geojson.py
+++ b/mapsnap/keymap/keymap_geojson.py
@@ -46,7 +46,7 @@ from mapsnap.keymap.page_regions import (
     RegionParams,
     keymap_image_path,
     load_seeds,
-    segment_page_regions,
+    segment_page_regions_multiscale,
 )
 from mapsnap.utils import source_id_to_page_key
 
@@ -127,7 +127,9 @@ def region_features(
     lon0, lat0 = origin
     boxes, texts = load_seeds(keymap_path)
     rgb = np.asarray(Image.open(keymap_image_path(keymap_path)).convert("RGB"))
-    polygons = segment_page_regions(rgb.astype(np.float64) / 255.0, boxes, params)
+    polygons, _scale = segment_page_regions_multiscale(
+        rgb.astype(np.float64) / 255.0, boxes, params
+    )
     features: list[dict] = []
     for index, pixel_polygon in polygons.items():
         text = texts[index]

--- a/mapsnap/keymap/page_regions.py
+++ b/mapsnap/keymap/page_regions.py
@@ -25,6 +25,7 @@ courtyard) are filled; edge concavities are kept, since some blocks are genuinel
 """
 
 import argparse
+import dataclasses
 import json
 from collections import defaultdict
 from dataclasses import dataclass
@@ -653,6 +654,107 @@ def segment_page_regions(
     return polygons
 
 
+MULTISCALE_LADDER = (3000, 2250, 1500, 1000)
+"""Working scales (long-side px) the multi-scale segmentation tries, finest first.
+
+No single scale suits every sheet: fine linework wants resolution, but foxing —
+the same block fill aging into several shades — fragments the colour clustering at
+full detail and averages away under coarser downsampling. Measured against
+hand-traced truth, Kansas City (foxed) goes 0.48 -> 0.71 mean IoU at 1500 while
+Brooklyn 1939 v1 p0b (clean) is best at 3000, so the right scale is a per-sheet
+property of the paper, not a constant.
+"""
+
+MULTISCALE_MARGIN = 0.3
+"""How decisively a coarser scale must beat a finer one to be picked.
+
+Resolution is free information when the segmentation is not failing, so the pick
+prefers the finest scale whose irregularity is within this margin of the best;
+coarsening happens only when the fine scales fail loudly (foxing fragmentation).
+Without the margin (plain argmin) 8 of 13 truth sheets came out marginally worse
+than fixed-3000, the picker trading resolution for cosmetic smoothness; with it,
+none do, and the three hand-traced sheets score 0.746 mean IoU — equal to the
+per-sheet oracle. The result is flat for margins 0.3-0.5.
+"""
+
+
+def polygon_area(polygon: list[Point]) -> float:
+    """Absolute shoelace area of a polygon given as vertices."""
+    total = 0.0
+    for i in range(len(polygon)):
+        x1, y1 = polygon[i]
+        x2, y2 = polygon[(i + 1) % len(polygon)]
+        total += x1 * y2 - x2 * y1
+    return abs(total) / 2
+
+
+def segmentation_irregularity(polygons: dict[int, list[Point]], n_seeds: int) -> float:
+    """Truth-free quality score for one sheet's segmentation; lower is better.
+
+    Two terms, both grounded in how a key map is drawn. Block areas on one sheet
+    are roughly uniform, so the mean |log2(area / median area)| is near zero for a
+    sound segmentation and blows up in both failure directions — foxing fragments
+    (many splinters far below the median) and leaks (a region far above it).
+    The unresolved-seed rate guards the spread's blind spot: a degenerate output
+    of one or two giant regions has near-zero spread but resolves almost no seeds.
+
+    Ranking scales by this score matches the truth-best scale imperfectly, but
+    that is the wrong yardstick: when scales genuinely diverge the bad ones fail
+    loudly on these terms, and when they barely differ a "wrong" pick is nearly
+    free. With the prefer-finest margin (:data:`MULTISCALE_MARGIN`), the three
+    held-out hand-traced sheets score 0.746 mean IoU — equal to the per-sheet
+    oracle, against 0.717 for the best fixed scale and 0.657 for the previous
+    fixed-3000 configuration — and no truth sheet does worse than fixed-3000.
+    The result is flat across a wide sweep of the term weighting, so the weight
+    of 2 is not a tuned constant.
+    """
+    if not polygons:
+        return float("inf")
+    areas = np.array([polygon_area(p) for p in polygons.values()], dtype=np.float64)
+    areas = areas[areas > 0]
+    if len(areas) == 0:
+        return float("inf")
+    spread = float(np.mean(np.abs(np.log2(areas / np.median(areas)))))
+    unresolved = 1.0 - len(areas) / max(1, n_seeds)
+    return spread + 2.0 * unresolved
+
+
+def pick_ladder_scale(
+    scores: dict[int, float], margin: float = MULTISCALE_MARGIN
+) -> int:
+    """The finest scale whose irregularity is within ``margin`` of the best."""
+    best = min(scores.values())
+    for side in sorted(scores, reverse=True):
+        if scores[side] <= best + margin:
+            return side
+    raise ValueError("scores is empty")
+
+
+def segment_page_regions_multiscale(
+    rgb: np.ndarray,
+    seeds: list[Box],
+    params: RegionParams,
+    scales: tuple[int, ...] = MULTISCALE_LADDER,
+) -> tuple[dict[int, list[Point]], int]:
+    """Segment at every ladder scale; keep the finest that is not failing.
+
+    Each scale's result is scored by :func:`segmentation_irregularity` and the
+    finest scale within :data:`MULTISCALE_MARGIN` of the best score wins (see
+    :func:`pick_ladder_scale`). Polygons are in full-resolution pixels at every
+    scale, so results are directly comparable. Returns (polygons, picked scale).
+    """
+    results: dict[int, dict[int, list[Point]]] = {}
+    scores: dict[int, float] = {}
+    for side in scales:
+        polygons = segment_page_regions(
+            rgb, seeds, dataclasses.replace(params, target_long_side=side)
+        )
+        results[side] = polygons
+        scores[side] = segmentation_irregularity(polygons, len(seeds))
+    picked = pick_ladder_scale(scores)
+    return results[picked], picked
+
+
 def keymap_image_path(keymap_path: Path) -> Path:
     """Sibling JPEG of a ``<stem>.keymap.json`` (e.g. ``p0b.keymap.json`` -> ``p0b.jpg``)."""
     name = keymap_path.name
@@ -743,6 +845,14 @@ def main() -> None:
         action="store_true",
         help="Quantize with plain k-means instead of the seed-colour palette (ablation).",
     )
+    parser.add_argument(
+        "--scale",
+        type=int,
+        help=(
+            "Segment at this single working scale (long-side px) instead of trying "
+            "the multi-scale ladder and keeping the least-irregular result."
+        ),
+    )
     args = parser.parse_args()
 
     image_path = args.image or keymap_image_path(args.keymap)
@@ -754,10 +864,22 @@ def main() -> None:
     seeds, texts = load_seeds(args.keymap)
     image = Image.open(image_path).convert("RGB")
     rgb = np.asarray(image)
-    polygons = segment_page_regions(rgb.astype(np.float64) / 255.0, seeds, params)
+    if args.scale:
+        params = dataclasses.replace(params, target_long_side=args.scale)
+        polygons = segment_page_regions(rgb.astype(np.float64) / 255.0, seeds, params)
+        picked = args.scale
+    else:
+        polygons, picked = segment_page_regions_multiscale(
+            rgb.astype(np.float64) / 255.0, seeds, params
+        )
+        # The debug outputs below re-derive geometry from params; keep them at the
+        # scale the segmentation actually used.
+        params = dataclasses.replace(params, target_long_side=picked)
     doc = regions_panels_doc(image_path.name, image.size, polygons, texts)
     output.write_text(json.dumps(doc))
-    print(f"Wrote {output}: {len(polygons)}/{len(seeds)} regions found.")
+    print(
+        f"Wrote {output}: {len(polygons)}/{len(seeds)} regions found (scale {picked})."
+    )
     if args.overlay:
         render_overlay(image_path, polygons, texts, args.overlay)
         print(f"Wrote {args.overlay}")

--- a/mapsnap/keymap/page_regions_test.py
+++ b/mapsnap/keymap/page_regions_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from mapsnap.keymap.page_regions import (
+    MULTISCALE_LADDER,
     RegionParams,
     background_clusters,
     box_center,
@@ -12,11 +13,15 @@ from mapsnap.keymap.page_regions import (
     mask_to_polygon,
     merge_cluster_families,
     nearest_neighbor_distance,
+    pick_ladder_scale,
+    polygon_area,
     polygon_bounds,
     regions_panels_doc,
     scale_boxes,
     seed_palette,
     segment_page_regions,
+    segment_page_regions_multiscale,
+    segmentation_irregularity,
     split_component,
     working_scale,
 )
@@ -288,3 +293,49 @@ def test_segment_page_regions_drops_a_runaway_region():
         rgb, seeds, RegionParams(n_clusters=3, max_region_sheet_frac=1.0)
     )
     assert set(uncapped) == {0}
+
+
+def test_polygon_area():
+    assert polygon_area([(0, 0), (10, 0), (10, 10), (0, 10)]) == 100.0
+    assert polygon_area([(0, 0), (4, 0), (0, 3)]) == 6.0
+
+
+def test_segmentation_irregularity_prefers_uniform_resolved_output():
+    ring: list[tuple[float, float]] = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    uniform = {i: ring for i in range(10)}
+    # One region 8x the median blows the spread term.
+    leaked = dict(uniform)
+    leaked[0] = [(0.0, 0.0), (80.0, 0.0), (80.0, 10.0), (0.0, 10.0)]
+    assert segmentation_irregularity(uniform, 10) < segmentation_irregularity(
+        leaked, 10
+    )
+    # A degenerate one-giant-region output has near-zero spread; the
+    # unresolved-seed term is what rejects it.
+    degenerate = {0: [(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (0.0, 100.0)]}
+    assert segmentation_irregularity(uniform, 10) < segmentation_irregularity(
+        degenerate, 10
+    )
+    assert segmentation_irregularity({}, 10) == float("inf")
+
+
+def test_segment_page_regions_multiscale_matches_single_scale_when_tiny():
+    # On an image smaller than every ladder rung nothing is ever downscaled, so all
+    # rungs produce identical output and the pick must simply return one of them.
+    rgb = np.full((80, 80, 3), 0.85, dtype=np.float64)
+    rgb[30:50, 15:30] = [0.8, 0.1, 0.1]
+    rgb[30:50, 50:65] = [0.1, 0.1, 0.8]
+    seeds = [(18.0, 35.0, 27.0, 45.0), (53.0, 35.0, 62.0, 45.0)]
+    params = RegionParams(n_clusters=3, max_region_sheet_frac=1.0)
+    single = segment_page_regions(rgb, seeds, params)
+    multi, picked = segment_page_regions_multiscale(rgb, seeds, params)
+    assert multi == single
+    assert picked in MULTISCALE_LADDER
+
+
+def test_pick_ladder_scale_prefers_the_finest_within_margin():
+    # 3000 is within the margin of the best (1500), so resolution wins the tie.
+    assert pick_ladder_scale({3000: 0.55, 2250: 0.5, 1500: 0.4, 1000: 0.45}) == 3000
+    # A decisive gap (foxing fragmentation at fine scales) does coarsen.
+    assert pick_ladder_scale({3000: 1.6, 2250: 1.2, 1500: 0.4, 1000: 0.5}) == 1500
+    # Infinite scores (no regions at all) never win.
+    assert pick_ladder_scale({3000: float("inf"), 1500: 0.9}) == 1500


### PR DESCRIPTION
No single working scale suits every key map. Fine linework wants resolution, but foxing — one block's fill aged into several shades — fragments the colour clustering at full detail and averages away under coarser downsampling. Against hand-traced truth, **Kansas City goes 0.483 → 0.714 mean IoU just by dropping the working scale from 3000 to 1500 px**, while clean Brooklyn p0b is best at 3000 and Hudson degrades badly below it. The right scale is a property of the paper, not a constant.

`segment_page_regions_multiscale` runs the ladder (3000/2250/1500/1000) and keeps **the finest scale that is not failing**, judged by a truth-free irregularity score:

```
irregularity = mean |log2(area / median area)|  +  2 × unresolved-seed rate
```

Both terms are grounded in how key maps are drawn: block areas on one sheet are roughly uniform, so the spread is near zero when segmentation works and blows up under both fragmentation (foxing splinters) and leaks; the unresolved rate guards the spread's blind spot — a degenerate one-giant-region output whose spread is trivially small.

## The prefer-finest margin is load-bearing

Plain argmin trades resolution for cosmetic smoothness: it left **8 of 13** truth sheets marginally worse than fixed-3000 (−0.01 to −0.03 each). Preferring the finest scale within `MULTISCALE_MARGIN = 0.3` of the best leaves every healthy sheet byte-identical and coarsens only the sheets that fail loudly:

| margin | mean (13 sheets) | hand-truth (3 sheets) | worse than fixed-3000 |
|---|---|---|---|
| 0 (argmin) | 0.551 | 0.729 | 8 |
| **0.3** | **0.563** | **0.746** | **0** |
| 0.5 | 0.561 | 0.734 | 0 |

Neither constant is tuned to a knife-edge: the irregularity weighting is flat across an 18-cell sweep, and margins 0.3–0.5 are equivalent.

## Verified on the 13 truth key maps

(Grand Rapids excluded — its OIM projection scores ~0.09 against *every* configuration and is almost certainly misprojected.)

| sheet | truth | picked | fixed 3000 | picked IoU |
|---|---|---|---|---|
| brooklyn 1939 v1 p0 | hand | 2250 | 0.654 | **0.689** |
| brooklyn 1939 v1 p0b | hand | 3000 | 0.835 | 0.835 |
| kansas city p0__1 | hand | 1500 | 0.483 | **0.714** |
| ten remaining sheets | OIM | 3000 | — | **identical** |

Hand-truth mean: 0.657 → **0.746, equal to the per-sheet oracle** (best scale chosen by truth). Rung-flipping — the area error that mis-snaps a page's scale prior and produced 1000-ft disasters — falls from 44% to ~21% on the hand-truth sheets. No sheet does worse. Cost is one segmentation per rung, tens of seconds, once per volume.

## Provenance

This came out of the learned-embedding experiment discussed earlier ("are these two patches the same fill?"). The net beat the shipped configuration on the foxed sheet (0.483 → 0.636) but **lost to its own control**: the matched-scale heuristic (0.714). That ablation exposed working scale as the dominant variable, and the picker captures it with zero learned parameters. The net's artifacts live in the session scratchpad if it's ever worth revisiting; on this evidence it isn't.

## Notes

- The `page_regions` CLI (what `mapsnap keymap` runs) now uses the ladder by default; `--scale N` forces a single rung. `keymap_geojson` uses the ladder too.
- `data/` sidecars are not regenerated here. Post-merge, only Kansas City and Brooklyn 1939 v1 p0 would change — every other truth sheet picks 3000.
- Eval caveat: the oracle-equal result is on three hand-traced sheets; the ten OIM-scored sheets are a no-regression check rather than a precise measurement, and per-truth-sheet numbers are reproducible from the scratch harness.

807 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
