### PR TITLE
Run the street-constraint channel in mapsnap fit

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -47,6 +47,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.snap",
         "Geometry-first OSM snap: rescue unplaced pages, arbitrate and refine fits",
     ),
+    "street-solve": (
+        "mapsnap.street_solve_run",
+        "Street-constraint georeferencing: solve key-map-prior pages, adopt where the referee prefers",
+    ),
     "iiif": (
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -109,8 +109,9 @@ def main() -> None:
         "--no-snap",
         action="store_true",
         help=(
-            "Skip the geometry-first OSM snap channel (rescue/arbitrate/"
-            "refine) and build the IIIF from RANSAC georefs alone."
+            "Skip the geometry channels — OSM snap (rescue/arbitrate/refine) "
+            "and the street-constraint solver, whose referee rides on snap's "
+            "machinery — and build the IIIF from RANSAC georefs alone."
         ),
     )
     args, georef_extra = parser.parse_known_args()
@@ -145,19 +146,30 @@ def main() -> None:
 
     # The geometry-first snap channel: rescue unplaced pages, arbitrate fits
     # OSM contradicts, refine mid-tier fits. Its pN.georef-osm.json sidecars
-    # take priority in the hybrid glob below.
+    # take priority over plain georefs in the hybrid glob below.
     if not args.no_snap:
         # Both passes are per-page and CPU-bound, so one --num-workers governs
         # both; the rest of the georef passthrough is georef-only.
         run_cmd(["mapsnap", "snap", str(dir_path), *worker_flag(georef_extra)])
+        # The street-constraint channel: fit key-map-prior pages from their
+        # street labels and adopt a pose only where the independent referee
+        # prefers it over whatever snap/georef published. Its
+        # pN.georef-streets.json sidecars take top priority in the glob. Runs
+        # after snap because the referee judges against (and shares machinery
+        # with) the snap channel; skipped with --no-snap for the same reason.
+        run_cmd(["mapsnap", "street-solve", str(dir_path)])
 
     output_iiif = dir_path / f"{run_id}.iiif.json"
     # Pass the glob as a literal string; make_iiif_georef does its own glob
-    # expansion (first glob wins per page, so snap sidecars take priority).
+    # expansion (first glob wins per page, so the channel priority is
+    # streets, then snap, then plain georefs).
     if args.no_snap:
         georef_glob = str(dir_path / "*.georef.json")
     else:
-        georef_glob = f"{dir_path / '*.georef-osm.json'},{dir_path / '*.georef.json'}"
+        georef_glob = (
+            f"{dir_path / '*.georef-streets.json'},"
+            f"{dir_path / '*.georef-osm.json'},{dir_path / '*.georef.json'}"
+        )
     run_cmd(
         [
             "mapsnap",

--- a/mapsnap/street_solve_run.py
+++ b/mapsnap/street_solve_run.py
@@ -1,0 +1,53 @@
+"""Street-constraint georeferencing: solve, then adopt where the referee prefers it.
+
+The production entry point for the street_solve channel (see street_solve.py for
+the solver and street_solve_experiment.py for the underlying commands). Every
+page with a key-map location prior gets a pose fitted from its street labels as
+position+angle constraints against named OSM polylines — no intersections
+required. On its own the channel is a coin flip against the incumbent, so a pose
+is only adopted where an independent referee (osm_snap.evaluate_pose: road-
+skeleton chamfer plus name alignment, evidence derived from neither channel)
+prefers it by a clear margin. Measured over every disagreement in the twelve
+truth volumes that picks the closer pose 85% of the time and never costs a page
+its <=25 ft placement.
+
+Writes pN.georef-streets.json sidecars for the adopted pages, deleting the
+previous run's first. Build the volume IIIF with the streets-first hybrid glob
+so the sidecars win where they exist:
+
+    mapsnap iiif <ref> '<dir>/*.georef-streets.json,<dir>/*.georef-osm.json,<dir>/*.georef.json' ...
+
+(`mapsnap fit` does this automatically.) The referee shares the snap channel's
+machinery (P(road) maps, OSM rasters), so run this after `mapsnap snap` — the
+incumbent it judges against is whatever the pipeline currently publishes,
+snap's sidecars included.
+
+Usage:
+    mapsnap street-solve DIR
+"""
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fit street-constraint poses for every key-map-prior page and adopt "
+            "each one only where the independent referee prefers it. Writes "
+            "pN.georef-streets.json sidecars; include them streets-first in the "
+            "IIIF glob."
+        )
+    )
+    parser.add_argument("dir", metavar="DIR", type=Path, help="Volume directory")
+    args = parser.parse_args()
+
+    from mapsnap.street_solve_experiment import ADOPT_GAP, cmd_candidates, cmd_select
+
+    common = {"volume": str(args.dir), "gates": None}
+    cmd_candidates(argparse.Namespace(**common, pages=None, truth_prior=False))
+    cmd_select(argparse.Namespace(**common, adopt_gap=ADOPT_GAP))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The street-constraint solver merged in #175 as a production channel — its `pN.georef-streets.json` sidecars take top priority in the hybrid glob — but **`mapsnap fit` never learned about it**. Every fit run since silently rebuilt volumes without the channel, and any page whose best pose lived in a streets sidecar regressed. Today's `2026-07-30` runs made that visible: Brooklyn p14 read **403 ft** and Kansas City p502 read **254 ft** while their street sidecars sat on disk saying 56 ft and 13 ft.

## What this adds

**`mapsnap street-solve DIR`** — the channel's production entry point, a thin wrapper over the experiment module on the same pattern as `snap.py`: solve every key-map-prior page, then adopt a pose only where the independent referee (`osm_snap.evaluate_pose`) prefers it by the production margin (0.2 — picks the closer pose 85% of the time across every disagreement in the twelve truth volumes, never costs a ≤25 ft placement). `cmd_select` deletes the previous run's sidecars before writing, so stale adoptions cannot linger.

**`mapsnap fit` runs it** after `snap` — the referee judges against (and shares P(road) machinery with) whatever snap just published — and builds the IIIF with the full channel-priority glob:

```
*.georef-streets.json, *.georef-osm.json, *.georef.json
```

`--no-snap` now skips both geometry channels, since the street referee cannot run without snap's machinery.

## Verified end to end

Brooklyn 1939 v1, `mapsnap fit --tag 2026-07-30c`, against this morning's pre-integration run:

| | ≤25 ft | ≥200 ft | score | p14 |
|---|---|---|---|---|
| fit without the channel | 47/55 | 2 | +81.8 | 403 ft |
| **fit with the channel** | 47/55 | **1** | **+83.6** | **56 ft** |

The chain re-adopted p14 *fresh* against the current incumbents (`gap +0.58, apart 448 ft`) rather than inheriting the stale sidecar — matching the channel-complete comparison assembled by hand earlier today.

## Notes

- The wrapper reuses `cmd_candidates`/`cmd_select` from `street_solve_experiment` unchanged, so the experiment CLI (`candidates | select | materialize | report`) keeps working for truth-aware analysis.
- Kansas City's fit was not re-run here; its next `mapsnap fit` will refresh its street sidecars the same way.
- Cost on Brooklyn: ~2 minutes for solve + referee on top of the fit pipeline.

807 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
