### PR TITLE
Keymap region labeler

### DIFF
--- a/app/regions.html
+++ b/app/regions.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Key Map Region Labeler</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/regions-main.tsx"></script>
+  </body>
+</html>

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -22,6 +22,11 @@ import type {
   LabelsJson,
   LabelsWriteRequest,
 } from '../src/keymap/types.ts';
+import type {
+  KeymapDetection,
+  RegionsJson,
+  RegionsWriteRequest,
+} from '../src/regions/types.ts';
 import type { AdjacencyData } from '../src/types.ts';
 
 /** Response of GET /iiif-api/adjacency — the volume's adjacency.json, or null when absent. */
@@ -50,6 +55,20 @@ export type LabelsResponse = LabelsJson | { exists: false };
 /** Response of PUT /api/labels. */
 export interface LabelsWriteResponse {
   ok: boolean;
+}
+
+/** GET /api/regions — the hand-drawn page regions, or a marker that none exist yet. */
+export type RegionsResponse = RegionsJson | { exists: false };
+
+/**
+ * GET /api/keymap-detections — the sheet's detected page numbers as points.
+ *
+ * The region labeler uses these to name a freshly drawn ring by whichever number it
+ * encloses, so a sheet can be traced without typing 40 page keys. Empty when the sheet
+ * has no `<stem>.keymap.json`.
+ */
+export interface KeymapDetectionsResponse {
+  detections: KeymapDetection[];
 }
 
 /** Query naming a volume directory. */
