### PR TITLE
fix-truth-splits: repair OIM's frame-mixed split selectors (OIM#402)

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -80,6 +80,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
     ),
     "split-twopage": ("mapsnap.split_twopage", "Split two-page images in half"),
     "split": ("mapsnap.split", "Split map pages into individual panels"),
+    "fix-truth-splits": (
+        "mapsnap.fix_truth_splits",
+        "Repair OIM-exported SvgSelectors for split pages (OIM#402)",
+    ),
     "oim-split-truth": (
         "mapsnap.oim_truth",
         "Locate OIM's manual split regions on the canvas for comparison",

--- a/mapsnap/fix_truth_splits.py
+++ b/mapsnap/fix_truth_splits.py
@@ -1,0 +1,212 @@
+"""Repair OIM-exported SvgSelectors for split pages (OIM#402 / mapsnap#188).
+
+OIM's IIIF export writes a split page's GCP resourceCoords in the FULL parent
+image's pixel frame but its SvgSelector polygon in the CROPPED split image's
+frame — one annotation, two coordinate systems. Projecting such a selector
+through the annotation's own transform lands the split's footprint translated by
+the crop offset: onto its sibling's territory for a 50/50 split. Fifty-five of
+the sixty-nine split groups in the truth corpus are affected. `mapsnap compare`
+is immune (it pairs and grades splits via the template-matched
+``oim/pN.panels.json`` regions), but everything that projects the selector —
+``mapsnap score``'s land weighting, the key-map region truth builder, the volume
+viewer's truth footprints — inherits the translation.
+
+The crop offset is recovered exactly, offline, from artifacts every affected
+volume already has: ``oim-split-truth`` built each ``oim/pN.panels.json`` ring
+as ``panel_polygon(crop image) + (template-matched offset)``, so re-deriving the
+crop's panel polygon and subtracting it from the stored ring returns the offset
+to the rounding of the file.
+
+A shifted selector is adopted only when it contains strictly more of the
+annotation's own GCPs than the original did — the GCPs are in the full frame,
+so containment is the frame test. That makes the repair self-validating and
+idempotent: an already-correct selector (or a rerun over a fixed file) shifts
+containment down or not at all and is left untouched.
+
+    mapsnap fix-truth-splits data/<vol>/main.iiif.json            # dry run
+    mapsnap fix-truth-splits data/<vol>/main.iiif.json --write
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+from shapely.geometry import Point, Polygon
+from shapely.validation import make_valid
+
+from mapsnap.compare_iiif_georef import (
+    extract_gcps,
+    label_split_index,
+    parse_svg_polygon,
+)
+from mapsnap.oim_truth import panel_polygon
+from mapsnap.utils import source_id_to_page_key
+
+# A GCP within this many canvas pixels of the selector counts as inside it;
+# GCPs are clicked at street corners, occasionally just outside the drawn edge.
+GCP_BUFFER_PX = 50.0
+
+
+def ring_offset(
+    ring: list[list[float]], crop_polygon: np.ndarray
+) -> tuple[float, float] | None:
+    """The crop's offset in the parent canvas, recovered from a panels.json ring.
+
+    ``oim-split-truth`` wrote the ring as ``crop_polygon + offset`` vertex for
+    vertex, so when the shapes still correspond the offset falls out exactly (to
+    the file's 0.1 px rounding). If the vertex counts differ — the mask tracer
+    changed since the ring was written — fall back to aligning bounding-box
+    corners, which is exact for identical masks and within a few pixels
+    otherwise; every downstream consumer tolerates far more.
+    """
+    if not len(crop_polygon):
+        return None
+    arr = np.asarray(ring, dtype=np.float64)
+    if len(arr) > 1 and np.allclose(arr[0], arr[-1]):
+        arr = arr[:-1]  # closed ring
+    if len(arr) == len(crop_polygon):
+        deltas = arr - crop_polygon
+        if float(np.ptp(deltas, axis=0).max()) <= 1.0:
+            mean = deltas.mean(axis=0)
+            return float(mean[0]), float(mean[1])
+    dx = float(arr[:, 0].min() - crop_polygon[:, 0].min())
+    dy = float(arr[:, 1].min() - crop_polygon[:, 1].min())
+    return dx, dy
+
+
+def gcp_containment(item: dict, points: list[tuple[float, float]]) -> float:
+    """Fraction of the annotation's GCPs inside the (buffered) selector polygon."""
+    gcps = extract_gcps(item)
+    if not gcps or len(points) < 3:
+        return 0.0
+    polygon = make_valid(Polygon(points)).buffer(GCP_BUFFER_PX)
+    return sum(1 for (px, py), _ in gcps if polygon.contains(Point(px, py))) / len(gcps)
+
+
+def shifted_selector(
+    value: str, offset: tuple[float, float]
+) -> tuple[str, list[tuple[float, float]]]:
+    """The SvgSelector value with every point translated by ``offset``."""
+    points = [(x + offset[0], y + offset[1]) for x, y in parse_svg_polygon(value)]
+    rendered = " ".join(f"{x},{y}" for x, y in points)
+    return f'<svg><polygon points="{rendered}" /></svg>', points
+
+
+def fix_annotation_page(doc: dict, oim_dir: Path) -> list[str]:
+    """Repair frame-mixed split selectors in place; return a log of actions."""
+    log: list[str] = []
+    groups: dict[str, list[dict]] = {}
+    for page_key, items in annotations_by_source_doc(doc).items():
+        splits = [i for i in items if label_split_index(i) is not None]
+        if len(splits) >= 2:
+            groups[page_key] = splits
+    for page_key, splits in sorted(groups.items()):
+        panels_path = oim_dir / f"{page_key}.panels.json"
+        rings = None
+        if panels_path.exists():
+            rings = json.loads(panels_path.read_text())["panels"]
+        for item in splits:
+            index = label_split_index(item)
+            crop_path = oim_dir / f"{page_key}__{index}.jpg"
+            selector = item["target"].get("selector") or {}
+            if selector.get("type") != "SvgSelector":
+                continue
+            label = f"{page_key} [{index}]"
+            if rings is None or index is None or index > len(rings):
+                if gcp_containment(item, parse_svg_polygon(selector["value"])) < 0.5:
+                    log.append(
+                        f"{label}: LOOKS BROKEN but {panels_path.name} is "
+                        "missing; cannot repair"
+                    )
+                continue
+            if crop_path.exists():
+                crop = np.asarray(Image.open(crop_path).convert("L"))
+                polygon = panel_polygon(crop)
+                if polygon is None:
+                    log.append(
+                        f"{label}: no panel polygon in {crop_path.name}; skipped"
+                    )
+                    continue
+                offset = ring_offset(rings[index - 1], polygon)
+            else:
+                # No crop image (panels.json built from the OIM API rather than
+                # oim-split-truth). The ring and the selector then trace the same
+                # drawn region in different frames, so align their corners.
+                offset = ring_offset(
+                    rings[index - 1],
+                    np.asarray(parse_svg_polygon(selector["value"]), dtype=np.float64),
+                )
+            if offset is None:
+                continue
+            before = gcp_containment(item, parse_svg_polygon(selector["value"]))
+            new_value, new_points = shifted_selector(selector["value"], offset)
+            after = gcp_containment(item, new_points)
+            if after > before:
+                selector["value"] = new_value
+                log.append(
+                    f"{label}: shifted by ({offset[0]:.0f}, {offset[1]:.0f}); "
+                    f"gcps inside {before:.0%} -> {after:.0%}"
+                )
+            elif before < 0.5:
+                log.append(
+                    f"{label}: still broken (gcps inside {before:.0%}); the "
+                    f"recovered offset ({offset[0]:.0f}, {offset[1]:.0f}) did not help"
+                )
+    return log
+
+
+def annotations_by_source_doc(doc: dict) -> dict[str, list[dict]]:
+    """Group items by parent page key (mirrors compare's annotations_by_source)."""
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for item in doc.get("items", []):
+        source_id = item["target"]["source"].get("id")
+        parent_key = source_id_to_page_key(source_id, item.get("label", "")).split(
+            "__"
+        )[0]
+        if parent_key:
+            groups[parent_key].append(item)
+    return dict(groups)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("truth", type=Path, help="main.iiif.json to repair")
+    parser.add_argument(
+        "--oim-dir",
+        type=Path,
+        help="Directory of OIM split crops and panels.json (default: sibling oim/)",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write the repaired file in place (default: report only). The "
+        "original is kept once as <name>.pre-oim402.json.",
+    )
+    args = parser.parse_args()
+
+    oim_dir = args.oim_dir if args.oim_dir else args.truth.parent / "oim"
+    doc = json.loads(args.truth.read_text())
+    log = fix_annotation_page(doc, oim_dir)
+    for line in log:
+        print(line)
+    fixed = sum(1 for line in log if "shifted by" in line)
+    unfixable = len(log) - fixed
+    print(f"{fixed} selector(s) repaired, {unfixable} problem(s) left", file=sys.stderr)
+    if not args.write:
+        if fixed:
+            print("(dry run; pass --write to apply)", file=sys.stderr)
+        return
+    if fixed:
+        backup = args.truth.with_suffix(".pre-oim402.json")
+        if not backup.exists():
+            backup.write_text(args.truth.read_text())
+        args.truth.write_text(json.dumps(doc, indent=1))
+        print(f"wrote {args.truth} (original at {backup.name})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/fix_truth_splits_test.py
+++ b/mapsnap/fix_truth_splits_test.py
@@ -1,0 +1,116 @@
+import json
+
+import numpy as np
+
+from mapsnap.fix_truth_splits import (
+    fix_annotation_page,
+    gcp_containment,
+    ring_offset,
+    shifted_selector,
+)
+
+
+def test_ring_offset_exact_vertexwise():
+    crop_polygon = np.array(
+        [[10.0, 20.0], [110.0, 20.0], [110.0, 220.0], [10.0, 220.0]]
+    )
+    ring = [[3010.1, 520.0], [3110.1, 520.0], [3110.1, 720.0], [3010.1, 720.0]]
+    offset = ring_offset(ring, crop_polygon)
+    assert offset is not None
+    assert abs(offset[0] - 3000.1) < 0.2 and abs(offset[1] - 500.0) < 0.2
+
+
+def test_ring_offset_handles_closed_ring_and_vertex_mismatch():
+    crop_polygon = np.array([[0.0, 0.0], [100.0, 0.0], [100.0, 50.0], [0.0, 50.0]])
+    closed = [
+        [200.0, 300.0],
+        [300.0, 300.0],
+        [300.0, 350.0],
+        [200.0, 350.0],
+        [200.0, 300.0],
+    ]
+    assert ring_offset(closed, crop_polygon) == (200.0, 300.0)
+    # Different vertex count -> bbox-corner fallback.
+    pentagon = [
+        [200.0, 300.0],
+        [300.0, 300.0],
+        [310.0, 320.0],
+        [300.0, 350.0],
+        [200.0, 350.0],
+    ]
+    assert ring_offset(pentagon, crop_polygon) == (200.0, 300.0)
+    assert ring_offset([[0, 0]], np.empty((0, 2))) is None
+
+
+def _item(gcps, selector_points, label="X p1 [2]"):
+    points = " ".join(f"{x},{y}" for x, y in selector_points)
+    return {
+        "label": label,
+        "target": {
+            "source": {"id": None, "width": 6000, "height": 8000},
+            "selector": {
+                "type": "SvgSelector",
+                "value": f'<svg><polygon points="{points}" /></svg>',
+            },
+        },
+        "body": {
+            "features": [
+                {
+                    "properties": {"resourceCoords": [px, py]},
+                    "geometry": {"coordinates": [0.0, 0.0]},
+                }
+                for px, py in gcps
+            ]
+        },
+    }
+
+
+def test_gcp_containment():
+    square = [(0.0, 0.0), (1000.0, 0.0), (1000.0, 1000.0), (0.0, 1000.0)]
+    inside = _item([(500, 500), (10, 10)], square)
+    outside = _item([(5000, 5000), (4000, 4000)], square)
+    assert gcp_containment(inside, square) == 1.0
+    assert gcp_containment(outside, square) == 0.0
+
+
+def test_shifted_selector_round_trips():
+    value = '<svg><polygon points="1,2 3,4 5,6" /></svg>'
+    new_value, points = shifted_selector(value, (10.0, 20.0))
+    assert points == [(11.0, 22.0), (13.0, 24.0), (15.0, 26.0)]
+    assert "11.0,22.0" in new_value
+
+
+def test_fix_applies_only_when_containment_improves(tmp_path):
+    # A synthetic 200x100 crop: white margins, one grey panel at (20,10)-(180,90).
+    crop = np.full((100, 200), 255, dtype=np.uint8)
+    crop[10:90, 20:180] = 128
+    from PIL import Image
+
+    oim = tmp_path
+    Image.fromarray(crop).save(oim / "p1__1.jpg")
+    Image.fromarray(crop).save(oim / "p1__2.jpg")
+    from mapsnap.oim_truth import panel_polygon
+
+    polygon = panel_polygon(np.asarray(Image.open(oim / "p1__1.jpg").convert("L")))
+    assert polygon is not None
+    # Split 1 sits at the canvas origin, split 2 at x=3000: rings = polygon + offset.
+    rings = [polygon.tolist(), (polygon + [3000.0, 0.0]).tolist()]
+    (oim / "p1.panels.json").write_text(json.dumps({"panels": rings}))
+
+    panel = [(20, 10), (180, 10), (180, 90), (20, 90)]  # crop-frame selector
+    # [1]: selector already in canvas frame, GCPs inside -> untouched.
+    # [2]: GCPs live at x~3000 (full frame) but the selector is crop-frame -> fixed.
+    doc = {
+        "items": [
+            _item([(100, 50)], panel, label="X p1 [1]"),
+            _item([(3100, 50), (3150, 80)], panel, label="X p1 [2]"),
+        ]
+    }
+    log = fix_annotation_page(doc, oim)
+    assert len(log) == 1 and "p1 [2]" in log[0] and "shifted by (3000, 0)" in log[0]
+    fixed = doc["items"][1]["target"]["selector"]["value"]
+    assert "3020.0,10.0" in fixed
+    unfixed = doc["items"][0]["target"]["selector"]["value"]
+    assert "20,10" in unfixed
+    # Idempotent: a second pass changes nothing.
+    assert fix_annotation_page(doc, oim) == []


### PR DESCRIPTION
Verifies, sizes, and works around OIM#402 (frame-mixed SvgSelectors for split pages). Closes #188.

## Verified — and it's frame-mixing, not just overlap

OIM's export writes a split's GCP `resourceCoords` in the **full parent image's** frame but its SvgSelector in the **cropped split image's** frame. The annotation's transform (fit from the GCPs) is correct; the selector is translated by the crop offset when projected through it. The clean detector is GCP containment: an annotation's own GCPs should fall inside its own selector.

## Extent: 55 of 69 split groups, 11 of 12 volumes

Far beyond the three named pages — and not always the `[2]` panel (Champaign p20 and KC p451 have a broken `[1]`; GR p721 has 4 of 5 members broken). What it does and doesn't hit:

- **Immune: `mapsnap compare`.** Split pairing *and* the metric-v2 grading region both come from the template-matched `oim/pN.panels.json`, never the selector. Truth-graded scores were largely protected all along.
- **Affected:** `mapsnap score`'s land-weighted footprints, `truth_regions` (the key-map region OIM truth), the volume viewer's truth footprints, and harness diagnostics in `edge_join`/`street_solve`/`georef_from_labels`.

## The workaround: `mapsnap fix-truth-splits`

The crop offset is recovered **exactly and offline**: `oim-split-truth` built each `panels.json` ring as `panel_polygon(crop) + offset`, so re-deriving the crop's panel polygon and subtracting returns the offset to the file's 0.1 px rounding. Where no crop images exist (DC — its panels came from the OIM API), the ring and selector trace the same drawn region in different frames, so bounding-box corners align instead.

The guard makes it self-validating and idempotent: a shifted selector is adopted **only if it contains strictly more of its own GCPs** than before. Already-correct selectors and re-runs are no-ops. Dry-run by default; `--write` keeps a one-time `.pre-oim402.json` backup.

## Applied to the corpus

- **69 selectors repaired; frame-mixed groups 55 → 11.**
- The three named pages — LA p1404, Brooklyn p12, KC p555 — go from heavily overlapping world footprints to **0.0% overlap**.
- Key-map OIM region truth regenerated for all 12 volumes.

Residue (11 groups): partial-containment cases where GCPs sit near drawn edges, three pages whose `[1]` "crop" is the full canvas (translation is not their defect), and two selectors wrong beyond any translation (NO-1951 p528 [1], DC p261 [2]).

## Two findings for the record

- **Grand Rapids' near-zero key-map OIM-truth scores are *not* explained by this bug** (0.09 → 0.11 after repair + regeneration). Its projection is bad for another reason; the earlier "exclude GR" calls stand.
- Re #188's worry about KC p555__2 in the #154 analysis: that analysis graded panels via `oim/pN.panels.json` regions (the immune path), so its truth RMSE numbers were not corrupted by this bug.

`data/` changes (repaired `main.iiif.json` + regenerated `.truth.regions.panels.json`) are on disk with backups; only the tool + tests + CLI registration are in this PR.

812 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