@@ -161,6 +180,13 @@ export interface API {
   '/api/labels': {
     get: GetEndpoint<LabelsResponse, KeymapTarget>;
     put: Endpoint<LabelsWriteRequest, LabelsWriteResponse, KeymapTarget>;
+  };
+  '/api/regions': {
+    get: GetEndpoint<RegionsResponse, KeymapTarget>;
+    put: Endpoint<RegionsWriteRequest, LabelsWriteResponse, KeymapTarget>;
+  };
+  '/api/keymap-detections': {
+    get: GetEndpoint<KeymapDetectionsResponse, KeymapTarget>;
   };
   '/api/adjacency-volumes': {
     get: GetEndpoint<AdjacencyVolumesResponse>;

--- a/app/server/keymapRoutes.ts
+++ b/app/server/keymapRoutes.ts
@@ -10,7 +10,7 @@
  */
 
 import { mkdir, readFile, writeFile } from 'fs/promises';
-import { basename, dirname } from 'path';
+import { basename, dirname, join } from 'path';
 import type { Express } from 'express';
 import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API, KeymapImagesResponse } from './api.ts';
@@ -20,6 +20,37 @@ import {
   resolveKeymapPage,
 } from './keymapPages.ts';
 import type { ImageInfo } from '../src/keymap/types.ts';
+import type { KeymapDetection } from '../src/regions/types.ts';
+
+/**
+ * Where a sheet's hand-drawn page regions live.
+ *
+ * Under `raw/truth/` beside the point labels, so hand work stays separate from the
+ * machine outputs in `raw/` — in particular from `<stem>.regions.panels.json`
+ * (page_regions' segmentation) and `<stem>.truth.regions.panels.json` (footprints
+ * projected from OIM fits), both of which this is meant to be scored against. The
+ * schema is identical to those, so `mapsnap.keymap.score_regions --truth` reads it
+ * directly.
+ */
+function regionsPath(page: { imagePath: string; stem: string }): string {
+  return join(
+    dirname(page.imagePath),
+    'truth',
+    `${page.stem}.regions.panels.json`,
+  );
+}
+
+// Centre of a keymap.json detection's box, in image pixels.
+function detectionCentre(street: {
+  polygon: number[][];
+  text?: string;
+}): KeymapDetection | null {
+  const ring = street.polygon;
+  if (!ring?.length) return null;
+  const x = ring.reduce((sum, p) => sum + (p[0] ?? 0), 0) / ring.length;
+  const y = ring.reduce((sum, p) => sum + (p[1] ?? 0), 0) / ring.length;
+  return { text: String(street.text ?? ''), x, y };
+}
 
 /**
  * Mount the raw key-map image endpoint under `/api/keymaps/<page id>`.
@@ -79,5 +110,53 @@ export function registerKeymapApi(
     await mkdir(dirname(page.labelsPath), { recursive: true });
     await writeFile(page.labelsPath, JSON.stringify(sidecar, null, 2) + '\n');
     return { ok: true };
+  });
+
+  // Read a sheet's hand-drawn regions, or report that none exist yet.
+  router.get('/api/regions', async (_params, request) => {
+    const page = await resolveKeymapPage(dataDir, request.query.id);
+    if (!page) throw new HTTPError(400, `no such key map: ${request.query.id}`);
+    try {
+      return JSON.parse(await readFile(regionsPath(page), 'utf8'));
+    } catch {
+      return { exists: false };
+    }
+  });
+
+  // Write a sheet's hand-drawn regions in the panels.json schema, so the result can be
+  // scored against a segmentation without conversion.
+  router.put('/api/regions', async (_params, body, request) => {
+    const page = await resolveKeymapPage(dataDir, request.query.id);
+    if (!page) throw new HTTPError(400, `no such key map: ${request.query.id}`);
+    const target = regionsPath(page);
+    const sidecar = {
+      image: basename(page.imagePath),
+      width: body.width,
+      height: body.height,
+      panels: body.panels,
+      labels: body.labels,
+    };
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, JSON.stringify(sidecar, null, 2) + '\n');
+    return { ok: true };
+  });
+
+  // A sheet's detected page numbers as points, for naming a drawn ring by what it encloses.
+  router.get('/api/keymap-detections', async (_params, request) => {
+    const page = await resolveKeymapPage(dataDir, request.query.id);
+    if (!page) throw new HTTPError(400, `no such key map: ${request.query.id}`);
+    const keymap = join(dirname(page.imagePath), `${page.stem}.keymap.json`);
+    try {
+      const doc = JSON.parse(await readFile(keymap, 'utf8'));
+      const streets: { polygon: number[][]; text?: string }[] =
+        doc.streets ?? [];
+      return {
+        detections: streets
+          .map(detectionCentre)
+          .filter((d): d is KeymapDetection => d !== null),
+      };
+    } catch {
+      return { detections: [] };
+    }
   });
 }

--- a/app/src/regions-main.tsx
+++ b/app/src/regions-main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RegionsApp } from './regions/RegionsApp';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('missing #root element');
+createRoot(root).render(
+  <StrictMode>
+    <RegionsApp />
+  </StrictMode>,
+);

--- a/app/src/regions/PolygonCanvas.tsx
+++ b/app/src/regions/PolygonCanvas.tsx
@@ -49,7 +49,7 @@ const COLORS = [
  * with its own colour so there is no doubt which is being edited.
  */
 const TRACED_TINT = '#10243f';
-const TRACED_TINT_OPACITY = 0.1;
+const TRACED_TINT_OPACITY = 0.25;
 const SELECTED_FILL_OPACITY = 0.3;
 
 function ringPoints(ring: [number, number][], zoom: number): string {
@@ -198,7 +198,7 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
                     selected ? SELECTED_FILL_OPACITY : TRACED_TINT_OPACITY
                   }
                   stroke={color}
-                  strokeWidth={selected ? 3 : 1.5}
+                  strokeWidth={selected ? 4 : 3}
                 />
                 {selected &&
                   region.ring.map(([x, y], vertex) => (

--- a/app/src/regions/PolygonCanvas.tsx
+++ b/app/src/regions/PolygonCanvas.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  MIN_RING_VERTICES,
+  VERTEX_HIT_RADIUS,
+  regionAt,
+  sheetFraction,
+  vertexAt,
+} from './polygons';
+import type { KeymapDetection, RegionPolygon } from './types';
+
+interface PolygonCanvasProps {
+  imageSrc: string;
+  width: number;
+  height: number;
+  /** Displayed size = image size x zoom; the container scrolls to pan. */
+  zoom: number;
+  regions: RegionPolygon[];
+  /** Ring being drawn, or [] when not drawing. */
+  draft: [number, number][];
+  selectedIndex: number | null;
+  detections: readonly KeymapDetection[];
+  showDetections: boolean;
+  onAddVertex: (point: [number, number]) => void;
+  onCloseDraft: () => void;
+  onSelect: (index: number | null) => void;
+  onMoveVertex: (region: number, vertex: number, to: [number, number]) => void;
+}
+
+/** Colour cycle for finished regions; index-based so a region keeps its colour. */
+const COLORS = [
+  '#e6194b',
+  '#3cb44b',
+  '#4363d8',
+  '#f58231',
+  '#911eb4',
+  '#008080',
+  '#9a6324',
+  '#800000',
+];
+
+function ringPoints(ring: [number, number][], zoom: number): string {
+  return ring.map(([x, y]) => `${x * zoom},${y * zoom}`).join(' ');
+}
+
+/**
+ * The sheet with its regions drawn over it, and the pointer interactions for
+ * tracing new ones.
+ *
+ * Zoom is a plain CSS-size multiplier on both the image and the SVG overlay, so the
+ * browser's own scrolling does the panning — a key map is ~5600x8300 px and needs to
+ * be worked at 1:1, which no fit-to-window view can offer.
+ *
+ * Drawing: click to drop vertices; click the first vertex again (or double-click) to
+ * close. Clicking a finished region selects it; dragging one of its vertices moves
+ * that vertex. Hit radii are in screen pixels, so targets keep their size at any zoom.
+ */
+export function PolygonCanvas(props: PolygonCanvasProps) {
+  const {
+    imageSrc,
+    width,
+    height,
+    zoom,
+    regions,
+    draft,
+    selectedIndex,
+    detections,
+    showDetections,
+    onAddVertex,
+    onCloseDraft,
+    onSelect,
+    onMoveVertex,
+  } = props;
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [cursor, setCursor] = useState<[number, number] | null>(null);
+  const dragRef = useRef<{ region: number; vertex: number } | null>(null);
+
+  // Image-pixel position of a pointer event.
+  function imagePoint(
+    event: React.PointerEvent | React.MouseEvent,
+  ): [number, number] {
+    const rect = wrapperRef.current!.getBoundingClientRect();
+    return [
+      (event.clientX - rect.left) / zoom,
+      (event.clientY - rect.top) / zoom,
+    ];
+  }
+
+  function handlePointerDown(event: React.PointerEvent): void {
+    if (event.button !== 0) return;
+    const [x, y] = imagePoint(event);
+    const radius = VERTEX_HIT_RADIUS / zoom;
+
+    if (draft.length > 0) {
+      // Returning to the first vertex closes the ring.
+      const first = draft[0]!;
+      if (
+        draft.length >= MIN_RING_VERTICES &&
+        Math.hypot(first[0] - x, first[1] - y) <= radius
+      ) {
+        onCloseDraft();
+        return;
+      }
+      onAddVertex([x, y]);
+      return;
+    }
+
+    // Not drawing. A handle of the selected region starts a drag; a finished region
+    // gets selected; empty sheet starts a new ring — which is the only way to begin
+    // one, so it must not be shadowed by the two cases above.
+    if (selectedIndex !== null) {
+      const vertex = vertexAt(regions[selectedIndex]!, x, y, radius);
+      if (vertex !== null) {
+        dragRef.current = { region: selectedIndex, vertex };
+        (event.target as Element).setPointerCapture?.(event.pointerId);
+        return;
+      }
+    }
+    const hit = regionAt(regions, x, y);
+    if (hit !== null) {
+      onSelect(hit);
+      return;
+    }
+    onSelect(null);
+    onAddVertex([x, y]);
+  }
+
+  function handlePointerMove(event: React.PointerEvent): void {
+    const point = imagePoint(event);
+    setCursor(point);
+    const drag = dragRef.current;
+    if (drag) onMoveVertex(drag.region, drag.vertex, point);
+  }
+
+  function handlePointerUp(): void {
+    dragRef.current = null;
+  }
+
+  // Double-click closes the ring too, which is the habit most drawing tools train.
+  function handleDoubleClick(event: React.MouseEvent): void {
+    if (draft.length >= MIN_RING_VERTICES) {
+      event.preventDefault();
+      onCloseDraft();
+    }
+  }
+
+  useEffect(() => {
+    if (draft.length === 0) setCursor(null);
+  }, [draft.length]);
+
+  const draftFraction = sheetFraction(draft, width, height);
+
+  return (
+    <div className="polygon-scroll">
+      <div
+        ref={wrapperRef}
+        className="polygon-wrapper"
+        style={{ width: width * zoom, height: height * zoom }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+      >
+        <img
+          src={imageSrc}
+          width={width * zoom}
+          height={height * zoom}
+          draggable={false}
+        />
+        <svg
+          className="polygon-overlay"
+          width={width * zoom}
+          height={height * zoom}
+        >
+          {regions.map((region, index) => {
+            const color = COLORS[index % COLORS.length]!;
+            const selected = index === selectedIndex;
+            return (
+              <g key={index}>
+                <polygon
+                  points={ringPoints(region.ring, zoom)}
+                  fill={color}
+                  fillOpacity={selected ? 0.34 : 0.16}
+                  stroke={color}
+                  strokeWidth={selected ? 3 : 1.5}
+                />
+                {selected &&
+                  region.ring.map(([x, y], vertex) => (
+                    <circle
+                      key={vertex}
+                      cx={x * zoom}
+                      cy={y * zoom}
+                      r={VERTEX_HIT_RADIUS / 2}
+                      fill="#fff"
+                      stroke={color}
+                      strokeWidth={2}
+                    />
+                  ))}
+                {region.text !== '' && region.ring.length > 0 && (
+                  <text
+                    className="polygon-label"
+                    x={
+                      (region.ring.reduce((s, p) => s + p[0], 0) /
+                        region.ring.length) *
+                      zoom
+                    }
+                    y={
+                      (region.ring.reduce((s, p) => s + p[1], 0) /
+                        region.ring.length) *
+                      zoom
+                    }
+                  >
+                    {region.text}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+
+          {showDetections &&
+            detections.map((detection, index) => (
+              <g key={`d${index}`}>
+                <circle
+                  cx={detection.x * zoom}
+                  cy={detection.y * zoom}
+                  r={3}
+                  fill="#111"
+                  fillOpacity={0.7}
+                />
+                <text
+                  className="polygon-detection"
+                  x={detection.x * zoom + 5}
+                  y={detection.y * zoom - 5}
+                >
+                  {detection.text}
+                </text>
+              </g>
+            ))}
+
+          {draft.length > 0 && (
+            <>
+              <polyline
+                points={ringPoints(cursor ? [...draft, cursor] : draft, zoom)}
+                fill="#ffd400"
+                fillOpacity={0.2}
+                stroke="#ffd400"
+                strokeWidth={2}
+                strokeDasharray="6 4"
+              />
+              {draft.map(([x, y], index) => (
+                <circle
+                  key={index}
+                  cx={x * zoom}
+                  cy={y * zoom}
+                  r={index === 0 ? VERTEX_HIT_RADIUS / 2 + 1 : 3}
+                  fill={index === 0 ? '#ffd400' : '#fff'}
+                  stroke="#8a6d00"
+                  strokeWidth={2}
+                />
+              ))}
+            </>
+          )}
+        </svg>
+        {draft.length >= MIN_RING_VERTICES && (
+          <div
+            className="polygon-hint"
+            style={{
+              left: (draft[0]![0] * zoom).toFixed(0) + 'px',
+              top: (draft[0]![1] * zoom - 26).toFixed(0) + 'px',
+            }}
+          >
+            {(draftFraction * 100).toFixed(1)}% of sheet
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/regions/PolygonCanvas.tsx
+++ b/app/src/regions/PolygonCanvas.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  MIN_RECT_DRAG,
   MIN_RING_VERTICES,
   VERTEX_HIT_RADIUS,
+  rectRing,
   regionAt,
   sheetFraction,
   vertexAt,
 } from './polygons';
-import type { KeymapDetection, RegionPolygon } from './types';
+import type { DrawMode, KeymapDetection, RegionPolygon } from './types';
 
 interface PolygonCanvasProps {
   imageSrc: string;
@@ -14,6 +16,8 @@ interface PolygonCanvasProps {
   height: number;
   /** Displayed size = image size x zoom; the container scrolls to pan. */
   zoom: number;
+  /** 'polygon' clicks out vertices; 'rectangle' drags out two corners. */
+  mode: DrawMode;
   regions: RegionPolygon[];
   /** Ring being drawn, or [] when not drawing. */
   draft: [number, number][];
@@ -21,7 +25,14 @@ interface PolygonCanvasProps {
   detections: readonly KeymapDetection[];
   showDetections: boolean;
   onAddVertex: (point: [number, number]) => void;
-  onCloseDraft: () => void;
+  /** Replace the draft outright, as a rectangle drag does on every move. */
+  onSetDraft: (ring: [number, number][]) => void;
+  /**
+   * Finish a region. A rectangle drag passes its ring directly rather than relying on
+   * the draft it just set: a quick drag can put the pointerup in the same tick as the
+   * last pointermove, and React will not have flushed that state yet.
+   */
+  onCloseDraft: (ring?: [number, number][]) => void;
   onSelect: (index: number | null) => void;
   onMoveVertex: (region: number, vertex: number, to: [number, number]) => void;
 }
@@ -74,12 +85,14 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
     width,
     height,
     zoom,
+    mode,
     regions,
     draft,
     selectedIndex,
     detections,
     showDetections,
     onAddVertex,
+    onSetDraft,
     onCloseDraft,
     onSelect,
     onMoveVertex,
@@ -88,6 +101,8 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [cursor, setCursor] = useState<[number, number] | null>(null);
   const dragRef = useRef<{ region: number; vertex: number } | null>(null);
+  // Anchor corner of a rectangle drag in progress, in image pixels.
+  const rectAnchorRef = useRef<[number, number] | null>(null);
 
   // Image-pixel position of a pointer event.
   function imagePoint(
@@ -136,6 +151,12 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
       return;
     }
     onSelect(null);
+    if (mode === 'rectangle') {
+      // Anchor a drag rather than dropping a vertex; the ring is built on move.
+      rectAnchorRef.current = [x, y];
+      (event.target as Element).setPointerCapture?.(event.pointerId);
+      return;
+    }
     onAddVertex([x, y]);
   }
 
@@ -143,11 +164,29 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
     const point = imagePoint(event);
     setCursor(point);
     const drag = dragRef.current;
-    if (drag) onMoveVertex(drag.region, drag.vertex, point);
+    if (drag) {
+      onMoveVertex(drag.region, drag.vertex, point);
+      return;
+    }
+    const anchor = rectAnchorRef.current;
+    if (anchor) onSetDraft(rectRing(anchor, point));
   }
 
-  function handlePointerUp(): void {
+  function handlePointerUp(event: React.PointerEvent): void {
     dragRef.current = null;
+    const anchor = rectAnchorRef.current;
+    if (!anchor) return;
+    rectAnchorRef.current = null;
+    const [x, y] = imagePoint(event);
+    const minimum = MIN_RECT_DRAG / zoom;
+    if (
+      Math.abs(x - anchor[0]) < minimum ||
+      Math.abs(y - anchor[1]) < minimum
+    ) {
+      onSetDraft([]); // a click, not a drag
+      return;
+    }
+    onCloseDraft(rectRing(anchor, [x, y]));
   }
 
   // Double-click closes the ring too, which is the habit most drawing tools train.
@@ -255,25 +294,31 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
 
           {draft.length > 0 && (
             <>
+              {/* A rectangle drag already holds every corner, so the rubber-band to
+                  the cursor belongs only to the click-out-vertices mode. */}
               <polyline
-                points={ringPoints(cursor ? [...draft, cursor] : draft, zoom)}
+                points={ringPoints(
+                  mode === 'polygon' && cursor ? [...draft, cursor] : draft,
+                  zoom,
+                )}
                 fill="#ffd400"
                 fillOpacity={0.2}
                 stroke="#ffd400"
                 strokeWidth={2}
                 strokeDasharray="6 4"
               />
-              {draft.map(([x, y], index) => (
-                <circle
-                  key={index}
-                  cx={x * zoom}
-                  cy={y * zoom}
-                  r={index === 0 ? VERTEX_HIT_RADIUS / 2 + 1 : 3}
-                  fill={index === 0 ? '#ffd400' : '#fff'}
-                  stroke="#8a6d00"
-                  strokeWidth={2}
-                />
-              ))}
+              {mode === 'polygon' &&
+                draft.map(([x, y], index) => (
+                  <circle
+                    key={index}
+                    cx={x * zoom}
+                    cy={y * zoom}
+                    r={index === 0 ? VERTEX_HIT_RADIUS / 2 + 1 : 3}
+                    fill={index === 0 ? '#ffd400' : '#fff'}
+                    stroke="#8a6d00"
+                    strokeWidth={2}
+                  />
+                ))}
             </>
           )}
         </svg>

--- a/app/src/regions/PolygonCanvas.tsx
+++ b/app/src/regions/PolygonCanvas.tsx
@@ -38,6 +38,20 @@ const COLORS = [
   '#800000',
 ];
 
+/**
+ * Shading laid over every traced region, so covered ground reads at a glance.
+ *
+ * One neutral tint for all of them rather than each region's own colour: a key map
+ * is already a field of saturated pastels, and a faint wash of eight different hues
+ * disappears into it, which is exactly what a per-region fill did. A single dark
+ * tint instead mutes what is done and leaves untraced blocks at full brightness.
+ * Each region keeps its colour in its outline, and the selected one still fills
+ * with its own colour so there is no doubt which is being edited.
+ */
+const TRACED_TINT = '#10243f';
+const TRACED_TINT_OPACITY = 0.1;
+const SELECTED_FILL_OPACITY = 0.3;
+
 function ringPoints(ring: [number, number][], zoom: number): string {
   return ring.map(([x, y]) => `${x * zoom},${y * zoom}`).join(' ');
 }
@@ -179,8 +193,10 @@ export function PolygonCanvas(props: PolygonCanvasProps) {
               <g key={index}>
                 <polygon
                   points={ringPoints(region.ring, zoom)}
-                  fill={color}
-                  fillOpacity={selected ? 0.34 : 0.16}
+                  fill={selected ? color : TRACED_TINT}
+                  fillOpacity={
+                    selected ? SELECTED_FILL_OPACITY : TRACED_TINT_OPACITY
+                  }
                   stroke={color}
                   strokeWidth={selected ? 3 : 1.5}
                 />

--- a/app/src/regions/RegionsApp.tsx
+++ b/app/src/regions/RegionsApp.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './regions.css';
+import { isTypingTarget } from '../keyboard';
+import { loadImage } from '../loadImage';
+import { ImageList } from '../keymap/ImageList';
+import type { ImageInfo } from '../keymap/types';
+import {
+  fetchDetections,
+  fetchImages,
+  fetchRegions,
+  imageUrl,
+  saveRegions,
+} from './api';
+import { MIN_RING_VERTICES, autoLabel } from './polygons';
+import { PolygonCanvas } from './PolygonCanvas';
+import { RegionsTable } from './RegionsTable';
+import type { KeymapDetection, RegionPolygon } from './types';
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+const MIN_ZOOM = 0.05;
+const MAX_ZOOM = 2;
+
+/**
+ * Key-map page-region labeler: pick a sheet, trace the coloured block around each
+ * page number, and have a `<stem>.regions.panels.json` written under `raw/truth/`.
+ *
+ * The output is deliberately the same schema `page_regions` produces, so a traced
+ * sheet can be scored against the detected segmentation — or against the footprints
+ * projected from OIM fits — with `mapsnap.keymap.score_regions --truth`.
+ *
+ * Tracing 40 blocks would mean typing 40 page keys, so a closed ring takes its key
+ * from whichever detected page number it encloses (see {@link autoLabel}); the table
+ * is for the ones that stay ambiguous.
+ */
+export function RegionsApp() {
+  const [images, setImages] = useState<ImageInfo[]>([]);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [imageWidth, setImageWidth] = useState(0);
+  const [imageHeight, setImageHeight] = useState(0);
+  const [regions, setRegions] = useState<RegionPolygon[]>([]);
+  const [draft, setDraft] = useState<[number, number][]>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [detections, setDetections] = useState<KeymapDetection[]>([]);
+  const [showDetections, setShowDetections] = useState(true);
+  const [zoom, setZoom] = useState(0.25);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  // Only persist regions that changed through user edits, not freshly loaded ones.
+  const dirtyRef = useRef(false);
+  // Mirrors of the live state, so keyboard handlers registered once always see it.
+  const regionsRef = useRef<RegionPolygon[]>([]);
+  const draftRef = useRef<[number, number][]>([]);
+  const selectedRef = useRef<number | null>(null);
+  regionsRef.current = regions;
+  draftRef.current = draft;
+  selectedRef.current = selectedIndex;
+
+  useEffect(() => {
+    fetchImages().then(setImages).catch(console.error);
+  }, []);
+
+  // Load the selected sheet, its existing regions, and its detected page numbers.
+  useEffect(() => {
+    if (!selectedName) return;
+    let cancelled = false;
+    dirtyRef.current = false;
+    setSelectedIndex(null);
+    setDraft([]);
+    setSaveStatus('idle');
+    Promise.all([
+      loadImage(imageUrl(selectedName)),
+      fetchRegions(selectedName),
+      fetchDetections(selectedName).catch(() => []),
+    ])
+      .then(([element, sidecar, points]) => {
+        if (cancelled) return;
+        setImageWidth(sidecar?.width ?? element.naturalWidth);
+        setImageHeight(sidecar?.height ?? element.naturalHeight);
+        setRegions(sidecar?.regions ?? []);
+        setDetections(points);
+        dirtyRef.current = false;
+      })
+      .catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedName]);
+
+  // Persist edits (debounced), skipping freshly loaded data.
+  useEffect(() => {
+    if (!dirtyRef.current || !selectedName) return;
+    const handle = setTimeout(() => {
+      setSaveStatus('saving');
+      saveRegions(selectedName, imageWidth, imageHeight, regions)
+        .then(() => setSaveStatus('saved'))
+        .catch((error) => {
+          console.error(error);
+          setSaveStatus('error');
+        });
+    }, 600);
+    return () => clearTimeout(handle);
+  }, [regions, selectedName, imageWidth, imageHeight]);
+
+  function update(next: RegionPolygon[]): void {
+    dirtyRef.current = true;
+    setRegions(next);
+  }
+
+  function closeDraft(): void {
+    const ring = draftRef.current;
+    if (ring.length < MIN_RING_VERTICES) return;
+    const taken = new Set(
+      regionsRef.current.map((r) => r.text).filter((t) => t !== ''),
+    );
+    update([
+      ...regionsRef.current,
+      { ring, text: autoLabel(ring, detections, taken) },
+    ]);
+    setSelectedIndex(regionsRef.current.length);
+    setDraft([]);
+  }
+
+  // One keyboard handler for the drawing verbs; inputs keep their own typing.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (isTypingTarget(event.target)) return;
+      if (event.key === 'Enter') {
+        closeDraft();
+      } else if (event.key === 'Escape') {
+        setDraft([]);
+      } else if (event.key === 'Backspace' && draftRef.current.length > 0) {
+        event.preventDefault();
+        setDraft(draftRef.current.slice(0, -1));
+      } else if (
+        (event.key === 'Delete' || event.key === 'Backspace') &&
+        draftRef.current.length === 0 &&
+        selectedRef.current !== null
+      ) {
+        event.preventDefault();
+        const index = selectedRef.current;
+        update(regionsRef.current.filter((_, i) => i !== index));
+        setSelectedIndex(null);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // closeDraft closes over `detections`, so re-register when those load.
+  }, [detections]);
+
+  const duplicates = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const region of regions) {
+      if (region.text === '') continue;
+      seen.set(region.text, (seen.get(region.text) ?? 0) + 1);
+    }
+    return new Set(
+      [...seen.entries()].filter(([, n]) => n > 1).map(([text]) => text),
+    );
+  }, [regions]);
+
+  const unlabeled = regions.filter((r) => r.text === '').length;
+
+  return (
+    <div className="regions-app">
+      <div className="regions-sidebar">
+        <ImageList
+          images={images}
+          selectedName={selectedName}
+          onSelect={setSelectedName}
+        />
+      </div>
+
+      <div className="regions-main">
+        <div className="regions-toolbar">
+          <span className="regions-title">
+            {selectedName ?? 'pick a key map'}
+          </span>
+          <label>
+            Zoom
+            <input
+              type="range"
+              min={MIN_ZOOM}
+              max={MAX_ZOOM}
+              step={0.01}
+              value={zoom}
+              onChange={(e) => setZoom(parseFloat(e.target.value))}
+            />
+            <span className="regions-zoom">{(zoom * 100).toFixed(0)}%</span>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showDetections}
+              onChange={(e) => setShowDetections(e.target.checked)}
+            />
+            Show page numbers
+          </label>
+          <span className="regions-count">
+            {regions.length} region{regions.length === 1 ? '' : 's'}
+            {unlabeled > 0 && `, ${unlabeled} unnamed`}
+            {duplicates.size > 0 && `, ${duplicates.size} duplicated`}
+          </span>
+          <span className={`regions-save regions-save-${saveStatus}`}>
+            {saveStatus === 'saving'
+              ? 'saving…'
+              : saveStatus === 'saved'
+                ? 'saved'
+                : saveStatus === 'error'
+                  ? 'save failed'
+                  : ''}
+          </span>
+        </div>
+
+        <p className="regions-help">
+          Click to drop vertices; click the first vertex again, double-click, or
+          press Enter to close. Escape abandons the ring, Backspace removes its
+          last vertex. Click a region to select it, drag its handles to adjust,
+          Delete to remove it.
+        </p>
+
+        {selectedName && imageWidth > 0 && (
+          <PolygonCanvas
+            imageSrc={imageUrl(selectedName)}
+            width={imageWidth}
+            height={imageHeight}
+            zoom={zoom}
+            regions={regions}
+            draft={draft}
+            selectedIndex={selectedIndex}
+            detections={detections}
+            showDetections={showDetections}
+            onAddVertex={(point) => setDraft([...draftRef.current, point])}
+            onCloseDraft={closeDraft}
+            onSelect={setSelectedIndex}
+            onMoveVertex={(region, vertex, to) => {
+              const next = regionsRef.current.map((r, i) =>
+                i === region
+                  ? {
+                      ...r,
+                      ring: r.ring.map((p, j) => (j === vertex ? to : p)),
+                    }
+                  : r,
+              );
+              update(next);
+            }}
+          />
+        )}
+      </div>
+
+      <RegionsTable
+        regions={regions}
+        width={imageWidth}
+        height={imageHeight}
+        selectedIndex={selectedIndex}
+        duplicates={duplicates}
+        onSelect={setSelectedIndex}
+        onSetText={(index, text) =>
+          update(
+            regionsRef.current.map((r, i) =>
+              i === index ? { ...r, text } : r,
+            ),
+          )
+        }
+        onDelete={(index) => {
+          update(regionsRef.current.filter((_, i) => i !== index));
+          setSelectedIndex(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/regions/RegionsApp.tsx
+++ b/app/src/regions/RegionsApp.tsx
@@ -14,7 +14,7 @@ import {
 import { MIN_RING_VERTICES, autoLabel } from './polygons';
 import { PolygonCanvas } from './PolygonCanvas';
 import { RegionsTable } from './RegionsTable';
-import type { KeymapDetection, RegionPolygon } from './types';
+import type { DrawMode, KeymapDetection, RegionPolygon } from './types';
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -43,6 +43,7 @@ export function RegionsApp() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [detections, setDetections] = useState<KeymapDetection[]>([]);
   const [showDetections, setShowDetections] = useState(true);
+  const [mode, setMode] = useState<DrawMode>('rectangle');
   const [zoom, setZoom] = useState(0.25);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
 
@@ -107,8 +108,9 @@ export function RegionsApp() {
     setRegions(next);
   }
 
-  function closeDraft(): void {
-    const ring = draftRef.current;
+  // `ring` is passed by the rectangle drag, which knows its final shape before the
+  // draft state it set has flushed; polygon mode omits it and uses the draft.
+  function closeDraft(ring: [number, number][] = draftRef.current): void {
     if (ring.length < MIN_RING_VERTICES) return;
     const taken = new Set(
       regionsRef.current.map((r) => r.text).filter((t) => t !== ''),
@@ -125,7 +127,14 @@ export function RegionsApp() {
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
       if (isTypingTarget(event.target)) return;
-      if (event.key === 'Enter') {
+      if (event.key === 'r' || event.key === 'R') {
+        // Both modes get used on one sheet — rectangles for the plain blocks, the
+        // polygon for the ragged ones — so switching wants to be a keystroke.
+        setDraft([]);
+        setMode((current) =>
+          current === 'rectangle' ? 'polygon' : 'rectangle',
+        );
+      } else if (event.key === 'Enter') {
         closeDraft();
       } else if (event.key === 'Escape') {
         setDraft([]);
@@ -188,6 +197,22 @@ export function RegionsApp() {
             />
             <span className="regions-zoom">{(zoom * 100).toFixed(0)}%</span>
           </label>
+          <span className="regions-mode">
+            {(['rectangle', 'polygon'] as DrawMode[]).map((option) => (
+              <label key={option}>
+                <input
+                  type="radio"
+                  name="draw-mode"
+                  checked={mode === option}
+                  onChange={() => {
+                    setDraft([]); // a half-drawn ring does not survive the switch
+                    setMode(option);
+                  }}
+                />
+                {option === 'rectangle' ? 'Rectangle' : 'Polygon'}
+              </label>
+            ))}
+          </span>
           <label>
             <input
               type="checkbox"
@@ -213,10 +238,11 @@ export function RegionsApp() {
         </div>
 
         <p className="regions-help">
-          Click to drop vertices; click the first vertex again, double-click, or
-          press Enter to close. Escape abandons the ring, Backspace removes its
-          last vertex. Click a region to select it, drag its handles to adjust,
-          Delete to remove it.
+          {mode === 'rectangle'
+            ? 'Drag out a rectangle to trace a block. '
+            : 'Click to drop vertices; click the first vertex again, double-click, or press Enter to close. Backspace removes the last vertex. '}
+          Press R to switch modes, Escape to abandon. Click a region to select
+          it, drag its handles to adjust, Delete to remove it.
         </p>
 
         {selectedName && imageWidth > 0 && (
@@ -225,12 +251,14 @@ export function RegionsApp() {
             width={imageWidth}
             height={imageHeight}
             zoom={zoom}
+            mode={mode}
             regions={regions}
             draft={draft}
             selectedIndex={selectedIndex}
             detections={detections}
             showDetections={showDetections}
             onAddVertex={(point) => setDraft([...draftRef.current, point])}
+            onSetDraft={setDraft}
             onCloseDraft={closeDraft}
             onSelect={setSelectedIndex}
             onMoveVertex={(region, vertex, to) => {

--- a/app/src/regions/RegionsTable.tsx
+++ b/app/src/regions/RegionsTable.tsx
@@ -1,0 +1,99 @@
+import { sheetFraction } from './polygons';
+import type { RegionPolygon } from './types';
+
+interface RegionsTableProps {
+  regions: RegionPolygon[];
+  width: number;
+  height: number;
+  selectedIndex: number | null;
+  /** Page keys used by more than one region, which is always a mistake. */
+  duplicates: ReadonlySet<string>;
+  onSelect: (index: number) => void;
+  onSetText: (index: number, text: string) => void;
+  onDelete: (index: number) => void;
+}
+
+/**
+ * One row per traced region: its page key, how much of the sheet it covers, and how
+ * many vertices it has.
+ *
+ * The sheet-share column is here because it is the quantity that made a leaked
+ * segmentation catastrophic — a hand-traced sheet is also the reference for judging
+ * what a plausible share looks like.
+ */
+export function RegionsTable(props: RegionsTableProps) {
+  const {
+    regions,
+    width,
+    height,
+    selectedIndex,
+    duplicates,
+    onSelect,
+    onSetText,
+    onDelete,
+  } = props;
+
+  return (
+    <div className="regions-panel">
+      <table className="regions-table">
+        <thead>
+          <tr>
+            <th>Page</th>
+            <th className="numeric">% sheet</th>
+            <th className="numeric">pts</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {regions.map((region, index) => {
+            const duplicate = region.text !== '' && duplicates.has(region.text);
+            return (
+              <tr
+                key={index}
+                className={
+                  [
+                    index === selectedIndex ? 'selected' : '',
+                    region.text === '' ? 'unlabeled' : '',
+                    duplicate ? 'duplicate' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ') || undefined
+                }
+                onClick={() => onSelect(index)}
+              >
+                <td>
+                  <input
+                    value={region.text}
+                    placeholder="page"
+                    size={6}
+                    title={
+                      duplicate ? 'another region claims this page' : undefined
+                    }
+                    onChange={(e) => onSetText(index, e.target.value)}
+                    onFocus={() => onSelect(index)}
+                  />
+                </td>
+                <td className="numeric">
+                  {(sheetFraction(region.ring, width, height) * 100).toFixed(2)}
+                </td>
+                <td className="numeric">{region.ring.length}</td>
+                <td>
+                  <button
+                    type="button"
+                    title="Delete this region"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete(index);
+                    }}
+                  >
+                    ×
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/regions/api.ts
+++ b/app/src/regions/api.ts
@@ -1,0 +1,64 @@
+import { typedApi } from 'crosswalk';
+import { jsonFetch } from '../apiFetch';
+import type { API } from '../../server/api';
+import type { ImageInfo } from '../keymap/types';
+import type { KeymapDetection, RegionPolygon } from './types';
+import { createRegionsJson, openRing } from './polygons';
+
+const api = typedApi<API>({ fetch: jsonFetch });
+
+/** A sheet's regions with the sheet dimensions its coordinates are in. */
+export interface LoadedRegions {
+  width: number;
+  height: number;
+  regions: RegionPolygon[];
+}
+
+/**
+ * URL the server serves a key map image from (a binary, non-JSON endpoint).
+ *
+ * Page ids contain slashes ("queens_1950/vol2/p0") and the endpoint is a
+ * wildcard path, so each segment is encoded separately to keep them.
+ */
+export function imageUrl(id: string): string {
+  const path = id.split('/').map(encodeURIComponent).join('/');
+  return `/api/keymaps/${path}`;
+}
+
+/** Key-map sheets available to trace, reusing the point labeler's page list. */
+export async function fetchImages(): Promise<ImageInfo[]> {
+  const { images } = await api.get('/api/images')();
+  return images;
+}
+
+/** Fetch a sheet's hand-drawn regions, or null if none exist yet. */
+export async function fetchRegions(id: string): Promise<LoadedRegions | null> {
+  const data = await api.get('/api/regions')(null, { id });
+  if ('exists' in data) return null;
+  return {
+    width: data.width,
+    height: data.height,
+    regions: data.panels.map((ring, index) => ({
+      ring: openRing(ring),
+      text: data.labels[index] ?? '',
+    })),
+  };
+}
+
+/** Write a sheet's regions in the panels.json schema. */
+export async function saveRegions(
+  id: string,
+  width: number,
+  height: number,
+  regions: RegionPolygon[],
+): Promise<void> {
+  await api.put('/api/regions')({}, createRegionsJson(width, height, regions), {
+    id,
+  });
+}
+
+/** Fetch the sheet's detected page numbers, for auto-naming a drawn ring. */
+export async function fetchDetections(id: string): Promise<KeymapDetection[]> {
+  const { detections } = await api.get('/api/keymap-detections')(null, { id });
+  return detections;
+}

--- a/app/src/regions/polygons.test.ts
+++ b/app/src/regions/polygons.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autoLabel,
+  closedRing,
+  createRegionsJson,
+  openRing,
+  regionAt,
+  sheetFraction,
+  vertexAt,
+} from './polygons';
+import type { KeymapDetection, RegionPolygon } from './types';
+
+const SQUARE: [number, number][] = [
+  [0, 0],
+  [10, 0],
+  [10, 10],
+  [0, 10],
+];
+
+function region(ring: [number, number][], text = ''): RegionPolygon {
+  return { ring, text };
+}
+
+describe('closedRing', () => {
+  it('repeats the first vertex so the ring is explicitly closed', () => {
+    expect(closedRing(SQUARE)).toEqual([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+      [0, 0],
+    ]);
+  });
+
+  it('leaves an already-closed ring alone', () => {
+    const closed: [number, number][] = [...SQUARE, [0, 0]];
+    expect(closedRing(closed)).toHaveLength(5);
+  });
+
+  it('rounds to the one decimal the panels schema uses', () => {
+    expect(closedRing([[1.234, 5.678]])[0]).toEqual([1.2, 5.7]);
+  });
+
+  it('handles an empty ring', () => {
+    expect(closedRing([])).toEqual([]);
+  });
+});
+
+describe('openRing', () => {
+  it('round-trips with closedRing', () => {
+    expect(openRing(closedRing(SQUARE))).toEqual(SQUARE);
+  });
+
+  it('leaves an open ring alone', () => {
+    expect(
+      openRing([
+        [0, 0],
+        [1, 1],
+      ]),
+    ).toEqual([
+      [0, 0],
+      [1, 1],
+    ]);
+  });
+});
+
+describe('createRegionsJson', () => {
+  it('writes parallel panels and labels arrays', () => {
+    const json = createRegionsJson(100, 200, [region(SQUARE, '12')]);
+    expect(json).toEqual({
+      width: 100,
+      height: 200,
+      panels: [
+        [
+          [0, 0],
+          [10, 0],
+          [10, 10],
+          [0, 10],
+          [0, 0],
+        ],
+      ],
+      labels: ['12'],
+    });
+  });
+});
+
+describe('autoLabel', () => {
+  const detections: KeymapDetection[] = [
+    { text: '12', x: 5, y: 5 },
+    { text: '13', x: 50, y: 50 },
+  ];
+
+  it('names a ring that encloses exactly one page number', () => {
+    // The whole point: a block contains its own printed number, so the user types nothing.
+    expect(autoLabel(SQUARE, detections)).toBe('12');
+  });
+
+  it('stays blank when the ring encloses nothing', () => {
+    expect(
+      autoLabel(
+        [
+          [100, 100],
+          [110, 100],
+          [110, 110],
+        ],
+        detections,
+      ),
+    ).toBe('');
+  });
+
+  it('stays blank when the ring encloses two different numbers', () => {
+    // Ambiguous: a ring spanning two blocks must not silently pick one.
+    const wide: [number, number][] = [
+      [0, 0],
+      [60, 0],
+      [60, 60],
+      [0, 60],
+    ];
+    expect(autoLabel(wide, detections)).toBe('');
+  });
+
+  it('accepts a repeated detection of the same number', () => {
+    const doubled = [...detections, { text: '12', x: 6, y: 6 }];
+    expect(autoLabel(SQUARE, doubled)).toBe('12');
+  });
+
+  it('ignores a key another region already claimed', () => {
+    expect(autoLabel(SQUARE, detections, new Set(['12']))).toBe('');
+  });
+
+  it('ignores blank detection text', () => {
+    expect(autoLabel(SQUARE, [{ text: '', x: 5, y: 5 }])).toBe('');
+  });
+
+  it('needs a real ring', () => {
+    expect(
+      autoLabel(
+        [
+          [0, 0],
+          [1, 1],
+        ],
+        detections,
+      ),
+    ).toBe('');
+  });
+});
+
+describe('regionAt', () => {
+  it('finds the region under a point', () => {
+    expect(regionAt([region(SQUARE)], 5, 5)).toBe(0);
+    expect(regionAt([region(SQUARE)], 50, 50)).toBeNull();
+  });
+
+  it('prefers the most recently drawn of two overlapping regions', () => {
+    const bigger: [number, number][] = [
+      [0, 0],
+      [20, 0],
+      [20, 20],
+      [0, 20],
+    ];
+    expect(regionAt([region(SQUARE), region(bigger)], 5, 5)).toBe(1);
+  });
+});
+
+describe('vertexAt', () => {
+  it('finds a vertex within the radius and ignores one outside it', () => {
+    expect(vertexAt(region(SQUARE), 10, 1, 3)).toBe(1);
+    expect(vertexAt(region(SQUARE), 5, 5, 3)).toBeNull();
+  });
+
+  it('picks the nearest when two are in range', () => {
+    expect(vertexAt(region(SQUARE), 9, 9, 100)).toBe(2);
+  });
+});
+
+describe('sheetFraction', () => {
+  it('reports the share of the sheet a ring covers', () => {
+    expect(sheetFraction(SQUARE, 10, 10)).toBeCloseTo(1.0);
+    expect(sheetFraction(SQUARE, 20, 20)).toBeCloseTo(0.25);
+  });
+
+  it('is zero for a degenerate ring or sheet', () => {
+    expect(
+      sheetFraction(
+        [
+          [0, 0],
+          [1, 1],
+        ],
+        10,
+        10,
+      ),
+    ).toBe(0);
+    expect(sheetFraction(SQUARE, 0, 0)).toBe(0);
+  });
+});

--- a/app/src/regions/polygons.test.ts
+++ b/app/src/regions/polygons.test.ts
@@ -4,6 +4,7 @@ import {
   closedRing,
   createRegionsJson,
   openRing,
+  rectRing,
   regionAt,
   sheetFraction,
   vertexAt,
@@ -191,5 +192,31 @@ describe('sheetFraction', () => {
       ),
     ).toBe(0);
     expect(sheetFraction(SQUARE, 0, 0)).toBe(0);
+  });
+});
+
+describe('rectRing', () => {
+  it('spans two opposite corners clockwise from the top left', () => {
+    expect(rectRing([2, 3], [8, 9])).toEqual([
+      [2, 3],
+      [8, 3],
+      [8, 9],
+      [2, 9],
+    ]);
+  });
+
+  it('normalizes a drag made in any direction', () => {
+    // Dragging up-left must give the same rectangle as dragging down-right.
+    const expected = rectRing([2, 3], [8, 9]);
+    expect(rectRing([8, 9], [2, 3])).toEqual(expected);
+    expect(rectRing([2, 9], [8, 3])).toEqual(expected);
+    expect(rectRing([8, 3], [2, 9])).toEqual(expected);
+  });
+
+  it('produces a ring the rest of the pipeline accepts', () => {
+    const ring = rectRing([0, 0], [10, 20]);
+    expect(ring).toHaveLength(4);
+    expect(sheetFraction(ring, 10, 20)).toBeCloseTo(1.0);
+    expect(closedRing(ring)).toHaveLength(5);
   });
 });

--- a/app/src/regions/polygons.ts
+++ b/app/src/regions/polygons.ts
@@ -1,0 +1,126 @@
+import { pointInPolygon, polygonArea } from '../geometry';
+import type {
+  KeymapDetection,
+  RegionPolygon,
+  RegionsWriteRequest,
+} from './types';
+
+/** Vertices a ring needs before it can be closed into a region. */
+export const MIN_RING_VERTICES = 3;
+
+/**
+ * Screen-pixel radius within which a click counts as hitting a vertex, or as
+ * closing the ring by returning to its first vertex. Screen rather than image
+ * pixels so the target stays the same size at every zoom level.
+ */
+export const VERTEX_HIT_RADIUS = 9;
+
+/** Ring with its first vertex repeated at the end, as the panels schema wants. */
+export function closedRing(ring: [number, number][]): number[][] {
+  if (ring.length === 0) return [];
+  const first = ring[0]!;
+  const last = ring[ring.length - 1]!;
+  const closed: number[][] = ring.map(([x, y]) => [round1(x), round1(y)]);
+  if (first[0] !== last[0] || first[1] !== last[1]) {
+    closed.push([round1(first[0]), round1(first[1])]);
+  }
+  return closed;
+}
+
+/** Drop a ring's duplicated closing vertex, for editing an on-disk sidecar. */
+export function openRing(ring: number[][]): [number, number][] {
+  const points: [number, number][] = ring.map(([x = 0, y = 0]) => [x, y]);
+  if (points.length < 2) return points;
+  const first = points[0]!;
+  const last = points[points.length - 1]!;
+  if (first[0] === last[0] && first[1] === last[1]) points.pop();
+  return points;
+}
+
+// One decimal is the precision page_regions writes; more is false detail at this scale.
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/** Build the sidecar payload for a sheet. The server fills in `image`. */
+export function createRegionsJson(
+  width: number,
+  height: number,
+  regions: RegionPolygon[],
+): RegionsWriteRequest {
+  return {
+    width,
+    height,
+    panels: regions.map((region) => closedRing(region.ring)),
+    labels: regions.map((region) => region.text),
+  };
+}
+
+/**
+ * The page key a freshly drawn ring should take, from the sheet's detected numbers.
+ *
+ * A key map's blocks each contain exactly one printed page number, so a ring that
+ * encloses exactly one detection names itself and the user types nothing. Enclosing
+ * none (or several, where the detector doubled up or the ring spans two blocks) is
+ * ambiguous, so it stays blank for the user to fill in rather than guessing.
+ *
+ * `taken` are keys already used on this sheet; a detection whose key is taken is
+ * ignored, so re-drawing near an existing region does not silently duplicate its key.
+ */
+export function autoLabel(
+  ring: [number, number][],
+  detections: readonly KeymapDetection[],
+  taken: ReadonlySet<string> = new Set(),
+): string {
+  if (ring.length < MIN_RING_VERTICES) return '';
+  const enclosed = detections.filter(
+    (d) =>
+      d.text !== '' && !taken.has(d.text) && pointInPolygon(d.x, d.y, ring),
+  );
+  const keys = new Set(enclosed.map((d) => d.text));
+  return keys.size === 1 ? enclosed[0]!.text : '';
+}
+
+/** Index of the region under a point, topmost (last drawn) first; null if none. */
+export function regionAt(
+  regions: readonly RegionPolygon[],
+  x: number,
+  y: number,
+): number | null {
+  for (let i = regions.length - 1; i >= 0; i--) {
+    if (pointInPolygon(x, y, regions[i]!.ring)) return i;
+  }
+  return null;
+}
+
+/** A region's vertex within `radius` image px of a point, or null. */
+export function vertexAt(
+  region: RegionPolygon,
+  x: number,
+  y: number,
+  radius: number,
+): number | null {
+  let best: number | null = null;
+  let bestDistance = radius;
+  region.ring.forEach(([vx, vy], index) => {
+    const distance = Math.hypot(vx - x, vy - y);
+    if (distance <= bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+  });
+  return best;
+}
+
+/**
+ * Share of the sheet a ring covers — the quantity that made a leaked segmentation
+ * catastrophic, so it is worth showing while drawing.
+ */
+export function sheetFraction(
+  ring: [number, number][],
+  width: number,
+  height: number,
+): number {
+  if (ring.length < MIN_RING_VERTICES || width <= 0 || height <= 0) return 0;
+  return polygonArea(ring) / (width * height);
+}

--- a/app/src/regions/polygons.ts
+++ b/app/src/regions/polygons.ts
@@ -15,6 +15,38 @@ export const MIN_RING_VERTICES = 3;
  */
 export const VERTEX_HIT_RADIUS = 9;
 
+/**
+ * Screen pixels a rectangle drag must span before it counts as a rectangle.
+ *
+ * Below this it was a click, not a drag — usually a mis-aimed attempt to select an
+ * existing region — and turning it into a sliver polygon would be worse than nothing.
+ */
+export const MIN_RECT_DRAG = 6;
+
+/**
+ * Axis-aligned ring spanning two opposite corners, clockwise from the top left.
+ *
+ * Key-map blocks are overwhelmingly rectangles aligned with the sheet, so dragging
+ * out two corners beats clicking four. The result is an ordinary four-vertex ring —
+ * nothing downstream knows it was drawn differently, so editing, auto-naming and the
+ * sidecar format are all unchanged.
+ */
+export function rectRing(
+  a: [number, number],
+  b: [number, number],
+): [number, number][] {
+  const x0 = Math.min(a[0], b[0]);
+  const x1 = Math.max(a[0], b[0]);
+  const y0 = Math.min(a[1], b[1]);
+  const y1 = Math.max(a[1], b[1]);
+  return [
+    [x0, y0],
+    [x1, y0],
+    [x1, y1],
+    [x0, y1],
+  ];
+}
+
 /** Ring with its first vertex repeated at the end, as the panels schema wants. */
 export function closedRing(ring: [number, number][]): number[][] {
   if (ring.length === 0) return [];

--- a/app/src/regions/regions.css
+++ b/app/src/regions/regions.css
@@ -1,0 +1,172 @@
+/* Key-map page-region labeler: sheet list, tracing canvas, region table. */
+
+.regions-app {
+  display: flex;
+  height: 100vh;
+  font:
+    13px/1.4 system-ui,
+    sans-serif;
+  overflow: hidden;
+}
+
+.regions-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  border-right: 1px solid #ddd;
+}
+
+.regions-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.regions-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 10px;
+  border-bottom: 1px solid #ddd;
+  flex-wrap: wrap;
+}
+
+.regions-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.regions-title {
+  font-weight: 600;
+}
+
+.regions-zoom {
+  width: 3.5em;
+  text-align: right;
+  color: #555;
+}
+
+.regions-count {
+  color: #555;
+}
+
+.regions-save {
+  margin-left: auto;
+  min-width: 6em;
+  text-align: right;
+}
+.regions-save-saved {
+  color: #2a7;
+}
+.regions-save-error {
+  color: #c33;
+}
+
+.regions-help {
+  margin: 0;
+  padding: 4px 10px;
+  color: #666;
+  border-bottom: 1px solid #eee;
+}
+
+/* The scroll container is the viewport; the wrapper is the full zoomed sheet, so
+   native scrollbars do the panning. */
+.polygon-scroll {
+  flex: 1;
+  overflow: auto;
+  background: #f4f4f4;
+}
+
+.polygon-wrapper {
+  position: relative;
+  cursor: crosshair;
+  user-select: none;
+}
+
+.polygon-wrapper img {
+  display: block;
+  pointer-events: none;
+}
+
+.polygon-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.polygon-label {
+  font:
+    600 13px system-ui,
+    sans-serif;
+  fill: #111;
+  paint-order: stroke;
+  stroke: #fff;
+  stroke-width: 3px;
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+.polygon-detection {
+  font:
+    11px system-ui,
+    sans-serif;
+  fill: #111;
+  paint-order: stroke;
+  stroke: #fff;
+  stroke-width: 3px;
+}
+
+.polygon-hint {
+  position: absolute;
+  padding: 1px 5px;
+  background: #ffd400;
+  border: 1px solid #8a6d00;
+  border-radius: 3px;
+  font-size: 11px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.regions-panel {
+  width: 260px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  border-left: 1px solid #ddd;
+}
+
+.regions-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.regions-table th,
+.regions-table td {
+  padding: 2px 6px;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+}
+
+.regions-table th.numeric,
+.regions-table td.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.regions-table tbody tr {
+  cursor: pointer;
+}
+
+.regions-table tbody tr.selected {
+  background: #e8f0fe;
+}
+
+.regions-table tbody tr.unlabeled input {
+  background: #fff6e0;
+}
+
+.regions-table tbody tr.duplicate input {
+  background: #ffe0e0;
+}

--- a/app/src/regions/regions.css
+++ b/app/src/regions/regions.css
@@ -170,3 +170,16 @@
 .regions-table tbody tr.duplicate input {
   background: #ffe0e0;
 }
+
+/* Draw-mode toggle: two radios that read as one control. */
+.regions-mode {
+  display: flex;
+  gap: 10px;
+  padding: 2px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.regions-mode label {
+  gap: 4px;
+}

--- a/app/src/regions/types.ts
+++ b/app/src/regions/types.ts
@@ -1,3 +1,11 @@
+/**
+ * How a new region is drawn.
+ *
+ * Both produce an ordinary ring; 'rectangle' just gets there in one drag, which suits
+ * the many key-map blocks that are plain rectangles.
+ */
+export type DrawMode = 'polygon' | 'rectangle';
+
 /** One hand-drawn page region: a closed ring in image-pixel space plus its page key. */
 export interface RegionPolygon {
   /** Ring vertices as [x, y] in image pixels. Stored open; closed on save. */

--- a/app/src/regions/types.ts
+++ b/app/src/regions/types.ts
@@ -1,0 +1,36 @@
+/** One hand-drawn page region: a closed ring in image-pixel space plus its page key. */
+export interface RegionPolygon {
+  /** Ring vertices as [x, y] in image pixels. Stored open; closed on save. */
+  ring: [number, number][];
+  /** Page key this region belongs to, e.g. "12" or "35A". Empty until entered. */
+  text: string;
+}
+
+/**
+ * A `<stem>.regions.panels.json` sidecar.
+ *
+ * Deliberately the same schema `page_regions` writes and `score_regions` reads, so a
+ * hand-drawn sheet can be scored against a detected segmentation — or against the
+ * OIM-projected footprints — with no conversion step.
+ */
+export interface RegionsJson {
+  /** Filename of the labelled image within the volume's `raw/`, e.g. "p0.jpg". */
+  image: string;
+  width: number;
+  height: number;
+  /** Closed rings (first vertex repeated as the last), one per region. */
+  panels: number[][][];
+  /** Page key per panel, parallel to `panels`. */
+  labels: string[];
+}
+
+/** A sidecar as written by the client; the server fills in `image`. */
+export type RegionsWriteRequest = Omit<RegionsJson, 'image'>;
+
+/** One detected page number from a `<stem>.keymap.json`, for auto-labelling. */
+export interface KeymapDetection {
+  text: string;
+  /** Centre of the detection's box, in image pixels. */
+  x: number;
+  y: number;
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         main: 'index.html',
         keymap: 'keymap.html',
         adjacency: 'adjacency.html',
+        regions: 'regions.html',
       },
     },
   },


### PR DESCRIPTION
This is used to generate real truth data for keymap regions, rather than regions inferred from OIM multimasks. Kind of tedious, but it's been helpful for informing #182 and #186. In particular, it demonstrated that large areas Claude had been considering correct were actually "leaks."

<img width="1907" height="847" alt="image" src="https://github.com/user-attachments/assets/27b4c715-9c6d-4fad-a92e-701830ef2ff0" />
