### PR TITLE
Refresh the performance table and gallery from the 2026-07-30 run

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,171 +23,125 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
 <table>
   <thead>
     <tr>
-      <th rowspan="2">Volume</th>
-      <th rowspan="2">Fit / Total</th>
-      <th colspan="3">RMSE Stats</th>
-      <th colspan="5">RMSE Distribution</th>
-      <th rowspan="2">Allmaps</th>
-    </tr>
-    <tr>
-      <th>Median</th>
-      <th>Mean</th>
-      <th>Max</th>
+      <th>Volume</th>
+      <th>Pages Placed</th>
       <th>≤25ft</th>
-      <th>25–50ft</th>
-      <th>50–100ft</th>
-      <th>100–200ft</th>
-      <th>200ft+</th>
+      <th>≥200ft</th>
+      <th>Score</th>
+      <th>Allmaps</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_029">New Orleans 1951 Vol 5</a></td>
-      <td align="right">103/109 (94%)</td>
-      <td align="right">12ft</td>
-      <td align="right">18ft</td>
-      <td align="right">112ft</td>
-      <td align="right">84%</td>
-      <td align="right">10%</td>
-      <td align="right">5%</td>
-      <td align="right">1%</td>
-      <td align="right">0%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_006">New Orleans 1896 Vol 2</a></td>
-      <td align="right">81/91 (89%)</td>
-      <td align="right">27ft</td>
-      <td align="right">65ft</td>
-      <td align="right">772ft</td>
-      <td align="right">46%</td>
-      <td align="right">14%</td>
-      <td align="right">21%</td>
-      <td align="right">16%</td>
-      <td align="right">4%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn03985_041">Detroit 1929 Vol 11</a></td>
-      <td align="right">82/103 (79%)</td>
-      <td align="right">14ft</td>
-      <td align="right">25ft</td>
-      <td align="right">246ft</td>
-      <td align="right">77%</td>
-      <td align="right">12%</td>
-      <td align="right">7%</td>
-      <td align="right">2%</td>
-      <td align="right">1%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json">view</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn01790_085">Chicago 1950 Vol 1</a></td>
-      <td align="right">99/111 (89%)</td>
-      <td align="right">10ft</td>
-      <td align="right">46ft</td>
-      <td align="right">2989ft</td>
-      <td align="right">84%</td>
-      <td align="right">11%</td>
-      <td align="right">4%</td>
-      <td align="right">0%</td>
-      <td align="right">1%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json">view</a></td>
-    </tr>
-    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn01778_006">Champaign, Ill. 1915</a></td>
-      <td align="right">26/33 (78%)</td>
-      <td align="right">10ft</td>
-      <td align="right">11ft</td>
-      <td align="right">27ft</td>
-      <td align="right">92%</td>
-      <td align="right">8%</td>
-      <td align="right">0%</td>
-      <td align="right">0%</td>
-      <td align="right">0%</td>
+      <td align="right">29/33 (88%)</td>
+      <td align="right">98.0%</td>
+      <td align="right">0.2%</td>
+      <td align="right"><b>97.8%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchampaign_ill_1915.iiif.json">view</a></td>
     </tr>
     <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_029">New Orleans 1951 Vol 5</a></td>
+      <td align="right">104/109 (95%)</td>
+      <td align="right">93.1%</td>
+      <td align="right">0.9%</td>
+      <td align="right"><b>92.2%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1951_vol_5.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn00656_064">Los Angeles 1949 Vol 14</a></td>
+      <td align="right">123/129 (95%)</td>
+      <td align="right">84.2%</td>
+      <td align="right">1.6%</td>
+      <td align="right"><b>82.6%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Flos_angeles_ca_1949_vol_14.iiif.json">view</a></td>
+    </tr>
+    <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn05791_053">Brooklyn 1939 Vol 1</a></td>
-      <td align="right">55/62 (88%)</td>
-      <td align="right">10ft</td>
-      <td align="right">79ft</td>
-      <td align="right">1706ft</td>
-      <td align="right">75%</td>
-      <td align="right">9%</td>
-      <td align="right">9%</td>
-      <td align="right">0%</td>
-      <td align="right">7%</td>
+      <td align="right">54/62 (87%)</td>
+      <td align="right">82.8%</td>
+      <td align="right">2.9%</td>
+      <td align="right"><b>80.0%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn01227_003">Washington DC 1916 Vol 2</a></td>
-      <td align="right">84/134 (62%)</td>
-      <td align="right">23ft</td>
-      <td align="right">118ft</td>
-      <td align="right">4757ft</td>
-      <td align="right">51%</td>
-      <td align="right">27%</td>
-      <td align="right">11%</td>
-      <td align="right">4%</td>
-      <td align="right">7%</td>
+      <td align="right">121/134 (90%)</td>
+      <td align="right">83.8%</td>
+      <td align="right">4.5%</td>
+      <td align="right"><b>79.3%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fwashington_dc_1916_vol_2.iiif.json">view</a></td>
     </tr>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn05511_036">Hudson County 1950 Vol 9</a></td>
-      <td align="right">60/95 (63%)</td>
-      <td align="right">13ft</td>
-      <td align="right">33ft</td>
-      <td align="right">874ft</td>
-      <td align="right">70%</td>
-      <td align="right">25%</td>
-      <td align="right">3%</td>
-      <td align="right">0%</td>
-      <td align="right">2%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json">view</a></td>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn01790_085">Chicago 1950 Vol 1</a></td>
+      <td align="right">100/111 (90%)</td>
+      <td align="right">78.9%</td>
+      <td align="right">0.0%</td>
+      <td align="right"><b>78.9%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fchicago_il_1950_vol_1.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn04720_021">Kansas City 1951 Vol 4</a></td>
-      <td align="right">108/142 (76%)</td>
-      <td align="right">19ft</td>
-      <td align="right">42ft</td>
-      <td align="right">830ft</td>
-      <td align="right">69%</td>
-      <td align="right">23%</td>
-      <td align="right">2%</td>
-      <td align="right">1%</td>
-      <td align="right">6%</td>
+      <td align="right">128/142 (90%)</td>
+      <td align="right">79.5%</td>
+      <td align="right">3.6%</td>
+      <td align="right"><b>75.9%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fkansas_city_mo_1951_vol_4.iiif.json">view</a></td>
     </tr>
     <tr>
-      <td><a href="https://oldinsurancemaps.net/map/sanborn08356_019">Nashville 1957 Vol 1A</a></td>
-      <td align="right">55/71 (77%)</td>
-      <td align="right">14ft</td>
-      <td align="right">43ft</td>
-      <td align="right">746ft</td>
-      <td align="right">65%</td>
-      <td align="right">15%</td>
-      <td align="right">15%</td>
-      <td align="right">2%</td>
-      <td align="right">4%</td>
-      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json">view</a></td>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03376_006">New Orleans 1896 Vol 2</a></td>
+      <td align="right">86/91 (95%)</td>
+      <td align="right">72.0%</td>
+      <td align="right">2.3%</td>
+      <td align="right"><b>69.7%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnew_orleans_la_1896_vol_2.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn03985_041">Detroit 1929 Vol 11</a></td>
+      <td align="right">86/103 (83%)</td>
+      <td align="right">72.2%</td>
+      <td align="right">3.9%</td>
+      <td align="right"><b>68.2%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fdetroit_mich_1929_vol_11.iiif.json">view</a></td>
     </tr>
     <tr>
       <td><a href="https://oldinsurancemaps.net/map/sanborn04023_023">Grand Rapids 1953 Vol 7</a></td>
-      <td align="right">62/83 (74%)</td>
-      <td align="right">18ft</td>
-      <td align="right">58ft</td>
-      <td align="right">1149ft</td>
-      <td align="right">73%</td>
-      <td align="right">18%</td>
-      <td align="right">3%</td>
-      <td align="right">2%</td>
-      <td align="right">5%</td>
+      <td align="right">64/83 (77%)</td>
+      <td align="right">72.6%</td>
+      <td align="right">4.5%</td>
+      <td align="right"><b>68.1%</b></td>
       <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fgrand_rapids_mi_1953_vol7.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn08356_019">Nashville 1957 Vol 1A</a></td>
+      <td align="right">60/71 (85%)</td>
+      <td align="right">66.0%</td>
+      <td align="right">4.4%</td>
+      <td align="right"><b>61.6%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fnashville_tn_1957_vol1a.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><a href="https://oldinsurancemaps.net/map/sanborn05511_036">Hudson County 1950 Vol 9</a></td>
+      <td align="right">70/95 (74%)</td>
+      <td align="right">50.6%</td>
+      <td align="right">0.0%</td>
+      <td align="right"><b>50.6%</b></td>
+      <td><a href="https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fhudson_co_nj_1950_vol_9.iiif.json">view</a></td>
+    </tr>
+    <tr>
+      <td><b>All 12 volumes</b></td>
+      <td align="right"><b>1025/1163 (88%)</b></td>
+      <td align="right"><b>78.0%</b></td>
+      <td align="right"><b>2.7%</b></td>
+      <td align="right"><b>75.3%</b></td>
+      <td></td>
     </tr>
   </tbody>
 </table>
 
-RMSE was measured across 49 equally-spaced points on each image. You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
+**Score** is the land-weighted share of each volume georeferenced to within 25ft, minus the share placed 200ft or worse — so a volume is rewarded for accurate coverage and penalised for confident mistakes. Pages left unplaced count against coverage but are not penalised as errors. RMSE is measured over a grid of points inside each page's own truth footprint (split sheets are graded per panel).
+
+You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 
 [detroit]: https://oldinsurancemaps.net/map/sanborn03985_041
 [brooklyn1-iiif]: https://dev.viewer.allmaps.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanvk%2Fmapsnap%2Frefs%2Fheads%2Fmain%2Fgallery%2Fbrooklyn_ny_1939_vol_1.iiif.json

--- a/gallery/brooklyn_ny_1939_vol_1.iiif.json
+++ b/gallery/brooklyn_ny_1939_vol_1.iiif.json
@@ -7,6 +7,2628 @@
   "label": "Mosaic of main content, Brooklyn, N.Y. | 1939 | Vol. 1",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,0.0 5612.0,-0.0 5612.0,8268.0 0.0,8268.0 -0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0118501,
+                40.6729257
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0080533,
+                40.6718436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0101552,
+                40.6676011
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0139519,
+                40.6686832
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5627
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1150.8,0.0 2729.8,0.0 2740.9,208.4 5479.9,232.1 5416.4,4941.9 4730.9,7092.5 4428.2,6309.5 2563.6,7044.6 2167.3,7025.0 1674.8,7215.5 1755.2,7354.4 173.0,7947.5 221.0,186.5 1149.8,194.6 1150.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.010652962033,
+                40.68040606769846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00798379310916,
+                40.682719840565944
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5627.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00353300211398,
+                40.67972514733078
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00620217103784,
+                40.6774113744633
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5622
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5048.2,1786.0 5158.8,7527.3 2363.5,7621.9 2311.3,6401.7 2804.0,5156.3 2981.1,4671.0 726.2,3818.8 1947.6,619.7 5048.2,1786.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00921660483176,
+                40.679516856478045
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5622.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00544299753432,
+                40.678399841854606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5622.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0075931189448,
+                40.67416279867534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01136672624224,
+                40.67527981329877
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
+          "type": "ImageService2",
+          "height": 8267,
+          "width": 5490
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2642.2,157.3 2617.5,0.0 3141.5,0.0 3501.2,159.9 5490.0,147.0 5490.0,7728.7 1376.9,7728.2 1271.5,7802.8 195.3,6840.0 183.3,135.9 2642.2,157.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0066291077756,
+                40.677124981072986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5490.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00525572989353,
+                40.679969691974954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5490.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99964421939927,
+                40.67838945893789
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8267.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00101759728132,
+                40.675544748035925
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5589
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5417.9,7743.6 188.4,7784.0 188.3,8268.0 98.8,8268.0 93.6,7784.8 0.0,7785.5 0.0,213.0 5344.9,154.8 5417.9,7743.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00415169345409,
+                40.682341055717245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5589.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00272168009951,
+                40.68522512559574
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5589.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99713390341819,
+                40.683609298181686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99856391677277,
+                40.68072522830318
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1065.9,219.4 2100.6,231.0 2099.8,0.0 4183.1,0.0 4181.2,254.3 4738.1,260.5 4753.1,7762.7 637.0,7771.3 1065.9,219.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00180610595875,
+                40.68724584358484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00040176565317,
+                40.69016942145453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99476124169132,
+                40.6885895083947
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99616558199689,
+                40.68566593052501
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"688.2,317.2 4588.8,330.6 4599.1,0.0 5612.0,0.0 5612.0,8268.0 5484.4,8268.0 5524.3,7859.7 767.9,7892.8 688.2,317.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00083080452261,
+                40.68937195251413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9994077953061,
+                40.69225776534815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99383997383913,
+                40.69065689491532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99526298305564,
+                40.6877710820813
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5612.0,1846.0 5612.0,4843.4 5408.1,4841.6 5433.9,6702.5 5229.5,6700.6 5229.7,8268.0 0.0,8268.0 -0.0,-0.0 5394.6,0.0 5378.4,1844.0 5612.0,1846.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00576995836045,
+                40.669438595001104
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00441054388666,
+                40.6723103795477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99887142908764,
+                40.67078059951198
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00023084356143,
+                40.66790881496538
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"371.4,1191.4 5106.6,1129.8 5215.3,5932.6 5183.1,6617.0 3189.4,6409.7 481.5,6437.0 371.4,1191.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00094920708945,
+                40.67845548475203
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99949957343593,
+                40.6813517251926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99391252213593,
+                40.679720643068116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99536215578945,
+                40.676824402627545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5599
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0160042372145,
+                40.681997439651376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01343961577352,
+                40.68435601301376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5599.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.00887984898229,
+                40.68146430186943
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.01144447042329,
+                40.67910572850705
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,1270.4 5612.0,1224.9 5612.0,7413.9 2355.6,7032.5 2419.6,6422.1 1406.2,6277.3 1415.8,6928.7 0.0,6764.6 0.0,1270.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99970195756843,
+                40.68116566779925
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99826398436265,
+                40.68406376815667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99267314833308,
+                40.68244586295928
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99411112153886,
+                40.67954776260186
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1463.6,7707.6 676.9,1570.6 5010.4,969.4 5248.0,3876.2 4573.4,3969.0 4652.3,7666.5 1463.6,7707.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99866851020772,
+                40.68390220160998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9967590721513,
+                40.686637805930125
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99148150105509,
+                40.68448952846099
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9933909391115,
+                40.68175392414085
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"212.8,7739.9 195.8,4038.8 872.3,3957.3 683.2,1044.7 4789.7,534.8 5138.0,3446.1 4079.7,3572.9 4096.1,7755.9 212.8,7739.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99724216695672,
+                40.686019686113795
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99539420923524,
+                40.688777133024075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99007435113825,
+                40.68669808388661
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99192230885973,
+                40.68394063697633
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,1293.5 5612.0,120.5 5612.0,7813.7 0.0,7758.7 0.0,1293.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99933858846394,
+                40.67354456682527
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99715979564584,
+                40.676208720988384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99202087341916,
+                40.673757012373066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99419966623725,
+                40.67109285820995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4678.2,6922.6 4679.7,7302.6 821.2,7322.3 811.3,867.3 4664.6,847.5 4666.8,2135.9 5612.0,2131.9 5612.0,6914.4 4678.2,6922.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99202620956171,
+                40.67505738336967
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98860161921547,
+                40.67338244766921
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99183234595556,
+                40.669528798696014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9952569363018,
+                40.67120373439647
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5175.6,7366.2 5612.0,7377.8 5612.0,8268.0 264.1,8268.0 375.3,2027.2 5317.1,1096.8 5175.6,7366.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99851332014305,
+                40.67658051395916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99637732681974,
+                40.67929867071314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99113398503887,
+                40.67689523874753
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99326997836218,
+                40.67417708199355
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5612
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4108.4,0.0 5131.9,0.0 5154.9,613.2 4978.3,619.1 5028.4,4008.0 5273.8,3997.5 5383.8,7369.4 1532.1,7229.3 1468.1,8268.0 468.5,8268.0 478.8,8082.9 781.9,8093.9 815.0,7184.1 369.4,7156.0 747.2,753.6 2751.0,682.5 2785.4,681.3 4210.0,643.4 4108.4,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.9965322421002,
+                40.6786767219269
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99457160533635,
+                40.68139065541001
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5612.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98933626098261,
+                40.67918459856209
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99129689774647,
+                40.67647066507897
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5556
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1413.6,7307.1 0.0,7304.0 0.0,1015.4 2651.2,1021.4 5100.8,806.0 5418.8,4126.7 4140.7,4239.7 4421.9,7255.9 3144.0,7337.8 3237.8,8268.0 1417.7,8268.0 1413.6,7307.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.99204459319745,
+                40.67779187024772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5556.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98987674190028,
+                40.68039986131314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5556.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.984795155143,
+                40.67793602015926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98696300644016,
+                40.67532802909383
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
+          "type": "ImageService2",
+          "height": 8268,
+          "width": 5629
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1870.2,8268.0 1875.1,7278.7 875.0,7276.1 875.9,864.0 4750.3,922.6 4758.4,7298.4 5629.0,7304.3 5629.0,8268.0 1870.2,8268.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.988277483819,
+                40.68291091943069
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98642257480213,
+                40.68569083472924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5629.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.981074852768,
+                40.68360980584073
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8268.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -73.98292976178486,
+                40.68082989054218
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0001/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +2646,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -73,8 +2695,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02289018107028,
-                40.67714948768619
+                -74.02289018107355,
+                40.67714948768647
               ]
             }
           },
@@ -94,8 +2716,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.02016831234491,
-                40.67945579741581
+                -74.02016831234688,
+                40.6794557974172
               ]
             }
           },
@@ -115,8 +2737,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01568020824068,
-                40.676406872239305
+                -74.01568020824051,
+                40.676406872239234
               ]
             }
           },
@@ -136,8 +2758,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01840207696604,
-                40.67410056250968
+                -74.01840207696718,
+                40.67410056250851
               ]
             }
           },
@@ -183,8 +2805,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -203,7 +2825,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5372.6,8268.0 5360.7,7293.3 4422.3,7304.7 4411.2,7664.0 0.0,7664.9 0.0,-0.0 5599.0,0.0 5599.0,8268.0 5372.6,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"5599.0,4786.8 5599.0,8268.0 5421.8,8268.0 5422.9,7335.4 4421.8,7338.9 4411.2,7664.0 0.0,7664.4 -0.0,-0.0 5599.0,0.0 5599.0,4786.8 5599.0,4786.8\" /></svg>"
         }
       },
       "body": {
@@ -276,8 +2898,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -296,7 +2918,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,381.8 5031.7,460.5 5064.5,8258.3 -0.0,8268.0 -0.0,381.8\" /></svg>"
+          "value": "<svg><polygon points=\"207.0,468.1 5599.0,462.1 5599.0,8268.0 -0.0,8268.0 -0.0,381.8 206.6,381.4 207.0,468.1\" /></svg>"
         }
       },
       "body": {
@@ -369,8 +2991,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -389,7 +3011,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,-0.0 5531.3,226.8 5612.0,373.4 5612.0,8268.0 -0.0,8268.0 -0.0,455.3 5092.8,541.9 5520.6,413.1 5353.4,-0.0 5612.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0,8268 0,0 5612,0 5612,8268 0,8268\" /></svg>"
         }
       },
       "body": {
@@ -418,8 +3040,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01380777799662,
-                40.67443386703624
+                -74.01380777799659,
+                40.674433867036385
               ]
             }
           },
@@ -439,8 +3061,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01075662051599,
-                40.672368452884655
+                -74.0107566205145,
+                40.67236845288381
               ]
             }
           },
@@ -460,8 +3082,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0147673447663,
-                40.668957980170475
+                -74.01476734476672,
+                40.66895798016801
               ]
             }
           },
@@ -481,8 +3103,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01781850224693,
-                40.67102339432206
+                -74.01781850224882,
+                40.671023394320585
               ]
             }
           },
@@ -511,99 +3133,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p14",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5351.8,924.5 -0.0,361.3 -0.0,-0.0 5612.0,0.0 5612.0,684.9 5351.8,924.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0014/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                -208.0,
-                336.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0110067,
-                40.6722317
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5196.0,
-                952.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0092373,
-                40.6717583
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0019/georef",
       "type": "Annotation",
       "@context": [
@@ -621,8 +3150,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -641,7 +3170,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5535.6,6829.9 339.7,6829.2 319.0,1618.7 5384.5,1611.6 5370.2,5386.8 5523.3,5644.6 5535.6,6829.9\" /></svg>"
+          "value": "<svg><polygon points=\"5523.3,5644.6 5535.6,6829.9 339.7,6829.2 319.0,1618.7 5384.5,1611.6 5370.2,5386.8 5523.3,5644.6\" /></svg>"
         }
       },
       "body": {
@@ -714,8 +3243,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -807,8 +3336,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -827,7 +3356,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"197.3,7342.1 188.0,4776.6 -0.0,4777.8 -0.0,-0.0 1236.7,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.3 5213.6,4302.0 5211.5,7334.0 197.3,7342.1\" /></svg>"
+          "value": "<svg><polygon points=\"5211.5,7334.0 197.3,7342.1 188.0,4776.6 -0.0,4777.8 -0.0,-0.0 1236.7,-0.0 1240.0,916.0 5612.0,916.3 5612.0,4303.3 5213.6,4302.0 5211.5,7334.0\" /></svg>"
         }
       },
       "body": {
@@ -883,99 +3412,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5627
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"267.7,248.9 1185.4,249.3 1186.4,0.0 2743.9,0.0 2757.6,249.9 5464.0,251.0 5407.2,4901.1 5095.3,5992.7 2591.0,7000.4 2093.4,6979.8 1815.6,7091.1 1586.6,6959.4 1792.6,7312.8 230.1,7911.3 267.7,248.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2831.5,
-                4184.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007061,
-                40.680042
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5423.0,
-                1436.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.007303,
-                40.682123
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0022/georef",
       "type": "Annotation",
       "@context": [
@@ -993,8 +3429,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1013,7 +3449,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4966.8,5596.2 4988.1,8127.5 4291.9,7601.9 -0.0,5891.8 863.0,3570.2 1070.7,3632.5 1241.5,3639.3 1288.2,3495.4 -0.0,3077.5 -0.0,-0.0 1975.3,0.0 1992.4,432.0 5152.4,412.0 5196.1,5592.7 4966.8,5596.2\" /></svg>"
+          "value": "<svg><polygon points=\"5621.0,4303.3 5621.0,8268.0 5174.1,8268.0 4291.9,7601.9 -0.0,5891.8 863.0,3570.2 1241.4,3639.3 1288.1,3495.3 -0.0,3077.4 -0.0,-0.0 1975.3,0.0 1992.4,432.0 5152.4,412.0 5185.3,4308.0 5621.0,4303.3\" /></svg>"
         }
       },
       "body": {
@@ -1086,8 +3522,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1106,7 +3542,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"900.4,459.4 2073.9,449.3 2329.4,298.1 4764.0,304.0 4759.3,4109.5 3818.5,4492.8 5275.3,8268.0 -0.0,8268.0 -0.0,5741.6 1131.5,5660.1 1357.9,5740.5 1357.8,5482.4 945.6,5649.6 816.8,5222.7 900.4,459.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4390.7 -0.0,708.7 891.3,710.1 893.9,461.9 2068.2,449.8 2323.7,298.0 4760.1,299.7 4762.1,4108.0 3821.2,4493.2 4824.3,7094.8 3705.5,7556.9 3535.9,7127.2 2502.4,7531.8 1110.4,3958.1 -0.0,4390.7\" /></svg>"
         }
       },
       "body": {
@@ -1141,7 +3577,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4764.0,
+                3468.0,
                 304.0
               ],
               "creator": {
@@ -1153,8 +3589,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.01206,
-                40.675781
+                -74.012687,
+                40.675247
               ]
             }
           }
@@ -1179,8 +3615,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1199,7 +3635,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"305.1,4609.9 1252.4,4218.1 1236.8,378.4 5612.0,377.9 5612.0,3185.2 3759.4,3183.1 2638.4,3669.8 3559.0,5869.6 1164.9,6816.5 305.1,4609.9\" /></svg>"
+          "value": "<svg><polygon points=\"305.1,4609.9 1252.4,4218.1 1236.8,378.4 5612.0,377.9 5612.0,3185.2 3759.4,3183.1 2638.4,3669.8 3558.9,5869.5 1164.9,6816.5 305.1,4609.9\" /></svg>"
         }
       },
       "body": {
@@ -1255,99 +3691,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5622
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4997.4,2539.3 5622.0,2527.8 5622.0,7427.9 2371.2,7532.0 2313.1,6326.2 2962.0,4615.3 740.6,3775.1 1923.6,612.8 4978.2,1762.7 4997.4,2539.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2371.2,
-                7532.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0096123,
-                40.6751413
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1527.5,
-                464.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.008302,
-                40.67897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0026/georef",
       "type": "Annotation",
       "@context": [
@@ -1365,8 +3708,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1458,8 +3801,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1478,7 +3821,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2688.5,7920.0 2689.0,6019.7 0.0,6053.9 0.0,655.7 2690.2,1703.0 2690.7,0.0 5248.1,0.0 5264.8,7861.6 2688.5,7920.0\" /></svg>"
+          "value": "<svg><polygon points=\"2689.0,6115.4 0.0,6150.6 0.0,1725.3 360.6,1725.8 363.5,0.0 1475.0,0.0 1476.4,462.5 2688.5,440.0 2690.7,0.0 5248.0,0.0 5264.6,7861.7 2688.5,7920.0 2689.0,6115.4\" /></svg>"
         }
       },
       "body": {
@@ -1551,8 +3894,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1571,7 +3914,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"235.9,760.0 5233.7,821.9 5270.3,6865.5 5612.0,7294.9 5612.0,7875.5 5355.1,7755.3 4616.2,7714.5 264.0,7819.2 235.9,760.0\" /></svg>"
+          "value": "<svg><polygon points=\"233.9,246.3 5229.8,178.3 5270.3,6865.5 5612.0,7294.9 5612.0,7875.5 5355.1,7755.3 4616.2,7714.5 264.0,7819.2 233.9,246.3\" /></svg>"
         }
       },
       "body": {
@@ -1627,99 +3970,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p29",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/info.json",
-          "type": "ImageService2",
-          "height": 8267,
-          "width": 5490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2681.0,196.0 2651.9,0.0 3081.5,0.0 3533.0,202.6 5490.0,199.3 5490.0,1030.1 5490.0,1030.1 5490.0,7679.6 1356.2,7659.5 1250.9,7732.7 192.3,6777.7 242.1,163.3 2681.0,196.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0029/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1440.5,
-                4959.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0028805,
-                40.6769149
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2681.0,
-                196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0058614,
-                40.678464
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0003/georef",
       "type": "Annotation",
       "@context": [
@@ -1737,8 +3987,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1823,15 +4073,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "14"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1850,7 +4100,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3890.4,0.0 3892.0,228.0 4972.3,227.7 5011.9,7698.7 516.8,7700.3 490.5,1043.3 490.5,1043.3 487.2,211.5 1197.5,207.5 1373.1,0.0 3890.4,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4956.7,7687.8 503.9,7712.3 505.4,1050.6 1233.6,197.5 1232.1,641.5 5019.8,653.8 4956.7,7687.8\" /></svg>"
         }
       },
       "body": {
@@ -1864,7 +4114,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1888.0,
+                3476.0,
                 4992.0
               ],
               "creator": {
@@ -1876,8 +4126,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.001516,
-                40.679753
+                -74.001122,
+                40.680569
               ]
             }
           },
@@ -1906,99 +4156,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5589
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5374.1,227.1 5343.2,7742.7 0.0,7734.8 0.0,236.0 5374.1,227.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2768.5,
-                5016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.000048,
-                40.682803
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1480.3,
-                5016.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.000371,
-                40.682133
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0032/georef",
       "type": "Annotation",
       "@context": [
@@ -2016,8 +4173,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2092,285 +4249,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p33",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "11"
-        },
-        {
-          "label": "intersections",
-          "value": "24"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7758.8 553.6,7724.7 1089.6,175.0 2129.8,196.4 2131.8,0.0 4227.2,0.0 4222.2,239.5 5612.0,268.2 5612.0,7758.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0033/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                820.0,
-                3852.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9989348,
-                40.6869431
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4732.0,
-                5004.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9971968,
-                40.6887645
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4648.3,362.7 4663.9,0.0 5612.0,0.0 5612.0,7849.5 1653.4,7835.8 1585.8,325.3 4648.3,362.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2048.0,
-                2808.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9984232,
-                40.6898645
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                732.0,
-                7840.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9953209,
-                40.6882386
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,1890.4 5612.0,4803.8 5292.6,4801.2 5310.5,6610.0 5110.8,6608.2 5104.2,8268.0 0.0,8268.0 0.0,-0.0 5299.9,0.0 5275.5,1887.6 5612.0,1890.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1676.0,
-                4784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0021257,
-                40.6694201
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2912.0,
-                1868.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0038317,
-                40.670616
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0036/georef",
       "type": "Annotation",
       "@context": [
@@ -2388,8 +4266,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2408,7 +4286,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"174.5,3521.4 493.5,3522.7 481.9,613.0 5612.0,508.6 5612.0,680.5 5153.5,677.3 5215.1,3217.7 4938.6,3507.8 5612.0,3516.6 5134.4,4008.9 5137.0,5813.1 4615.3,5815.6 4231.4,8268.0 0.0,8268.0 0.0,5326.8 199.5,5327.8 174.5,3521.4\" /></svg>"
+          "value": "<svg><polygon points=\"174.5,3521.4 373.5,3522.2 373.9,612.4 5612.0,508.6 5612.0,680.5 5153.5,677.3 5215.1,3217.7 4938.6,3507.8 5612.0,3516.6 5134.4,4008.9 5137.0,5813.1 4545.7,5815.9 4016.9,8268.0 0.0,8268.0 0.0,5326.8 199.5,5327.8 174.5,3521.4\" /></svg>"
         }
       },
       "body": {
@@ -2481,8 +4359,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2501,7 +4379,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1314.8,1498.7 1313.4,1325.2 3402.8,1371.6 3656.0,1491.2 3658.1,917.9 4405.5,1514.4 5612.0,1433.1 5612.0,6665.1 875.7,6684.1 858.9,4862.7 1344.7,4354.1 657.2,4358.4 934.1,4063.3 851.8,1499.1 1314.8,1498.7\" /></svg>"
+          "value": "<svg><polygon points=\"2105.8,1330.6 3402.8,1371.6 3656.0,1491.2 3658.1,917.9 4405.5,1514.4 5612.0,1433.1 5612.0,6665.1 875.7,6684.1 858.9,4862.7 1344.7,4354.1 657.2,4358.4 934.1,4063.3 851.8,1499.1 1314.8,1498.7 1313.7,1356.4 2105.8,1340.2 2105.8,1330.6\" /></svg>"
         }
       },
       "body": {
@@ -2574,8 +4452,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2594,7 +4472,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4611.1,6724.3 4308.7,8268.0 1917.6,8268.0 2157.4,6729.6 1690.2,6730.6 1727.7,1484.6 4593.1,1488.5 4611.1,6724.3\" /></svg>"
+          "value": "<svg><polygon points=\"4593.1,1488.5 4611.1,6724.3 1690.2,6730.6 1727.7,1484.6 4593.1,1488.5\" /></svg>"
         }
       },
       "body": {
@@ -2650,564 +4528,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"412.4,1148.1 5227.0,1142.1 5158.1,6626.6 3158.5,6396.2 437.3,6391.7 412.4,1148.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                4064.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9972734,
-                40.6794993
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.0,
-                1144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9992597,
-                40.6800511
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p4",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5599
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8268 0,0 5599,0 5599,8268 0,8268\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0004/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2687.5,
-                7784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0104477,
-                40.6804294
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5243.1,
-                7784.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0091934,
-                40.6815021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5612.0,7446.7 2323.6,7030.6 2394.8,6437.9 1380.1,6255.4 1380.4,6917.5 0.0,6751.9 0.0,1245.5 5612.0,1255.6 5612.0,7446.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                4168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9965238,
-                40.6810573
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1376.0,
-                1248.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9985089,
-                40.6816069
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1440.5,7684.4 676.6,1545.0 5108.2,991.4 5292.1,3901.7 4613.1,3985.7 4622.8,7684.8 1440.5,7684.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                4144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9949023,
-                40.6844304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3324.0,
-                7680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.992623,
-                40.683544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"196.1,7689.9 238.8,3990.2 919.1,3915.8 776.4,1002.5 4906.5,535.9 5209.2,3449.5 4144.8,3565.2 4093.7,7746.6 196.1,7689.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3280.0,
-                724.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9957232,
-                40.6873919
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2796.0,
-                7728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991332,
-                40.685448
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2347.6,1852.5 2401.3,1588.0 2515.3,1671.3 2969.4,1807.2 3267.1,0.0 5612.0,0.0 5612.0,8268.0 -0.0,8268.0 -0.0,-0.0 901.9,0.0 848.5,347.5 661.5,313.0 834.3,458.6 595.7,659.6 1089.5,1167.2 1457.0,1705.8 2347.6,1852.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                956.0,
-                860.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9965417,
-                40.6683659
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2400.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9948535,
-                40.6668553
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0046/georef",
       "type": "Annotation",
       "@context": [
@@ -3225,8 +4545,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3245,7 +4565,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4266.7,8268.0 2263.6,8268.0 1264.4,7221.1 -0.0,6287.5 450.0,5761.2 19.2,5504.8 441.1,5512.8 432.6,4732.7 -0.0,4803.9 -0.0,1402.9 429.2,1403.0 430.3,366.1 4281.3,380.4 4280.7,0.0 5612.0,0.0 5612.0,7944.5 4568.5,7810.8 4288.8,7669.4 4266.7,8268.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8268.0 -0.0,700.8 430.0,699.8 430.3,366.1 4281.3,380.4 4280.7,0.0 5612.0,0.0 5612.0,8268.0 -0.0,8268.0\" /></svg>"
         }
       },
       "body": {
@@ -3301,285 +4621,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p47",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1142.0 5612.0,269.1 5612.0,7977.0 0.0,7637.0 0.0,1142.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0047/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4168.0,
-                508.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.997447,
-                40.6754
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                516.0,
-                1060.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.998388,
-                40.673471
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4664.6,6882.0 4665.3,7257.4 864.5,7244.6 863.8,8268.0 -0.0,8268.0 -0.0,7188.9 864.6,7137.1 868.4,867.3 4664.0,880.0 4663.5,2152.9 5612.0,2156.9 5612.0,6881.7 4664.6,6882.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                4716.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.991023,
-                40.671458
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4664.0,
-                880.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9895109,
-                40.6732702
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p49",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"510.7,8268.0 389.2,2000.0 5362.1,1138.0 5096.4,7386.7 5612.0,7406.6 5612.0,8268.0 510.7,8268.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0049/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3956.0,
-                4496.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9941559,
-                40.6772043
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2748.0,
-                1588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9964751,
-                40.6774341
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0005/georef",
       "type": "Annotation",
       "@context": [
@@ -3597,8 +4638,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3617,7 +4658,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5325.6,7856.0 -0.0,7574.6 0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.2,8268.0 5325.6,7856.0\" /></svg>"
+          "value": "<svg><polygon points=\"5325.6,7856.1 -0.0,7574.5 -0.0,-0.0 5599.0,0.0 5599.0,8268.0 5441.2,8268.0 5325.6,7856.1\" /></svg>"
         }
       },
       "body": {
@@ -3690,8 +4731,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3710,7 +4751,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1986.0,6768.8 1924.8,5717.0 5612.0,5574.4 5612.0,8268.0 2500.4,8268.0 2508.1,6769.7 1986.0,6768.8\" /></svg>"
+          "value": "<svg><polygon points=\"2508.1,6769.7 1653.6,6768.3 1652.5,5689.0 5612.0,5589.9 5612.0,8268.0 2500.4,8268.0 2508.1,6769.7\" /></svg>"
         }
       },
       "body": {
@@ -3766,99 +4807,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5612
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4150.0,647.6 4033.2,0.0 5057.7,0.0 5092.5,592.2 4916.3,602.8 5036.8,3971.9 5281.5,3954.9 5461.4,7305.4 1481.1,7263.0 1464.1,8268.0 576.2,8268.0 581.1,8126.4 981.8,8124.7 978.1,7245.7 451.9,7227.6 695.9,850.1 2694.5,725.6 2770.7,728.5 4150.0,647.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1744.0,
-                7272.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.99137,
-                40.67755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3456.0,
-                680.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.994889,
-                40.6802
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0052/georef",
       "type": "Annotation",
       "@context": [
@@ -3876,8 +4824,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3969,8 +4917,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4062,8 +5010,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4082,7 +5030,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"686.9,668.2 4591.3,679.3 4579.7,7402.0 689.7,7367.2 689.3,6478.9 639.0,6478.7 686.9,668.2\" /></svg>"
+          "value": "<svg><polygon points=\"686.9,668.2 4591.2,679.3 4579.7,7402.0 689.7,7367.2 689.3,6478.9 639.0,6478.7 686.9,668.2\" /></svg>"
         }
       },
       "body": {
@@ -4155,8 +5103,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4248,8 +5196,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4268,7 +5216,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"768.0,7400.0 796.1,710.7 4977.0,738.4 4968.2,0.0 5612.0,0.0 5612.0,7406.3 768.0,7400.0\" /></svg>"
+          "value": "<svg><polygon points=\"796.1,710.6 4977.0,738.4 4968.2,0.0 5612.0,0.0 5606.8,7406.3 768.0,7400.0 796.1,710.6\" /></svg>"
         }
       },
       "body": {
@@ -4341,8 +5289,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4361,7 +5309,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4029.5,726.1 4538.0,775.4 4474.4,1458.3 5476.1,1554.6 5280.9,3702.0 5630.0,3733.7 5630.0,4232.8 4227.8,4129.9 4158.6,4873.4 3525.4,4814.5 3453.5,5795.6 4058.6,5793.3 4039.5,7169.4 3502.0,7168.8 3500.1,8267.0 0.0,8267.0 0.0,0.0 4096.7,-0.0 4029.5,726.1\" /></svg>"
+          "value": "<svg><polygon points=\"4108.1,-0.0 4039.1,727.2 4538.2,775.6 4474.6,1458.4 5476.3,1554.7 5281.0,3702.0 5630.0,3733.8 5630.0,4257.3 4228.7,4120.9 4158.6,4873.4 3648.7,4826.0 3560.6,5795.2 4058.6,5793.3 4039.5,7169.4 3501.9,7168.8 3500.7,7857.0 4036.1,7855.9 4035.6,8267.0 0.0,8267.0 0.0,0.0 4108.1,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -4417,99 +5365,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p58",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5556
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1360.8,7108.8 0.0,7082.1 0.0,970.0 2712.7,1023.1 5104.9,855.6 5337.9,4087.1 4089.7,4175.2 4293.9,7110.3 3046.5,7168.1 3131.4,8268.0 1338.1,8268.0 1360.8,7108.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0058/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2828.0,
-                4264.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9882559,
-                40.6778311
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1412.0,
-                1012.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9908957,
-                40.6781021
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0059/georef",
       "type": "Annotation",
       "@context": [
@@ -4527,8 +5382,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4547,7 +5402,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2069.7,4236.3 2068.0,904.0 5516.0,896.1 5516.0,8268.0 2073.5,8268.0 2072.9,7260.0 776.8,7261.1 782.8,4235.0 2069.7,4236.3\" /></svg>"
+          "value": "<svg><polygon points=\"782.8,4235.0 2069.7,4236.3 2068.0,904.0 5516.0,896.1 5516.0,8268.0 4132.6,8268.0 4130.8,7263.6 3360.0,7264.0 3364.0,8268.0 2073.5,8268.0 2072.9,7260.0 776.8,7261.1 782.8,4235.0\" /></svg>"
         }
       },
       "body": {
@@ -4620,8 +5475,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4713,8 +5568,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4789,99 +5644,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Brooklyn, N.Y. | 1939 | Vol. 1 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/info.json",
-          "type": "ImageService2",
-          "height": 8268,
-          "width": 5629
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1871.7,7220.6 876.4,7214.8 933.6,859.8 4789.2,930.1 4741.1,7249.2 5629.0,7258.1 5629.0,8268.0 1857.2,8268.0 1871.7,7220.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3472.6,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.984371,
-                40.6835414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4748.8,
-                4252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -73.9839511,
-                40.6841757
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd380m:g3804m:g3804bm:g3804bm_g05791193901:05791_01_1939-0062/georef",
       "type": "Annotation",
       "@context": [
@@ -4899,8 +5661,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4919,7 +5681,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"675.9,7341.5 666.2,940.4 5549.0,935.4 5549.0,8268.0 1583.9,8268.0 1575.4,7342.2 675.9,7341.5\" /></svg>"
+          "value": "<svg><polygon points=\"675.9,7341.5 666.2,940.4 5549.0,935.4 5549.0,8268.0 1553.9,8268.0 1553.6,7342.2 675.9,7341.5\" /></svg>"
         }
       },
       "body": {
@@ -4992,8 +5754,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5085,8 +5847,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5105,7 +5867,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4242.1,7596.7 1044.2,7591.3 1030.5,7153.8 -0.0,7145.6 -0.0,-0.0 4235.0,0.0 4242.1,7596.7\" /></svg>"
+          "value": "<svg><polygon points=\"4242.1,7596.4 1044.2,7591.2 1030.5,7153.8 -0.0,7145.6 -0.0,-0.0 4234.9,0.0 4242.1,7596.4\" /></svg>"
         }
       },
       "body": {
@@ -5178,8 +5940,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:30:38Z",
-      "modified": "2026-07-18T02:30:38Z",
+      "created": "2026-07-30T21:24:27Z",
+      "modified": "2026-07-30T21:24:27Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",

--- a/gallery/champaign_ill_1915.iiif.json
+++ b/gallery/champaign_ill_1915.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,34 +44,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6101.1,498.3 6057.2,4723.8 6160.3,6565.7 -0.0,6611.8 -0.0,5973.2 254.9,5413.4 229.9,537.9 6101.1,498.3\" /></svg>"
+          "value": "<svg><polygon points=\"5981.5,580.2 5958.6,6880.9 903.0,6876.5 272.7,7650.0 -0.0,7650.0 112.6,567.2 5981.5,580.2\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0010/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                232.1,
-                4809.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2371024,
-                40.1163368
+                -88.23717033985356,
+                40.11857163839229
               ]
             }
           },
@@ -79,20 +82,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                232.1,
-                2664.7
+                6450.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2371003,
-                40.117326
+                -88.2332573443544,
+                40.11859363161224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23322347152777,
+                40.11501931987334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23713646702693,
+                40.11499732665339
               ]
             }
           }
@@ -110,15 +155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "8"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "18"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,34 +182,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6359.7,7523.8 4298.7,7650.0 258.3,7650.0 121.7,92.3 315.9,-0.0 6450.0,-0.0 6450.0,145.4 5841.6,158.2 5844.9,316.9 6239.3,310.6 6359.7,7523.8\" /></svg>"
+          "value": "<svg><polygon points=\"93.3,-0.0 3063.3,-0.0 3063.3,-0.0 6450.0,-0.0 6450.0,7618.8 149.4,7650.0 93.3,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6273.9,
-                2624.7
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.230434,
-                40.11539
+                -88.22882227845818,
+                40.118387279778375
               ]
             }
           },
@@ -172,20 +220,752 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4301.3,
-                5297.4
+                6450.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.232105,
-                40.116357
+                -88.22882732701478,
+                40.11532487591362
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23354389999362,
+                40.11532948748394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23353885143702,
+                40.1183918913487
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6273.7,6700.9 -0.0,6770.6 -0.0,6260.3 1214.8,6256.0 1227.3,5992.0 435.1,5352.3 421.6,277.0 5204.5,268.6 6224.6,409.8 6273.7,6700.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23335854127455,
+                40.11557370779762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23334383327276,
+                40.11257181515842
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23796697687482,
+                40.11255837955588
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23798168487662,
+                40.11556027219508
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p17",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"797.3,7555.9 819.9,86.6 5750.5,-0.0 5867.0,61.1 5838.6,7562.2 797.3,7555.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22890066547163,
+                40.11311466572948
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22883771952931,
+                40.11002532149513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23359536275264,
+                40.10996781884346
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23365830869497,
+                40.11305716307781
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p18",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"669.8,98.7 5865.7,119.1 5864.7,0.0 6450.0,0.0 6450.0,7650.0 661.8,7650.0 669.8,98.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23245526892467,
+                40.110325252899614
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22852639629983,
+                40.110363464276936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.22846755270606,
+                40.10677418581048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2323964253309,
+                40.10673597443316
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p22",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"137.5,7324.6 95.4,1213.6 481.6,1217.2 474.3,192.6 6069.2,185.2 6048.8,3388.4 6344.7,3388.0 6359.2,7351.5 137.5,7324.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25441368536025,
+                40.119372538574225
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24670111113998,
+                40.119379331098315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24669064984558,
+                40.11233417174689
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.25440322406584,
+                40.11232737922279
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p9",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3601.9,7568.2 3591.6,7034.6 2187.8,6598.2 1853.7,7650.0 1543.6,7650.0 1899.3,6501.7 -0.0,5903.6 -0.0,4531.9 389.2,3183.8 -0.0,3025.3 -0.0,-0.0 6229.0,0.0 6208.1,7102.4 5701.1,7107.8 5897.8,6784.6 5105.0,7494.8 3601.9,7568.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24088776589767,
+                40.118909979993276
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23696463232005,
+                40.11888896144595
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6450.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.23699700416668,
+                40.115305406900156
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7650.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.2409201377443,
+                40.115326425447485
               ]
             }
           }
@@ -210,8 +990,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +1010,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"595.5,7167.5 591.8,0.0 5962.1,0.0 5967.4,6345.4 6450.0,6500.1 6450.0,7266.7 595.5,7167.5\" /></svg>"
+          "value": "<svg><polygon points=\"6450.0,7266.7 595.5,7167.5 586.8,626.0 5967.2,649.3 5967.4,6345.4 6450.0,6500.1 6450.0,7266.7\" /></svg>"
         }
       },
       "body": {
@@ -319,8 +1099,8 @@
           "value": "7650.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -339,7 +1119,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2499.7,7650.0 57.8,79.4 1672.9,50.4 1671.5,166.8 1671.5,329.5 2648.6,261.5 3462.1,0.0 4771.1,145.8 6450.0,86.0 6450.0,7270.2 5339.1,7650.0 2499.7,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"57.8,79.4 1672.9,50.4 1671.5,258.2 2648.6,261.5 3462.1,0.0 6450.0,73.6 6450.0,7270.2 5339.1,7650.0 2499.7,7650.0 57.8,79.4\" /></svg>"
         }
       },
       "body": {
@@ -412,8 +1192,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -432,7 +1212,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6450.0,7299.8 623.5,7259.1 2943.8,423.6 4339.7,894.2 4338.3,1432.4 5844.8,1391.2 6450.0,937.0 6450.0,7299.8\" /></svg>"
+          "value": "<svg><polygon points=\"623.5,7259.1 729.7,6946.2 460.6,6944.9 2275.9,1470.0 2586.3,1476.7 2943.8,423.6 4339.7,894.2 4338.3,1432.4 5844.8,1391.1 6450.0,937.0 6450.0,7299.8 623.5,7259.1\" /></svg>"
         }
       },
       "body": {
@@ -488,99 +1268,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p15",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6264.9,6767.0 -0.0,6822.8 -0.0,261.5 5189.3,259.1 6228.0,404.1 6264.9,6767.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0015/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4493.4,
-                6153.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2370335,
-                40.1134532
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4493.4,
-                260.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.233512,
-                40.113469
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0016/georef",
       "type": "Annotation",
       "@context": [
@@ -598,8 +1285,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -618,7 +1305,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6003.7,168.8 6031.9,7620.7 5036.8,7478.6 367.8,7462.3 399.2,162.6 -0.0,160.7 -0.0,0.0 6450.0,-0.0 6450.0,169.2 6003.7,168.8\" /></svg>"
+          "value": "<svg><polygon points=\"6031.9,7620.7 5036.8,7478.6 367.8,7462.3 544.0,-0.0 6450.0,-0.0 6450.0,169.2 6003.7,168.8 6031.9,7620.7\" /></svg>"
         }
       },
       "body": {
@@ -674,192 +1361,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p17",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5844.5,7440.3 886.9,7459.8 869.9,165.8 5833.0,115.4 5844.5,7440.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0017/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3353.0,
-                2492.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.230412,
-                40.1115
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3353.0,
-                7457.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2335732,
-                40.1114748
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p18",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.2,112.0 5822.5,119.0 5821.2,0.0 6450.0,0.0 6450.0,7650.0 714.8,7650.0 704.2,112.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0018/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3409.1,
-                7421.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2303281,
-                40.1068384
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                704.2,
-                112.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2320465,
-                40.1102829
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0019/georef",
       "type": "Annotation",
       "@context": [
@@ -870,15 +1371,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "11"
+          "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -897,7 +1398,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"371.8,175.8 4949.7,180.8 4955.6,2801.4 6200.9,2793.0 6198.7,6673.3 6450.0,6662.7 6450.0,7650.0 -0.0,7650.0 -0.0,828.5 370.5,830.9 371.8,175.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,179.2 4949.5,184.0 4955.7,2798.1 6197.9,2789.6 6196.3,6660.2 6450.0,6624.8 6450.0,7650.0 -0.0,7650.0 -0.0,830.8 -0.0,179.2\" /></svg>"
         }
       },
       "body": {
@@ -933,7 +1434,7 @@
             "properties": {
               "resourceCoords": [
                 4949.5,
-                6801.8
+                184.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -944,8 +1445,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -88.2334956,
-                40.1065769
+                -88.233592,
+                40.112676
               ]
             }
           }
@@ -986,8 +1487,8 @@
           "value": "7650.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1006,7 +1507,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"96.2,4032.9 108.4,120.3 6450.0,163.2 6450.0,814.0 6081.9,812.3 6094.5,7588.2 6450.0,7587.5 6450.0,7650.0 -0.0,7650.0 -0.0,4030.6 96.2,4032.9\" /></svg>"
+          "value": "<svg><polygon points=\"108.4,120.3 3084.2,186.7 3085.2,0.0 3708.0,0.0 4214.3,165.3 4811.4,157.1 4862.7,0.0 4997.5,0.0 4945.0,157.0 6068.3,163.4 6081.1,7602.8 -0.0,7650.0 -0.0,4030.6 96.2,4032.9 108.4,120.3\" /></svg>"
         }
       },
       "body": {
@@ -1095,8 +1596,8 @@
           "value": "4277.9"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1115,7 +1616,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6215.1,7650.0 3475.1,7650.0 3475.1,6152.1 3603.1,6150.7 3579.0,3502.2 6268.8,3503.5 6307.0,7381.7 6211.6,7380.7 6215.1,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"3475.1,7650.0 3475.1,3502.1 6268.8,3503.5 6307.0,7381.7 6211.6,7380.7 6215.1,7650.0 3475.1,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1204,8 +1705,8 @@
           "value": "7650.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1224,7 +1725,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7650.0 -0.0,-0.0 5964.3,0.0 5918.6,84.2 5879.1,7432.1 4063.0,7406.7 4063.3,7281.9 3236.5,7282.8 3236.6,7394.9 3098.1,7395.6 3097.6,7650.0 -0.0,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"3097.6,7650.0 -0.0,7650.0 -0.0,-0.0 5964.3,0.0 5959.5,288.3 6450.0,292.2 6450.0,1318.6 6065.9,1312.3 6065.0,7434.7 4063.0,7406.7 4063.3,7281.9 3236.5,7282.8 3236.6,7394.9 3098.1,7395.6 3097.6,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1313,8 +1814,8 @@
           "value": "5028.1"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1333,7 +1834,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"142.4,7336.7 -0.0,7335.8 0.0,2621.9 4258.5,2621.9 4258.5,7379.9 4056.0,7379.1 4055.2,7494.5 143.6,7501.5 142.4,7336.7\" /></svg>"
+          "value": "<svg><polygon points=\"143.6,7501.5 142.4,7336.7 -0.0,7335.8 -0.0,7032.3 140.1,7033.8 135.1,5879.5 -0.0,5879.5 0.0,2621.9 4258.5,2621.9 4258.5,7379.9 4056.0,7379.1 4055.2,7494.5 143.6,7501.5\" /></svg>"
         }
       },
       "body": {
@@ -1389,99 +1890,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p22",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "33"
-        }
-      ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7300.1 -0.0,-0.0 44.1,0.0 41.8,202.5 6058.8,205.3 6033.4,3393.4 6325.8,3393.5 6333.8,7338.3 -0.0,7300.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0022/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3605.1,
-                5445.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2501072,
-                40.1143535
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2228.7,
-                208.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.25179,
-                40.119196
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0023__1/georef",
       "type": "Annotation",
       "@context": [
@@ -1515,8 +1923,8 @@
           "value": "3239.6"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1535,7 +1943,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3239.6 -0.0,-0.0 816.1,0.0 815.7,123.1 6197.6,195.4 6189.9,2855.6 6061.4,2855.5 6056.8,3239.6 -0.0,3239.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 816.1,0.0 815.7,123.1 6093.2,194.0 6056.8,3239.6 -0.0,3239.6 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -1624,8 +2032,8 @@
           "value": "5355.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1717,8 +2125,8 @@
           "value": "24"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1737,7 +2145,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1797.8,7650.0 1798.6,7577.1 -0.0,7557.1 -0.0,0.0 6450.0,-0.0 6450.0,272.6 6348.1,271.7 6282.1,7098.7 5627.4,7088.3 5610.8,7650.0 1797.8,7650.0\" /></svg>"
+          "value": "<svg><polygon points=\"1797.8,7650.0 1798.6,7577.1 -0.0,7557.0 -0.0,0.0 6450.0,-0.0 6450.0,300.0 6348.1,271.7 6282.1,7098.7 5656.1,7088.7 5643.5,7650.0 1797.8,7650.0\" /></svg>"
         }
       },
       "body": {
@@ -1793,6 +2201,202 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Champaign, Ill. | 1915 p2 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1480.1"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2105.8"
+        }
+      ],
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002/info.json",
+          "type": "ImageService2",
+          "height": 7650,
+          "width": 6450
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1210.0,1137.5 1210.0,1437.1 -0.0,1429.7 -0.0,-0.0 1343.0,0.0 1348.1,1139.0 1210.0,1137.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24524642809439,
+                40.127488944030006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1480.1,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24342089382718,
+                40.12750059319046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1480.1,
+                2105.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24339924047179,
+                40.12551574427962
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                2105.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.24522477473901,
+                40.125504095119155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1348.1,
+                1136.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.243572,
+                40.126426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1348.1,
+                1136.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -88.243563,
+                40.125991
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0002__2/georef",
       "type": "Annotation",
       "@context": [
@@ -1826,8 +2430,8 @@
           "value": "7650.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1846,7 +2450,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4469.7,7430.0 680.0,7462.1 675.0,4731.3 -0.0,4723.9 -0.0,-0.0 6061.2,0.0 6060.1,7650.0 4469.7,7430.0\" /></svg>"
+          "value": "<svg><polygon points=\"675.0,4731.3 -0.0,4723.9 -0.0,-0.0 6061.1,0.0 6060.2,7328.9 679.7,7317.1 675.0,4731.3\" /></svg>"
         }
       },
       "body": {
@@ -1919,8 +2523,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1939,7 +2543,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5983.0,6934.6 406.1,6869.5 440.8,158.8 6267.2,131.9 6253.3,2417.0 6089.4,2417.0 5992.2,2417.7 5983.0,6934.6\" /></svg>"
+          "value": "<svg><polygon points=\"5983.4,6934.4 406.1,6869.5 440.7,158.8 6267.4,131.8 6253.5,2416.9 5992.5,2417.6 5983.4,6934.4\" /></svg>"
         }
       },
       "body": {
@@ -2028,8 +2632,8 @@
           "value": "7650.0"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2121,8 +2725,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2141,7 +2745,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5964.4,362.0 5974.4,5935.6 6076.1,5938.4 5950.1,6333.3 5947.6,7370.9 642.9,7442.4 616.2,144.0 4382.7,103.7 5964.4,362.0\" /></svg>"
+          "value": "<svg><polygon points=\"642.4,7442.1 615.6,0.0 5964.1,0.0 5974.7,5935.8 6076.4,5938.6 5950.4,6333.4 5947.8,7371.0 642.4,7442.1\" /></svg>"
         }
       },
       "body": {
@@ -2214,8 +2818,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2234,7 +2838,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6450.0,-0.0 6290.2,7278.2 -0.0,7326.9 -0.0,1577.5 720.8,1570.6 707.4,178.7 151.0,-0.0 6450.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6290.2,7278.2 -0.0,7326.9 -0.0,1577.5 720.8,1570.6 707.4,178.7 151.0,-0.0 6450.0,-0.0 6290.2,7278.2\" /></svg>"
         }
       },
       "body": {
@@ -2307,8 +2911,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2327,7 +2931,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6438.7 -0.0,113.6 5886.6,43.3 5971.6,6993.5 541.7,7017.0 543.8,6437.8 -0.0,6438.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6438.7 -0.0,113.6 5886.6,43.3 5979.7,7650.0 539.4,7650.0 543.8,6437.8 -0.0,6438.7\" /></svg>"
         }
       },
       "body": {
@@ -2400,8 +3004,8 @@
           "value": "29"
         }
       ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
+      "created": "2026-07-30T21:31:39Z",
+      "modified": "2026-07-30T21:31:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2420,7 +3024,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3597.1,7441.9 1980.4,7476.6 -0.0,1503.2 -0.0,1077.3 3393.4,0.0 6450.0,0.0 6450.0,1190.0 4557.0,1764.4 5449.9,4706.3 5975.8,4743.1 5977.8,6445.5 6257.9,7368.6 6450.0,7500.0 5395.1,7386.2 4574.6,7650.0 3596.4,7650.0 3597.1,7441.9\" /></svg>"
+          "value": "<svg><polygon points=\"1980.4,7476.6 -0.0,1503.1 -0.0,1077.3 3393.4,0.0 6450.0,0.0 6450.0,1281.1 4668.1,1835.8 5562.2,4706.9 5975.8,4743.1 6007.5,6136.7 6412.9,7438.4 5395.1,7386.2 4574.6,7650.0 3596.4,7650.0 3597.1,7441.9 1980.4,7476.6\" /></svg>"
         }
       },
       "body": {
@@ -2469,99 +3073,6 @@
               "coordinates": [
                 -88.2425666,
                 40.1165462
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Champaign, Ill. | 1915 p9",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:39:31Z",
-      "modified": "2026-07-18T02:39:31Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/info.json",
-          "type": "ImageService2",
-          "height": 7650,
-          "width": 6450
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3549.4,6942.0 371.1,6053.6 -0.0,5777.9 -0.0,4826.2 486.0,3218.5 -0.0,3033.0 -0.0,-0.0 6148.9,0.0 6249.2,5982.4 6217.2,6240.8 6009.9,6525.9 6017.6,7142.5 5689.5,7149.1 5683.9,6954.5 5108.4,7412.9 3645.3,7495.4 3549.4,6942.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g017781915:01778_1915-0009/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                484.2,
-                3216.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2406645,
-                40.1174173
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6193.9,
-                3328.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -88.2371003,
-                40.117326
               ]
             }
           }

--- a/gallery/chicago_il_1950_vol_1.iiif.json
+++ b/gallery/chicago_il_1950_vol_1.iiif.json
@@ -7,6 +7,3870 @@
   "label": "Mosaic of main content, Chicago, Ill. | 1950 | Vol. 1",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p14N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5809
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"124.9,6509.0 -0.0,6510.3 -0.0,3.0 4725.6,0.0 4732.0,741.6 5809.0,739.1 5809.0,6476.3 414.8,6511.7 424.0,7323.0 129.1,7323.0 124.9,6509.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62446296148048,
+                41.89707140829943
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6209766087251,
+                41.897106108552215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5809.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62091823545789,
+                41.893810516702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62440458821327,
+                41.893775816449214
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p17N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5806
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4282.0,936.2 4352.5,6121.3 675.0,5672.4 582.9,1772.8 2565.1,1774.1 2545.0,960.7 4282.0,936.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64298951142077,
+                41.89433187853268
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63950716061633,
+                41.89433846002852
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5806.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63949608963671,
+                41.89104650014511
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64297844044114,
+                41.89103991864927
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p19N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4101.2,6357.3 1714.1,6337.2 1711.3,962.0 4112.3,970.8 4101.2,6357.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63812835395369,
+                41.894375165652036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6346544591882,
+                41.89443085922295
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63456056703458,
+                41.89113963494603
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63803446180007,
+                41.89108394137512
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p21N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5794
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1716.2,6315.3 1622.1,956.9 4191.0,929.7 4211.7,2713.1 3951.6,2717.4 3956.9,6286.3 1716.2,6315.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63511663234931,
+                41.894424441446084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6316234717072,
+                41.89444333496467
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5794.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63159161957478,
+                41.89113386879023
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63508478021689,
+                41.89111497527164
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p24N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5798
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1599.0,6287.5 1576.7,918.7 4189.1,914.3 4212.6,6280.4 1599.0,6287.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63065825819686,
+                41.894457430323854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62718254091192,
+                41.894500289737024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5798.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6271103454376,
+                41.891210096735726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63058606272254,
+                41.891167237322556
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p26N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5803
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"682.9,880.6 2556.7,867.5 2555.9,1734.4 2850.9,1757.7 2846.2,872.0 5185.0,872.4 5200.9,6230.7 2842.8,6229.3 2851.0,7323.0 2625.6,7323.0 2615.4,6229.1 699.9,6229.1 682.9,880.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62588204973852,
+                41.894511306855996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62239598970031,
+                41.894561852295695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62231090606107,
+                41.8912641408813
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62579696609927,
+                41.8912135954416
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p28N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5803
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"267.0,6278.9 269.5,948.5 3003.4,952.3 3078.7,1865.2 4504.5,1749.7 4579.0,4558.5 3397.0,4552.5 3383.6,7323.0 1147.5,7323.0 1145.5,6278.8 267.0,6278.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62048287848486,
+                41.894639757156895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61698205850622,
+                41.89469989607006
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5803.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61688082617945,
+                41.891388218864705
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62038164615811,
+                41.89132807995154
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p29N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5753
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4274.0,4665.4 -0.0,4530.3 -0.0,966.7 -0.0,966.5 -0.0,-0.0 4087.9,0.0 5753.0,3550.3 5753.0,7323.0 4190.6,7323.0 4274.0,4665.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61779415283317,
+                41.89469719386528
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5753.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61428616959715,
+                41.894827289273394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5753.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61406519909019,
+                41.891478837243305
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.61757318232623,
+                41.89134874183519
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p2N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5845
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1738.7,6538.8 1734.3,6310.7 -0.0,6352.1 0.0,0.0 3761.4,0.0 4066.8,995.8 4166.9,7323.0 2165.0,7323.0 2145.8,6532.5 1738.7,6538.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64393107203104,
+                41.89679488863338
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5845.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64045987192623,
+                41.89679973068996
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5845.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64045177674903,
+                41.89353866604549
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64392297685384,
+                41.8935338239889
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p33N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5825
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1698.8,3839.9 1673.1,2047.1 4211.0,2041.8 4214.7,2796.6 5825.0,2787.7 5825.0,4588.9 4223.7,4701.7 4222.4,3819.2 1698.8,3839.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63659728610038,
+                41.892028297083456
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63308909569456,
+                41.892067363930614
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63302356204835,
+                41.88876000654493
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63653175245418,
+                41.88872093969777
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p34N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5825
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4103.8,4477.0 3461.8,4485.1 3446.9,2682.0 1835.0,2704.1 1812.3,970.5 4057.6,940.2 4103.8,4477.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6351487210747,
+                41.8920080391646
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6316441178456,
+                41.89202549197342
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5825.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.631614841374,
+                41.888721496889374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6351194446031,
+                41.88870404408056
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p3N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5879
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1685.3,1065.3 1401.0,74.1 5879.0,0.0 5879.0,754.6 4259.7,755.0 4127.5,1041.7 4135.2,6523.9 1665.9,6517.4 1685.3,1065.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64253892445781,
+                41.89681882473948
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5879.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63901065356383,
+                41.89687127068059
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5879.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63892355635592,
+                41.89357868502362
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6424518272499,
+                41.89352623908251
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p42N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5820
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"54.1,7323.0 -0.0,2538.2 423.5,2556.3 425.8,754.2 2850.1,766.6 2848.2,0.0 5379.0,0.0 5277.0,7323.0 54.1,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63725003811102,
+                41.89027585337611
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5820.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6337553082809,
+                41.890336291148316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5820.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63365385874765,
+                41.88703926263375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63714858857777,
+                41.88697882486154
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p44N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1964.3,122.8 5828.0,96.2 5828.0,295.5 4128.3,6941.9 2510.1,7323.0 -0.0,7323.0 -0.0,6610.8 1964.3,122.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63370172092277,
+                41.890001810006446
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63007683021503,
+                41.890080468962175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62994497680529,
+                41.8866653226597
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63356986751305,
+                41.886586663703966
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p48N",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1943.9,7323.0 2160.8,3563.1 2710.4,3541.9 2848.9,3221.3 2832.1,71.9 5026.4,75.8 5009.0,3008.9 5828.0,2837.4 5828.0,7323.0 1943.9,7323.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62840488560174,
+                41.89089711093142
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62487844790707,
+                41.89095945871732
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62477393568486,
+                41.88763709057721
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.62830037337953,
+                41.88757474279131
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p59W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5865
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,7323 0,0 5865,0 5865,7323 0,7323\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64774762975053,
+                41.89175872797537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64418978335152,
+                41.89179987637617
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64412122943041,
+                41.88846855444844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6476790758294,
+                41.88842740604764
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p63W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5877
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5643.0,644.5 5670.5,5553.4 370.2,5508.2 367.0,5189.2 353.2,4354.9 -0.0,4352.3 -0.0,711.0 5643.0,644.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64778546376625,
+                41.889312956230214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64419945470908,
+                41.88935027485021
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5877.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64413744448575,
+                41.88600114296365
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64772345354291,
+                41.88596382434365
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p64W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"501.9,5622.2 486.7,692.2 5271.8,762.8 5316.8,5702.5 501.9,5622.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64463931080418,
+                41.88936560604935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6410993508854,
+                41.8894091856897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64102630085424,
+                41.8860740065474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64456626077302,
+                41.886030426907055
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p73W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3547.9 693.3,3555.5 720.4,556.5 1311.1,563.3 1692.5,826.8 4068.5,863.6 4038.9,7322.0 1653.4,7322.0 1657.8,6605.8 -0.0,6582.2 -0.0,3547.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64521642014523,
+                41.884775921991064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64168509722084,
+                41.88485094675541
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64156027205362,
+                41.88154814985045
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64509159497801,
+                41.88147312508611
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p80W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5828
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4112.1,6517.9 1686.5,6500.4 1668.0,0.0 4102.6,0.0 4112.1,6517.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64368093700237,
+                41.88218730215457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64019523211542,
+                41.88224912884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5828.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64009166371467,
+                41.878966495429154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64357736860164,
+                41.87890466874372
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p86W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5868
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4129.2,823.3 4222.2,6473.8 1834.0,6506.7 1719.6,849.7 4129.2,823.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64361868962304,
+                41.879670361338434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64008491288529,
+                41.87968492443814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64006067172343,
+                41.87637775870114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64359444846117,
+                41.876363195601435
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p87W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/info.json",
+          "type": "ImageService2",
+          "height": 7322,
+          "width": 5853
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1714.7,858.6 5853.0,887.2 5853.0,6507.1 1717.4,6484.1 1714.7,858.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64217782057226,
+                41.879681542800235
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63863684868684,
+                41.87973854368926
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5853.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6385417594751,
+                41.87641740977256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7322.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64208273136053,
+                41.876360408883535
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p88W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5868
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1485.0,859.7 1466.2,0.0 5868.0,0.0 5787.1,6406.3 3309.0,6457.2 3188.5,840.3 1485.0,859.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6405548712098,
+                41.87971744505398
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63700380696233,
+                41.879717499493935
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5868.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6370037163434,
+                41.876394166506635
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64055478059088,
+                41.87639411206668
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p89W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5822
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5822.0,932.2 5822.0,7323.0 1110.1,7323.0 1177.0,895.6 5822.0,932.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64342774182519,
+                41.877273469111664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5822.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64331666119966,
+                41.874638589619636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5822.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64773558342432,
+                41.87453384381077
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64784666404985,
+                41.877168723302795
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p92W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1720.4,3086.3 1695.7,1032.4 4098.8,1008.8 4131.0,3055.6 4139.8,4243.2 4151.7,6272.9 1759.4,6294.1 1720.4,3086.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64351347917867,
+                41.87719274836241
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64000260861316,
+                41.877217673493405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63996109241585,
+                41.87392958536759
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64347196298135,
+                41.8739046602366
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p93W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4227.8 -0.0,3034.3 1799.8,3046.5 1801.4,983.2 4218.9,1016.1 4127.9,5174.5 1778.7,5186.6 1788.8,4243.5 -0.0,4227.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64213972915066,
+                41.87717418924201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63865515375689,
+                41.877242204819815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63854194174714,
+                41.87398096889155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64202651714092,
+                41.87391295331375
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p94W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5866
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2953.9,6331.4 453.8,6323.7 319.9,5642.8 396.9,1028.3 4708.9,1029.3 4743.4,0.0 5866.0,0.0 5866.0,7323.0 2964.1,7323.0 2953.9,6331.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63986716174652,
+                41.87722590600444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63637703321152,
+                41.87728038470866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5866.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63628629103637,
+                41.87401173972364
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63977641957138,
+                41.87395726101943
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p97W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5867
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3328.7,0.0 3438.5,1107.6 5867.0,1146.6 5867.0,5081.2 1029.0,5024.9 1051.3,0.0 3328.7,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64164716339417,
+                41.87486995448859
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63805313169799,
+                41.874954004375724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5867.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6379132356894,
+                41.8715902043101
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64150726738558,
+                41.87150615442296
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0100W/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +3888,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -117,8 +3981,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +4001,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1785.5,6239.8 1727.2,42.6 4123.1,0.0 4130.9,1244.3 5844.0,1243.0 5844.0,6223.5 1785.5,6239.8\" /></svg>"
+          "value": "<svg><polygon points=\"4196.0,6231.1 1785.5,6239.8 1727.2,42.6 4123.1,0.0 4196.0,6231.1\" /></svg>"
         }
       },
       "body": {
@@ -210,8 +4074,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +4094,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3408.1,1295.1 1712.6,1287.8 1711.0,0.0 4071.3,0.0 4129.4,6223.2 3383.3,6222.9 3408.1,1295.1\" /></svg>"
+          "value": "<svg><polygon points=\"1752.1,6222.2 1712.6,1287.8 2491.8,1291.2 2455.9,6222.5 1752.1,6222.2\" /></svg>"
         }
       },
       "body": {
@@ -303,8 +4167,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,7 +4187,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4153.9,6219.8 1684.0,6207.2 1580.4,0.0 4102.0,0.0 4153.9,6219.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1253.7 1601.7,1248.9 1580.8,0.0 4102.1,0.0 4162.8,7256.5 1698.0,7323.0 1684.0,6207.2 -0.0,6218.8 -0.0,1253.7\" /></svg>"
         }
       },
       "body": {
@@ -396,8 +4260,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -489,8 +4353,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +4373,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3479.2,1059.6 3328.4,7323.0 -0.0,7323.0 -0.0,6997.4 2212.8,7029.4 2299.5,1041.3 3479.2,1059.6\" /></svg>"
+          "value": "<svg><polygon points=\"3479.2,1059.6 3328.5,7323.0 -0.0,7323.0 -0.0,6997.4 2212.8,7029.4 2299.5,1041.3 3479.2,1059.6\" /></svg>"
         }
       },
       "body": {
@@ -582,8 +4446,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -602,7 +4466,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1035.1 5085.5,1000.0 5090.8,1717.0 5266.0,1714.1 5877.0,1703.6 5877.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"5877.0,7323.0 -0.0,7323.0 -0.0,1035.1 5085.5,1000.0 5090.8,1717.0 5714.6,1706.4 5683.4,-0.0 5877.0,-0.0 5877.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -675,8 +4539,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +4559,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"905.8,7323.0 906.6,6684.8 1640.4,6692.8 1704.3,947.9 4163.9,988.3 4095.5,7323.0 905.8,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"905.8,7323.0 906.6,6684.8 1640.4,6692.9 1704.3,947.9 4163.9,988.3 4095.5,7323.0 905.8,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -768,8 +4632,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -788,7 +4652,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4111.6,735.4 4137.3,6529.2 1684.3,6531.1 1684.4,742.2 4111.6,735.4\" /></svg>"
+          "value": "<svg><polygon points=\"4111.8,735.4 4137.5,6529.2 1684.3,6531.1 1684.4,742.2 4111.8,735.4\" /></svg>"
         }
       },
       "body": {
@@ -861,8 +4725,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +4745,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1688.2,7241.6 1696.3,963.9 4125.2,978.0 4124.2,7283.3 1688.2,7241.6\" /></svg>"
+          "value": "<svg><polygon points=\"1696.3,963.9 4125.2,978.0 4124.2,7283.3 1688.2,7241.6 1696.3,963.9\" /></svg>"
         }
       },
       "body": {
@@ -954,8 +4818,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -974,7 +4838,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"398.3,7323.0 408.1,999.9 2922.2,1048.4 2916.7,2103.5 5861.0,2123.0 5861.0,7323.0 398.3,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"5861.0,7323.0 398.3,7323.0 406.3,2135.7 5861.0,2123.0 5861.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -1047,8 +4911,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1067,7 +4931,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1535.5,6543.1 1514.7,795.6 876.9,796.9 877.6,42.9 4096.9,0.0 4112.9,6543.0 1535.5,6543.1\" /></svg>"
+          "value": "<svg><polygon points=\"1514.7,795.6 -0.0,798.6 -0.0,-0.0 5485.9,43.4 5487.9,785.2 4098.2,792.3 4112.4,6543.0 1535.5,6543.1 1514.7,795.6\" /></svg>"
         }
       },
       "body": {
@@ -1140,8 +5004,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,7 +5024,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1791.6,6518.4 1810.4,1971.1 3202.2,2426.3 3192.6,6521.3 1791.6,6518.4\" /></svg>"
+          "value": "<svg><polygon points=\"4063.6,731.1 4036.7,6523.1 1791.6,6518.4 1806.8,730.8 4063.6,731.1\" /></svg>"
         }
       },
       "body": {
@@ -1233,8 +5097,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1253,7 +5117,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2908.9,753.1 3962.7,749.5 4205.9,0.0 5806.0,0.0 5806.0,6468.0 5135.7,6467.5 5138.3,7227.6 4848.3,7227.1 4850.3,6462.6 -0.0,6475.3 -0.0,2419.0 1566.6,2927.6 3034.1,2933.0 3018.6,1006.9 2908.9,753.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,739.5 -0.0,-0.0 4777.6,8.5 4727.3,6463.0 835.7,6475.1 848.9,737.9 -0.0,739.5\" /></svg>"
         }
       },
       "body": {
@@ -1309,99 +5173,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p14N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5809
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4714.2,0.0 4730.2,6543.6 1022.7,6546.4 1012.4,0.0 4714.2,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0014N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2692.5,
-                2947.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6227988,
-                41.8957629
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2692.5,
-                6547.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6227571,
-                41.8941636
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0015N/georef",
       "type": "Annotation",
       "@context": [
@@ -1419,8 +5190,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1439,7 +5210,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5806.0,0.0 5806.0,6515.8 -0.0,6539.2 -0.0,770.7 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1024.0,6541.9 1074.0,777.3 -0.0,770.7 -0.0,-0.0 5806.0,0.0 5806.0,6515.8 1024.0,6541.9\" /></svg>"
         }
       },
       "body": {
@@ -1528,8 +5299,8 @@
           "value": "7323.0"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1548,7 +5319,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1576.0,0.0 5798.0,0.0 5798.0,5796.4 1123.0,5470.0 1576.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5798.0,0.0 5798.0,5708.7 1581.0,5477.7 1478.6,7323.0 -0.0,7323.0 -0.0,6369.5 1041.4,6455.9 1576.0,0.0 5798.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1604,99 +5375,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p17N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5806
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2609.8,946.6 4314.2,962.5 4657.2,7323.0 280.7,7224.7 226.2,6704.6 2609.8,946.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0017N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4114.6,
-                4535.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6404837,
-                41.8922885
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5034.3,
-                967.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6399796,
-                41.893922
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0018N/georef",
       "type": "Annotation",
       "@context": [
@@ -1714,8 +5392,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1734,7 +5412,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5560.6,6348.7 419.5,6371.9 353.9,5526.4 -0.0,4887.2 -0.0,965.6 5529.5,957.4 5560.6,6348.7\" /></svg>"
+          "value": "<svg><polygon points=\"5560.5,6348.8 -0.0,6434.7 -0.0,965.4 5529.6,957.4 5560.5,6348.8\" /></svg>"
         }
       },
       "body": {
@@ -1790,99 +5468,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p19N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4048.8,6330.2 1692.6,6313.7 1683.4,970.7 4053.4,976.0 4048.8,6330.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0019N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1692.6,
-                2764.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6370626,
-                41.893148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1692.6,
-                6313.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6370194,
-                41.8915431
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0020N/georef",
       "type": "Annotation",
       "@context": [
@@ -1900,8 +5485,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1920,7 +5505,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4268.4,6335.8 1714.9,6333.8 1705.2,1762.3 4233.9,1750.9 4268.4,6335.8\" /></svg>"
+          "value": "<svg><polygon points=\"4270.9,7323.0 1725.6,7323.0 1703.4,915.9 4227.6,916.7 4270.9,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -1976,99 +5561,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p21N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5794
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1660.6,5268.3 1660.6,948.3 4193.6,963.5 4183.2,2736.0 3926.7,2735.8 3886.1,5278.5 1660.6,5268.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0021N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1660.6,
-                948.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6341345,
-                41.8939972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1660.6,
-                6269.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340545,
-                41.8915756
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0022N/georef",
       "type": "Annotation",
       "@context": [
@@ -2086,8 +5578,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2179,8 +5671,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2255,99 +5747,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p24N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5798
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1531.5,6267.1 1529.3,949.7 4098.6,954.3 4101.9,6269.1 1531.5,6267.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0024N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1531.5,
-                2715.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6296811,
-                41.8932553
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1531.5,
-                6267.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6296377,
-                41.8916443
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0025N/georef",
       "type": "Annotation",
       "@context": [
@@ -2365,8 +5764,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2385,7 +5784,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5053.9,6273.9 613.4,6298.3 595.1,936.5 5026.6,917.2 5053.9,6273.9\" /></svg>"
+          "value": "<svg><polygon points=\"595.1,936.5 5026.6,917.2 5053.9,6273.9 4338.1,6279.4 4340.3,7322.0 4222.9,7322.0 4196.1,6280.0 613.4,6298.3 595.1,936.5\" /></svg>"
         }
       },
       "body": {
@@ -2441,99 +5840,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p26N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5803
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"672.7,4419.0 683.9,851.9 2553.0,853.3 2546.1,1627.0 2839.6,1629.3 2841.8,860.0 5174.6,878.6 5155.0,4441.5 2812.6,4435.2 2821.1,4225.7 2306.8,4431.4 672.7,4419.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0026N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                683.9,
-                2643.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6254322,
-                41.8933176
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                683.9,
-                851.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6254616,
-                41.8941207
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0027N/georef",
       "type": "Annotation",
       "@context": [
@@ -2551,8 +5857,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2627,285 +5933,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p28N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5803
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"327.9,6331.1 327.9,955.9 4078.0,958.2 4078.4,0.0 4526.7,0.0 4530.9,957.0 5803.0,961.2 5803.0,4597.9 3461.4,4587.8 3449.5,7323.0 1209.5,7323.0 1207.1,6330.3 327.9,6331.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0028N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                327.9,
-                955.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6203072,
-                41.8942136
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                327.9,
-                6331.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.620235,
-                41.891803
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p29N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5753
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1562.4,990.5 302.9,978.6 304.5,31.3 4439.4,0.0 5753.0,2609.1 5753.0,7323.0 4654.8,7323.0 4683.1,4623.3 1540.2,4590.3 1562.4,990.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0029N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4240.7,
-                1015.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6153782,
-                41.894289
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5424.9,
-                4591.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6145965,
-                41.8926846
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p2N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5845
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1719.0,6578.4 1717.9,6347.3 -0.0,6364.1 0.0,0.0 3852.8,0.0 4140.7,997.9 4140.7,6575.6 3839.8,7323.0 2135.8,7323.0 2128.5,6577.9 1719.0,6578.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0002N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4140.7,
-                2915.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6414965,
-                41.8955118
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4140.7,
-                4739.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6414791,
-                41.8947101
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0030N/georef",
       "type": "Annotation",
       "@context": [
@@ -2923,8 +5950,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2943,7 +5970,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2597.8,6375.6 2577.6,5235.8 -0.0,5281.3 0.0,-0.0 5803.0,-0.0 5803.0,6352.7 2597.8,6375.6\" /></svg>"
+          "value": "<svg><polygon points=\"5803.0,6352.7 2583.5,6375.7 2520.1,4750.0 -0.0,4846.5 0.0,-0.0 5803.0,-0.0 5803.0,6352.7\" /></svg>"
         }
       },
       "body": {
@@ -3016,8 +6043,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3036,7 +6063,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2698.7,6432.3 -0.0,6516.2 -0.0,1077.6 5162.4,1024.0 5206.2,6429.4 3481.1,6431.9 3476.5,7201.7 5172.0,7167.2 5171.2,7323.0 2696.6,7323.0 2698.7,6432.3\" /></svg>"
+          "value": "<svg><polygon points=\"3476.5,7201.7 4792.1,7209.5 4793.6,7323.0 2696.6,7323.0 2698.7,6432.3 827.6,6465.8 1326.4,2646.1 394.8,1058.5 5162.4,1024.0 5206.2,6429.4 4855.9,6415.8 4650.5,6418.2 3430.3,6432.5 3476.5,7201.7\" /></svg>"
         }
       },
       "body": {
@@ -3109,8 +6136,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3129,7 +6156,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6544.3 1667.7,1063.9 4081.4,1042.5 4167.3,4659.4 1672.1,7323.0 -0.0,7323.0 -0.0,6544.3\" /></svg>"
+          "value": "<svg><polygon points=\"1667.7,1063.9 4081.4,1042.5 4167.3,4659.4 1330.3,7323.0 -0.0,7323.0 -0.0,6544.3 1667.7,1063.9\" /></svg>"
         }
       },
       "body": {
@@ -3185,192 +6212,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p33N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5825
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4209.6,4050.5 1750.0,4021.7 1748.2,1123.0 5825.0,1164.0 5825.0,4732.4 4204.7,4619.4 4209.6,4050.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0033N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1728.3,
-                2839.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6355706,
-                41.8907681
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4204.7,
-                4619.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340121,
-                41.8899822
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p34N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5825
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1805.0,1004.2 1800.4,0.0 4033.2,0.0 4021.8,1003.6 1805.0,1004.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0034N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1804.3,
-                2727.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340339,
-                41.8907935
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1804.3,
-                4515.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340121,
-                41.8899822
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0035N/georef",
       "type": "Annotation",
       "@context": [
@@ -3388,8 +6229,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3408,7 +6249,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4043.6,2018.0 4043.9,2795.6 5831.0,2803.3 5831.0,4608.9 831.6,4617.4 840.0,2790.4 -0.0,2793.6 -0.0,1037.2 1407.2,1032.2 1410.0,2018.0 4043.6,2018.0\" /></svg>"
+          "value": "<svg><polygon points=\"4043.6,2018.0 4043.9,2795.6 5831.0,2803.3 5831.0,4817.4 5741.9,4609.0 1417.4,4615.8 1408.9,2018.0 4043.6,2018.0\" /></svg>"
         }
       },
       "body": {
@@ -3481,8 +6322,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3501,7 +6342,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1758.6,2749.3 1760.8,978.5 2784.3,975.8 2804.4,2755.4 1758.6,2749.3\" /></svg>"
+          "value": "<svg><polygon points=\"3543.3,2759.8 1758.6,2749.3 1760.8,978.5 4244.7,971.9 4248.2,2763.9 3723.9,2760.8 3724.9,4639.5 3538.5,4629.8 3543.3,2759.8\" /></svg>"
         }
       },
       "body": {
@@ -3574,8 +6415,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3594,7 +6435,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4092.7,3706.3 927.1,3679.2 905.3,5703.4 772.8,5702.3 684.0,5491.8 743.1,3676.0 -0.0,3663.3 -0.0,1868.0 4107.3,1907.7 4092.7,3706.3\" /></svg>"
+          "value": "<svg><polygon points=\"1455.7,3688.3 1472.6,1880.7 4107.3,1907.7 4092.7,3706.3 1455.7,3688.3\" /></svg>"
         }
       },
       "body": {
@@ -3667,8 +6508,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3687,7 +6528,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1944.6,3650.0 1948.3,1839.7 4227.2,1844.3 5683.6,5488.3 5710.4,6862.8 4739.5,7081.0 1944.6,3650.0\" /></svg>"
+          "value": "<svg><polygon points=\"4215.8,3649.3 1944.6,3650.0 1948.3,1839.7 4227.5,1844.3 4215.8,3649.3\" /></svg>"
         }
       },
       "body": {
@@ -3760,8 +6601,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3780,7 +6621,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1806.7,3494.0 1821.1,1706.4 3192.8,1707.9 3293.4,7322.0 3120.8,7322.0 2317.4,7322.0 1806.7,3494.0\" /></svg>"
+          "value": "<svg><polygon points=\"1821.1,1706.4 3192.8,1707.9 3326.4,3498.7 1806.7,3494.0 1821.1,1706.4\" /></svg>"
         }
       },
       "body": {
@@ -3836,99 +6677,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p3N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5879
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1687.8,1056.1 1405.8,73.9 5879.0,0.0 5879.0,732.1 4260.7,736.8 4129.3,1025.8 4150.2,6543.9 1681.7,6544.0 1687.8,1056.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0003N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4143.3,
-                4737.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6400025,
-                41.8947291
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1683.7,
-                4737.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6414791,
-                41.8947101
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0040N/georef",
       "type": "Annotation",
       "@context": [
@@ -3946,8 +6694,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3966,7 +6714,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"708.9,118.1 2537.6,117.5 2536.2,0.0 5129.8,105.6 5134.6,1497.3 708.1,1601.6 708.9,118.1\" /></svg>"
+          "value": "<svg><polygon points=\"2823.9,2981.8 2816.1,1898.5 5136.0,1899.7 5159.6,3651.7 5789.3,3650.3 5820.0,5493.8 4273.8,5620.4 4282.7,7323.0 1526.9,7323.0 1523.2,6401.8 712.2,6576.4 717.9,3649.1 -0.0,3652.0 -0.0,1902.4 2592.4,1898.3 2602.2,2981.9 2823.9,2981.8\" /></svg>"
         }
       },
       "body": {
@@ -4022,99 +6770,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p42N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5820
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"75.6,635.3 2654.3,630.5 2648.8,0.0 5337.4,0.0 5339.3,621.9 5820.0,735.0 5331.9,738.8 5282.7,7323.0 -0.0,7323.0 75.6,635.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0042N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                464.0,
-                2579.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6367468,
-                41.889126
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5292.0,
-                2579.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6340209,
-                41.8891589
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0043N/georef",
       "type": "Annotation",
       "@context": [
@@ -4132,8 +6787,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4152,7 +6807,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6609.8 1797.5,6624.0 1899.4,0.0 4662.6,0.0 4648.9,3458.8 4456.4,4669.8 4429.2,7209.5 -0.0,7323.0 -0.0,6609.8\" /></svg>"
+          "value": "<svg><polygon points=\"1906.2,0.0 4662.6,0.0 4648.9,3458.7 4456.4,4669.5 4429.2,7208.9 -0.0,7323.0 -0.0,6936.0 1793.2,6937.6 1906.2,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4208,99 +6863,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p44N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2025.8,109.6 5828.0,152.8 5828.0,7323.0 -0.0,7323.0 -0.0,6414.4 2025.8,109.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0044N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1684.0,
-                1791.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6326564,
-                41.8891834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4132.0,
-                1791.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6310629,
-                41.8892182
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0045N/georef",
       "type": "Annotation",
       "@context": [
@@ -4318,8 +6880,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4338,7 +6900,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1646.2,7003.2 -0.0,6866.3 -0.0,6527.5 1644.1,6556.1 1665.2,0.0 4110.8,0.0 4083.3,6668.8 2946.1,6650.7 2893.0,7323.0 1645.0,7323.0 1646.2,7003.2\" /></svg>"
+          "value": "<svg><polygon points=\"1648.1,6839.8 1665.2,0.0 4110.8,0.0 4083.3,6668.8 2946.1,6650.6 2981.3,6863.5 4080.6,6949.0 4079.0,7192.2 -0.0,7323.0 -0.0,6807.9 1648.1,6839.8\" /></svg>"
         }
       },
       "body": {
@@ -4411,8 +6973,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4431,7 +6993,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"776.5,6842.5 1919.4,6797.7 1658.3,1665.0 4248.0,1539.8 4356.2,3050.2 5611.9,2573.7 5554.7,3157.5 5828.0,3875.8 5828.0,7323.0 1389.3,7323.0 1373.1,7066.7 823.6,7054.3 776.5,6842.5\" /></svg>"
+          "value": "<svg><polygon points=\"5828.0,1372.4 5828.0,7323.0 1944.4,7323.0 1932.6,7078.7 824.0,7053.7 776.9,6841.9 1919.7,6797.1 1577.5,98.2 795.3,141.4 873.7,0.0 1577.1,90.5 1658.5,1665.0 5828.0,1372.4\" /></svg>"
         }
       },
       "body": {
@@ -4460,8 +7022,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63055037602706,
-                41.890018528868744
+                -87.63055065734466,
+                41.89001861291401
               ]
             }
           },
@@ -4481,8 +7043,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62701827447748,
-                41.88992961513789
+                -87.62701816505513,
+                41.88992968934704
               ]
             }
           },
@@ -4502,8 +7064,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62716834559428,
-                41.88662468346147
+                -87.62716825277359,
+                41.886624392061414
               ]
             }
           },
@@ -4523,8 +7085,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.63070044714385,
-                41.886713597192326
+                -87.63070074506312,
+                41.886713315628384
               ]
             }
           },
@@ -4591,8 +7153,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4611,7 +7173,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5866.0,7323.0 4512.3,7323.0 4577.8,6079.6 4367.5,5515.8 4429.9,4763.2 3145.7,5174.4 3117.0,3654.9 514.0,3643.7 515.4,2068.9 -0.0,2070.2 -0.0,78.2 5866.0,59.2 5866.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"515.4,2061.2 -0.0,2070.2 -0.0,78.0 5365.9,60.0 5397.3,3237.1 5260.1,3561.1 514.0,3643.9 515.4,2061.2\" /></svg>"
         }
       },
       "body": {
@@ -4667,99 +7229,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p48N",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"999.4,7323.0 354.2,5355.2 -0.0,5469.1 -0.0,0.0 5828.0,0.0 5828.0,4438.5 4800.2,4775.8 4987.7,4988.8 5612.8,6863.4 4178.3,7323.0 999.4,7323.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0048N/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                604.0,
-                6127.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6282103,
-                41.8966783
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2784.0,
-                5415.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6268484,
-                41.8967018
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0049N/georef",
       "type": "Annotation",
       "@context": [
@@ -4777,8 +7246,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4797,7 +7266,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"842.5,294.9 849.6,0.0 5247.3,0.0 5221.7,2141.0 5847.0,2154.3 5847.0,3985.8 4296.1,4076.1 4238.2,7242.6 -0.0,7322.0 -0.0,279.2 842.5,294.9\" /></svg>"
+          "value": "<svg><polygon points=\"4265.1,5767.8 4238.1,7243.4 1497.1,7322.0 1528.7,5703.3 4265.1,5767.8\" /></svg>"
         }
       },
       "body": {
@@ -4870,8 +7339,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4890,7 +7359,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4038.0,692.1 4116.7,6565.3 1688.9,6575.4 1644.8,1000.5 1776.5,708.0 4038.0,692.1\" /></svg>"
+          "value": "<svg><polygon points=\"4038.0,692.1 4116.7,6565.4 1688.9,6575.5 1644.8,1000.4 1776.5,708.0 4038.0,692.1\" /></svg>"
         }
       },
       "body": {
@@ -4963,8 +7432,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4983,7 +7452,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,4113.9 1570.7,3993.7 1536.7,2138.2 902.5,2136.3 888.0,371.9 5804.0,357.4 5804.0,7323.0 -0.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,4113.5 1570.6,3993.3 1536.6,2138.0 902.5,2136.1 888.0,371.9 5804.0,357.4 5804.0,7323.0 -0.0,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -5012,8 +7481,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.62322919076904,
-                41.89190881135782
+                -87.62322925093714,
+                41.891908828837884
               ]
             }
           },
@@ -5033,8 +7502,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61971069727562,
-                41.89197349973473
+                -87.61971036820916,
+                41.89197352437097
               ]
             }
           },
@@ -5054,8 +7523,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.61960106291846,
-                41.88866768739859
+                -87.61960072172367,
+                41.88866734632819
               ]
             }
           },
@@ -5075,8 +7544,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6231195564119,
-                41.88860299902168
+                -87.62311960445166,
+                41.88860265079511
               ]
             }
           },
@@ -5122,8 +7591,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5142,7 +7611,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5811.0,0.0 5811.0,7323.0 -0.0,7323.0 0.0,-0.0 5811.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5811.0,0.0 5811.0,7323.0 -0.0,7323.0 0.0,0.0 5811.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -5215,8 +7684,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5235,7 +7704,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7323.0 -0.0,0.0 3926.7,12.2 3961.2,6080.1 1404.6,6061.4 1392.3,7323.0 -0.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 3926.7,12.2 3947.7,3703.2 4401.0,3703.6 4376.8,6083.2 1404.6,6061.4 2895.7,7323.0 -0.0,7323.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -5308,8 +7777,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5328,7 +7797,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5464.8,0.0 5463.6,226.4 5865.0,229.8 5865.0,6037.4 -0.0,6050.7 -0.0,0.0 5464.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"414.3,6056.0 452.1,3683.5 -0.0,3680.5 -0.0,0.0 5464.8,0.0 5463.6,226.5 5865.0,229.9 5865.0,6037.4 414.3,6056.0\" /></svg>"
         }
       },
       "body": {
@@ -5401,8 +7870,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5421,7 +7890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"409.9,2463.4 404.1,1245.6 5615.0,1207.8 5574.1,3552.1 5728.1,3547.5 5664.3,5893.6 110.7,6004.9 125.4,7323.0 -0.0,7323.0 -0.0,2469.4 409.9,2463.4\" /></svg>"
+          "value": "<svg><polygon points=\"404.2,1245.3 5615.0,1207.8 5574.0,3552.3 5728.0,3547.8 5664.0,5894.0 131.1,6004.9 141.6,7323.0 -0.0,7323.0 -0.0,2469.2 1861.3,2442.3 404.2,1245.3\" /></svg>"
         }
       },
       "body": {
@@ -5477,99 +7946,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p59W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5865
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7323 0,0 5865,0 5865,7323 0,7323\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0059W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2940.5,
-                3671.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6459018,
-                41.890103
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                268.0,
-                1247.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6476267,
-                41.891194
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0005N/georef",
       "type": "Annotation",
       "@context": [
@@ -5587,8 +7963,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5607,7 +7983,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1066.5,679.9 1063.8,0.0 5879.0,0.0 5879.0,666.4 4072.8,665.7 4141.4,6418.6 1755.5,6428.2 1678.8,675.6 1066.5,679.9\" /></svg>"
+          "value": "<svg><polygon points=\"1067.1,680.1 1062.7,0.0 5879.0,0.0 5879.0,666.6 4072.8,665.9 4141.4,6418.2 1755.5,6427.8 1678.8,675.9 1067.1,680.1\" /></svg>"
         }
       },
       "body": {
@@ -5680,8 +8056,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5700,7 +8076,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1662.6,3634.5 1704.3,1259.8 4258.9,1160.7 4304.9,1724.6 5813.0,1728.0 5813.0,6023.6 1753.6,6006.4 1818.6,3629.9 1662.6,3634.5\" /></svg>"
+          "value": "<svg><polygon points=\"1662.6,3634.5 1704.3,1259.8 4259.0,1161.2 3959.5,3531.4 3810.3,3532.0 4059.0,3662.8 4062.7,5991.2 1753.6,6006.4 1818.6,3629.9 1662.6,3634.5\" /></svg>"
         }
       },
       "body": {
@@ -5756,6 +8132,165 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Chicago, Ill. | 1950 | Vol. 1 p61W",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        }
+      ],
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/info.json",
+          "type": "ImageService2",
+          "height": 7323,
+          "width": 5865
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"416.1,6037.2 294.3,4723.0 116.7,3697.5 -0.0,3578.1 -0.0,1157.9 418.5,1095.0 257.8,0.0 3922.7,0.0 3958.8,264.1 4748.0,76.6 5865.0,1514.1 5865.0,5323.6 416.1,6037.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0061W/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64273124018955,
+                41.89179660253598
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63920036329695,
+                41.89148028391397
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5865.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.63973097719644,
+                41.88819678058
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7323.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.64326185408903,
+                41.888513099202015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                416.1,
+                6039.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -87.6429182,
+                41.8890672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0062W/georef",
       "type": "Annotation",
       "@context": [
@@ -5773,8 +8308,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5793,7 +8328,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1029.7,6097.3 942.0,1119.5 261.5,1071.3 263.4,0.0 3159.2,0.0 3161.9,1115.8 3558.7,1140.0 4810.5,982.4 5828.0,1026.5 5828.0,4888.9 3376.5,4935.4 3393.6,5468.1 3405.1,5730.6 3416.0,6091.2 1029.7,6097.3\" /></svg>"
+          "value": "<svg><polygon points=\"1029.7,6097.3 942.0,1119.5 5828.0,1026.5 5828.0,4888.9 3376.5,4935.4 3416.0,6091.2 1029.7,6097.3\" /></svg>"
         }
       },
       "body": {
@@ -5849,192 +8384,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p63W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5877
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5653.0,584.2 5665.0,5518.1 375.3,5457.1 362.0,4297.9 -0.0,4294.1 -0.0,634.4 5653.0,584.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0063W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                360.1,
-                4153.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6475357,
-                41.8873891
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5653.0,
-                584.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6443368,
-                41.889054
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p64W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"484.0,5655.2 385.9,662.1 5199.8,652.7 5328.0,5655.2 484.0,5655.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0064W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                484.0,
-                5655.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6442784,
-                41.8868088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5328.0,
-                5655.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.641353,
-                41.8868082
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0065W/georef",
       "type": "Annotation",
       "@context": [
@@ -6052,8 +8401,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6072,7 +8421,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 1442.0,0.0 1467.2,1149.0 4456.8,1152.3 4882.8,3562.8 5877.0,3554.5 5877.0,6104.0 5274.1,6110.3 5116.9,6376.8 2706.4,6350.3 102.6,6554.6 115.6,7322.0 -0.0,7322.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1442.0,0.0 1467.2,1149.0 5877.0,1153.9 5864.3,6104.1 5274.2,6110.3 5116.9,6376.8 1553.4,6337.7 1555.7,6533.5 102.6,6554.6 115.6,7322.0 -0.0,7322.0 -0.0,-0.0 1442.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -6145,8 +8494,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6165,7 +8514,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4055.3,1199.7 4174.2,6485.6 3789.7,6230.1 3202.7,6235.9 3204.2,3641.4 2437.1,3646.3 2192.2,3649.2 1760.0,1195.8 4055.3,1199.7\" /></svg>"
+          "value": "<svg><polygon points=\"4174.2,6485.6 3789.7,6230.1 3202.7,6235.9 3205.7,1198.3 4055.3,1199.7 4174.2,6485.6\" /></svg>"
         }
       },
       "body": {
@@ -6238,8 +8587,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6258,7 +8607,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4128.7,1020.3 4173.4,6226.9 1836.9,6253.2 1691.0,1022.5 4128.7,1020.3\" /></svg>"
+          "value": "<svg><polygon points=\"1836.9,6253.2 1691.0,1022.5 2476.2,1021.8 2453.9,6246.3 1836.9,6253.2\" /></svg>"
         }
       },
       "body": {
@@ -6331,8 +8680,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6351,7 +8700,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1744.0,6267.2 1676.0,987.9 2193.4,988.2 2409.2,6261.6 1744.0,6267.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,996.6 5828.0,966.6 5828.0,6237.8 4137.9,6247.0 4123.5,5398.8 1733.6,5460.4 1744.0,6267.2 -0.0,6294.3 -0.0,996.6\" /></svg>"
         }
       },
       "body": {
@@ -6424,8 +8773,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6444,7 +8793,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5741.3 -0.0,621.9 4124.0,761.9 4101.2,5038.5 1694.1,5025.1 1675.6,5795.7 -0.0,5741.3\" /></svg>"
+          "value": "<svg><polygon points=\"4124.0,761.9 4096.7,5881.6 4115.7,761.6 4124.0,761.9\" /></svg>"
         }
       },
       "body": {
@@ -6517,8 +8866,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6537,7 +8886,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1782.4,6597.8 1709.6,745.0 3547.9,744.9 3547.6,66.9 4204.4,36.2 4197.2,6585.5 1782.4,6597.8\" /></svg>"
+          "value": "<svg><polygon points=\"1782.4,6597.8 1709.6,745.0 3548.0,744.9 3547.6,66.6 4204.5,0.0 4204.4,36.2 4197.2,6585.5 1782.4,6597.8\" /></svg>"
         }
       },
       "body": {
@@ -6610,8 +8959,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6630,7 +8979,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5813.0,7323.0 5421.3,7323.0 5425.5,6348.1 1340.7,6270.2 1291.0,0.0 5813.0,0.0 5813.0,7323.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6238.3 -0.0,1110.4 1300.0,1131.7 1291.0,0.0 5813.0,0.0 5813.0,7323.0 5421.3,7323.0 5425.5,6347.9 -0.0,6238.3\" /></svg>"
         }
       },
       "body": {
@@ -6703,8 +9052,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6723,7 +9072,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,772.1 2702.7,606.0 2659.9,6418.9 381.6,6408.1 372.1,7322.0 -0.0,7322.0 -0.0,772.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,772.1 1478.1,775.6 1479.2,576.4 5102.2,677.6 5266.7,409.2 5867.0,413.1 5867.0,3412.1 2682.2,3393.6 2659.9,6418.9 381.6,6408.1 372.1,7322.0 -0.0,7322.0 -0.0,772.1\" /></svg>"
         }
       },
       "body": {
@@ -6796,8 +9145,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6816,7 +9165,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,685.1 2382.5,738.6 2543.8,471.2 3734.8,470.2 4113.9,726.9 4148.7,6459.1 -0.0,6451.4 -0.0,685.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3450.4 2478.2,3446.6 2514.5,6456.1 -0.0,6451.4 -0.0,3450.4\" /></svg>"
         }
       },
       "body": {
@@ -6872,99 +9221,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p73W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3990.0,6599.3 1657.7,6539.8 1837.3,842.8 4162.6,937.6 3990.0,6599.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0073W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4083.3,
-                3661.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6427118,
-                41.8831922
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1659.7,
-                6537.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.644106,
-                41.8818174
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0074W/georef",
       "type": "Annotation",
       "@context": [
@@ -6982,8 +9238,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7002,7 +9258,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4214.9,5804.6 1822.3,5823.6 1822.3,799.9 4195.7,841.0 4214.9,5804.6\" /></svg>"
+          "value": "<svg><polygon points=\"1822.3,5726.5 1832.6,0.0 4203.2,0.0 4214.5,5725.0 1822.3,5726.5\" /></svg>"
         }
       },
       "body": {
@@ -7075,8 +9331,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7095,7 +9351,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1720.6,6341.5 1766.5,0.0 4178.3,0.0 4037.0,3265.1 4176.2,3578.2 4147.3,6381.7 1720.6,6341.5\" /></svg>"
+          "value": "<svg><polygon points=\"4147.3,6381.7 1720.7,6341.5 1752.2,772.4 4178.5,844.9 4053.5,1031.5 4037.0,3265.1 4176.2,3578.2 4147.3,6381.7\" /></svg>"
         }
       },
       "body": {
@@ -7168,8 +9424,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7261,8 +9517,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7354,8 +9610,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7374,7 +9630,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1350.6,945.6 4152.0,898.2 4162.0,7322.0 1341.1,7322.0 1350.6,945.6\" /></svg>"
+          "value": "<svg><polygon points=\"1350.6,945.6 4152.0,898.2 4162.0,7316.8 1341.1,7322.0 1350.6,945.6\" /></svg>"
         }
       },
       "body": {
@@ -7447,8 +9703,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7467,7 +9723,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4062.7,6489.8 1689.4,6488.0 1715.6,871.6 4062.7,868.2 4062.7,6489.8\" /></svg>"
+          "value": "<svg><polygon points=\"1689.1,6488.0 1671.2,3695.9 1712.1,1582.0 4062.7,1577.9 4062.7,6489.8 1689.1,6488.0\" /></svg>"
         }
       },
       "body": {
@@ -7540,8 +9796,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7560,7 +9816,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1736.7,0.0 5835.0,0.0 5835.0,715.1 4187.0,719.3 4190.0,7323.0 1670.1,7323.0 1736.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1672.1,6479.6 1736.7,0.0 5835.0,0.0 5835.0,715.1 4187.0,719.3 4187.5,6491.7 1672.1,6479.6\" /></svg>"
         }
       },
       "body": {
@@ -7616,99 +9872,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p80W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5828
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4126.9,6561.6 1672.0,6525.8 1703.2,0.0 4167.8,0.0 4126.9,6561.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0080W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4148.0,
-                3701.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6411695,
-                41.880567
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1672.0,
-                6525.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6425803,
-                41.8792909
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0081W/georef",
       "type": "Annotation",
       "@context": [
@@ -7726,8 +9889,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7819,8 +9982,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7839,7 +10002,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1136.0,1150.3 5828.0,1208.7 5828.0,6832.1 1128.2,6777.0 1136.0,1150.3\" /></svg>"
+          "value": "<svg><polygon points=\"1136.0,1150.3 5828.0,1208.6 5828.0,6001.7 3539.7,5942.1 3536.1,6799.0 1128.2,6777.0 1136.0,1150.3\" /></svg>"
         }
       },
       "body": {
@@ -7912,8 +10075,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7932,7 +10095,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1455.5,7322.0 1462.1,2637.1 4293.2,2651.3 4277.3,7268.7 1455.5,7322.0\" /></svg>"
+          "value": "<svg><polygon points=\"4276.9,7268.7 1455.5,7322.0 1464.6,878.0 4299.9,855.2 4276.9,7268.7\" /></svg>"
         }
       },
       "body": {
@@ -8005,8 +10168,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8025,7 +10188,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4395.3,6264.0 5868.0,6258.2 5868.0,7323.0 1586.1,7323.0 1590.9,898.4 4376.4,881.9 4395.3,6264.0\" /></svg>"
+          "value": "<svg><polygon points=\"1586.1,7323.0 1590.9,898.4 4376.4,881.9 4408.1,7292.7 1586.1,7323.0\" /></svg>"
         }
       },
       "body": {
@@ -8098,8 +10261,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8118,7 +10281,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4188.7,6473.8 1807.2,6458.3 1778.1,3694.7 -0.0,3696.9 -0.0,882.5 4125.3,848.3 4188.7,6473.8\" /></svg>"
+          "value": "<svg><polygon points=\"4125.3,848.3 4188.7,6473.8 1807.2,6458.3 1748.3,876.2 4125.3,848.3\" /></svg>"
         }
       },
       "body": {
@@ -8174,378 +10337,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p86W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5868
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4137.4,829.4 4139.8,6499.8 1760.0,6495.1 1736.5,817.8 4137.4,829.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0086W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.0,
-                3663.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6425293,
-                41.8780106
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1760.0,
-                6495.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424927,
-                41.8767364
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p87W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/info.json",
-          "type": "ImageService2",
-          "height": 7322,
-          "width": 5853
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1671.5,6442.9 1720.3,882.2 4299.2,919.3 4240.6,3522.4 4128.7,3689.0 4159.7,5253.6 4001.2,6484.9 1671.5,6442.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0087W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4128.7,
-                3689.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6395924,
-                41.878055
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1720.3,
-                880.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6411293,
-                41.8793088
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p88W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5868
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1189.6,6452.4 1431.4,5220.4 1504.0,3639.5 1628.0,3478.8 1860.1,855.9 3962.2,1033.6 4034.9,0.0 5868.0,0.0 5795.2,6806.1 1189.6,6452.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0088W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1860.0,
-                855.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6395395,
-                41.879328
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1504.0,
-                3639.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6395924,
-                41.878055
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p89W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5822
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"718.7,910.2 5822.0,901.7 5822.0,7323.0 703.6,7312.9 718.7,910.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0089W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2863.0,
-                903.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6439182,
-                41.8759164
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4590.4,
-                903.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6438986,
-                41.8752612
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0008N/georef",
       "type": "Annotation",
       "@context": [
@@ -8563,8 +10354,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8583,7 +10374,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4274.1,6565.3 1671.4,6564.2 1655.5,719.5 4037.8,710.1 4023.9,2964.4 4309.8,2963.7 4274.1,6565.3\" /></svg>"
+          "value": "<svg><polygon points=\"1661.7,6559.1 1661.7,717.9 2530.7,716.8 2505.8,6561.7 1661.7,6559.1\" /></svg>"
         }
       },
       "body": {
@@ -8598,7 +10389,7 @@
             "properties": {
               "resourceCoords": [
                 1663.7,
-                2963.6
+                6559.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8609,8 +10400,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6341809,
-                41.8955921
+                -87.6341345,
+                41.8939972
               ]
             }
           },
@@ -8618,8 +10409,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4147.3,
-                4771.3
+                1659.7,
+                719.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8630,8 +10421,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -87.6326816,
-                41.8948122
+                -87.6342099,
+                41.8965861
               ]
             }
           }
@@ -8656,8 +10447,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8676,7 +10467,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4105.7,6321.6 -0.0,6280.1 -0.0,5336.6 1731.6,5338.2 1728.6,1070.9 4115.3,1107.8 4105.7,6321.6\" /></svg>"
+          "value": "<svg><polygon points=\"1728.6,1070.9 4115.3,1107.8 4111.4,3143.0 4725.2,3138.3 4728.2,4311.5 4115.8,4310.7 4110.9,5280.0 1729.9,5263.7 1728.6,1070.9\" /></svg>"
         }
       },
       "body": {
@@ -8732,285 +10523,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p92W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2326.3,3813.4 4141.4,3815.5 4134.6,5871.6 1728.0,5871.5 1712.6,540.9 4130.0,538.7 4143.5,2612.4 3768.0,2611.3 2933.1,2612.5 2325.2,2614.0 2326.3,3813.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0092W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4141.4,
-                3815.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6410117,
-                41.8753051
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1728.6,
-                3815.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6424471,
-                41.8752853
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p93W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1759.7,6283.1 1768.1,4279.3 -0.0,4275.8 -0.0,3106.8 1771.1,3106.8 1759.7,1085.9 5867.0,1101.5 5867.0,6302.3 1759.7,6283.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0093W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1759.7,
-                6283.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6409931,
-                41.8743938
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1759.7,
-                1087.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6410546,
-                41.8767572
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p94W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5866
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2189.6,6308.2 2235.9,1106.1 5091.1,1130.9 5026.2,0.0 5866.0,0.0 5866.0,7323.0 2834.2,7323.0 2778.7,6314.3 2189.6,6308.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0094W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                316.1,
-                1087.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6397176,
-                41.8767699
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                316.1,
-                6287.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396278,
-                41.8744068
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0095W/georef",
       "type": "Annotation",
       "@context": [
@@ -9028,8 +10540,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9048,7 +10560,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4169.0,5058.0 -0.0,5115.5 41.1,1028.4 4148.9,1041.9 4169.0,5058.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5115.5 -0.0,475.7 1768.0,448.4 1764.8,0.0 4147.0,0.0 4169.0,5058.0 -0.0,5115.5\" /></svg>"
         }
       },
       "body": {
@@ -9121,8 +10633,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9141,7 +10653,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4163.2,5000.8 1795.3,5011.6 1772.6,1083.9 4108.4,1077.2 4163.2,5000.8\" /></svg>"
+          "value": "<svg><polygon points=\"4108.7,1077.4 4181.4,6303.1 1802.5,6303.7 1772.6,1083.9 4108.7,1077.4\" /></svg>"
         }
       },
       "body": {
@@ -9197,99 +10709,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Chicago, Ill. | 1950 | Vol. 1 p97W",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/info.json",
-          "type": "ImageService2",
-          "height": 7323,
-          "width": 5867
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5867.0,1262.7 5867.0,5162.3 1071.0,4856.9 1280.7,949.8 5867.0,1262.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0097W/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3463.4,
-                6231.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6393618,
-                41.8720327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3463.4,
-                1103.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -87.6396278,
-                41.8744068
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd410m:g4104m:g4104cm:g01790195001N:01790_01N_1950-0009N/georef",
       "type": "Annotation",
       "@context": [
@@ -9307,8 +10726,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:31:54Z",
-      "modified": "2026-07-18T02:31:54Z",
+      "created": "2026-07-30T21:34:59Z",
+      "modified": "2026-07-30T21:34:59Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9327,7 +10746,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4055.3,6539.1 1731.3,6538.0 1760.9,2989.9 1479.3,2991.0 1489.5,770.2 787.0,772.1 784.0,58.8 5835.0,0.0 5835.0,758.3 4055.4,763.3 4055.3,6539.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6540.0 -0.0,778.4 787.2,772.1 784.2,58.8 4951.9,0.0 4952.6,760.8 4055.4,763.3 4055.3,6539.1 -0.0,6540.0\" /></svg>"
         }
       },
       "body": {

--- a/gallery/detroit_mich_1929_vol_11.iiif.json
+++ b/gallery/detroit_mich_1929_vol_11.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,34 +44,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,-0.0 6221.5,0.0 6165.3,6361.6 100.8,6389.1 101.2,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6465.5 -0.0,-0.0 6273.8,0.0 6229.7,6461.6 -0.0,6465.5\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0001/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4151.4,
-                1655.8
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.985309,
-                42.369703
+                -82.98802140066985,
+                42.369471461278906
               ]
             }
           },
@@ -79,20 +82,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                312.0,
-                1655.8
+                6447.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.987428,
-                42.368865
+                -82.98455359743794,
+                42.37085562394279
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98230434797169,
+                42.36773603368998
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9857721512036,
+                42.3663518710261
               ]
             }
           }
@@ -110,15 +155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,34 +182,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5968.8,0.0 5889.1,6354.7 2079.5,6351.1 2071.7,7205.5 110.2,7210.7 211.6,0.0 5968.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"177.0,7142.9 169.3,0.0 5944.2,0.0 5961.0,6232.2 2139.4,6265.6 2144.6,7118.7 177.0,7142.9\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0010/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4111.4,
-                336.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.958873,
-                42.379947
+                -82.9611727246079,
+                42.37923697520953
               ]
             }
           },
@@ -172,20 +220,4754 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5963.1,
-                336.0
+                6447.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.957861,
-                42.380321
+                -82.9576437448456,
+                42.38050969488415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95557525936867,
+                42.37733557699387
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95910423913098,
+                42.376062857319255
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p11",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5871.1,7061.3 503.4,7021.0 581.3,758.6 -0.0,749.8 -0.0,-0.0 5952.5,0.0 5871.1,7061.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95843980732523,
+                42.380597777932216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95495422329297,
+                42.3819036190684
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95283186943347,
+                42.3787685889984
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95631745346573,
+                42.37746274786221
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"109.1,0.0 6036.8,0.0 5935.5,6264.7 6354.0,6238.2 6320.4,7795.0 -0.0,7795.0 109.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9841341192104,
+                42.36418732164819
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.98064493631544,
+                42.365608332409515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97833597587295,
+                42.36246928256145
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9818251587679,
+                42.36104827180012
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p24",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5690.6,6503.2 -0.0,7110.4 -0.0,297.9 5795.4,185.1 5690.6,6503.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97862876368627,
+                42.366986434628046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97511712836338,
+                42.368314315472844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9729594170835,
+                42.365155176099584
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97647105240641,
+                42.36382729525479
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6204.3,6488.6 140.6,7153.5 167.3,751.9 6241.4,547.5 6204.3,6488.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97571174128686,
+                42.36837460291842
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97222372382983,
+                42.36965317534148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97014608691327,
+                42.36651535602082
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9736341043703,
+                42.36523678359776
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p27",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"544.7,657.1 4400.7,564.3 4680.8,1137.5 5245.5,1394.9 5233.6,2187.5 6447.0,2154.6 6440.2,6655.7 5348.6,6437.5 537.7,6483.4 544.7,657.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9696917708006,
+                42.37072226163177
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9661842420126,
+                42.37199267438672
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96411976826786,
+                42.368837449426586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96762729705586,
+                42.36756703667164
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5036.3,7377.9 97.1,7329.4 92.5,7795.0 -0.0,7795.0 -0.0,-0.0 1270.3,0.0 1268.6,184.5 5100.8,202.8 5036.3,7377.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96326349047264,
+                42.3753911134661
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95981109660643,
+                42.37666854230736
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95773508595674,
+                42.373563117057884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96118747982295,
+                42.37228568821663
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4953.1,0.0 4975.1,7795.0 4332.1,7795.0 -0.0,6421.9 -0.0,-0.0 4953.1,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96125951406515,
+                42.37249042347053
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95779995912336,
+                42.373739104603516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95577076632134,
+                42.3706270868059
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95923032126312,
+                42.36937840567291
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5084.2,7795.0 4228.7,7795.0 1195.5,6621.1 1081.6,0.0 4968.2,0.0 5084.2,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95895404358765,
+                42.37285601916815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95536006091773,
+                42.374107137736345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.953326877956,
+                42.370874242807965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95692086062593,
+                42.369623124239766
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5140.9,1652.9 5124.5,6157.1 1306.8,6199.4 1305.8,1669.3 5140.9,1652.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95949514583018,
+                42.37752466594
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95598622226375,
+                42.37880455136526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95390615132717,
+                42.375648380844275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9574150748936,
+                42.37436849541901
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p36",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"461.2,1623.5 5816.5,1706.5 5723.5,6169.9 360.8,6122.9 461.2,1623.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9569548911912,
+                42.378432632375954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95347578551736,
+                42.37976211134733
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9513150890488,
+                42.37663279885589
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95479419472264,
+                42.37530331988451
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1116.1,6878.0 1170.9,308.6 4975.5,278.4 4943.0,7796.0 3071.1,7796.0 3077.4,6866.6 1116.1,6878.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95785127674671,
+                42.375164435081956
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95435737264992,
+                42.376448916030085
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95225687272591,
+                42.373286531829386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95575077682271,
+                42.37200205088126
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"519.6,334.0 5861.5,285.5 5847.0,7796.0 504.4,7796.0 519.6,334.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95543670179056,
+                42.3760810118301
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95193448059332,
+                42.377361081714135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94984117564637,
+                42.374191197439686
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95334339684361,
+                42.37291112755565
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5758.2,428.6 5717.9,7516.5 5488.6,7728.4 5493.8,7524.1 4041.1,7441.7 268.2,6119.0 300.4,399.2 5758.2,428.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95333405538337,
+                42.37311096076978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94991489061447,
+                42.3743777516019
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9478433840505,
+                42.371282918149795
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95126254881939,
+                42.370016127317676
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p44",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5895.2,145.4 5802.2,7630.9 4986.4,7621.3 4986.5,7607.9 -0.0,7556.3 120.3,7463.3 143.7,187.8 5895.2,145.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95035054012358,
+                42.37423994650195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94688097983419,
+                42.37551749789219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94479181666134,
+                42.372377140252645
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94826137695073,
+                42.37109958886241
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p45",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"279.0,282.0 6014.6,281.9 5958.2,7796.0 201.8,7796.0 279.0,282.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94927524988134,
+                42.37835731423622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94580899284993,
+                42.379647470358776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94369911274332,
+                42.37651025806155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94716536977472,
+                42.37522010193899
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"151.1,505.5 5921.2,528.0 5843.0,6975.5 4574.0,7023.4 4581.6,7796.0 -0.0,7760.9 151.1,505.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94727509335209,
+                42.37543272364276
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94382389496118,
+                42.376729770003934
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94170284802279,
+                42.37360603776251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94515404641368,
+                42.37230899140133
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p48",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6407.0,7796.0 5628.7,7796.0 5640.2,6886.8 463.7,6997.8 527.0,529.9 6291.5,615.3 6297.2,0.0 6407.0,0.0 6407.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94439039023158,
+                42.37655380844336
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94091028908323,
+                42.377854066789475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93878393380685,
+                42.37470425689823
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94226403495519,
+                42.37340399855211
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"682.0,1471.5 5633.0,1113.1 5499.3,6907.7 2264.1,6891.9 2251.9,7796.0 561.1,7796.0 682.0,1471.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97964562744885,
+                42.363521496146255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97622097374878,
+                42.36490807831028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97395393038578,
+                42.36180779702065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97737858408584,
+                42.36042121485663
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5430.2,0.0 5313.3,7421.3 6407.0,7464.7 6407.0,7796.0 -0.0,7796.0 0.0,-0.0 558.5,0.0 545.7,903.3 2223.4,447.9 2227.3,0.0 5430.2,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97763695100328,
+                42.36078825463025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9741686710518,
+                42.36217619712672
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9718995022462,
+                42.35903628518255
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97536778219768,
+                42.357648342686076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"698.6,1188.8 5539.7,713.1 5579.5,7796.0 737.9,7796.0 698.6,1188.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97702305948263,
+                42.36463717637
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97351956965849,
+                42.365960966106314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97135516071268,
+                42.362789360298414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97485865053683,
+                42.3614655705621
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"25.9,7796.0 -0.0,910.1 6194.3,324.5 6086.9,6058.5 5663.4,7796.0 25.9,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97404600298088,
+                42.3658557572093
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97060043409788,
+                42.36716642531413
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9684574359741,
+                42.36404731645966
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97190300485711,
+                42.36273664835483
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6407
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7796.0 29.9,596.1 5687.3,582.8 5684.7,1019.1 5984.4,944.0 6099.4,1084.6 6078.6,1428.8 5869.4,1479.7 5684.0,1139.6 5645.3,7618.1 5342.1,7615.1 5341.1,7796.0 -0.0,7796.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.97206827050653,
+                42.36297915810509
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96855385349984,
+                42.3642815595979
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6407.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96642446494427,
+                42.36109998642275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96993888195095,
+                42.35979758492995
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p59",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1204.5,270.4 5291.7,296.9 6346.0,525.7 6346.0,7795.0 1067.3,7795.0 1204.5,270.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96810729219975,
+                42.36818146802246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96457377084914,
+                42.36951513885007
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96237108442202,
+                42.36628425751052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96590460577262,
+                42.364950586682916
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p60",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"120.8,7629.0 162.2,633.0 6278.9,502.3 6346.0,7667.4 120.8,7629.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96596181152321,
+                42.36522201057293
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96247057782506,
+                42.36650351276586
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96035414992286,
+                42.363311150944135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96384538362102,
+                42.362029648751204
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p63",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5514.2,6883.4 -0.0,6968.4 -0.0,1182.6 5938.9,3012.6 5307.5,3042.8 5514.2,6883.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96134074765561,
+                42.37026404719837
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95777350278676,
+                42.37153082392424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95568123787335,
+                42.36826920185025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9592484827422,
+                42.367002425124376
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,238.8 6346.0,157.0 6346.0,7795.0 6259.8,7351.5 1091.5,7290.9 1078.9,7795.0 -0.0,7795.0 -0.0,238.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94296790658828,
+                42.37364149264738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9395050449734,
+                42.374975118640414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93730223121008,
+                42.37180913461796
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94076509282495,
+                42.37047550862493
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p72",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6346.0,0.0 6346.0,7583.3 6084.9,7586.8 6083.1,7795.0 4780.9,7795.0 4787.4,7559.6 -0.0,7516.4 -0.0,869.5 476.3,878.2 480.8,516.5 1121.8,508.9 1128.5,0.0 6346.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94092563809346,
+                42.37068002446507
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9374745780204,
+                42.37197116622146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93534203267164,
+                42.36881583116244
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9387930927447,
+                42.367524689406046
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p77",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6346
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96412828091496,
+                42.36226631586028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96052113296615,
+                42.36365227430838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6346.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9582323003594,
+                42.360353767035576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96183944830821,
+                42.35896780858748
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p82",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5488.6 -0.0,376.0 6335.0,441.7 6335.0,1359.8 5035.7,1342.1 5035.6,7795.0 406.9,7795.0 401.4,6690.7 -0.0,5488.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94975713060377,
+                42.3673714759656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94633195088865,
+                42.368637042306034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9442391369972,
+                42.3655012232617
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94766431671232,
+                42.36423565692127
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p87",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5649.0,7091.6 4501.1,7079.8 4497.7,7795.0 1786.1,7795.0 -0.0,6574.7 -0.0,321.8 5565.1,372.0 5649.0,7091.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9507215608298,
+                42.36354794633756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94724858607239,
+                42.36482355758148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94513927909472,
+                42.361643803746055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94861225385212,
+                42.360368192502136
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p9",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6447
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4109.2,7227.2 4114.3,6345.4 297.4,6338.0 298.6,6154.3 -0.0,6155.1 -0.0,-0.0 6138.5,0.0 6093.9,7217.3 4109.2,7227.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9643801933179,
+                42.37804875172279
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9609090747262,
+                42.37932391326744
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6447.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.95883666904872,
+                42.37620176524906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.96230778764041,
+                42.3749266037044
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p90",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5276.5,6956.3 -0.0,6945.1 15.5,383.2 5264.6,426.0 5276.5,6956.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94203276157015,
+                42.36669071704257
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93852469490673,
+                42.36798419521184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93638574839356,
+                42.3647724555122
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93989381505698,
+                42.363478977342936
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p96",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 11.3,0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9401462929611,
+                42.36382211715533
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93656157997654,
+                42.36513676191381
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.93438772917264,
+                42.36185470284726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9379724421572,
+                42.36054005808878
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Detroit, Mich. | 1929 | Vol. 11 p97",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6335
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6335.0,943.6 6335.0,2244.3 5299.2,2238.6 5289.2,7795.0 -0.0,7795.0 -0.0,5903.5 509.3,970.0 6335.0,943.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0097/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94439690336553,
+                42.35880803998002
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94095950521618,
+                42.36006308814021
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6335.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.9388843701054,
+                42.35691565020228
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -82.94232176825474,
+                42.3556606020421
               ]
             }
           }
@@ -210,8 +4992,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,7 +5012,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"750.9,672.7 6335.0,677.1 6335.0,7795.0 -0.0,7795.0 -0.0,1940.4 742.2,1942.7 750.9,672.7\" /></svg>"
+          "value": "<svg><polygon points=\"1026.8,864.8 1027.3,673.0 6335.0,677.1 6335.0,7795.0 703.1,7795.0 750.7,865.6 1026.8,864.8\" /></svg>"
         }
       },
       "body": {
@@ -286,99 +5068,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p11",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5891.1,7023.1 539.9,7096.2 520.4,708.1 -0.0,716.3 -0.0,-0.0 5862.7,0.0 5891.1,7023.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0011/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                519.9,
-                1047.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.957861,
-                42.380321
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5891.1,
-                7023.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953343,
-                42.378947
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0012/georef",
       "type": "Annotation",
       "@context": [
@@ -396,8 +5085,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -489,8 +5178,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +5198,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"381.4,6932.1 414.2,0.0 6095.8,66.2 6065.3,6845.7 381.4,6932.1\" /></svg>"
+          "value": "<svg><polygon points=\"6065.3,6845.7 381.4,6932.1 414.2,0.0 6095.7,0.0 6065.3,6845.7\" /></svg>"
         }
       },
       "body": {
@@ -582,8 +5271,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -602,7 +5291,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6418.3,6760.4 632.3,6773.1 637.5,0.0 6447.0,0.0 6418.3,6760.4\" /></svg>"
+          "value": "<svg><polygon points=\"632.3,6773.2 637.5,0.0 6447.0,0.0 6418.2,6760.5 632.3,6773.2\" /></svg>"
         }
       },
       "body": {
@@ -675,8 +5364,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +5384,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6172.6,348.3 6132.8,7795.0 -0.0,7795.0 -0.0,374.2 6172.6,348.3\" /></svg>"
+          "value": "<svg><polygon points=\"6172.4,348.1 6140.4,7080.7 188.4,7152.4 186.1,7795.0 -0.0,7795.0 -0.0,374.4 6172.4,348.1\" /></svg>"
         }
       },
       "body": {
@@ -768,8 +5457,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -788,7 +5477,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"452.9,6908.7 415.9,959.9 5465.9,998.8 5378.6,6857.4 452.9,6908.7\" /></svg>"
+          "value": "<svg><polygon points=\"5378.2,6857.4 452.9,6908.7 415.9,959.9 5465.5,998.8 5378.2,6857.4\" /></svg>"
         }
       },
       "body": {
@@ -861,8 +5550,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +5570,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5666.2,6761.7 -0.0,6907.4 -0.0,1015.3 5751.8,1097.7 5666.2,6761.7\" /></svg>"
+          "value": "<svg><polygon points=\"5666.0,6761.4 -0.0,6908.0 -0.0,1015.8 5751.6,1097.5 5666.0,6761.4\" /></svg>"
         }
       },
       "body": {
@@ -954,8 +5643,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -974,7 +5663,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3848.6,1092.8 3851.7,0.0 4649.4,0.0 4673.3,2004.8 5613.8,1993.0 5752.6,5778.1 3833.2,5807.6 3830.9,6535.2 145.7,6688.5 154.5,1091.7 3848.6,1092.8\" /></svg>"
+          "value": "<svg><polygon points=\"3848.6,1092.8 3851.7,0.0 4649.4,0.0 4673.3,2004.7 5613.7,1992.8 5830.2,6455.1 145.7,6688.5 154.5,1091.7 3848.6,1092.8\" /></svg>"
         }
       },
       "body": {
@@ -1047,8 +5736,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1067,7 +5756,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5197.1,6514.9 303.4,6526.9 235.5,30.8 5198.7,0.0 5197.1,6514.9\" /></svg>"
+          "value": "<svg><polygon points=\"5197.1,6514.8 303.4,6527.0 235.3,0.0 5198.7,0.0 5197.1,6514.8\" /></svg>"
         }
       },
       "body": {
@@ -1140,8 +5829,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,7 +5849,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5153.3,6395.9 -0.0,6396.3 -0.0,2011.8 5185.8,2136.6 5153.3,6395.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2011.6 5358.0,2140.5 5411.0,0.0 6447.0,0.0 6447.0,6405.7 -0.0,6396.3 -0.0,2011.6\" /></svg>"
         }
       },
       "body": {
@@ -1233,8 +5922,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1253,7 +5942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5211.4,7005.4 4659.0,6733.7 4399.2,6155.0 1205.8,6153.0 1218.7,5784.6 -0.0,5741.3 -0.0,1783.7 176.9,1786.7 207.5,0.0 6447.0,0.0 6447.0,7795.0 5187.5,7736.6 5211.4,7005.4\" /></svg>"
+          "value": "<svg><polygon points=\"4659.1,6733.7 4399.3,6155.0 1327.6,6153.1 1280.6,0.0 6447.0,0.0 6447.0,7795.0 5174.4,7795.0 5211.5,7005.5 4659.1,6733.7\" /></svg>"
         }
       },
       "body": {
@@ -1282,8 +5971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97126750350563,
-                42.37289893611845
+                -82.97126745573003,
+                42.37289888158939
               ]
             }
           },
@@ -1303,8 +5992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96778431727944,
-                42.374248690039224
+                -82.96778435083468,
+                42.37424860399401
               ]
             }
           },
@@ -1324,8 +6013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96557738950662,
-                42.371134559774134
+                -82.96557747459265,
+                42.37113454644248
               ]
             }
           },
@@ -1345,8 +6034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.96906057573281,
-                42.369784805853364
+                -82.969060579488,
+                42.36978482403786
               ]
             }
           },
@@ -1392,8 +6081,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1412,7 +6101,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5059.7,7189.0 -0.0,7696.2 -0.0,1967.8 390.9,1961.7 383.9,403.9 5139.1,328.1 5059.7,7189.0\" /></svg>"
+          "value": "<svg><polygon points=\"5076.7,7186.2 423.1,7610.6 383.9,403.9 5137.0,328.1 5076.7,7186.2\" /></svg>"
         }
       },
       "body": {
@@ -1468,192 +6157,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p24",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5687.6,6517.4 -0.0,7176.3 -0.0,353.9 5774.5,192.2 5687.6,6517.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0024/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3935.4,
-                6703.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.974639,
-                42.3650909
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1879.7,
-                300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9775274,
-                42.3672704
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p25",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"276.6,813.9 3919.1,718.7 3932.5,0.0 5828.8,0.0 5843.1,670.9 6447.0,656.7 6447.0,6423.4 165.1,7055.7 276.6,813.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0025/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1863.7,
-                6879.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.972836,
-                42.3659479
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4999.2,
-                691.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9728344,
-                42.3691355
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0026/georef",
       "type": "Annotation",
       "@context": [
@@ -1671,8 +6174,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1691,7 +6194,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3052.1,6254.8 685.7,6501.0 560.8,609.6 5239.0,407.1 5224.8,0.0 6447.0,0.0 6447.0,369.6 5807.7,391.9 5817.1,6207.2 3052.1,6254.8\" /></svg>"
+          "value": "<svg><polygon points=\"5807.7,382.5 5817.1,6207.2 3052.1,6254.8 292.6,6541.9 285.2,621.5 5807.7,382.5\" /></svg>"
         }
       },
       "body": {
@@ -1747,99 +6250,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p27",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"523.9,615.9 4417.3,465.6 4705.4,1042.9 5278.1,1295.8 5284.3,2040.1 6447.0,2045.5 6447.0,6603.4 5427.9,6409.2 569.7,6525.9 523.9,615.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0027/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2391.6,
-                6487.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9667038,
-                42.3685644
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                523.9,
-                615.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9692214,
-                42.3705636
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0003/georef",
       "type": "Annotation",
       "@context": [
@@ -1857,8 +6267,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1933,279 +6343,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p31",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5076.9,7204.2 -0.0,7380.4 -0.0,-0.0 1314.4,0.0 1313.9,265.4 5091.3,236.3 5076.9,7204.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0031/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3131.5,
-                256.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.961544,
-                42.375929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5083.2,
-                4799.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.959272,
-                42.374477
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5296.0,0.0 5030.2,7795.0 4466.5,7795.0 -0.0,6211.8 -0.0,-0.0 5296.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96149367386279,
-                42.372388777282204
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95801677371153,
-                42.37374736438934
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6447.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95579540315474,
-                42.37063885416721
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.959272303306,
-                42.36928026706008
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.2,
-                8003.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.956922,
-                42.3702159
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.2,
-                8003.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.956504,
-                42.3702559
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0033/georef",
       "type": "Annotation",
       "@context": [
@@ -2223,8 +6360,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2243,7 +6380,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5192.7,0.0 5066.3,7795.0 1161.8,7795.0 1292.0,0.0 5192.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5192.3,0.0 5076.6,7210.8 1172.3,7108.7 1291.6,0.0 5192.3,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2299,285 +6436,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4132.8,7795.0 294.7,6583.6 1098.5,6631.2 1002.9,629.9 4905.5,511.5 5007.0,7795.0 4132.8,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1103.8,
-                6839.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.956504,
-                42.3702559
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5011.2,
-                8071.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9540111,
-                42.3704972
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1391.2,1609.5 5243.7,1635.8 5151.2,6179.2 1315.8,6179.2 1391.2,1609.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1315.8,
-                6179.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9571296,
-                42.375274
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5151.2,
-                6179.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.955063,
-                42.376049
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"415.9,1671.8 5777.4,1623.7 5768.5,6112.3 400.3,6196.8 415.9,1671.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3983.4,
-                6139.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953123,
-                42.376775
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                415.9,
-                1671.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.956256,
-                42.377876
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0037/georef",
       "type": "Annotation",
       "@context": [
@@ -2595,8 +6453,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2688,8 +6546,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2764,99 +6622,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1270.4,253.9 5087.5,245.6 4970.7,7673.6 6407.0,7673.1 6407.0,7796.0 3090.7,7796.0 3107.5,6872.0 1139.8,6872.0 1270.4,253.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1139.8,
-                6872.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9553895,
-                42.3725982
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3107.5,
-                6872.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.954323,
-                42.372996
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0004/georef",
       "type": "Annotation",
       "@context": [
@@ -2867,15 +6632,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2894,7 +6659,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"65.3,6819.7 72.6,0.0 4493.9,0.0 4576.8,5711.5 3775.7,5713.6 3775.4,6811.1 65.3,6819.7\" /></svg>"
+          "value": "<svg><polygon points=\"3775.4,6811.1 65.2,6819.5 72.5,0.0 4493.9,0.0 4576.8,5711.5 3775.7,5713.6 3775.4,6811.1\" /></svg>"
         }
       },
       "body": {
@@ -2967,8 +6732,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2987,7 +6752,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1494.4,6131.8 236.2,5714.2 1116.0,5727.1 1113.3,824.9 3071.5,792.0 3070.3,1711.8 4939.2,1680.4 4955.2,7278.7 1686.0,6195.4 1634.9,7796.0 1444.2,7796.0 1494.4,6131.8\" /></svg>"
+          "value": "<svg><polygon points=\"1494.4,6131.8 249.5,5718.6 1113.6,5727.6 1113.3,824.9 3071.5,792.0 3070.3,1724.0 4939.3,1703.4 4955.2,7278.7 1686.0,6195.5 1634.9,7796.0 1444.2,7796.0 1494.4,6131.8\" /></svg>"
         }
       },
       "body": {
@@ -3043,192 +6808,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"507.1,387.5 4079.4,384.0 5859.1,384.0 6407.0,7657.4 6407.0,7796.0 387.5,7796.0 507.1,387.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4079.4,
-                384.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.953123,
-                42.376775
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5859.1,
-                384.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.952156,
-                42.377136
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4067.8,0.0 5864.5,0.0 5860.6,210.0 6407.0,210.5 6407.0,1204.7 5841.3,1227.7 5734.6,7538.9 4075.8,7454.7 356.5,6117.9 453.7,456.4 4061.3,343.5 4067.8,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3927.4,
-                7416.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9492906,
-                42.3709414
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2139.7,
-                6748.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950434,
-                42.3708449
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0043/georef",
       "type": "Annotation",
       "@context": [
@@ -3246,8 +6825,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3322,285 +6901,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p44",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"586.4,0.0 6407.0,0.0 6407.0,7796.0 -0.0,7432.5 164.0,7332.0 586.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0044/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                164.0,
-                7332.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9482854,
-                42.3712576
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5859.1,
-                7332.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9457108,
-                42.372325
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p45",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"232.0,352.9 5975.1,328.0 5909.1,7796.0 145.9,7796.0 232.0,352.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0045/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4139.4,
-                328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.946939,
-                42.379089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5975.1,
-                328.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.945945,
-                42.379455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,135.0 443.0,148.6 436.8,274.1 6183.8,493.3 5872.1,7028.9 4712.3,7038.2 4722.1,7796.0 -0.0,7639.4 -0.0,135.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2179.7,
-                7160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9441559,
-                42.3729755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4039.4,
-                7160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9431666,
-                42.3733752
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0047/georef",
       "type": "Annotation",
       "@context": [
@@ -3618,8 +6918,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3694,99 +6994,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1019.3,6860.6 517.1,6858.9 890.2,747.3 6314.2,1075.8 6407.0,7796.0 5205.6,7796.0 5257.8,6971.1 2186.6,6851.6 2212.7,7072.4 1016.6,7066.5 1019.3,6860.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2199.7,
-                6960.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.941251,
-                42.3741723
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                515.9,
-                6960.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9421978,
-                42.3737775
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0049/georef",
       "type": "Annotation",
       "@context": [
@@ -3804,8 +7011,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3897,8 +7104,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3946,8 +7153,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97631448257037,
-                42.37405836891457
+                -82.97631447042669,
+                42.37405836192443
               ]
             }
           },
@@ -3967,8 +7174,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9728005377993,
-                42.375363801034986
+                -82.97280060770466,
+                42.37536376356359
               ]
             }
           },
@@ -3988,8 +7195,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9706660788007,
-                42.372222171202175
+                -82.97066619854473,
+                42.37222220708644
               ]
             }
           },
@@ -4009,8 +7216,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.97418002357178,
-                42.37091673908176
+                -82.97418006126676,
+                42.37091680544728
               ]
             }
           },
@@ -4039,192 +7246,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p51",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5665.6,1184.0 5128.3,7796.0 -0.0,7796.0 -0.0,1358.4 5665.6,1184.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0051/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2303.6,
-                1284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9779957,
-                42.3634758
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                623.9,
-                1284.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9788532,
-                42.3630839
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"657.4,1174.7 6407.0,525.3 6407.0,4896.0 5648.8,4896.0 5634.8,7060.3 5632.5,7796.0 751.3,7796.0 657.4,1174.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5647.1,
-                4896.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9725798,
-                42.3637904
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                695.9,
-                4896.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.975287,
-                42.362803
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0054/georef",
       "type": "Annotation",
       "@context": [
@@ -4242,8 +7263,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4262,7 +7283,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7329.9 -0.0,533.2 579.6,481.2 580.6,569.7 5490.1,599.4 5395.7,7374.5 -0.0,7329.9\" /></svg>"
+          "value": "<svg><polygon points=\"581.4,634.5 5490.2,594.6 5424.5,7612.4 6407.0,7612.1 6407.0,7796.0 1768.7,7682.9 1760.0,7345.0 647.9,7336.0 581.4,634.5\" /></svg>"
         }
       },
       "body": {
@@ -4318,258 +7339,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5382.7,7796.0 -0.0,7796.0 -0.0,5089.2 748.2,5111.4 875.5,798.9 6087.0,372.6 5877.4,6011.1 5548.1,7468.0 5382.7,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                136.0,
-                860.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.973729,
-                42.3655229
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6087.0,
-                372.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9706256,
-                42.3669931
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p56",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6407
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5601.1,449.1 5489.7,646.7 5749.6,411.3 6407.0,422.1 6407.0,7796.0 -0.0,7796.0 63.6,0.0 155.3,576.4 5601.1,449.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0056/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.972037294464,
-                42.36290142842276
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6407.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96854333840123,
-                42.36419609488956
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6407.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96641326804937,
-                42.36105283677052
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7796.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96990722411212,
-                42.35975817030372
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1671.7,
-                7476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.969083,
-                42.360225
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0057/georef",
       "type": "Annotation",
       "@context": [
@@ -4587,8 +7356,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4680,8 +7449,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4700,7 +7469,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5607.1,7552.0 736.8,7552.5 659.2,429.7 5633.5,453.9 5607.1,7552.0\" /></svg>"
+          "value": "<svg><polygon points=\"5633.5,453.9 5607.1,7552.0 -0.0,7552.6 -0.0,990.4 189.0,1332.8 399.8,1278.8 418.7,929.9 301.8,788.9 -0.0,868.4 -0.0,426.4 5633.5,453.9\" /></svg>"
         }
       },
       "body": {
@@ -4756,417 +7525,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p59",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5230.6,383.5 6175.7,573.6 6181.7,0.0 6346.0,0.0 6346.0,7795.0 1247.9,7795.0 1272.4,438.7 5230.6,383.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0059/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4249.3,
-                5415.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.964228,
-                42.366806
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4249.3,
-                395.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9656433,
-                42.3689608
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p60",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"254.7,492.6 6346.0,517.1 6346.0,7795.0 614.4,7795.0 616.3,7570.4 168.1,7567.0 254.7,492.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0060/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96597363779351,
-                42.365143188509464
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96251045321513,
-                42.36641882001719
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96039052763906,
-                42.36327181399255
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96385371221744,
-                42.36199618248483
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                168.1,
-                7567.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.963824,
-                42.362122
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p63",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6770.1 -0.0,-0.0 2074.1,0.0 2049.8,1575.2 5983.9,3029.9 5337.2,3026.1 5317.0,6974.0 -0.0,6770.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0063/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96128124384971,
-                42.37009031031805
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95788866455436,
-                42.371465779262955
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.955602822775,
-                42.36838293246692
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95899540207036,
-                42.367007463522015
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4765.5,
-                2559.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.957983,
-                42.3701109
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0064/georef",
       "type": "Annotation",
       "@context": [
@@ -5184,8 +7542,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5204,7 +7562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,300.8 152.0,0.0 6346.0,0.0 6346.0,7337.6 -0.0,7279.7 -0.0,300.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,300.4 151.8,0.0 6346.0,0.0 6346.0,7337.6 -0.0,7279.7 -0.0,300.4\" /></svg>"
         }
       },
       "body": {
@@ -5233,8 +7591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.9596999504274,
-                42.36726358466757
+                -82.95969983786036,
+                42.36726353998621
               ]
             }
           },
@@ -5254,8 +7612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95623857341917,
-                42.36854189597805
+                -82.95623854167373,
+                42.368541821448694
               ]
             }
           },
@@ -5275,8 +7633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95411419437643,
-                42.365396532497726
+                -82.95411421223429,
+                42.3653965314112
               ]
             }
           },
@@ -5296,8 +7654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95757557138467,
-                42.36411822118724
+                -82.95757550842092,
+                42.364118249948724
               ]
             }
           },
@@ -5343,8 +7701,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5363,7 +7721,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4032.5,7505.7 4023.1,7795.0 -0.0,7795.0 -0.0,7136.9 2061.3,1755.7 3751.8,1883.4 3760.6,1689.5 2134.8,1563.8 2498.0,616.0 6346.0,806.5 6346.0,7582.5 4032.5,7505.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,7136.9 2061.3,1755.7 3751.9,1883.5 3760.7,1689.6 2134.8,1563.8 2498.0,616.0 5978.3,788.7 5698.8,7561.4 4033.0,7506.0 4023.6,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5436,8 +7794,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5456,7 +7814,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"628.4,7284.8 369.6,1019.9 919.1,557.2 1738.8,174.8 5675.3,135.2 5633.8,7244.3 628.4,7284.8\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1331.2 -0.0,1301.1 -0.0,0.0 5675.2,-0.0 5633.8,7244.4 -0.0,7289.9 -0.0,1331.2\" /></svg>"
         }
       },
       "body": {
@@ -5529,8 +7887,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5549,7 +7907,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4274.2,7795.0 631.4,7795.0 2482.3,2188.3 2643.4,752.6 6346.0,800.3 6346.0,969.2 4206.4,905.4 4274.2,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"4206.4,905.4 4267.2,7105.0 3858.5,7108.4 3864.1,7795.0 631.4,7795.0 2482.3,2188.3 2564.7,753.1 6346.0,800.1 6346.0,969.0 4206.4,905.4\" /></svg>"
         }
       },
       "body": {
@@ -5622,8 +7980,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5642,7 +8000,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,452.6 1860.5,537.4 2263.4,540.5 2265.2,361.7 -0.0,333.1 -0.0,0.0 5323.5,-0.0 5313.7,7159.1 1327.8,7195.8 256.2,7795.0 -0.0,7795.0 -0.0,452.6\" /></svg>"
+          "value": "<svg><polygon points=\"2263.6,540.4 2265.4,361.6 -0.0,333.0 -0.0,-0.0 5323.5,-0.0 5313.9,7022.1 -0.0,7017.7 -0.0,452.5 2263.6,540.4\" /></svg>"
         }
       },
       "body": {
@@ -5671,8 +8029,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94778615344397,
-                42.37056250874725
+                -82.94778621168354,
+                42.37056242532842
               ]
             }
           },
@@ -5692,8 +8050,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94608261777996,
-                42.367993752665896
+                -82.94608271579632,
+                42.36799372922638
               ]
             }
           },
@@ -5713,8 +8071,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95035154002169,
-                42.3664457447915
+                -82.95035153836061,
+                42.36644575749728
               ]
             }
           },
@@ -5734,8 +8092,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95205507568569,
-                42.36901450087285
+                -82.95205503424782,
+                42.36901445359932
               ]
             }
           },
@@ -5797,8 +8155,8 @@
           "value": "7113.5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5817,7 +8175,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"634.7,2315.7 685.5,681.5 5678.2,681.5 5661.8,7575.1 983.0,7578.8 964.3,2314.3 634.7,2315.7\" /></svg>"
+          "value": "<svg><polygon points=\"635.1,2315.5 686.0,681.5 5678.7,681.5 5661.8,7575.1 982.8,7578.8 964.5,2314.1 635.1,2315.5\" /></svg>"
         }
       },
       "body": {
@@ -5906,8 +8264,8 @@
           "value": "7262.3"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5926,7 +8284,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"305.6,7570.7 312.2,532.7 5865.0,532.7 6346.0,7570.5 305.6,7570.7\" /></svg>"
+          "value": "<svg><polygon points=\"312.2,532.7 5725.5,532.7 5893.0,7441.2 6346.0,7427.6 6346.0,7795.0 5864.3,7795.0 5861.5,7570.5 305.6,7570.7 312.2,532.7\" /></svg>"
         }
       },
       "body": {
@@ -5982,192 +8340,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p71",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,283.7 1742.4,291.4 1739.5,513.8 3049.3,522.8 3020.6,281.1 6346.0,410.2 6346.0,7795.0 747.7,7630.1 737.2,7795.0 -0.0,7795.0 -0.0,283.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0071/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3033.0,
-                399.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.941251,
-                42.3741723
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4897.5,
-                399.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.9402943,
-                42.3745709
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p72",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,719.7 1127.0,733.6 1131.1,0.0 6346.0,0.0 6346.0,7795.0 6086.3,7795.0 6043.5,7795.0 4765.4,7795.0 4772.0,7464.9 -0.0,7483.3 -0.0,719.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0072/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1108.3,
-                7475.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.938297,
-                42.367849
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6041.9,
-                7475.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.935541,
-                42.368847
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0073__2/georef",
       "type": "Annotation",
       "@context": [
@@ -6201,8 +8373,8 @@
           "value": "3855.1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6221,7 +8393,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,3939.9 321.4,3939.9 321.4,4110.0 5475.5,4152.6 5510.1,3939.9 5509.9,4477.2 6346.0,4477.0 6346.0,7795.0 -0.0,7795.0 0.0,3939.9\" /></svg>"
+          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
         }
       },
       "body": {
@@ -6294,8 +8466,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6314,7 +8486,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,533.4 1043.0,521.4 1040.0,248.5 6346.0,247.3 6346.0,7795.0 -0.0,7795.0 -0.0,533.4\" /></svg>"
+          "value": "<svg><polygon points=\"6346.0,247.3 6346.0,7795.0 -0.0,7795.0 -0.0,249.1 6346.0,247.3\" /></svg>"
         }
       },
       "body": {
@@ -6370,165 +8542,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p77",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6346
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,7795 0,0 6346,0 6346,7795 0,7795\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0077/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96402349576199,
-                42.362197651366635
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96056031118361,
-                42.36347328287436
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6346.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.95844038560755,
-                42.36032627684972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.96190357018592,
-                42.359050645342
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                216.1,
-                296.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.963824,
-                42.362122
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0079/georef",
       "type": "Annotation",
       "@context": [
@@ -6546,8 +8559,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6566,7 +8579,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6037.9,423.9 6017.3,7795.0 -0.0,7795.0 -0.0,-0.0 885.9,0.0 890.1,428.9 6037.9,423.9\" /></svg>"
+          "value": "<svg><polygon points=\"6037.9,423.9 6017.3,7795.0 -0.0,7795.0 -0.0,-0.0 886.0,0.0 890.2,428.9 6037.9,423.9\" /></svg>"
         }
       },
       "body": {
@@ -6636,11 +8649,11 @@
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "7"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6659,7 +8672,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"478.6,446.3 4887.9,429.6 4919.6,7795.0 476.8,7795.0 478.6,446.3\" /></svg>"
+          "value": "<svg><polygon points=\"4891.1,7295.3 475.1,7313.3 478.5,446.3 4887.9,429.7 4891.1,7295.3\" /></svg>"
         }
       },
       "body": {
@@ -6732,8 +8745,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6752,7 +8765,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5441.9,6290.6 5538.6,7345.6 -0.0,7351.3 -0.0,451.0 4910.2,474.5 5010.5,5373.2 5137.6,5782.1 5441.9,6290.6\" /></svg>"
+          "value": "<svg><polygon points=\"5441.9,6290.6 5538.6,7345.6 -0.0,7351.3 -0.0,451.0 5076.3,473.9 5111.7,5546.4 5264.3,5993.9 5441.9,6290.6\" /></svg>"
         }
       },
       "body": {
@@ -6808,165 +8821,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p82",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5155.2,520.4 5066.8,7077.4 477.1,6988.1 -0.0,5334.9 -0.0,424.1 5155.2,520.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0082/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94986450941857,
-                42.36735709946554
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94642268298534,
-                42.36865603962062
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6335.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94426129603403,
-                42.36552449281823
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94770312246726,
-                42.36422555266316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                487.9,
-                7319.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.94757,
-                42.3645168
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0083/georef",
       "type": "Annotation",
       "@context": [
@@ -6984,8 +8838,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7004,7 +8858,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5711.1,439.9 5671.3,7304.8 3932.5,7277.3 3824.0,7376.0 3819.2,7795.0 -0.0,7795.0 -0.0,410.3 5711.1,439.9\" /></svg>"
+          "value": "<svg><polygon points=\"5673.4,6939.2 -0.0,6911.2 -0.0,1312.6 1277.9,1322.9 1277.9,416.1 5711.1,439.9 5673.4,6939.2\" /></svg>"
         }
       },
       "body": {
@@ -7077,8 +8931,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7097,7 +8951,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5834.9,7340.5 394.3,7354.8 392.8,492.2 5809.8,497.0 5834.9,7340.5\" /></svg>"
+          "value": "<svg><polygon points=\"5915.1,7340.3 394.3,7354.8 392.8,492.2 5839.5,496.9 5915.1,7340.3\" /></svg>"
         }
       },
       "body": {
@@ -7170,8 +9024,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7190,7 +9044,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,861.4 4963.1,846.4 4944.4,6555.1 1641.5,4428.7 -0.0,4366.9 -0.0,861.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4367.6 -0.0,861.5 460.9,860.9 459.9,352.0 4891.7,340.2 4913.9,6691.3 1560.4,4426.3 -0.0,4367.6\" /></svg>"
         }
       },
       "body": {
@@ -7246,99 +9100,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p87",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5726.6,7795.0 1759.4,7795.0 -0.0,6670.5 -0.0,409.4 5594.7,390.6 5726.6,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0087/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5719.1,
-                3543.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.946681,
-                42.363278
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                611.9,
-                399.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.950266,
-                42.363553
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0088/georef",
       "type": "Annotation",
       "@context": [
@@ -7356,8 +9117,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7376,7 +9137,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5639.6,0.0 5641.4,343.6 6335.0,343.6 6335.0,702.2 5643.4,715.7 5644.3,876.2 6335.0,872.6 6335.0,3437.0 5568.8,3437.2 5599.5,7795.0 1184.2,7795.0 1063.8,0.0 5639.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1072.2,817.1 6335.0,872.6 6335.0,3437.0 5596.5,3437.2 5598.9,7795.0 3270.7,7795.0 3271.0,7083.2 1184.8,7079.5 1072.2,817.1\" /></svg>"
         }
       },
       "body": {
@@ -7449,8 +9210,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7469,7 +9230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1969.9,7166.1 1968.7,7795.0 -0.0,7795.0 -0.0,3456.9 739.9,3457.1 741.4,885.9 3894.3,870.9 3897.1,449.0 4005.9,349.1 5817.7,368.4 5807.0,7171.7 1969.9,7166.1\" /></svg>"
+          "value": "<svg><polygon points=\"1969.0,7795.0 -0.0,7795.0 -0.0,3457.6 740.3,3457.6 741.9,886.4 -0.0,878.3 45.2,0.0 5756.9,0.0 5743.3,7171.3 1970.1,7166.4 1969.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7525,192 +9286,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p9",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6447
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6003.1,7221.0 4040.0,7227.8 4051.3,6351.6 276.1,6338.4 360.6,0.0 6099.2,0.0 6003.1,7221.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0009/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2171.7,
-                304.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.963142,
-                42.378373
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6095.1,
-                304.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.961008,
-                42.37916
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p90",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,404.7 5244.2,389.5 5293.7,7145.1 40.9,7172.3 -0.0,404.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0090/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4327.3,
-                5831.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.938051,
-                42.365194
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4327.3,
-                391.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.939505,
-                42.367408
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0091/georef",
       "type": "Annotation",
       "@context": [
@@ -7728,8 +9303,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7748,7 +9323,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7118.9 -0.0,369.6 4999.2,368.0 6335.0,381.6 6335.0,381.6 6255.0,7795.0 1147.1,7795.0 1043.2,7795.0 -0.0,7118.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6991.4 -0.0,369.6 4999.2,368.0 4993.6,603.2 6288.6,590.7 6335.0,381.6 6335.0,7121.2 1166.0,7110.8 1166.5,6989.4 -0.0,6991.4\" /></svg>"
         }
       },
       "body": {
@@ -7821,8 +9396,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7841,7 +9416,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4828.5,0.0 6121.9,677.4 6127.8,0.0 6335.0,0.0 6335.0,7795.0 882.8,7792.7 883.8,687.9 1081.2,0.0 4828.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,0.0 6335.0,7795.0 990.7,7795.0 1005.8,0.0 6335.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7914,8 +9489,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7934,7 +9509,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 727.8,0.0 4245.0,1791.4 6190.1,1601.7 6335.0,3016.1 6335.0,7795.0 -0.0,7795.0 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"728.1,0.0 4275.8,1905.7 5628.2,1756.6 5984.4,5305.2 6335.0,5270.2 6335.0,7795.0 -0.0,7795.0 -0.0,0.0 728.1,0.0\" /></svg>"
         }
       },
       "body": {
@@ -7963,8 +9538,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95333063886339,
-                42.36101499355048
+                -82.95333056430151,
+                42.36101500639521
               ]
             }
           },
@@ -7984,8 +9559,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94607404702856,
-                42.36298107430166
+                -82.94607414190487,
+                42.36298104123928
               ]
             }
           },
@@ -8005,8 +9580,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.94280256353161,
-                42.356378662065765
+                -82.9428027347956,
+                42.356378783166775
               ]
             }
           },
@@ -8026,8 +9601,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -82.95005915536645,
-                42.354412581314584
+                -82.95005915719224,
+                42.35441274832271
               ]
             }
           },
@@ -8073,8 +9648,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8093,7 +9668,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5513.8,7795.0 699.3,7795.0 1146.0,3342.5 1143.5,712.2 5508.5,704.4 5513.8,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"5513.8,7795.0 -0.0,7795.0 -0.0,-0.0 3219.4,0.0 3220.4,708.5 5508.5,704.4 5513.8,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -8166,8 +9741,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8186,7 +9761,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5982.1,7068.5 5982.0,7795.0 162.7,7795.0 163.9,668.3 2178.5,633.9 2178.8,0.0 6046.1,0.0 6123.3,7068.6 5982.1,7068.5\" /></svg>"
+          "value": "<svg><polygon points=\"193.8,636.1 2178.5,633.5 2178.8,0.0 5982.4,0.0 5996.7,7795.0 162.7,7795.0 193.8,636.1\" /></svg>"
         }
       },
       "body": {
@@ -8242,99 +9817,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Detroit, Mich. | 1929 | Vol. 11 p96",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6335
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6335.0,0.0 6335.0,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0096/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2115.7,
-                2911.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.938116,
-                42.363046
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4295.3,
-                2911.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -82.936924,
-                42.363479
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114dm:g03985192911:03985_11_1929-0098/georef",
       "type": "Annotation",
       "@context": [
@@ -8352,8 +9834,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8372,7 +9854,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5911.1,2175.7 6335.0,2173.8 6335.0,7795.0 -0.0,7795.0 -0.0,945.3 5910.9,871.5 5911.1,2175.7\" /></svg>"
+          "value": "<svg><polygon points=\"5910.9,871.5 5911.1,2175.7 5788.8,2175.7 5785.5,7795.0 -0.0,7795.0 -0.0,2178.8 1033.7,2176.9 1031.4,873.1 5910.9,871.5\" /></svg>"
         }
       },
       "body": {
@@ -8445,8 +9927,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:10Z",
-      "modified": "2026-07-18T02:42:10Z",
+      "created": "2026-07-30T22:02:15Z",
+      "modified": "2026-07-30T22:02:15Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8465,7 +9947,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"120.0,1991.7 118.6,0.0 256.9,0.0 261.3,737.3 6335.0,701.2 6335.0,1960.1 120.0,1991.7\" /></svg>"
+          "value": "<svg><polygon points=\"6335.0,7749.3 -0.0,7795.0 -0.0,1991.9 120.0,1991.7 134.2,954.7 6335.0,892.9 6335.0,7749.3\" /></svg>"
         }
       },
       "body": {

--- a/gallery/grand_rapids_mi_1953_vol7.iiif.json
+++ b/gallery/grand_rapids_mi_1953_vol7.iiif.json
@@ -7,6 +7,4852 @@
   "label": "Mosaic of main content, Grand Rapids, Mich. | 1953 | Vol. 7",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6845.4 0.0,0.0 6660.0,0.0 6660.0,7464.5 6499.7,7471.7 6486.6,6729.3 4098.9,6772.0 4126.1,8070.0 723.2,8070.0 686.0,6833.1 -0.0,6845.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6644604,
+                42.9277147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6602161,
+                42.9277332
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6601855,
+                42.9239664
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6644298,
+                42.9239479
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p704",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2304.4,8070.0 2288.2,6330.4 2288.2,6330.4 2048.3,5798.0 824.7,5804.7 852.2,8070.0 -0.0,8070.0 0.0,-0.0 743.9,0.0 759.6,1252.9 4229.2,1314.6 4217.7,0.0 6660.0,0.0 6660.0,751.9 4376.1,812.7 4569.5,8070.0 2304.4,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66446208597398,
+                42.92451902371712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66030105985708,
+                42.92459172508833
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66018157229865,
+                42.92087265635371
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66434259841556,
+                42.920799954982506
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p705",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,2198.8 397.0,2215.7 397.0,2191.6 395.6,322.9 1422.8,348.5 1429.2,2282.0 4466.3,2271.4 4466.3,2271.4 6660.0,2269.5 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66665088921427,
+                42.92179299711838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66247622769983,
+                42.921882669572256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6623288540054,
+                42.91815124901441
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66650351551982,
+                42.91806157656053
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p706",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6358.2,0.0 6378.0,4087.6 6096.8,4070.0 6090.4,7004.7 6384.5,7025.0 6397.7,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66171597994604,
+                42.924192245076306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65753933007673,
+                42.92434739970937
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65728432258858,
+                42.92061443630069
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66146097245789,
+                42.920459281667625
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p707",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6533.1,6112.4 5528.6,6101.7 5507.7,8070.0 605.2,8070.0 602.0,6842.8 -0.0,6842.7 0.0,0.0 6660.0,0.0 6660.0,536.4 6525.4,539.1 6533.1,6112.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6583176486417,
+                42.92746419929678
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65417722403363,
+                42.92761831694946
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65392391432772,
+                42.923917826528985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65806433893577,
+                42.9237637088763
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p708",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"298.4,6896.2 -0.0,6876.3 -0.0,3899.2 285.3,3916.6 264.7,1004.3 5192.1,993.0 5189.5,1301.4 6660.0,1393.3 6660.0,8070.0 4278.6,8070.0 4271.0,6991.9 2562.1,6911.4 2301.3,6822.3 2282.4,6641.3 296.9,6628.8 298.4,6896.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65788006484095,
+                42.92422998530395
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65376223799372,
+                42.92437627546083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65352180538241,
+                42.92069580224756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65763963222965,
+                42.92054951209068
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p709",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5964.5,3256.7 5963.9,4393.3 6543.1,4385.3 6380.1,7279.6 260.1,7297.5 273.3,7005.3 -0.0,7008.4 0.0,0.0 5434.9,-0.0 5466.5,4400.8 5841.9,4395.0 6041.5,1166.0 6660.0,1164.2 6660.0,3256.6 5964.5,3256.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64528633715562,
+                42.92760571518475
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64510665989758,
+                42.924545552549354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65013640120276,
+                42.92438496723762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6503160784608,
+                42.927445129873014
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p710",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6468.4,2693.7 6185.1,2685.2 6183.2,2841.6 6457.8,2844.7 6277.4,5500.3 5660.5,5482.2 5633.0,7317.8 112.3,7301.2 -0.0,7167.4 -0.0,0.0 571.9,-0.0 555.5,289.8 6213.4,339.0 6203.8,1139.0 6573.4,1141.6 6660.0,1713.8 6534.8,1711.9 6468.4,2693.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64966479027876,
+                42.927605434994454
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64943542735917,
+                42.924523140521174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65450109368764,
+                42.924318130729596
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65473045660724,
+                42.927400425202876
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p712",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5114.6,-0.0 5048.1,6898.8 -0.0,6884.1 0.0,0.0 5114.6,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64099825110019,
+                42.927566770966216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64080711303028,
+                42.924516175006644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64582115066054,
+                42.9243453473647
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64601228873045,
+                42.92739594332427
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p713",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5336.2,6937.4 1497.8,7042.3 1458.8,2347.6 -0.0,2268.6 -0.0,0.0 2850.4,0.0 2841.5,621.2 6660.0,823.1 6660.0,2611.6 5524.4,2547.7 5538.7,6658.8 5334.8,6659.7 5336.2,6937.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65468906082093,
+                42.92479419843116
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65053482422009,
+                42.9249162983638
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65033414710189,
+                42.9212033180683
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65448838370273,
+                42.92108121813566
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p715",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4708.0 -0.0,1025.1 621.1,0.0 6660.0,0.0 6660.0,787.8 5895.3,5364.8 5896.5,6209.8 1711.2,5917.3 1717.2,5075.8 -0.0,4708.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64827274165192,
+                42.924991832323066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64407982793853,
+                42.92514793001471
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64382327818727,
+                42.921400317711075
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64801619190067,
+                42.92124422001943
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p716",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 2341.0,8070.0 2334.7,7172.2 -0.0,7021.4 -0.0,635.0 775.7,689.6 776.7,0.0 6660.0,0.0 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64456279228084,
+                42.92508192610229
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64039342828666,
+                42.925241593728245
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64013100569605,
+                42.92151510931384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64430036969023,
+                42.92135544168788
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p717",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5533.9,7643.5 6660.0,7615.0 6660.0,8070.0 -0.0,8070.0 -0.0,1316.6 537.3,1361.8 510.9,0.0 2473.9,0.0 2493.8,178.9 2752.1,265.3 4442.1,334.3 4456.3,1400.0 5375.7,1394.3 5533.9,7643.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65781861657688,
+                42.92120345024951
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65365230237235,
+                42.92133212946535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65344082433549,
+                42.91760813520464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65760713854003,
+                42.9174794559888
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p718",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1875.2 1421.7,1902.3 1457.8,0.0 5251.6,0.0 5075.6,7798.5 6660.0,7834.3 6660.0,8070.0 -0.0,8070.0 -0.0,1875.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6544987013236,
+                42.921535943267784
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65030019930178,
+                42.921744190720936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64995795256472,
+                42.91799144967682
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65415645458654,
+                42.917783202223674
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p719",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,-0.0 5583.1,92.1 5614.2,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65119579870867,
+                42.921827884247485
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64698944781237,
+                42.921966314121605
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6467619425915,
+                42.9182065742023
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65096829348778,
+                42.91806814432818
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p726 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "4736.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "5705.4"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "1924.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "2364.6"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,8070.0 4736.0,8070.0 4736.0,5705.4 6660.0,5705.4 6660.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0726__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4736.0,
+                5705.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66076255673129,
+                42.904687140867566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                5705.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66066453244811,
+                42.90380773569571
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6621287924303,
+                42.903718927338986
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4736.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66222681671347,
+                42.904598332510844
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p810",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1706.6,784.8 3662.3,814.7 3669.4,0.0 4465.7,0.0 4460.0,826.9 4750.3,831.3 4749.8,951.1 5496.8,954.7 5435.2,4342.4 6660.0,4364.7 6660.0,4464.3 5584.8,4394.9 5579.7,7871.0 6660.0,7872.5 6660.0,8070.0 -0.0,8070.0 0.0,-0.0 1718.6,0.0 1706.6,784.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70388246572027,
+                42.934050018135174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69561118250184,
+                42.934370322075424
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6950846836505,
+                42.926978498494016
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70335596686895,
+                42.92665819455377
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p811",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4900.9,0.0 4998.9,8070.0 -0.0,8070.0 -0.0,1342.8 1066.6,1328.6 1057.4,0.0 4900.9,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69702236984851,
+                42.93405986424449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69285301804727,
+                42.93416530916534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69267968838969,
+                42.93043937501035
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69684904019093,
+                42.9303339300895
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p812",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,1245.6 2111.2,1378.7 2110.9,1183.1 3197.0,1201.3 3194.2,1448.8 6660.0,1678.1 6660.0,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69670000828143,
+                42.93087416457513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6924869128498,
+                42.93103278675899
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69222618980655,
+                42.927267486165576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69643928523817,
+                42.92710886398171
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p815",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 6533.9,8070.0 6585.2,6295.6 -0.0,6102.2 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6903961204317,
+                42.9359948624763
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68616829216899,
+                42.936189431243065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.68584845101272,
+                42.93241136154815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69007627927543,
+                42.93221679278138
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p817",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7019014945732,
+                42.937175532910445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6976912887352,
+                42.93729095772033
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.69750154443383,
+                42.93352870812941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.70171175027184,
+                42.933413283319524
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p821",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,758.2 6660.0,8070.0 -0.0,8070.0 0.0,-0.0 4708.3,0.0 4729.6,666.2 6660.0,758.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6687012813034,
+                42.89892347754242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6645742522625,
+                42.8989271712772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6645681839914,
+                42.895236952548814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66869521303232,
+                42.89523325881403
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p822",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2798.1,955.8 6438.3,975.9 6443.7,0.0 6660.0,0.0 6660.0,8070.0 2861.5,8070.0 2798.1,955.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66863809670899,
+                42.8956715297314
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66443234442593,
+                42.89569245674803
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66439796617466,
+                42.891931649498666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66860371845772,
+                42.89191072248204
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p823",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4423.8,6901.1 4491.2,8070.0 -0.0,8070.0 0.0,0.0 6564.5,0.0 6660.0,6819.8 4423.8,6901.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67272094917983,
+                42.8989057610224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66864258932138,
+                42.898787020044416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66883766328165,
+                42.895140314373634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67291602314012,
+                42.895259055351616
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p824",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,949.7 1687.2,1129.7 1684.3,0.0 3918.8,0.0 3904.8,966.5 6660.0,1006.3 6660.0,8070.0 -0.0,8070.0 -0.0,949.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67129572397307,
+                42.89567654302394
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66687746553309,
+                42.89572754488754
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66679368138703,
+                42.89177670743836
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67121193982702,
+                42.89172570557476
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p827",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 6660.0,0.0 6660.0,299.8 5792.3,279.1 5754.1,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67747906541716,
+                42.92796671886238
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67325042173645,
+                42.92792991799349
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67331090871308,
+                42.92415062001421
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67753955239378,
+                42.9241874208831
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p829",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,-0.0 5638.8,106.6 5647.5,2403.6 6660.0,2401.1 6660.0,4294.2 5649.9,4296.7 5663.6,6653.5 3880.6,6641.8 3952.6,8070.0 -0.0,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6738034708917,
+                42.927804009399416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66960154164906,
+                42.927752254351034
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66968660751424,
+                42.92399682169377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67388853675688,
+                42.92404857674215
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p831",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5447.8,0.0 5566.9,1467.1 5705.7,1465.1 5770.5,8070.0 -0.0,8070.0 -0.0,1452.3 3743.3,1427.7 3664.8,0.0 5447.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67373691023644,
+                42.92472273140331
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6695356698518,
+                42.92465064073275
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66965415386771,
+                42.92089563435503
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67385539425236,
+                42.92096772502558
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p832",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5799.4,1236.3 6113.9,8070.0 -0.0,8070.0 -0.0,1260.9 5799.4,1236.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67014846617165,
+                42.92456583368622
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.66594869571207,
+                42.92452416350849
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6660171811723,
+                42.92077040459088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.67021695163187,
+                42.92081207476862
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p835",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5920.8,467.0 6660.0,440.5 6660.0,762.7 6440.3,861.2 6660.0,8070.0 -0.0,8070.0 -0.0,0.0 5903.6,0.0 5920.8,467.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7695942715332,
+                42.9091292382804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76537018615949,
+                42.90920062505002
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76525288847779,
+                42.90542425246298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76947697385148,
+                42.90535286569337
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p836",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1856.4 220.8,1769.8 234.3,1451.9 1022.8,1457.0 4835.0,0.0 6320.3,0.0 6318.9,429.3 6660.0,433.5 6660.0,3890.6 6357.5,3888.4 6363.2,4373.6 6660.0,4374.5 6660.0,5374.5 6390.5,5268.5 6368.2,4797.9 5662.3,4777.4 5577.1,8070.0 -0.0,8070.0 -0.0,1856.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76557489547953,
+                42.90967422242667
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76130397685033,
+                42.9098800714183
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7609657376038,
+                42.90606186071251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76523665623299,
+                42.905856011720886
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p838",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"630.1,4043.5 281.7,4040.3 281.7,3601.7 152.7,3602.1 154.6,2866.2 639.0,2870.3 3061.9,1925.8 3069.4,0.0 6660.0,0.0 6660.0,8070.0 6238.5,8070.0 6259.3,7162.6 639.2,7034.3 630.1,4043.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76183958336365,
+                42.91152967512083
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.757658415402,
+                42.91172178587172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.75734274008573,
+                42.907983930379196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7615239080474,
+                42.90779181962831
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p839",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1486.0 727.7,1488.2 763.2,1972.5 1043.7,2074.5 1017.0,1044.3 711.2,1051.3 692.4,551.6 1004.1,545.9 990.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1486.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76178001290509,
+                42.90827206705503
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.75762982466586,
+                42.90839267143202
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.75743165885035,
+                42.90468231207423
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.76158184708959,
+                42.90456170769725
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p841 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3712.2,0.0 3715.6,666.4 5466.4,730.1 5461.8,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 3712.2,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72624061768371,
+                42.91995298751354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.7178810954617,
+                42.92004808753656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.71772481272153,
+                42.91257560498814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72608433494354,
+                42.912480504965124
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p842",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4572.9,8070.0 -0.0,8070.0 0.0,0.0 305.1,-0.0 643.6,310.4 1837.8,292.5 1829.4,831.1 4369.6,747.8 4572.9,8070.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72107501440277,
+                42.92203583327511
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72112679432051,
+                42.918935500730846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72622211685173,
+                42.918981782697344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.72617033693399,
+                42.92208211524161
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0701/georef",
       "type": "Annotation",
       "@context": [
@@ -24,8 +4870,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +4890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1947.9,0.0 4321.5,0.0 4321.9,356.4 5029.9,351.3 5111.1,1782.6 4323.6,1796.2 4328.1,5744.7 4475.0,8070.0 1423.8,8070.0 990.1,263.8 1964.7,331.6 1947.9,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"1964.7,332.1 1947.9,0.0 4494.8,0.0 4721.4,8070.0 3476.7,8070.0 3396.3,6845.9 2384.8,6904.3 2448.0,8070.0 1423.8,8070.0 990.1,264.4 1964.7,332.1\" /></svg>"
         }
       },
       "body": {
@@ -117,8 +4963,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +4983,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1203.5,1092.7 4065.1,1257.9 4022.4,2011.8 4398.4,2033.1 4536.0,8043.9 5227.3,8028.1 5223.4,6259.4 6660.0,6341.8 6660.0,8070.0 2221.8,8070.0 2222.9,6143.7 1206.5,6114.6 1203.5,1092.7\" /></svg>"
+          "value": "<svg><polygon points=\"1206.2,6114.6 1203.2,1093.1 2215.7,0.0 2442.6,0.0 3214.9,0.0 4449.9,1280.5 6660.0,6341.8 6660.0,8070.0 5227.6,8070.0 3650.6,8070.0 2221.6,8070.0 1206.2,6114.6\" /></svg>"
         }
       },
       "body": {
@@ -193,1095 +5039,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p703",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"694.2,1853.6 624.0,591.9 -0.0,595.7 0.0,-0.0 6660.0,0.0 6660.0,6506.3 6003.4,6533.1 5960.9,5999.4 4005.0,6155.1 4034.8,7074.4 4328.2,8070.0 1055.6,8070.0 955.6,6397.7 208.3,6457.1 336.6,8070.0 -0.0,8070.0 -0.0,7394.9 127.1,7395.1 -0.0,5432.8 -0.0,1864.8 694.2,1853.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0703/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2412.0,
-                591.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.662865,
-                42.927449
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                624.0,
-                591.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.664131,
-                42.927471
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p704",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 6660.0,0.0 6660.0,617.8 4342.5,8070.0 -0.0,8070.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0704/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5104.0,
-                4618.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.661237,
-                42.922483
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4628.0,
-                2351.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.661605,
-                42.92349
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p705",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,2185.4 429.6,2220.0 425.9,354.4 1444.6,378.2 1453.4,2308.6 6660.0,2189.6 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0705/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2288.0,
-                5726.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665126,
-                42.9191848
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2456.0,
-                399.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665113,
-                42.921653
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p706",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 6096.0,0.0 6139.5,1221.9 6660.0,1237.1 6660.0,6657.9 6340.5,6670.9 6348.9,6901.8 5999.8,6889.4 5994.2,6685.0 5762.7,6694.4 5818.6,8070.0 -0.0,8070.0 -0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0706/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4492.0,
-                6838.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6586894,
-                42.9211064
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                596.0,
-                3863.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.661237,
-                42.922483
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p707",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,5746.6 5800.1,5775.7 5877.9,8070.0 1084.5,8070.0 1014.8,6874.6 -0.0,6897.5 0.0,0.0 5553.0,50.8 5566.9,449.8 6394.6,453.4 6660.0,5746.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0707/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2568.0,
-                431.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.656707,
-                42.927389
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                640.0,
-                431.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.657948,
-                42.927394
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p708",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 4305.3,8070.0 4293.8,6936.6 2601.5,6862.8 2343.0,6775.0 2326.7,6562.6 688.0,6613.5 842.1,1018.0 6660.0,1348.1 6660.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0708/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4268.0,
-                1203.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.655207,
-                42.923758
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                360.0,
-                6854.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6574901,
-                42.9210914
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p709",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6535.6,4378.1 6380.6,7200.2 374.1,7224.9 392.5,6803.8 -0.0,6798.9 0.0,0.0 2661.4,-0.0 2626.0,565.3 4478.2,561.3 4426.2,1402.2 5267.4,1451.8 5292.0,4397.6 6535.6,4378.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0709/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2384.0,
-                4418.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.64798,
-                42.926454
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                500.0,
-                4418.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6480304,
-                42.927337
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p710",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6258.4,2607.5 6260.5,2759.9 6529.6,2756.2 6420.0,5342.7 5712.3,5340.0 5710.6,7165.2 430.0,7246.2 397.8,8070.0 -0.0,8070.0 0.0,0.0 699.9,-0.0 686.8,417.1 6227.0,325.2 6237.7,1103.4 6599.8,1096.8 6660.0,1497.2 6536.1,2608.7 6258.4,2607.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0710/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6420.0,
-                5342.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6529012,
-                42.9245605
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                432.0,
-                7246.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.654244,
-                42.927368
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p711",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"624.7,6378.8 -0.0,6331.6 11.2,-0.0 6660.0,0.0 6660.0,721.6 6263.8,692.4 6277.5,2559.0 6660.0,2592.0 6660.0,8070.0 -0.0,8070.0 -0.0,6648.7 617.4,6664.5 624.7,6378.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0711/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5332.0,
-                2335.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.634793,
-                42.925639
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6276.0,
-                2335.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.633643,
-                42.925687
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p712",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,2869.4 6660.0,8070.0 4568.8,8070.0 4216.7,8070.0 -0.0,6900.0 -0.0,3013.2 -0.0,821.4 2368.0,-0.0 4234.8,-0.0 6660.0,471.7 6660.0,2869.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0712/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2368.0,
-                3495.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.643079,
-                42.92638
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2364.0,
-                351.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.641088,
-                42.926355
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p713",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1484.5,7057.7 1409.9,2454.6 -0.0,2394.6 0.0,0.0 2737.4,0.0 2735.2,722.7 6660.0,885.5 6660.0,2661.9 5400.8,2605.5 5459.2,6609.1 5160.9,6619.0 5170.4,6903.8 1484.5,7057.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0713/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65464554050445,
-                42.924859391118964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65042981436704,
-                42.92494687598149
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65028490101578,
-                42.92120826091182
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.65450062715318,
-                42.92112077604929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                968.0,
-                2439.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.653989,
-                42.923742
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0714/georef",
       "type": "Annotation",
       "@context": [
@@ -1299,8 +5056,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1319,7 +5076,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6339.8,4669.6 6660.0,4734.7 6660.0,6481.5 -0.0,6242.1 0.0,-0.0 6660.0,0.0 6659.0,3967.5 6339.8,4669.6\" /></svg>"
+          "value": "<svg><polygon points=\"6340.8,4667.6 6660.0,4733.9 6660.0,6481.5 -0.0,6324.5 0.0,-0.0 6660.0,0.0 6659.2,3967.6 6340.8,4667.6\" /></svg>"
         }
       },
       "body": {
@@ -1375,471 +5132,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p715",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,4946.8 -0.0,1223.7 675.4,0.0 6660.0,0.0 6660.0,977.5 5986.2,5611.1 5953.8,7327.9 1765.2,7028.0 1777.5,5321.5 -0.0,4946.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0715/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                680.0,
-                567.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.647868,
-                42.924834
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                680.0,
-                6950.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.647667,
-                42.921901
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p716",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "21"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7185.0 -0.0,641.8 2457.2,765.0 6660.0,1315.7 6660.0,1639.3 6660.0,3350.7 6660.0,7503.2 6660.0,8070.0 2425.0,8070.0 -0.0,7185.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0716/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2472.0,
-                7294.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.642826,
-                42.9218255
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5688.0,
-                1263.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.640966,
-                42.924587
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p717",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 0.0,-0.0 236.5,0.0 233.8,208.7 589.3,235.8 590.2,0.0 2533.6,0.0 2550.1,181.0 2804.4,271.1 4476.0,365.9 4472.8,1486.2 5317.5,1497.2 5392.7,7586.4 6660.0,7570.7 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0717/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.0,
-                4071.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.656222,
-                42.9193653
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4476.0,
-                367.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.655031,
-                42.921135
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p718",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1996.5 1478.1,2034.0 1529.9,0.0 5213.4,0.0 5146.8,7848.5 6660.0,7861.3 6660.0,8070.0 -0.0,8070.0 -0.0,1996.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0718/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2976.0,
-                3287.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6525184,
-                42.9201334
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1000.0,
-                6698.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.653617,
-                42.918487
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p719",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,0.0 2502.2,0.0 5616.0,259.9 5511.9,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0719/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1708.0,
-                3867.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6500182,
-                42.9201024
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5616.0,
-                259.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.647667,
-                42.921901
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0720/georef",
       "type": "Annotation",
       "@context": [
@@ -1857,8 +5149,8 @@
           "value": "25"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1877,7 +5169,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 -0.0,8070.0 -0.0,4483.2 657.3,4429.7 385.8,432.2 4238.3,439.0 4268.3,822.6 5752.6,746.9 5859.0,2134.8 6660.0,2073.4 6660.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4540.1 661.9,4497.4 386.2,430.0 934.4,431.0 907.4,0.0 3030.0,0.0 3060.9,434.9 4238.7,437.0 4274.2,890.5 6441.6,734.8 6389.3,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,4540.1\" /></svg>"
         }
       },
       "body": {
@@ -1966,8 +5258,8 @@
           "value": "4848.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1986,7 +5278,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,7212.9 4901.1,7377.8 4896.4,7001.6 4707.6,7017.9 4707.6,3222.0 6660.0,3222.0 6660.0,7212.9\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,8070.0 4707.6,8070.0 4707.6,3222.0 6660.0,3222.0 6660.0,8070.0\" /></svg>"
         }
       },
       "body": {
@@ -2042,6 +5334,181 @@
       }
     },
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p722 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "6660.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8070.0"
+        }
+      ],
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722",
+          "type": "ImageService2",
+          "height": 8070,
+          "width": 6660
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6660.0,6886.7 1541.5,6967.7 1538.1,8070.0 -0.0,8070.0 -0.0,120.5 230.8,130.0 236.1,-0.0 6660.0,-0.0 6660.0,6886.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0722__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6481755524638,
+                42.91515322890007
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.64799259251292,
+                42.908982767827105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6660.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65821358580342,
+                42.90882051420645
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8070.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.6583965457543,
+                42.914990975279416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2416.0,
+                4518.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -85.65383,
+                42.912824
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0724__1/georef",
       "type": "Annotation",
       "@context": [
@@ -2075,8 +5542,8 @@
           "value": "3994.2"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2095,7 +5562,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5062.9,3994.2 -0.0,3994.2 -0.0,0.0 6660.0,-0.0 6660.0,526.8 5062.9,3994.2\" /></svg>"
+          "value": "<svg><polygon points=\"5062.3,3994.2 -0.0,3994.2 0.0,0.0 6660.0,-0.0 6660.0,526.8 5062.3,3994.2\" /></svg>"
         }
       },
       "body": {
@@ -2184,8 +5651,8 @@
           "value": "4077.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2204,7 +5671,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5479.1,7245.0 3894.6,7316.2 3909.1,7675.8 6660.0,7564.9 6660.0,8070.0 -0.0,8070.0 -0.0,4227.5 3192.9,4088.8 3196.4,3993.0 5578.0,3993.0 5479.1,7245.0\" /></svg>"
+          "value": "<svg><polygon points=\"5479.0,7244.9 3894.5,7316.2 3909.0,7675.6 6660.0,7564.6 6660.0,8070.0 -0.0,8070.0 -0.0,4227.6 3192.8,4088.8 3196.3,3993.0 4380.1,3993.0 4431.8,4565.5 5404.1,4479.0 5360.3,3993.0 5577.6,3993.0 5479.0,7244.9\" /></svg>"
         }
       },
       "body": {
@@ -2293,8 +5760,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2313,7 +5780,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2818.4,5856.6 2291.7,5837.6 2251.4,3331.1 2082.5,3244.6 1063.1,3198.1 1001.6,2482.5 -0.0,1469.5 -0.0,541.2 2728.6,671.9 2719.0,117.4 -0.0,164.5 -0.0,-0.0 6660.0,0.0 6660.0,6871.6 6323.6,6872.4 6336.7,8070.0 5333.3,8070.0 5306.0,6634.0 2833.9,6753.2 2818.4,5856.6\" /></svg>"
+          "value": "<svg><polygon points=\"2818.2,5856.6 2291.6,5837.7 2251.5,3331.0 2082.6,3244.6 1063.3,3198.0 1001.8,2482.4 -0.0,1469.1 -0.0,541.1 2728.3,671.9 2718.7,117.0 -0.0,164.2 -0.0,-0.0 6199.0,0.0 6296.3,5132.0 6660.0,5130.9 6660.0,6871.8 6323.1,6872.6 6336.0,8070.0 5332.8,8070.0 5305.6,6634.2 2833.8,6753.2 2818.2,5856.6\" /></svg>"
         }
       },
       "body": {
@@ -2402,8 +5869,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2422,7 +5889,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7097.2 -0.0,1040.1 2898.1,1145.8 2962.2,-0.0 6660.0,-0.0 6660.0,7303.8 3338.8,7031.9 3316.3,7220.0 -0.0,7097.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7097.2 -0.0,1040.6 2897.8,1146.2 2961.8,-0.0 6660.0,-0.0 6660.0,6000.8 5658.5,6007.8 5668.5,7223.0 3338.8,7032.1 3316.3,7220.0 -0.0,7097.2\" /></svg>"
         }
       },
       "body": {
@@ -2495,8 +5962,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2515,7 +5982,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,8070.0 6270.8,8070.0 6163.6,6066.5 2437.8,6265.9 2439.9,5397.0 -0.0,5402.5 -0.0,0.0 6660.0,-0.0 6660.0,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,5561.2 -0.0,5402.5 0.0,0.0 6660.0,-0.0 6660.0,5561.2\" /></svg>"
         }
       },
       "body": {
@@ -2604,8 +6071,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2624,7 +6091,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1549.9,7296.1 1544.6,8070.0 927.5,8070.0 925.1,7236.5 -0.0,7163.2 -0.0,0.0 360.2,0.0 367.5,1586.3 3616.0,1816.1 3643.9,1122.9 3891.6,1112.7 3891.6,6670.9 3725.1,6669.8 3726.6,7428.5 1549.9,7296.1\" /></svg>"
+          "value": "<svg><polygon points=\"1549.9,7296.1 1544.6,8070.0 941.4,8070.0 967.8,7240.6 -0.0,7163.2 -0.0,0.0 360.1,0.0 367.4,1586.3 3615.7,1816.1 3624.5,1598.9 3891.6,1585.7 3891.6,7427.9 1549.9,7296.1\" /></svg>"
         }
       },
       "body": {
@@ -2713,8 +6180,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2733,7 +6200,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3814.8,8070.0 3814.8,7529.0 5622.3,7586.6 5746.0,3693.0 3814.8,3631.5 3814.8,612.7 5893.5,715.5 5887.1,0.0 6660.0,0.0 6660.0,8070.0 3814.8,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"3814.8,612.7 6051.0,723.3 6046.1,0.0 6660.0,0.0 6660.0,8070.0 3814.8,8070.0 3814.8,612.7\" /></svg>"
         }
       },
       "body": {
@@ -2789,99 +6256,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p729 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"606.6,7542.9 339.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,7538.5 606.6,7542.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0729/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3200.0,
-                2731.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.663421,
-                42.894445
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                592.0,
-                6690.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66506,
-                42.8926442
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0809/georef",
       "type": "Annotation",
       "@context": [
@@ -2899,8 +6273,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2919,7 +6293,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1705.3,8070.0 -0.0,8070.0 0.0,0.0 3962.2,0.0 3970.3,697.3 4773.6,727.8 4782.9,1767.9 5788.3,1759.0 5809.0,7672.8 6660.0,7669.8 6660.0,8070.0 5625.1,8070.0 5675.2,6415.4 3559.9,6351.4 1705.3,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 3961.4,0.0 3969.5,696.5 4772.7,726.8 4782.3,1767.2 5839.1,1757.5 5903.5,7617.2 6660.0,7608.4 6660.0,8070.0 -0.0,8070.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2975,285 +6349,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p810",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "15"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"856.4,1357.0 853.2,2277.8 1294.7,2275.4 1282.1,0.0 1718.5,0.0 1716.0,794.4 3610.9,800.5 3611.9,0.0 4388.0,0.0 4388.5,803.0 4671.2,803.9 4671.8,993.6 5310.6,991.8 5323.5,4404.0 5550.2,4403.1 5551.7,7758.7 6660.0,7758.2 6660.0,8070.0 -0.0,8070.0 0.0,0.0 520.8,0.0 531.8,1339.3 856.4,1357.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0810/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3856.0,
-                6682.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6986358,
-                42.9280609
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2072.0,
-                1427.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.70121,
-                42.932893
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p811",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1290.7 1218.5,1291.9 1228.4,0.0 4977.6,0.0 4967.6,1610.7 3577.1,2313.9 3574.6,2579.8 4962.1,1892.6 4957.7,8070.0 -0.0,8070.0 -0.0,1290.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0811/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4960.0,
-                4382.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.69383,
-                42.932096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4960.0,
-                6334.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.693769,
-                42.931178
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p812",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1124.5 4647.4,1180.0 4648.0,1395.7 6660.0,1519.5 6660.0,8070.0 -0.0,8070.0 -0.0,1124.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0812/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3080.0,
-                6278.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.694549,
-                42.928007
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4648.0,
-                1395.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.69371,
-                42.930265
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0813/georef",
       "type": "Annotation",
       "@context": [
@@ -3271,8 +6366,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3291,7 +6386,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1309.2,668.2 301.5,633.1 282.9,0.0 3234.6,0.0 3240.8,425.1 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,3981.0 1396.5,3943.8 1309.2,668.2\" /></svg>"
+          "value": "<svg><polygon points=\"301.2,632.9 283.1,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,3987.6 1431.7,3940.9 1406.7,3160.1 301.2,632.9\" /></svg>"
         }
       },
       "body": {
@@ -3364,8 +6459,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3384,7 +6479,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"676.6,3338.4 -0.0,3681.6 -0.0,3551.3 678.0,3200.3 675.1,2389.6 -0.0,2417.4 -0.0,1826.6 668.0,1867.5 650.6,886.3 435.1,70.1 545.0,0.0 6660.0,0.0 6660.0,618.1 6267.7,618.2 5929.3,736.6 5929.3,618.4 3577.0,619.4 3578.3,3584.3 3516.0,3583.9 3502.1,5923.6 698.7,5866.1 676.6,3338.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6431.3 -0.0,-0.0 6660.0,0.0 6660.0,8070.0 2108.8,8070.0 -0.0,6431.3\" /></svg>"
         }
       },
       "body": {
@@ -3440,99 +6535,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p815",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6253.1 0.0,-0.0 4961.0,0.0 4960.9,249.3 5674.7,0.0 6660.0,0.0 6646.9,6295.5 -0.0,6253.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0815/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5764.0,
-                5998.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.686522,
-                42.93336
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5764.0,
-                7478.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6864856,
-                42.9326869
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0816/georef",
       "type": "Annotation",
       "@context": [
@@ -3550,8 +6552,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3570,7 +6572,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -3626,99 +6628,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p817",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,16.0 1413.0,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,16.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0817/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3628.0,
-                168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.699625,
-                42.93718
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                684.0,
-                3747.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.701383,
-                42.9354749
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0818/georef",
       "type": "Annotation",
       "@context": [
@@ -3736,8 +6645,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3756,7 +6665,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,38.9 2557.0,0.0 6660.0,0.0 6660.0,1856.7 6240.5,5665.0 4867.5,6775.7 2487.9,8070.0 -0.0,8070.0 -0.0,38.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,37.6 2558.1,0.0 6660.0,0.0 6660.0,1858.1 6238.5,5666.2 4865.6,6796.8 2486.7,8070.0 -0.0,8070.0 -0.0,931.7 -0.0,37.6\" /></svg>"
         }
       },
       "body": {
@@ -3829,8 +6738,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3849,7 +6758,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2604.2,8070.0 2604.1,7041.2 1809.8,7004.0 1807.9,6314.2 -0.0,6298.3 -0.0,-0.0 6660.0,0.0 6660.0,2561.7 5375.3,2558.7 5367.3,3489.1 6065.1,3526.9 6053.6,4442.8 5359.5,4405.7 5347.8,5772.6 4906.7,5770.3 4907.2,8070.0 4460.9,8070.0 4469.1,7139.5 4141.1,7119.8 4137.3,5766.2 3610.9,5763.4 3598.6,8070.0 2604.2,8070.0\" /></svg>"
+          "value": "<svg><polygon points=\"2604.5,7041.1 1810.6,7003.9 1808.8,6315.0 -0.0,6298.5 0.0,-0.0 6660.0,0.0 6660.0,2581.8 6079.0,2574.4 6078.5,2598.9 5382.1,2565.4 5369.7,3489.4 6064.3,3527.0 6052.7,4443.0 5357.5,4404.9 5338.0,5857.5 3645.6,5861.8 3649.6,8070.0 2604.5,8070.0 2604.5,7041.1\" /></svg>"
         }
       },
       "body": {
@@ -3905,444 +6814,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p821",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4843.0,646.1 6660.0,795.5 6660.0,7073.6 5531.0,7012.0 5538.2,8070.0 -0.0,8070.0 -0.0,-0.0 4844.9,0.0 4843.0,646.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0821/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5524.0,
-                5638.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66523,
-                42.8963374
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5524.0,
-                683.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6653419,
-                42.8986154
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p822",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5429.5,922.6 5671.7,7379.6 5068.3,7377.7 5070.5,7906.3 6660.0,7899.8 6660.0,8070.0 3052.6,8070.0 3040.1,5445.6 -0.0,5450.2 -0.0,1170.9 5429.5,922.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0822/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5492.0,
-                2551.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.665137,
-                42.8944719
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2160.0,
-                5450.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.667242,
-                42.893156
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p823",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,6696.2 4396.8,6643.9 4396.6,8070.0 -0.0,8070.0 -0.0,0.0 6660.0,0.0 6660.0,6696.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0823/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.67303996375303,
-                42.89879714656288
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66882323451921,
-                42.89885304867924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6660.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.66873063606513,
-                42.8951135440377
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8070.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.67294736529895,
-                42.89505764192133
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4364.0,
-                359.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6702728,
-                42.898667
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p824",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,1341.6 1617.9,1304.2 1587.9,0.0 3769.2,0.0 3819.5,1226.9 3923.9,1222.6 3905.5,5099.9 6660.0,5108.8 6660.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0824/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3680.0,
-                5098.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.668751,
-                42.893167
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1700.0,
-                5098.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.67012,
-                42.893172
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0825/georef",
       "type": "Annotation",
       "@context": [
@@ -4360,8 +6831,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4380,7 +6851,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 6660.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,0.0 6660.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -4436,208 +6907,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p826 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "1639.2"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5020.8"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8070.0"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1639.2,1179.5 2434.0,775.8 2414.5,199.2 1639.2,225.4 1639.2,0.0 4869.7,0.0 4868.4,118.2 6660.0,0.0 6660.0,579.1 4785.2,7428.0 4777.9,8070.0 2680.2,8070.0 2658.2,7418.9 1639.2,3810.0 1639.2,1179.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0826__2/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3885.8,
-                3839.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.678129,
-                42.926201
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2338.8,
-                3839.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.679111,
-                42.926211
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p827",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6453.3,1504.6 5632.0,3848.2 5863.4,8070.0 5007.1,8070.0 5011.3,7141.2 1929.5,7127.3 1925.2,8070.0 -0.0,8070.0 0.0,0.0 6660.0,0.0 6453.3,1504.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0827/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4660.0,
-                3859.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.674567,
-                42.926132
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                844.0,
-                3859.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.676997,
-                42.926177
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0828/georef",
       "type": "Annotation",
       "@context": [
@@ -4655,8 +6924,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4675,7 +6944,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"2148.0,279.9 -0.0,404.8 -0.0,0.0 2148.0,279.9\" /></svg>"
         }
       },
       "body": {
@@ -4731,99 +7000,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p829",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3757.7,8070.0 -0.0,8070.0 20.4,1161.8 940.2,1225.1 939.8,302.7 -0.0,250.4 -0.0,-0.0 6660.0,0.0 6660.0,380.3 5753.3,339.2 5468.3,6623.5 3756.1,6545.3 3757.7,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0829/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3744.0,
-                4302.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.67148,
-                42.925773
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3744.0,
-                451.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.671562,
-                42.927625
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0830/georef",
       "type": "Annotation",
       "@context": [
@@ -4841,8 +7017,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4861,7 +7037,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 6660.0,0.0 6623.0,335.2 5664.7,257.0 6002.5,7997.6 -0.0,8019.6 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,2297.9 -0.0,-0.0 6660.0,0.0 6623.4,335.7 5665.1,257.5 6002.4,7997.5 -0.0,8019.1 -0.0,4191.9 999.3,4192.4 1006.4,2299.5 -0.0,2297.9\" /></svg>"
         }
       },
       "body": {
@@ -4917,471 +7093,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p831",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5388.7,0.0 5787.1,8070.0 -0.0,8070.0 -0.0,1719.2 3714.6,1549.4 3645.2,0.0 5388.7,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0831/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                804.0,
-                383.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.673263,
-                42.924532
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3872.0,
-                5070.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.671324,
-                42.922295
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p832",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5938.0,1251.7 5931.3,8070.0 -0.0,8070.0 -0.0,998.9 5938.0,1251.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0832/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5936.0,
-                6238.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.666397,
-                42.921649
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5936.0,
-                1251.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.6665019,
-                42.9239545
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p834 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "13"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8070.0 -0.0,542.2 559.3,1043.4 762.7,1104.2 4579.1,1183.0 4649.9,-0.0 6660.0,-0.0 6660.0,7165.1 5326.8,7149.5 5316.0,8070.0 -0.0,8070.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0834/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2576.0,
-                3703.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.713678,
-                42.922711
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2340.0,
-                7430.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.718364,
-                42.922819
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p835",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5789.3,420.2 6660.0,353.9 6660.0,631.8 6317.5,803.0 6582.0,3701.8 6582.3,3701.8 6660.0,8070.0 -0.0,8070.0 -0.0,-0.0 5757.2,0.0 5789.3,420.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0835/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                652.0,
-                5686.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.769131,
-                42.906578
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2708.0,
-                5686.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.767833,
-                42.906562
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p836",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1666.2 360.5,1527.5 386.1,1247.8 1065.0,1257.9 4447.7,0.0 6527.0,0.0 6524.0,239.2 6660.0,241.9 6660.0,3238.0 6539.6,3233.6 6530.2,3822.8 6531.4,4321.8 6660.0,4325.9 6660.0,5316.4 6550.8,5252.9 6532.4,4765.1 5761.9,4736.1 5639.5,8070.0 -0.0,8070.0 -0.0,1666.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0836/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3752.0,
-                7290.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7629051,
-                42.9063545
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1928.0,
-                7074.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.7640512,
-                42.9063906
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0837__1/georef",
       "type": "Annotation",
       "@context": [
@@ -5415,8 +7126,8 @@
           "value": "8070.0"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5435,7 +7146,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4324.5,5838.6 4328.0,6986.5 1513.2,8070.0 -0.0,8070.0 0.0,-0.0 6660.0,0.0 6660.0,2344.6 4328.0,2327.4 4341.0,1046.2 3616.3,1042.5 3591.7,5834.8 4324.5,5838.6\" /></svg>"
+          "value": "<svg><polygon points=\"4328.0,6986.5 1513.8,8070.0 -0.0,8070.0 -0.0,0.0 6660.0,0.0 6660.0,2344.5 4328.0,2327.4 4341.0,1046.1 3616.5,1042.4 3591.8,5835.3 6660.0,5851.0 6660.0,6574.0 5305.5,6582.8 4328.0,6967.9 4328.0,6986.5\" /></svg>"
         }
       },
       "body": {
@@ -5491,192 +7202,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p838",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"326.1,3895.1 -0.0,3905.3 -0.0,2979.8 657.6,2972.4 2996.8,2000.7 2968.1,0.0 6660.0,0.0 6660.0,8070.0 6292.5,8070.0 6298.0,7050.0 552.7,7019.1 462.0,4124.8 330.5,4126.2 326.1,3895.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0838/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2992.0,
-                6014.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.759734,
-                42.908827
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5452.0,
-                2135.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.758253,
-                42.910712
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p839",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1501.4 756.6,1502.1 792.2,1979.7 901.6,2038.2 708.5,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 -0.0,1501.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0839/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3416.0,
-                4330.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.759531,
-                42.906329
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5792.0,
-                499.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.758111,
-                42.908156
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0840/georef",
       "type": "Annotation",
       "@context": [
@@ -5694,8 +7219,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5714,7 +7239,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3980.8,4333.9 3962.8,4187.4 -0.0,4120.0 0.0,-0.0 6660.0,0.0 6660.0,1052.9 5524.3,1060.5 5559.4,6339.0 5292.1,6337.6 5289.5,7097.9 3550.8,7017.5 3560.1,5073.1 3828.9,5087.4 3842.4,4487.1 3980.8,4333.9\" /></svg>"
+          "value": "<svg><polygon points=\"3842.2,4487.1 4003.6,4322.8 4009.3,4169.5 -0.0,4019.0 -0.0,0.0 6660.0,0.0 6660.0,8070.0 6465.8,8070.0 6482.4,6379.1 5292.0,6367.7 5289.5,7097.9 3550.6,7017.5 3559.9,5073.1 3828.7,5087.4 3842.2,4487.1\" /></svg>"
         }
       },
       "body": {
@@ -5770,192 +7295,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p841 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "12"
-        },
-        {
-          "label": "intersections",
-          "value": "35"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 1008.6,0.0 1016.0,886.1 1961.6,927.8 1960.0,1143.5 4083.9,1168.8 4089.5,708.4 5472.6,764.6 5471.4,0.0 6660.0,0.0 6660.0,8070.0 -0.0,8070.0 0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0841/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2884.0,
-                3875.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.722539,
-                42.916444
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2884.0,
-                5066.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.722509,
-                42.915347
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Grand Rapids, Mich. | 1953 | Vol. 7 p842",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "20"
-        }
-      ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842",
-          "type": "ImageService2",
-          "height": 8070,
-          "width": 6660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6167.0,6149.1 4392.3,6185.3 4414.8,8070.0 -0.0,8070.0 -0.0,-0.0 318.8,-0.0 607.7,232.2 1817.4,238.8 1797.8,780.4 5714.7,732.4 5737.5,-0.0 6660.0,-0.0 6660.0,4263.0 6228.0,4254.9 6167.0,6149.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0842/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6228.0,
-                4254.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.723772,
-                42.91914
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1732.0,
-                2459.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -85.722668,
-                42.921213
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd411m:g4114m:g4114gm:g04023195307:04023_07_1953-0843/georef",
       "type": "Annotation",
       "@context": [
@@ -5973,8 +7312,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5993,7 +7332,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2365.5,7442.8 1172.0,7396.2 1153.7,3616.9 1229.0,3344.9 1722.3,2771.2 -0.0,2806.8 0.0,0.0 969.3,0.0 1024.6,1829.6 2731.8,1778.0 4539.0,0.0 6660.0,0.0 6660.0,8070.0 2378.4,8070.0 2365.5,7442.8\" /></svg>"
+          "value": "<svg><polygon points=\"6660.0,1658.6 6660.0,8070.0 -0.0,8070.0 0.0,-0.0 968.2,0.0 1023.1,1827.9 6660.0,1658.6\" /></svg>"
         }
       },
       "body": {
@@ -6082,8 +7421,8 @@
           "value": "5072.7"
         }
       ],
-      "created": "2026-07-18T02:33:07Z",
-      "modified": "2026-07-18T02:33:07Z",
+      "created": "2026-07-30T22:18:39Z",
+      "modified": "2026-07-30T22:18:39Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6102,7 +7441,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3227.5,1360.0 3220.5,0.0 6660.0,0.0 6660.0,1951.1 6234.5,1946.3 6241.1,4069.5 3748.4,5072.7 -0.0,5072.7 0.0,-0.0 766.8,0.0 760.0,1356.2 3227.5,1360.0\" /></svg>"
+          "value": "<svg><polygon points=\"3227.9,1360.0 3220.9,0.0 6660.0,0.0 6660.0,2063.0 6233.4,2066.7 6241.1,4069.2 3747.2,5072.7 -0.0,5072.7 -0.0,0.0 766.8,0.0 760.0,1356.2 3227.9,1360.0\" /></svg>"
         }
       },
       "body": {

--- a/gallery/hudson_co_nj_1950_vol_9.iiif.json
+++ b/gallery/hudson_co_nj_1950_vol_9.iiif.json
@@ -7,6 +7,144 @@
   "label": "Mosaic of main content, Hudson Co., N.J. | 1950 | Vol. 9",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p10",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,4772.5 -0.0,0.0 2165.1,0.0 2172.1,1374.8 5714.0,1428.6 5714.0,5384.6 5270.6,5344.6 5315.7,7251.0 2157.2,6373.2 2161.4,4979.1 0.0,4772.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0010/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09463343931091,
+                40.71363404625721
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09267552619345,
+                40.71577662152983
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08866961592732,
+                40.71364367370425
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09062752904478,
+                40.71150109843164
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/georef",
       "type": "Annotation",
       "@context": [
@@ -17,15 +155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "9"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,34 +182,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8149.0 0.0,-0.0 5696.0,0.0 5696.0,8149.0 -0.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"3459.5,1893.8 3243.1,0.0 5696.0,0.0 5611.9,5074.0 1206.6,5193.2 1245.1,1526.7 3459.5,1893.8\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3528.0,
-                1960.2
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.089248,
-                40.7137296
+                -74.09145205067841,
+                40.71307553405375
               ]
             }
           },
@@ -79,20 +220,5858 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1924.0,
-                1668.2
+                5696.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0899757,
-                40.7132465
+                -74.08925388957918,
+                40.71507087174724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08551468207078,
+                40.7126706109224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08771284317,
+                40.710675273228915
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0012/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p12",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0012/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0012/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5714.0,8150.0 4618.6,8150.0 4638.9,6328.9 2005.5,6469.1 1013.1,6764.0 1242.0,0.0 5714.0,0.0 5714.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0012/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08906354473629,
+                40.711527264970115
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0869581316361,
+                40.713546879744726
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0831822346655,
+                40.711253174176626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0852876477657,
+                40.709233559402016
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0013/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p13",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0013/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0013/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5696
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"984.6,723.4 990.5,175.5 -0.0,164.8 0.0,-0.0 4216.9,0.0 4348.4,1419.4 5379.3,1642.0 5348.7,5977.0 2221.9,5980.5 2198.9,6998.0 257.6,7028.8 309.6,590.6 984.6,723.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0013/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09304619059455,
+                40.71170366302793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09088407373824,
+                40.71364571065078
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5696.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08724479380155,
+                40.711284766823226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08940691065784,
+                40.70934271920038
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0014/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p14",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0014/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0014/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4283.6,8150.0 411.1,8150.0 422.0,7195.1 -0.0,7155.3 -0.0,2560.7 1045.1,2573.1 1063.0,1073.7 2392.5,1054.1 2417.5,0.0 5659.1,0.0 5714.0,6478.8 4283.5,7079.7 4283.6,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0014/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09041597511428,
+                40.7099327254963
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08832653694927,
+                40.71181372039666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08480989065981,
+                40.709537363270634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08689932882484,
+                40.70765636837028
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5714
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5714.0,0.0 5714.0,538.7 5048.6,415.3 5066.1,6744.4 5714.0,6727.1 5714.0,8150.0 -0.0,8150.0 -0.0,481.8 1255.4,447.1 1251.6,0.0 5714.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0948245911307,
+                40.71002845862695
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09259183164838,
+                40.711990549551565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5714.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0889235500284,
+                40.70955806356978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09115630951072,
+                40.707595972645166
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0018/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p18",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0018/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0018/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5755
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"785.8,6253.1 -0.0,6626.8 -0.0,1916.4 4662.0,1856.6 4769.1,6178.8 5029.0,6196.3 5056.2,8150.0 2729.9,8150.0 2700.4,6026.1 785.8,6253.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0018/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09200918910815,
+                40.70818749248652
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.089707021776,
+                40.71015895507717
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5755.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08604950698978,
+                40.70766994813176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08835167432194,
+                40.70569848554111
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4827.1,551.6 4812.3,5382.7 3475.4,4998.7 2748.5,4956.9 1879.8,8000.2 1526.8,7426.9 1318.6,8149.0 -0.0,8149.0 -0.0,1782.7 360.5,1775.9 326.1,512.7 4827.1,551.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09574918892449,
+                40.709028354497114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09318222415732,
+                40.70730561273591
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09641486284028,
+                40.70449846164141
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09898182760745,
+                40.70622120340262
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4605.1,1284.4 4605.4,1149.7 5010.7,1702.9 5291.4,1699.4 5334.8,1292.2 5689.0,1283.9 5689.0,7354.6 5083.8,6655.5 5079.6,7265.8 1055.2,6096.5 1030.7,1301.5 4605.1,1284.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09184451679428,
+                40.70579316701995
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08930896739766,
+                40.70406307282247
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09255523904258,
+                40.70129013691142
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09509078843921,
+                40.7030202311089
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p23",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"489.4,797.4 1199.2,636.2 5689.0,644.5 5689.0,7143.1 3349.9,7124.9 2846.2,8149.0 -0.0,8149.0 -0.0,3508.4 497.9,3961.4 489.4,797.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09623012971066,
+                40.70687472384492
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09438843586975,
+                40.70467591170747
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5689.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09851427113327,
+                40.7026618325136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.1003559649742,
+                40.70486064465105
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0025/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5674
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4780.5,5913.1 1179.2,5715.1 -0.0,3468.6 -0.0,-0.0 4124.7,0.0 4043.4,1439.4 5032.5,1997.2 4780.5,5913.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10192340249223,
+                40.70320736193464
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0991451667171,
+                40.70473893878577
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09626332425206,
+                40.70169197527887
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09904156002722,
+                40.700160398427734
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p26",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3317.4,5478.7 824.6,5448.0 864.6,715.7 1632.0,675.3 1228.8,0.0 4880.0,0.0 4880.0,0.0 5747.0,0.0 5747.0,2878.3 4840.6,2873.6 4824.4,7248.8 3311.2,7657.9 3317.4,5478.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09994191866322,
+                40.70108651767954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09705619871718,
+                40.70250007470895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09443039363624,
+                40.699375435668955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0973161135823,
+                40.697961878639546
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0031/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p31",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0031/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0031/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5674
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1450.3 5674.0,1572.2 5674.0,6361.6 5381.7,6378.5 5555.0,7816.2 4966.2,7904.9 4959.5,8054.6 -0.0,8149.0 -0.0,1450.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0031/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09892963632298,
+                40.695392440941426
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0969695624868,
+                40.69324892667065
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10100227697957,
+                40.691098963942096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10296235081574,
+                40.69324247821287
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p32",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7996.3 599.1,7878.5 355.7,6413.6 654.3,6382.9 500.4,2943.1 3387.4,2875.0 3405.2,1743.6 3505.6,1894.2 5747.0,1800.2 5747.0,6868.7 3640.9,8017.9 3674.3,8150.0 -0.0,8150.0 -0.0,7996.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0971506060772,
+                40.69335432058157
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09534025139791,
+                40.691172824341145
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0993920261395,
+                40.68921232063305
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10120238081878,
+                40.69139381687348
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0033/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p33",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0033/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0033/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5674
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,241.5 5674.0,334.3 5674.0,4963.4 4806.9,6470.8 1917.8,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0033/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0970423602467,
+                40.69737473167971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09515599992156,
+                40.695220235348046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5674.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0992094947019,
+                40.693151188183165
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10109585502703,
+                40.69530568451483
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p34",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"808.5,4991.2 621.7,349.5 -0.0,360.5 -0.0,0.0 1986.5,-0.0 3408.5,3282.8 5747.0,6675.1 5747.0,7792.8 2898.5,7904.2 2810.9,6457.5 -0.0,6567.1 -0.0,5010.4 808.5,4991.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09533796606148,
+                40.69545978415972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.093549896283,
+                40.6932281919087
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09769487398451,
+                40.69129189508906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.099482943763,
+                40.69352348734008
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p35",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5716.0,5177.1 2286.0,5152.2 1992.9,5279.8 1188.1,2932.8 386.0,1308.7 5716.0,1341.4 5716.0,5177.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09528260498726,
+                40.699435272228136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09343508737625,
+                40.697253498083086
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09750842380316,
+                40.69524271280373
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09935594141417,
+                40.69742448694878
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p36",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"982.1,5194.1 902.6,1361.9 2793.8,1341.5 4019.2,3534.1 4540.5,4820.3 2552.1,4812.1 2550.6,5172.9 982.1,5194.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09369781713701,
+                40.69759718766084
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09189934360164,
+                40.69537343611193
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09602988524696,
+                40.69342593312246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09782835878235,
+                40.69564968467137
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p37",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1984.7,7183.7 370.3,7747.2 1903.3,732.9 5299.3,555.1 4133.6,5994.9 1984.7,7183.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09693009003577,
+                40.69858943446167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09450117292347,
+                40.70043135628769
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09106228108469,
+                40.697787834022094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09349119819699,
+                40.69594591219608
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p38",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5746.3,449.3 5274.0,1210.8 5516.7,3829.2 5289.1,3962.2 3385.7,6955.1 2104.8,7275.5 2138.0,5963.6 846.9,7101.1 1061.9,7401.1 418.3,7478.7 430.4,1872.1 5746.3,449.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0952620629667,
+                40.700724814854595
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09239273141719,
+                40.70213839611422
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08976689766224,
+                40.699031482996354
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09263622921176,
+                40.69761790173673
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p39",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4284.4,7220.4 1720.1,6743.8 1767.1,685.9 4560.8,642.7 4624.6,5171.8 4284.4,7220.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09034381286548,
+                40.70439561066492
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08777288895499,
+                40.7026685356516
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09099755421954,
+                40.69987062793981
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09356847813004,
+                40.70159770295313
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p40",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3306.9 556.4,2874.4 422.2,2872.4 1568.7,2122.9 2214.2,1915.2 3913.7,1952.7 5102.4,1458.9 5058.3,3896.8 5346.5,3923.0 5355.8,6718.3 438.2,6742.5 405.2,3599.3 -0.0,3551.0 -0.0,3306.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09176940424786,
+                40.70467397702948
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08950493237573,
+                40.70665848535581
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08581831004575,
+                40.70420667977251
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08808278191788,
+                40.70222217144619
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p41",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5716
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1339.4,4235.6 1049.5,4211.6 1074.2,1759.6 2371.6,1147.9 4142.1,1000.9 4164.5,3141.5 5716.0,3146.9 5716.0,3700.6 4492.0,3903.3 4543.8,6050.5 1360.2,6066.9 1339.4,4235.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09030969546318,
+                40.70616184194894
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08804919719125,
+                40.7081110749881
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5716.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08440952693408,
+                40.705651140710955
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.086670025206,
+                40.703701907671785
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p42",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5747
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5747.0,1165.9 5747.0,7142.8 4695.0,7101.2 4689.1,8150.0 1263.4,8150.0 1243.4,3746.4 2467.8,3564.6 2477.1,3012.3 3267.6,3028.2 3279.7,1064.5 5747.0,1165.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08897535023226,
+                40.707196421939884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0867406214647,
+                40.70918935517248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5747.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08303819160719,
+                40.706769855585186
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08527292037475,
+                40.70477692235259
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0045/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p45",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0045/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0045/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1000.1,7847.3 1258.9,-0.0 4478.1,-0.0 4362.9,6284.2 4605.5,6287.9 4573.5,7897.9 1000.1,7847.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0045/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08137208361273,
+                40.70973786653511
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07876995014982,
+                40.70806654622179
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08189294725854,
+                40.70523291505723
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08449508072145,
+                40.70690423537055
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p46",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5785
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,93.0 3668.0,168.9 5057.2,4151.5 5236.6,6341.8 -0.0,6293.1 -0.0,93.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07929440848865,
+                40.70845940182822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07666595121019,
+                40.70670727019976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07990072384868,
+                40.70387916432194
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08252918112714,
+                40.705631295950404
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0047/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p47",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0047/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0047/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2030.9,3036.6 4527.7,3027.6 4520.4,6430.2 2062.2,6445.0 2030.9,3036.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0047/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08317041446831,
+                40.70806564946952
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08058301584157,
+                40.70634302464722
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08380179755636,
+                40.703525367403756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0863891961831,
+                40.705247992226056
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p48",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5785
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6499.7 -0.0,1490.0 5029.9,1532.0 5424.8,6513.4 -0.0,6499.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08109449258161,
+                40.706716357311656
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07848665189069,
+                40.704972553523696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5785.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08170596903369,
+                40.70216655986398
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08431380972462,
+                40.703910363651936
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p50",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1319.8,6958.6 1236.1,0.0 4382.2,0.0 4470.2,8149.0 2887.0,8149.0 2881.1,6931.1 1319.8,6958.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08755385904857,
+                40.7043657436157
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08525069405852,
+                40.70637255197602
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08155022567902,
+                40.70389730094451
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08385339066909,
+                40.7018904925842
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4849.9,7158.8 1017.6,6824.3 1004.3,817.3 3737.5,774.9 3741.0,2325.0 4837.5,2340.6 4849.9,7158.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08807909526999,
+                40.70389421285448
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08545142061054,
+                40.70215011544844
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08866733448573,
+                40.699325996951195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0912950091452,
+                40.701070094357235
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p53",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"84.1,6284.5 945.9,1054.0 4133.5,120.2 5677.5,5420.4 3286.2,8149.0 586.6,8149.0 84.1,6284.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08952258446594,
+                40.70012043725274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08664600340884,
+                40.70154868548972
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08398311585448,
+                40.698422388190515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08685969691156,
+                40.69699413995353
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1359.2,1085.2 2868.4,1097.4 2886.4,0.0 4438.0,0.0 4453.0,6911.1 3526.6,6924.2 1326.6,6621.7 1359.2,1085.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08843370176892,
+                40.70095999964717
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08615709011943,
+                40.702968345427315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0824539815981,
+                40.7005215030234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0847305932476,
+                40.698513157243255
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p56",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4862.0,7667.4 339.9,6686.8 250.9,343.2 5312.4,483.0 5180.8,2300.4 5789.0,2209.2 5789.0,6849.2 4915.9,6746.9 4862.0,7667.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08866518428285,
+                40.700144410525226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08619883163806,
+                40.698283170588326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08963054536038,
+                40.695632281971406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09209689800515,
+                40.697493521908314
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1893.0,2604.7 4745.1,838.1 4822.8,5823.7 2942.4,6341.4 1893.0,2604.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09568249256436,
+                40.6961450079853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09277719649816,
+                40.69753820250326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09017982994507,
+                40.694380496449455
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09308512601127,
+                40.692987301931495
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p61",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5724
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4615.5,7237.6 1057.6,7016.9 1051.4,2814.8 4673.4,514.4 4566.0,718.2 4615.5,7237.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09844888670257,
+                40.692375378434306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0955878318483,
+                40.69382792019256
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5724.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09287998058521,
+                40.690718117782765
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09574103543946,
+                40.6892655760245
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p62",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,6658.2 2263.8,6076.4 3475.8,1289.8 5406.3,1772.1 4852.9,3634.3 5680.3,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09722439053591,
+                40.692274191861614
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09468467964851,
+                40.69043829178968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09806925889818,
+                40.68770822276298
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.10060896978558,
+                40.68954412283491
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p68",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5789
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,8149.0 0.0,506.5 3253.5,569.3 4361.0,1152.5 1338.7,7943.3 1792.9,8149.0 0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09791811736845,
+                40.68840890411571
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09608938154608,
+                40.69062595729073
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5789.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09200220844392,
+                40.68866011331494
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09383094426629,
+                40.68644306013992
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p70",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"923.3,6902.2 256.9,2672.9 325.7,-0.0 5334.1,-0.0 5415.1,7182.9 923.3,6902.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0895341198064,
+                40.69648561381614
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08737681751141,
+                40.69442612420541
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09119685038868,
+                40.69209325558345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09335415268369,
+                40.69415274519418
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p71",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5701
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5701.0,8005.3 543.6,6905.2 898.7,3033.7 951.3,-0.0 5701.0,-0.0 5701.0,8005.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08704292298158,
+                40.695549678360806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5701.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0846570978853,
+                40.693672059118406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5701.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08817393911602,
+                40.69106667357957
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0905597642123,
+                40.69294429282197
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p72",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"372.6,178.0 5634.7,464.0 5585.5,151.1 5757.0,120.0 5757.0,7176.7 4706.2,7151.1 4839.6,7870.6 835.5,7734.0 372.6,178.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0898367398109,
+                40.69335013348287
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08784098049713,
+                40.69118995272925
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0918475849712,
+                40.68903166889976
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.09384334428498,
+                40.69119184965338
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p76",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1014.1,8150.0 1391.2,1575.6 5757.0,1791.8 5757.0,8150.0 1014.1,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08043375755035,
+                40.70077466253589
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0779372106127,
+                40.69895889261507
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08130537263744,
+                40.69625932412919
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0838019195751,
+                40.69807509405001
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p78",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3877.7,7301.3 512.4,6828.2 518.5,1322.4 5215.5,672.0 5240.0,7280.0 3877.7,7301.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08249694990634,
+                40.70260813840289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.0800386267975,
+                40.704478385232854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07656920688864,
+                40.701820306772916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07902752999748,
+                40.69995005994295
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p82",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5757
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1305.9,1754.3 5757.0,1203.4 5757.0,8150.0 773.1,8150.0 1305.9,1754.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07727498247054,
+                40.70262736740334
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07490904324823,
+                40.70072745878532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5757.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07843340075655,
+                40.698169208026016
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.08079933997887,
+                40.70006911664403
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p83",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5723
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,1214.3 2081.6,632.9 2869.7,523.9 2785.2,0.0 5723.0,0.0 5723.0,8150.0 1100.9,8150.0 90.2,6325.4 -0.0,6176.4 -0.0,1214.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07574561809851,
+                40.70464727902192
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07333092627059,
+                40.706446489427606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5723.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.06997454825256,
+                40.70382105068174
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -74.07238924008048,
+                40.70202184027605
               ]
             }
           }
@@ -117,8 +6096,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +6116,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1011.9,7261.0 1037.4,662.5 5471.7,436.0 5451.3,7896.9 5696.0,7897.5 5696.0,8149.0 3982.2,8149.0 3984.0,7256.9 1011.9,7261.0\" /></svg>"
+          "value": "<svg><polygon points=\"1011.9,7261.0 1037.4,662.5 4216.9,492.8 4279.9,6359.6 3983.2,6360.0 3984.0,7256.9 1011.9,7261.0\" /></svg>"
         }
       },
       "body": {
@@ -193,99 +6172,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p16",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "1"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5714
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5714.0,-0.0 5714.0,8150.0 5074.7,8150.0 5074.7,8150.0 0.0,8150.0 0.0,0.0 5714.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0016/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3513.2,
-                3927.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0916998,
-                40.7100698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3513.2,
-                2127.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0908653,
-                40.7095012
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0017/georef",
       "type": "Annotation",
       "@context": [
@@ -303,8 +6189,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,7 +6209,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4712.0,898.1 4709.0,1791.4 5696.0,1792.8 5696.0,4625.4 5529.1,4623.1 5440.1,6242.0 3818.8,7084.7 3165.7,7227.5 1790.1,7162.6 1144.2,7380.5 566.9,7832.7 246.7,7596.3 276.5,908.8 4712.0,898.1\" /></svg>"
+          "value": "<svg><polygon points=\"4712.4,0.0 5009.5,0.0 5027.9,6497.3 4683.9,6661.8 3495.4,7174.6 1509.6,7248.8 -0.0,8149.0 -0.0,4578.1 244.8,4576.4 276.5,908.8 4712.0,898.1 4712.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -379,99 +6265,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"287.6,611.4 5689.0,668.9 5689.0,5677.7 3392.8,5013.6 2680.9,4971.2 1845.3,7951.7 1455.2,7321.9 1217.4,8149.0 -0.0,8149.0 -0.0,1854.9 335.9,1849.2 287.6,611.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2344.4,
-                6252.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.097152,
-                40.7061443
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1928.3,
-                7692.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0979312,
-                40.7057672
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0020/georef",
       "type": "Annotation",
       "@context": [
@@ -489,8 +6282,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -509,7 +6302,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2087.6,567.9 2087.6,2027.5 4686.6,2069.0 4703.3,6807.6 1010.0,5691.1 1019.8,554.5 2087.6,567.9\" /></svg>"
+          "value": "<svg><polygon points=\"5755.0,7125.5 -0.0,5396.6 -0.0,541.7 2087.6,567.9 2087.6,2027.5 5755.0,2086.1 5755.0,7125.5\" /></svg>"
         }
       },
       "body": {
@@ -565,99 +6358,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5749.0 -0.0,1060.8 4044.8,1112.0 4282.1,797.8 5054.0,1850.7 5261.1,1805.9 5310.1,1381.0 5689.0,1378.1 5689.0,7414.5 5021.8,6689.2 5006.8,7286.1 -0.0,5749.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3040.5,
-                4648.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0923216,
-                40.7032847
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3404.6,
-                3380.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0916507,
-                40.7036145
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0022/georef",
       "type": "Annotation",
       "@context": [
@@ -675,8 +6375,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -695,7 +6395,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5425.4,8150.0 834.5,8122.7 753.1,693.2 3370.2,749.9 5425.4,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"3370.2,749.9 5167.6,7221.6 815.9,7206.2 753.1,693.2 3370.2,749.9\" /></svg>"
         }
       },
       "body": {
@@ -751,99 +6451,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5689
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"533.5,860.2 1236.0,702.7 4906.2,715.6 4954.5,8137.7 -0.0,8149.0 -0.0,3482.9 554.3,3985.2 533.5,860.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                564.1,
-                2196.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.097152,
-                40.7061443
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                564.1,
-                3712.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0979312,
-                40.7057672
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0024/georef",
       "type": "Annotation",
       "@context": [
@@ -861,8 +6468,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -881,7 +6488,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5225.1,715.8 5250.4,8150.0 -0.0,8150.0 -0.0,639.9 5225.1,715.8\" /></svg>"
+          "value": "<svg><polygon points=\"769.8,7145.6 786.5,651.3 5225.1,715.8 5244.2,6333.6 2379.8,6312.3 2378.9,7172.5 769.8,7145.6\" /></svg>"
         }
       },
       "body": {
@@ -937,99 +6544,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p26",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"859.9,742.7 1515.9,706.2 1519.8,0.0 3912.0,0.0 3878.6,7583.8 3297.6,7742.8 3311.5,5543.2 802.8,5519.5 859.9,742.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0026/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3303.4,
-                2935.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0973521,
-                40.7007884
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2023.6,
-                5534.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0971575,
-                40.6994919
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0027/georef",
       "type": "Annotation",
       "@context": [
@@ -1047,8 +6561,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1067,7 +6581,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5674.0,0.0 5674.0,2831.1 4963.2,7592.4 693.0,7558.8 -0.0,4464.2 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4464.2 -0.0,-0.0 4473.9,0.0 5674.0,1220.8 5674.0,2831.1 4963.2,7592.4 693.0,7558.8 -0.0,4464.2\" /></svg>"
         }
       },
       "body": {
@@ -1140,8 +6654,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1160,7 +6674,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5430.1,7416.2 607.9,7414.2 607.9,697.8 2764.2,694.7 3578.7,2287.0 5430.1,7416.2\" /></svg>"
+          "value": "<svg><polygon points=\"607.9,7414.2 607.9,697.8 2764.2,694.7 3578.7,2287.0 4409.6,4589.0 4693.6,4462.8 4636.1,5216.3 5430.1,7416.2 607.9,7414.2\" /></svg>"
         }
       },
       "body": {
@@ -1233,8 +6747,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1253,7 +6767,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 0.0,0.0 5547.5,0.0 5747.0,593.8 5276.0,828.7 3461.0,8150.0 -0.0,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"3610.5,7531.0 131.0,8009.1 185.3,7794.9 -0.0,7813.5 -0.0,0.0 5547.4,0.0 5747.0,380.4 5747.0,593.8 5276.0,828.7 3610.5,7531.0\" /></svg>"
         }
       },
       "body": {
@@ -1309,1068 +6823,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p32",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,2677.1 2426.3,2825.2 3424.9,8150.0 -0.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0032/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4855.2,
-                4610.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0978855,
-                40.6904043
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4227.3,
-                2935.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0972861,
-                40.6911174
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p34",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,3443.6 3272.2,3188.6 3459.4,3263.2 5747.0,6275.0 5747.0,7578.4 4538.1,7676.3 2343.0,7854.2 2385.3,8150.0 -0.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0034/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3459.4,
-                3263.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.095942,
-                40.693365
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2675.5,
-                1739.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0953543,
-                40.6940276
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p35",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5716
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1129.5,2921.3 327.5,1312.4 5716.0,1362.1 5716.0,8149.0 2937.0,8095.8 1129.5,2921.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0035/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0952543612841,
-                40.699416197285395
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5716.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09338317135403,
-                40.69722188717088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5716.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09751159367121,
-                40.69520096606323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09938278360129,
-                40.697395276177744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2728.0,
-                1344.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0950423,
-                40.6980356
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p36",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2955.0,1401.4 4027.7,3585.7 5650.4,8093.0 986.4,7876.5 1222.7,1316.7 2955.0,1401.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0036/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4095.3,
-                3759.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0942954,
-                40.6951253
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4571.2,
-                5190.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0948523,
-                40.6945579
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p37",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5716
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2018.7,779.4 5716.0,716.5 5716.0,5270.3 4539.7,5870.5 4533.3,6201.0 4033.2,6138.5 2004.5,7199.0 181.7,7763.1 2018.7,779.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0037/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1396.0,
-                3116.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0950423,
-                40.6980356
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2004.0,
-                7200.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0930069,
-                40.6969752
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p38",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3425.1,6842.5 2151.6,7188.0 2167.5,5874.8 1873.6,6143.4 681.4,1736.1 3668.4,872.2 4647.9,4848.6 3425.1,6842.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0038/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2151.6,
-                7186.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0918671,
-                40.698469
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                471.9,
-                7426.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0926437,
-                40.6979767
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p39",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5716
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4501.9,478.5 4814.2,4986.2 4667.1,7291.7 5514.2,8149.0 1461.1,8149.0 1374.4,6017.3 2092.3,6716.2 1752.4,652.1 4501.9,478.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0039/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09028935124124,
-                40.70439011150769
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5716.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0878209745496,
-                40.70256601091597
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5716.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0912528766959,
-                40.69990011662188
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8149.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.09372125338754,
-                40.7017242172136
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1372.0,
-                676.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0899816,
-                40.7037311
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p40",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3481.8 -0.0,3253.7 1586.3,2064.8 2228.0,1857.4 3914.6,1890.5 5096.7,1398.2 5041.8,3815.6 5327.6,3840.9 5324.0,6612.6 443.1,6648.1 424.8,3531.5 -0.0,3481.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0040/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                695.9,
-                2267.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0904528,
-                40.7042068
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3575.4,
-                3707.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.088647,
-                40.704772
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p41",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5716
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1047.2,4276.5 1039.3,1950.4 1753.4,1541.3 1817.2,0.0 5716.0,0.0 5676.5,6963.5 1388.8,6959.1 1322.7,4293.6 1047.2,4276.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0041/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2568.0,
-                4244.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0873795,
-                40.7057945
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4160.0,
-                3948.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0868394,
-                40.706452
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p42",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5747
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2445.9,8150.0 3015.4,0.0 5747.0,0.0 5747.0,108.3 3592.8,6.2 3430.1,3441.4 4719.2,3275.1 4505.2,8054.4 2445.9,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0042/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3295.4,
-                3459.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0861447,
-                40.7073089
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4719.2,
-                3275.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0856905,
-                40.70788
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0043/georef",
       "type": "Annotation",
       "@context": [
@@ -2388,8 +6840,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2408,7 +6860,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1304.0,3273.4 -0.0,3508.2 0.0,-0.0 3631.7,0.0 3665.0,2876.3 4416.0,2743.6 4446.8,7246.1 5716.0,7289.1 5716.0,8149.0 1316.6,8149.0 1304.0,3273.4\" /></svg>"
+          "value": "<svg><polygon points=\"2365.7,7192.5 2330.9,2032.6 3654.9,2008.3 3643.2,998.5 5716.0,85.6 5716.0,7246.9 2365.7,7192.5\" /></svg>"
         }
       },
       "body": {
@@ -2481,8 +6933,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2501,7 +6953,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"764.1,3213.7 -0.0,3339.5 -0.0,0.0 1267.4,0.0 1267.4,0.0 5785.0,0.0 5785.0,8150.0 2027.1,8150.0 2119.4,7845.9 742.4,7783.3 764.1,3213.7\" /></svg>"
+          "value": "<svg><polygon points=\"2031.2,7799.0 2115.4,531.6 4927.3,275.1 4963.7,2099.8 5785.0,2068.7 5785.0,8150.0 5485.3,8150.0 5484.1,7841.2 2031.2,7799.0\" /></svg>"
         }
       },
       "body": {
@@ -2557,192 +7009,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p46",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5785
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5785.0,-0.0 5785.0,237.2 3801.3,383.9 5135.1,4214.9 5308.1,6318.1 381.5,6239.1 530.5,8150.0 -0.0,8150.0 0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0046/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4352.8,
-                2059.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0781256,
-                40.7065111
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5180.9,
-                4754.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0788466,
-                40.705278
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p48",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5785
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2015.4,6233.1 2107.1,4839.6 -0.0,4702.7 -0.0,979.6 5230.9,1471.6 5231.3,6554.8 2015.4,6233.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0048/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5232.9,
-                6486.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0811987,
-                40.7028627
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5232.9,
-                1471.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0794322,
-                40.7046727
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0049/georef",
       "type": "Annotation",
       "@context": [
@@ -2760,8 +7026,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2836,99 +7102,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p50",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1280.2,6976.9 1328.9,991.1 5789.0,1172.9 5789.0,6978.0 4424.8,6976.9 4406.7,8149.0 2823.1,8149.0 2842.2,6971.5 1280.2,6976.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0050/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1280.2,
-                6976.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0838689,
-                40.7027096
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4424.8,
-                6976.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0826385,
-                40.7038128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0051/georef",
       "type": "Annotation",
       "@context": [
@@ -2946,8 +7119,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2966,7 +7139,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"934.4,7224.7 927.6,2276.9 2105.2,2287.5 2093.7,703.9 4071.0,716.7 4585.0,7253.7 934.4,7224.7\" /></svg>"
+          "value": "<svg><polygon points=\"927.6,2276.9 2144.5,2287.9 2155.4,704.4 4071.0,716.7 4585.0,7253.7 934.4,7224.7 927.6,2276.9\" /></svg>"
         }
       },
       "body": {
@@ -3022,285 +7195,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4850.9,2390.5 4858.5,7223.3 1018.8,6857.1 1011.4,831.9 3710.5,811.6 3739.5,2365.8 4850.9,2390.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2512.4,
-                7008.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.089687,
-                40.7007253
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4008.7,
-                808.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0865693,
-                40.7024237
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p53",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"22.4,6260.4 987.1,1033.3 4189.5,140.8 5626.4,5469.9 3179.2,8149.0 1204.2,8149.0 490.0,8149.0 22.4,6260.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0053/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1828.0,
-                6024.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0866053,
-                40.6982793
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4188.0,
-                140.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.087406,
-                40.7011057
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2928.5,1096.1 2973.3,0.0 4507.4,0.0 4355.7,6866.1 3439.2,6863.0 1270.4,6526.3 1436.4,1058.2 2928.5,1096.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4444.8,
-                3240.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0852096,
-                40.7015321
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2928.5,
-                1096.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.086807,
-                40.7016256
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0055/georef",
       "type": "Annotation",
       "@context": [
@@ -3318,8 +7212,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3338,7 +7232,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2046.2,6650.4 815.8,3171.5 971.9,872.7 4809.7,1014.9 4854.9,7324.1 3191.3,8009.6 3176.6,8149.0 2849.3,8149.0 2046.2,6650.4\" /></svg>"
+          "value": "<svg><polygon points=\"2853.0,8149.0 2046.2,6650.4 738.0,2922.8 971.9,872.7 4809.7,1014.9 4854.9,7324.1 2853.0,8149.0\" /></svg>"
         }
       },
       "body": {
@@ -3394,192 +7288,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p56",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5066.1,2153.1 5789.0,2011.3 5789.0,6651.3 5086.1,6621.5 5091.1,7533.2 509.0,6811.1 13.9,478.7 5081.2,330.0 5066.1,2153.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0056/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3128.5,
-                3720.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0889051,
-                40.6979104
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5072.9,
-                3720.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0881258,
-                40.6972512
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2879.7,6335.3 1900.7,2508.0 4841.4,755.4 4803.2,5839.4 2879.7,6335.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2244.0,
-                6516.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0924233,
-                40.6941796
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1916.0,
-                2500.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0938855,
-                40.6956034
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0058/georef",
       "type": "Annotation",
       "@context": [
@@ -3597,8 +7305,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3617,7 +7325,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"668.3,7548.9 1330.2,2664.2 3193.0,1404.4 4854.6,1423.5 4051.1,7523.5 2323.3,7351.2 668.3,7548.9\" /></svg>"
+          "value": "<svg><polygon points=\"1168.2,2734.6 3193.0,1404.4 4854.6,1423.5 4051.1,7523.5 2323.3,7351.2 668.3,7548.9 1330.2,2664.2 1168.2,2734.6\" /></svg>"
         }
       },
       "body": {
@@ -3690,8 +7398,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3710,7 +7418,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1705.4,6116.8 1531.7,5961.2 745.5,-0.0 4656.6,-0.0 4645.3,6841.5 1705.4,6116.8\" /></svg>"
+          "value": "<svg><polygon points=\"1531.9,5961.2 671.4,-0.0 4671.8,-0.0 4645.6,6841.5 1705.7,6116.9 1531.9,5961.2\" /></svg>"
         }
       },
       "body": {
@@ -3783,8 +7491,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3803,7 +7511,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5715.0,0.0 5687.2,7475.4 -0.0,7627.3 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7618.6 -0.0,-0.0 5715.0,0.0 5681.3,7475.6 -0.0,7618.6\" /></svg>"
         }
       },
       "body": {
@@ -3832,8 +7540,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09978782699724,
-                40.71056629942739
+                -74.09978782694796,
+                40.71056629941337
               ]
             }
           },
@@ -3853,8 +7561,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.0975507234216,
-                40.71255427509454
+                -74.09755072339662,
+                40.71255427505893
               ]
             }
           },
@@ -3874,8 +7582,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.09381050317836,
-                40.71013816021313
+                -74.09381050319398,
+                40.710138160203755
               ]
             }
           },
@@ -3895,8 +7603,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -74.096047606754,
-                40.708150184545985
+                -74.09604760674533,
+                40.7081501845582
               ]
             }
           },
@@ -3942,8 +7650,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3962,7 +7670,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1333.4,6844.0 612.9,821.5 5050.0,1259.7 4803.7,7244.5 1333.4,6844.0\" /></svg>"
+          "value": "<svg><polygon points=\"4803.7,7244.5 1333.4,6844.0 612.9,821.5 5050.0,1259.7 4803.7,7244.5\" /></svg>"
         }
       },
       "body": {
@@ -4018,285 +7726,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p61",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5724
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"998.7,7020.2 965.1,2741.8 4627.7,352.3 4520.0,561.1 4612.5,7198.4 998.7,7020.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0061/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2544.0,
-                7104.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0947934,
-                40.6903121
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1384.0,
-                2460.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.096871,
-                40.6917766
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1473.9,935.6 4963.2,1802.8 5789.0,6441.9 5789.0,8149.0 -0.0,8149.0 -0.0,1526.4 915.2,1757.1 1331.8,530.4 1473.9,935.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1764.3,
-                1968.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0972861,
-                40.6911174
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5164.9,
-                5620.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0972549,
-                40.6887782
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p68",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5789
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5789.0,8149.0 0.0,8149.0 -0.0,-0.0 5697.2,0.0 5445.3,552.1 5789.0,718.4 5789.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0068/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3060.5,
-                6088.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0938821,
-                40.688018
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5444.9,
-                552.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0955886,
-                40.689966
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0069/georef",
       "type": "Annotation",
       "@context": [
@@ -4314,8 +7743,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4334,7 +7763,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4994.0,5066.2 4669.5,5134.7 4657.6,5606.5 5708.0,5632.9 5708.0,8149.0 54.8,8149.0 3520.4,6658.8 1036.7,883.2 5032.7,1061.8 4994.0,5066.2\" /></svg>"
+          "value": "<svg><polygon points=\"4994.0,5066.2 5708.0,4910.7 5708.0,8149.0 -0.0,8149.0 -0.0,826.1 5032.7,1061.8 4994.0,5066.2\" /></svg>"
         }
       },
       "body": {
@@ -4390,285 +7819,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p70",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"231.3,2658.6 328.2,-0.0 5333.9,-0.0 5346.3,7253.4 854.7,6895.8 231.3,2658.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0070/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5360.9,
-                3255.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0890056,
-                40.6936476
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5360.9,
-                1523.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0882002,
-                40.6941499
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p71",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5701
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5701.0,8150.0 531.1,6800.0 1033.9,3026.5 1208.5,-0.0 5701.0,-0.0 5701.0,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0071/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3452.6,
-                5874.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0880959,
-                40.6925422
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3452.6,
-                7558.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0888073,
-                40.6919702
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p72",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1081.6,7882.1 173.0,181.5 5757.0,194.3 5757.0,8150.0 5272.3,8150.0 5193.7,7818.7 1081.6,7882.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0072/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                676.1,
-                4366.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0917239,
-                40.6919777
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3872.7,
-                2435.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0897589,
-                40.6912295
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0073/georef",
       "type": "Annotation",
       "@context": [
@@ -4686,8 +7836,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4706,7 +7856,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5308.3,8150.0 -0.0,8150.0 -0.0,5400.2 3934.5,5303.8 3878.8,3043.8 2868.3,3027.7 3083.9,920.1 5359.4,1055.6 5308.3,8150.0\" /></svg>"
+          "value": "<svg><polygon points=\"5308.3,8150.0 -0.0,8150.0 -0.0,5323.3 3794.0,5385.5 3849.0,3043.8 2831.3,3026.6 3073.1,1006.1 5355.1,995.9 5308.3,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -4779,8 +7929,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4799,7 +7949,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"822.6,1303.0 2101.3,1565.5 2103.8,2675.4 3107.4,2684.5 3000.2,4859.7 5757.0,4995.6 5757.0,8150.0 -0.0,8150.0 -0.0,7711.1 740.9,7715.2 822.6,1303.0\" /></svg>"
+          "value": "<svg><polygon points=\"822.7,1295.8 2101.4,1576.3 2103.8,2675.4 3099.3,2684.3 3123.1,4984.0 5757.0,4938.3 5757.0,8150.0 -0.0,8150.0 -0.0,7711.1 740.9,7715.2 822.7,1295.8\" /></svg>"
         }
       },
       "body": {
@@ -4872,8 +8022,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4948,99 +8098,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p76",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1241.9,8150.0 1125.7,3394.9 1179.1,1594.5 5757.0,1432.9 5757.0,8150.0 1241.9,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0076/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1184.2,
-                6690.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0827378,
-                40.6982291
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1184.2,
-                1587.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.080498,
-                40.6998002
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0077/georef",
       "type": "Annotation",
       "@context": [
@@ -5058,8 +8115,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5078,7 +8135,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5064.9,6808.2 782.4,6522.7 1475.4,1855.9 5089.9,1263.8 5064.9,6808.2\" /></svg>"
+          "value": "<svg><polygon points=\"1475.4,1855.9 5089.9,1263.8 5064.9,6808.2 782.4,6522.7 1475.4,1855.9\" /></svg>"
         }
       },
       "body": {
@@ -5134,99 +8191,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p78",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3898.9,7297.3 563.0,6858.0 559.2,1401.2 5212.8,715.5 5249.0,7264.3 3898.9,7297.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0078/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3576.6,
-                7246.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0778951,
-                40.7013988
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3588.6,
-                931.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0805969,
-                40.7034842
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0079/georef",
       "type": "Annotation",
       "@context": [
@@ -5244,8 +8208,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5264,7 +8228,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1372.7,7425.0 1256.5,8150.0 -0.0,8150.0 -0.0,7379.2 312.6,7386.2 289.7,7235.0 1349.2,836.6 5140.6,821.9 5052.1,7101.7 1372.7,7425.0\" /></svg>"
+          "value": "<svg><polygon points=\"5730.0,671.4 5730.0,8150.0 1085.9,8150.0 1222.0,7419.5 312.6,7386.2 1349.2,836.6 5140.6,821.9 5730.0,671.4\" /></svg>"
         }
       },
       "body": {
@@ -5337,8 +8301,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5357,7 +8321,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1702.0,7445.6 1722.0,1269.9 5757.0,192.6 5757.0,7059.3 4795.1,7060.1 1702.0,7445.6\" /></svg>"
+          "value": "<svg><polygon points=\"2367.6,7362.6 2299.8,1115.6 5757.0,192.4 5757.0,7059.1 2367.6,7362.6\" /></svg>"
         }
       },
       "body": {
@@ -5430,8 +8394,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5450,7 +8414,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1278.4,6233.1 531.0,1552.5 5524.7,1856.0 5730.0,1730.0 5730.0,6669.0 1278.4,6233.1\" /></svg>"
+          "value": "<svg><polygon points=\"5727.1,8150.0 1288.6,8150.0 1281.7,6399.4 2021.6,6488.0 1721.6,1867.0 600.6,1939.7 521.6,1392.2 5334.6,1904.9 5730.0,1730.0 5727.1,8150.0\" /></svg>"
         }
       },
       "body": {
@@ -5506,192 +8470,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p82",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5757
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1302.2,1341.0 2051.9,1220.9 1856.3,-0.0 5757.0,-0.0 5757.0,8150.0 679.3,8150.0 1302.2,1341.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0082/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1008.2,
-                4227.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0786564,
-                40.7009756
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1104.2,
-                3551.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0783206,
-                40.7011646
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Hudson Co., N.J. | 1950 | Vol. 9 p83",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5723
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1079.3 3032.9,466.0 2979.3,0.0 5723.0,0.0 5723.0,8150.0 -0.0,8150.0 -0.0,6345.9 139.8,6337.4 -0.0,6137.9 -0.0,1079.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0083/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2051.6,
-                579.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0746712,
-                40.7050221
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5119.1,
-                4195.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -74.0718418,
-                40.7049109
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd381m:g3814m:g3814hm:g3814hm_g05511195009:05511_09_1950-0009/georef",
       "type": "Annotation",
       "@context": [
@@ -5709,8 +8487,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:33:17Z",
-      "modified": "2026-07-18T02:33:17Z",
+      "created": "2026-07-30T22:24:43Z",
+      "modified": "2026-07-30T22:24:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5729,7 +8507,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5711.0,8149.0 0.0,8149.0 -0.0,-0.0 5711.0,0.0 5711.0,8149.0\" /></svg>"
+          "value": "<svg><polygon points=\"5568.3,7081.3 2028.0,7029.9 2029.0,5657.7 0.0,5658.9 -0.0,-0.0 5711.0,0.0 5711.0,8149.0 5562.0,8149.0 5568.3,7081.3\" /></svg>"
         }
       },
       "body": {

--- a/gallery/kansas_city_mo_1951_vol_4.iiif.json
+++ b/gallery/kansas_city_mo_1951_vol_4.iiif.json
@@ -7,99 +7,6 @@
   "label": "Mosaic of main content, Kansas City, Mo. | 1951 | Vol. 4",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p452",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6367
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"272.0,7464.0 275.0,7796.0 -0.0,7796.0 -0.0,519.1 195.6,526.6 192.2,218.1 5977.0,511.9 6099.5,0.0 6367.0,0.0 6367.0,7518.0 272.0,7464.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5995.1,
-                2296.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.603925,
-                39.062859
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                272.0,
-                7464.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6072733,
-                39.0605726
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/georef",
       "type": "Annotation",
       "@context": [
@@ -114,11 +21,11 @@
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,34 +44,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"630.2,7569.0 390.3,1279.7 -0.0,1294.5 -0.0,-0.0 6553.0,0.0 6553.0,7187.5 630.2,7569.0\" /></svg>"
+          "value": "<svg><polygon points=\"5984.8,-0.0 5981.3,7742.1 833.4,7706.6 969.5,0.0 5984.8,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0453/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6241.0,
-                3883.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.591297,
-                39.069458
+                -94.5959263,
+                39.0713134
               ]
             }
           },
@@ -172,20 +82,614 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                240.0,
-                7599.0
+                6553.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.595977,
-                39.067766
+                -94.5920445,
+                39.071201
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5922168,
+                39.067615
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5960987,
+                39.0677275
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p502",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1032.8,-0.0 6325.2,0.0 6303.1,7795.0 -0.1,7795.0 0.0,1923.2 1032.4,1927.0 1032.8,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5812443,
+                39.0593472
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5814182,
+                39.0563421
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5860915,
+                39.0565051
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5859176,
+                39.0595103
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p548",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5935.1,6784.2 3186.9,6685.0 3075.1,5800.5 -0.0,5787.6 -0.0,3933.6 668.4,3943.8 459.5,3603.8 412.8,3206.1 598.1,2827.7 701.0,2758.1 707.1,444.3 -0.0,465.8 -0.0,0.0 6472.0,-0.0 6472.0,7775.4 5935.1,6784.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5616695,
+                39.0441828
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5617965,
+                39.0386219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5704213,
+                39.0387408
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5702943,
+                39.0443017
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p556",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6512.0,7795.0 683.6,7795.0 625.0,0.0 6512.0,-0.0 6512.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5935832,
+                39.0485633
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5896999,
+                39.0484389
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5898917,
+                39.0448285
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5937749,
+                39.0449529
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p452",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6367
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"167.3,7405.0 166.4,7796.0 -0.0,7796.0 -0.0,506.8 171.2,515.2 171.4,208.9 4198.0,363.4 4195.8,0.0 6367.0,0.0 6367.0,7532.3 167.3,7405.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0452/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60736360736298,
+                39.06392034150882
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6367.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60368197620123,
+                39.063916000376175
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6367.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60368877291346,
+                39.06039162626931
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60737040407521,
+                39.06039596740195
               ]
             }
           }
@@ -203,15 +707,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -230,34 +734,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2199.9,7709.0 2698.5,0.0 6367.0,0.0 6367.0,128.3 6209.9,142.5 6367.0,983.9 6012.2,1739.7 6065.3,7508.3 5191.3,7796.0 2199.9,7709.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 6367.0,0.0 6367.0,1029.4 6057.6,1691.7 6014.5,7661.5 5580.0,7796.0 -0.0,7723.9 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0454/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6047.1,
-                3908.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.588804,
-                39.06933
+                -94.59237675384273,
+                39.07129977346675
               ]
             }
           },
@@ -265,20 +772,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4031.4,
-                172.0
+                6367.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5899448,
-                39.0712099
+                -94.5885259480062,
+                39.07118528310287
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6367.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58870521960024,
+                39.06749935696361
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59255602543678,
+                39.067613847327486
               ]
             }
           }
@@ -296,15 +845,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "6"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -323,34 +872,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6235.6,6956.0 1366.3,6927.1 1102.0,7577.3 -0.0,7556.8 -0.0,60.8 6313.0,172.0 6235.6,6956.0\" /></svg>"
+          "value": "<svg><polygon points=\"6251.6,7795.0 897.3,7795.0 1667.5,6029.8 2096.6,4623.1 2224.6,67.8 6382.3,123.8 6251.6,7795.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0455/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2192.3,
-                4215.5
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.596094,
-                39.065904
+                -94.5972535809387,
+                39.06782475741638
               ]
             }
           },
@@ -358,20 +910,8756 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6313.0,
-                172.0
+                6553.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59359,
-                39.067688
+                -94.5934899493948,
+                39.067741455773465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59361671525171,
+                39.064239954783076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59738034679562,
+                39.06432325642599
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p457",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"106.0,5634.6 -0.0,151.3 6553.0,165.1 6553.0,5991.9 1813.3,5960.9 1129.1,5638.3 106.0,5634.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5852302053095,
+                39.07112594013398
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58536201311618,
+                39.068131070472106
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5899197619956,
+                39.068253691386445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58978795418892,
+                39.07124856104832
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p458",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6406
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2191.8,5869.8 770.1,5881.7 578.4,117.4 6201.8,-0.0 6340.6,7795.0 2530.0,7795.0 2530.0,7795.0 2366.6,7795.0 2342.7,6310.8 2191.8,5869.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58536622832973,
+                39.06839673449847
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6406.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58562222316168,
+                39.06544246263182
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6406.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59021903230494,
+                39.06568597657815
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58996303747298,
+                39.068640248444794
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p459",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6553
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6157.3,278.3 6120.8,6202.6 6409.7,7296.0 -0.0,7336.1 -0.0,0.0 516.5,-0.0 514.7,288.0 6157.3,278.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58104179711621,
+                39.07110899921574
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58119933033296,
+                39.06812454793662
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6553.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58574120229578,
+                39.06827110192126
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58558366907901,
+                39.07125555320038
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p461",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5813.4,6774.7 149.8,6855.6 148.0,6566.4 -0.0,6568.3 -0.0,-0.0 120.4,-0.0 124.4,815.6 5716.8,724.6 5779.0,4441.5 5803.9,4493.5 5813.4,6774.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57724104796777,
+                39.07078046210406
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57744521953413,
+                39.067816865404374
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.581966360132,
+                39.06800727372561
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58176218856565,
+                39.0709708704253
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p462",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6371
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6371.0,2059.3 6371.0,7796.0 -0.0,7796.0 -0.0,771.5 5516.9,863.8 6262.4,667.4 6284.0,1787.5 6371.0,2059.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5773825680238,
+                39.068192757603626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6371.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57752272754608,
+                39.065239192630166
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6371.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58214439623096,
+                39.06537327215292
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58200423670867,
+                39.06832683712637
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p467",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7437.4 0.0,0.0 142.3,-0.0 142.5,139.4 6536.0,2.0 6536.0,7536.4 -0.0,7437.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56546286776775,
+                39.07036896836865
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56564580121872,
+                39.0672483926762
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57040642612044,
+                39.06741899441702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57022349266948,
+                39.07053957010946
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p468",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2005.1,7795.0 2002.1,7597.3 753.2,7599.3 750.5,-0.0 5804.5,-0.0 5912.8,7775.8 2005.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56565540163972,
+                39.06760240963579
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56583276181243,
+                39.06459953960419
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57052270610802,
+                39.064768888690764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57034534593531,
+                39.067771758722365
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p469",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6106.8,7795.0 297.7,7795.0 231.5,0.0 6092.6,0.0 6106.8,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56568996008107,
+                39.07028439525214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56183044132855,
+                39.07015607979112
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56202619187339,
+                39.066556691178015
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5658857106259,
+                39.066685006639034
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p470",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2204.4,7524.7 2199.3,7761.9 194.8,7752.1 171.5,0.0 6010.9,0.0 6062.6,7497.3 2204.4,7524.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56219497284637,
+                39.070147441171585
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5584189469613,
+                39.07001853227895
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5586202849292,
+                39.06641316042752
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56239631081426,
+                39.06654206932015
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p471",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6536
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6238.0,0.0 6242.8,7795.0 316.0,7795.0 274.3,0.0 6238.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55880009296762,
+                39.07005826431658
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55497491252174,
+                39.069931835378746
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6536.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55516778623074,
+                39.0663644916453
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55899296667661,
+                39.066490920583135
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p472",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"278.4,27.8 -0.0,41.7 -0.0,0.0 6386.0,0.0 6386.0,262.0 6119.5,263.2 6128.3,7704.0 6386.0,7770.6 285.5,7773.6 278.4,27.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55531410937974,
+                39.06996249456324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55151030587731,
+                39.069835738219474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55170828100516,
+                39.06620382845588
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55551208450758,
+                39.066330584799644
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p476",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6386
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6089.4,7755.2 246.5,7754.0 213.1,83.8 6043.8,109.4 6089.4,7755.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59038293220094,
+                39.065761787659525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58659582192278,
+                39.06561487105436
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6386.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58682527340235,
+                39.06199872570999
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59061238368051,
+                39.06214564231515
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p477",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6531
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6275.7,2228.0 6279.3,7796.0 225.3,7796.0 194.2,190.8 4485.8,0.0 4514.5,1328.9 5907.9,1386.2 6411.1,1729.8 6275.7,2228.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58691072302034,
+                39.065663868092024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58307418963041,
+                39.06552100899838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6531.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58329224859074,
+                39.06194066921384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58712878198067,
+                39.062083528307475
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p479",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6257.9,7795.0 337.2,7759.2 357.5,62.1 6259.7,0.0 6257.9,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57997251708885,
+                39.06535434504492
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57613989575604,
+                39.065232930561216
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57632624715657,
+                39.06163638656445
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58015886848936,
+                39.06175780104815
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p480",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"197.6,7755.7 176.9,0.0 6158.6,0.0 6158.6,0.0 6402.0,9.4 6402.0,7590.0 6149.2,7592.3 6149.0,7774.7 197.6,7755.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57638388049378,
+                39.065173844830916
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57265277355883,
+                39.06504655164414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57285107690846,
+                39.061492722715855
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57658218384341,
+                39.06162001590263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"438.7,7795.0 439.0,7546.5 689.0,7544.6 701.0,57.9 2029.0,238.5 2672.0,23.7 6096.0,0.6 6045.6,7761.0 438.7,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5730655476779,
+                39.06508259454092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56923073532973,
+                39.0649565975906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56942411822185,
+                39.06135796318375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57325893057002,
+                39.061483960134076
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p482",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7792.6 -0.0,24.3 6237.3,0.0 6287.3,7795.0 -0.0,7792.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56946504893531,
+                39.06497617984603
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56569077771654,
+                39.06483300090092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56591383042053,
+                39.06123808707601
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5696881016393,
+                39.06138126602112
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6494.0,7736.3 3947.0,7707.2 3871.6,7795.0 -0.0,7696.1 114.0,2014.2 129.0,2014.3 164.6,50.9 6494.0,123.0 6494.0,7736.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56106124632792,
+                39.06659001833632
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56118049960506,
+                39.06352319549151
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56588767177107,
+                39.063635100766184
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56576841849393,
+                39.06670192361099
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6402
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1089.0,57.0 6242.7,82.3 6402.0,7663.1 1198.7,7676.5 1089.0,57.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56119099550111,
+                39.06403700060091
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56136388131853,
+                39.06101979953924
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6402.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56606417887856,
+                39.06118447238089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56589129306116,
+                39.06420167344256
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p485",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6494
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3872.0 222.6,3873.9 176.5,-0.0 5629.8,33.1 5554.3,7700.1 -0.0,7666.4 -0.0,3872.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55647510984572,
+                39.066490825429874
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55661789455566,
+                39.06343638333131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6494.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56130605488485,
+                39.06357037036526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56116327017492,
+                39.06662481246383
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p488",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6225.4,7715.7 -0.0,7678.9 -0.0,42.4 6430.0,91.9 6225.4,7715.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.551956427521,
+                39.06377203662124
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55209104368588,
+                39.060719687454636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55682242170616,
+                39.06084727120589
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5566878055413,
+                39.063899620372496
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6414
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"80.1,7460.0 174.8,7310.1 52.6,0.0 6414.0,0.0 6414.0,2815.0 6105.8,7623.5 80.1,7460.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60371932339602,
+                39.060658060004315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59992891144884,
+                39.060607408589625
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6414.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60000761661558,
+                39.05700585651198
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60379802856275,
+                39.05705650792667
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6430
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"189.7,-0.0 6430.0,-0.0 6430.0,4565.2 5406.1,5018.4 5302.8,4794.0 5631.2,7709.3 190.8,7728.7 189.7,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59554877462206,
+                39.056998474806385
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5957310171016,
+                39.05407551320619
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6430.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60026139395298,
+                39.05424825204088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60007915147344,
+                39.05717121364108
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p495",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6452
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6205.9,7668.9 156.3,7643.7 190.2,1199.1 6245.1,1185.9 6205.9,7668.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59759319870643,
+                39.06168369697277
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59382880722245,
+                39.06156159338172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6452.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59401748445649,
+                39.058004799801864
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59778187594047,
+                39.05812690339292
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p499",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"198.6,2007.2 -0.0,2005.6 117.6,-0.0 6500.0,54.5 6500.0,7754.9 128.5,7698.6 198.6,2007.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.585772776308,
+                39.06208913457321
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58591427033024,
+                39.05899350197861
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59066242496047,
+                39.05912620462901
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59052093093824,
+                39.06222183722362
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p501",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6500.0,1942.1 5473.3,1937.8 5474.4,7795.0 86.3,7795.0 40.2,-0.0 6500.0,-0.0 6500.0,1942.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5810899790216,
+                39.061909346852076
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58126443118012,
+                39.05886605669929
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58593231208654,
+                39.05902966935294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58575785992804,
+                39.06207295950573
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p503",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5650.7,6377.2 5650.7,6377.2 5651.3,6632.3 80.6,6615.1 106.4,377.2 5662.0,387.0 5636.1,415.7 5650.7,6377.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57277625498124,
+                39.06154795339668
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57293841872746,
+                39.058596085649064
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57746601623312,
+                39.058748175348
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57730385248689,
+                39.06170004309562
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p504",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1894.8,7795.0 1900.6,6605.4 -0.0,6594.9 -0.0,6339.7 -0.0,6339.7 -0.0,-0.0 6324.9,-0.0 6283.2,7795.0 1894.8,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5729400067642,
+                39.05898958731687
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57309184474597,
+                39.056058430084626
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57761819828745,
+                39.05620180978971
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57746636030568,
+                39.05913296702197
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p505",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6500.0,134.7 6500.0,7451.3 5464.6,7445.2 5462.7,7771.0 241.6,7724.5 263.4,56.1 6500.0,134.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56830140301264,
+                39.061463212009535
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56843805704214,
+                39.05837531660381
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5731743194292,
+                39.058503480652135
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57303766539968,
+                39.06159137605786
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p506",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6262.9,173.6 6249.1,7394.7 1262.0,7403.2 1206.8,121.5 6262.9,173.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56841465893659,
+                39.05895113706609
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56858094922923,
+                39.055870293763434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57333840746162,
+                39.056027322140004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57317211716897,
+                39.059108165442666
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p508",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,42.1 6218.2,120.4 6146.2,7784.0 -0.0,7702.2 -0.0,42.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56377655147304,
+                39.058761174125266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56392891202053,
+                39.05567410840522
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56869598164741,
+                39.05581798280407
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56854362109992,
+                39.05890504852412
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p509",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,1127.4 6477.0,2276.8 5543.2,2279.7 5557.0,7733.1 262.4,7739.6 244.1,3933.4 -0.0,3931.8 -0.0,2005.1 241.9,2003.9 231.5,-0.0 6332.3,-0.0 6325.0,1112.6 6477.0,1127.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55906987533398,
+                39.06112718950655
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55924368589939,
+                39.05812429958561
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56386659676213,
+                39.05828791719606
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56369278619671,
+                39.061290807117
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p511",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,6648.9 192.7,6690.2 133.9,708.2 3452.7,674.8 3452.6,467.7 6477.0,436.1 6477.0,6648.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55521981127002,
+                39.06095043989731
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55541302212644,
+                39.05803623382824
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5598994222482,
+                39.05821811333211
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55970621139177,
+                39.06113231940118
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p513",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5565.3,3904.3 6477.0,3916.8 6477.0,7632.3 3406.3,7589.4 3401.5,7789.2 197.8,7743.2 435.4,1897.7 -0.0,1873.1 -0.0,208.8 5625.0,317.8 5565.3,3904.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55100722702433,
+                39.06090009763125
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55111298456262,
+                39.05787838448316
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55576485224962,
+                39.057977940427136
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55565909471133,
+                39.06099965357522
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p514",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6423.0,0.1 6423.0,7788.6 6200.3,7643.2 977.5,7625.5 915.4,3894.6 -0.0,3897.3 -0.0,18.5 6423.0,0.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5511135883428,
+                39.0582739196025
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55128151314354,
+                39.05529093328776
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55591079220893,
+                39.05545029549522
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55574286740818,
+                39.05843328180996
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p516",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1737.9,7795.0 1738.2,7084.2 -0.0,7094.1 114.0,637.6 6423.0,620.8 6423.0,7042.6 3607.7,7074.9 3612.8,7795.0 1737.9,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60379664139793,
+                39.057506026710335
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60002893189466,
+                39.05736778178324
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60024346835598,
+                39.05379210629087
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60401117785926,
+                39.05393035121796
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p517",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6477
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6477.0,4525.6 6457.6,5938.5 5546.8,5842.2 5346.5,7761.4 2429.6,7459.3 2394.3,7795.0 1449.3,7795.0 1497.3,7362.8 763.2,7286.7 1045.8,4415.7 -0.0,4299.8 -0.0,1311.5 78.8,1549.6 5013.8,-0.0 6477.0,4525.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59773515776784,
+                39.054731447607416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59749974351234,
+                39.051835171085244
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6477.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60195812943402,
+                39.05161354284208
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60219354368954,
+                39.05450981936425
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p520",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"184.2,5728.7 -0.0,5651.7 -0.0,5313.3 178.1,5312.2 121.9,1727.0 332.7,1490.2 328.4,1077.8 698.3,1079.4 1659.2,0.0 2500.4,0.0 2506.5,779.0 5886.9,711.4 5941.2,4045.8 4335.4,7781.6 188.1,5984.7 184.2,5728.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5974705455601,
+                39.052153211888
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59395688528213,
+                39.053191425685284
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59234982497874,
+                39.04986493495401
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5958634852567,
+                39.04882672115672
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p521",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,5366.0 -0.0,555.4 396.4,0.0 1042.3,0.0 6347.6,3242.7 6481.0,5839.5 6270.6,6555.9 6266.9,7543.9 6481.0,7530.0 6481.0,7795.0 4920.3,7795.0 4632.4,7590.3 90.3,7719.3 390.6,5464.5 -0.0,5366.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5958802824169,
+                39.05487904250608
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59259347468424,
+                39.05633590539
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59035221680456,
+                39.053243511554946
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59363902453723,
+                39.051786648671026
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p522",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1719.6,7499.5 570.3,7515.5 543.9,3428.8 112.6,2453.8 3731.1,0.0 5950.2,0.0 6438.0,864.2 4972.0,1857.8 6125.8,3537.0 6122.7,7412.6 6438.0,7408.3 6438.0,7796.0 1724.4,7796.0 1719.6,7499.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59360727432136,
+                39.05295184279569
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58987476408817,
+                39.052801961103725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59010676595373,
+                39.04926825812009
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59383927618691,
+                39.04941813981206
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p523",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,4034.3 1674.6,3091.0 1529.6,2867.4 4813.3,589.7 5096.4,749.0 6481.0,712.7 6481.0,6222.5 6314.9,5993.2 4374.0,7328.2 3778.9,6463.7 2269.7,7555.8 1101.1,5884.7 2560.9,4878.7 2065.8,4018.0 -0.0,4034.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59121537148363,
+                39.05468794985382
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58746419645041,
+                39.05451405998375
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58773170789911,
+                39.05098472494279
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59148288293233,
+                39.05115861481286
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p524",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6438
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6438.0,7554.6 -0.0,7572.0 -0.0,3774.2 1553.3,2691.8 2124.8,3556.3 4064.6,2273.7 4224.3,2503.2 4272.3,1219.2 6415.2,1217.2 6438.0,7554.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59009756529012,
+                39.05292425336918
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58631863775994,
+                39.0528041450794
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6438.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58650455376834,
+                39.04922650467929
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59028348129851,
+                39.04934661296907
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p525",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6481
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"374.6,6985.3 -0.0,6017.6 166.4,241.1 5907.0,245.8 5882.8,5621.5 4681.0,5635.0 4399.7,5471.2 953.9,7795.0 374.6,6985.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59085281070912,
+                39.05685385419042
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58710647014202,
+                39.05672407834309
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6481.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58730612172846,
+                39.05319937953281
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59105246229555,
+                39.05332915538015
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p530",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6454
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5819.8,7701.8 680.9,7735.4 633.5,73.3 6449.5,-0.0 6454.0,2038.0 5756.6,2039.7 5819.8,7701.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58167864470313,
+                39.0519168379923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58186272860372,
+                39.04886572825838
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6454.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58657381780979,
+                39.049039575948704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5863897339092,
+                39.05209068568263
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p539",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,40.4 6456.0,6334.5 4883.4,7795.0 206.5,7728.8 210.4,2.5 6456.0,40.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57360739445402,
+                39.05084870768495
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57376354328512,
+                39.047787364482474
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57849032108506,
+                39.047934833975866
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57833417225395,
+                39.05099617717834
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p540",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7112.8 821.6,6350.4 973.7,-0.0 6250.4,146.3 6265.9,1305.2 6472.0,1122.0 6472.0,6015.8 6282.5,6115.0 6273.8,7795.0 -0.0,7795.0 -0.0,7112.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57378604033208,
+                39.048245215458905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57384792849064,
+                39.045208427055734
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57852505512834,
+                39.04526673256697
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57846316696977,
+                39.048303520970144
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p541",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,698.8 6456.0,7150.7 106.9,7081.2 169.7,665.8 6456.0,698.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56952422617715,
+                39.05068506157347
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56965497739752,
+                39.0477708558067
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57415459749434,
+                39.04789433868214
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57402384627397,
+                39.050808544448905
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0542/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p542",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0542/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0542/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"759.1,7124.8 663.1,711.7 6353.2,679.5 6422.7,2874.4 6419.8,7101.3 759.1,7124.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0542/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56962607447159,
+                39.04806667263274
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5698141358602,
+                39.04512963744793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5743376104605,
+                39.045306812788176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57414954907188,
+                39.04824384797299
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p543",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6456.0,165.5 6456.0,2153.6 5622.4,2153.7 5601.0,7654.2 140.9,7673.0 148.7,156.6 6456.0,165.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56537566785285,
+                39.05053055207242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56554082612078,
+                39.047548250680954
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57014561102037,
+                39.047704227162754
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56998045275243,
+                39.05068652855422
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p544",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6235.3,464.1 6472.0,463.8 6472.0,4035.7 6224.4,4039.6 6236.8,7585.4 -0.0,7602.9 -0.0,2133.3 828.9,2130.1 821.2,153.1 6233.6,129.1 6235.3,464.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56552460277516,
+                39.047929664650674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56570601760232,
+                39.044923416936825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57033609435283,
+                39.04509433029063
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57015467952566,
+                39.04810057800448
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p545",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6456
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"110.4,7795.0 -0.0,3728.6 172.5,3729.0 212.1,0.0 2171.2,0.0 2263.2,174.7 6456.0,104.5 6456.0,3641.2 4352.6,3628.1 4294.1,7723.4 110.4,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57876244747514,
+                39.04536583356501
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57503061357437,
+                39.04527045380583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6456.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57517787117553,
+                39.04174579223745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5789097050763,
+                39.04184117199663
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p546",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6472
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2338.8,7783.7 2153.4,7575.9 2151.5,3705.6 397.1,3710.9 364.1,274.4 1223.3,251.8 1033.1,49.0 1381.0,0.0 6327.6,0.0 6190.9,7734.6 2338.8,7783.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57524221592568,
+                39.04535801410488
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57139362150312,
+                39.04523073300155
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6472.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57158964495603,
+                39.04160475899732
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5754382393786,
+                39.04173204010065
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p547",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6433
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4197.7,7789.4 280.3,7665.3 521.2,0.0 6184.5,31.8 6183.7,278.1 6433.0,282.7 6433.0,1858.9 6279.0,1860.6 6315.5,7513.0 4197.7,7789.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5717920183994,
+                39.045224301911645
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56794949799934,
+                39.045138530404344
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6433.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.56808241483175,
+                39.04149576812713
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57192493523182,
+                39.04158153963443
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p551",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"281.6,131.3 4165.9,112.9 4200.7,4216.9 6005.6,4223.3 5968.2,7795.0 -0.0,7795.0 -0.0,4254.8 221.4,4239.2 281.6,131.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5764753664993,
+                39.043726343205826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.572754118439,
+                39.043598867775195
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57295264051088,
+                39.040053265455484
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57667388857118,
+                39.040180740886115
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p553",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2430.5,97.1 4342.3,132.1 4291.2,7369.0 710.9,7477.7 771.3,1925.3 -0.0,1885.2 -0.0,1796.7 772.6,1809.4 791.5,68.2 2431.6,-0.0 2430.5,97.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60291794665856,
+                39.05458069004749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60303211791434,
+                39.051648467763094
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60759940198278,
+                39.05175723030696
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60748523072701,
+                39.054689452591354
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p554",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6512
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5503.7,152.1 5423.3,5689.0 6512.0,5681.5 6512.0,7795.0 -0.0,7795.0 -0.0,138.5 5503.7,152.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60299162821681,
+                39.05259066965249
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60313488500779,
+                39.049604876977405
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6512.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60770550778408,
+                39.04973900340715
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6075622509931,
+                39.05272479608223
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p561",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6400
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6400.0,947.4 6400.0,7748.9 -0.0,7795.0 -0.0,1047.5 6400.0,947.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.596417034647,
+                39.049767320130265
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59658671568288,
+                39.04687005677081
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6400.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.6010992529086,
+                39.04703170992992
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.60092957187271,
+                39.049928973289376
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p565",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6392
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3384.7,7620.7 3060.2,7795.0 585.8,7795.0 555.7,1222.9 -0.0,1220.3 -0.0,272.5 6392.0,216.8 6392.0,7795.0 5273.9,7795.0 4626.4,6569.7 4096.8,6782.3 3384.7,7620.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58685399131663,
+                39.04947424192213
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6392.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5830696578046,
+                39.04934183307332
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6392.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58327614185562,
+                39.0457319758128
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58706047536766,
+                39.045864384661606
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p568",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6517.0,0.0 6517.0,7796.0 -0.0,7790.9 -0.0,-0.0 6517.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54844643439553,
+                39.06976409895329
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5445454128701,
+                39.06959328931583
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54480678629199,
+                39.06594397892634
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54870780781744,
+                39.0661147885638
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p569",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6360
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1767.3,0.0 6360.0,0.0 6360.0,5858.2 280.3,5931.2 283.5,6379.1 -0.0,6379.9 -0.0,972.9 2242.3,959.9 2239.5,132.5 1767.3,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55111698060293,
+                39.06115074511882
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5474576366419,
+                39.06101687570108
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6360.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54766748530342,
+                39.05750929369421
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55132682926447,
+                39.05764316311196
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p570",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"472.6,0.0 6517.0,0.0 6517.0,7796.0 -0.0,7796.0 -0.0,6984.6 429.6,6988.5 472.6,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0570/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55139083669515,
+                39.05848344024774
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54759254322508,
+                39.058380188704014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.54775051484042,
+                39.054826433398965
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.55154880831049,
+                39.05492968494269
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p574 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6517
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1026.5,3379.3 1411.8,2912.2 1655.2,2848.8 1981.7,3468.9 2547.1,3469.7 2552.1,0.0 6463.6,0.0 6517.0,73.7 6517.0,5541.3 6431.9,5542.0 6517.0,7796.0 -0.0,7796.0 -0.0,3466.0 862.3,3467.3 1026.5,3379.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.58608243745302,
+                39.04901078717636
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57845211625984,
+                39.04875231135949
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6517.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.57884751393513,
+                39.041612115346496
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5864778351283,
+                39.04187059116336
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Kansas City, Mo. | 1951 | Vol. 4 p576",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6491
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6491.0,7728.1 -0.0,7795.0 0.0,0.0 6491.0,0.0 6491.0,7728.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.5992733680164,
+                39.071581856809814
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6491.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59534385617367,
+                39.07141165266783
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6491.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59560527195849,
+                39.06772218628497
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -94.59953478380122,
+                39.067892390426955
               ]
             }
           }
@@ -396,8 +9684,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -416,7 +9704,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6135.0,6668.0 254.3,6646.6 256.0,136.0 5091.4,160.7 6123.5,306.4 6135.0,6668.0\" /></svg>"
+          "value": "<svg><polygon points=\"256.0,136.0 6367.0,172.4 6134.5,4212.0 6135.0,6668.0 255.1,6647.2 256.0,136.0\" /></svg>"
         }
       },
       "body": {
@@ -472,351 +9760,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p457",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6553
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1892.8,5878.1 1102.0,5451.5 188.4,5569.2 182.6,5399.8 44.7,5392.0 -0.0,16.4 6442.0,253.3 6553.0,6077.2 1892.8,5878.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0457/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58530645315699,
-                39.07125774290198
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6553.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58529826660597,
-                39.068276735161646
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6553.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58987057633462,
-                39.06826917859847
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58987876288563,
-                39.0712501863388
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2976.5,
-                4879.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.588166,
-                39.069899
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p458",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6406
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2289.4,7658.1 2346.7,6607.9 2047.2,5652.7 587.7,5626.9 249.6,126.0 6051.6,124.9 5976.6,7663.7 2289.4,7658.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0458/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1483.5,
-                3863.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.587793,
-                39.067805
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                247.9,
-                128.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.585447,
-                39.068327
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p459",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6553
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6553.0,7269.3 -0.0,7355.4 -0.0,0.0 216.2,-0.0 214.1,282.6 472.1,316.0 472.7,-0.0 6553.0,-0.0 6553.0,7269.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0459/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                472.1,
-                316.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5818218,
-                39.070903
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                472.1,
-                7339.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58532,
-                39.071032
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0460/georef",
       "type": "Annotation",
       "@context": [
@@ -834,8 +9777,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -854,7 +9797,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2206.1,4587.9 5417.6,4522.0 5406.6,5601.9 6068.8,5608.7 6008.6,6308.0 5336.7,6328.3 5329.2,7374.3 2185.7,7374.8 2206.1,4587.9\" /></svg>"
+          "value": "<svg><polygon points=\"2440.8,4604.4 5453.9,4594.5 5406.2,5602.0 6068.8,5608.7 6008.6,6308.0 5375.0,6317.1 5414.7,7392.6 2551.8,7374.5 2416.0,6861.0 2440.8,4604.4\" /></svg>"
         }
       },
       "body": {
@@ -910,192 +9853,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p461",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5338.7,7795.0 5336.7,7518.1 216.0,7555.4 217.3,7795.0 -0.0,7795.0 0.0,0.0 178.9,-0.0 183.7,881.1 5872.3,783.1 6156.3,7795.0 5338.7,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0461/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5000.0,
-                2831.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.579027,
-                39.068583
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                212.0,
-                6807.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.581222,
-                39.07088
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p462",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6371
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6243.5,5716.8 6371.0,5753.2 6371.0,7796.0 -0.0,7796.0 -0.0,588.6 5542.6,807.4 6319.1,622.9 6243.5,5716.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0462/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4255.3,
-                720.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.577955,
-                39.066226
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6287.0,
-                4808.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.580329,
-                39.065343
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0463/georef",
       "type": "Annotation",
       "@context": [
@@ -1113,8 +9870,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1133,7 +9890,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"29.9,7403.5 54.8,888.7 4101.6,881.9 4099.1,1411.2 6140.2,1395.0 6080.8,7357.6 29.9,7403.5\" /></svg>"
+          "value": "<svg><polygon points=\"29.9,7403.5 54.8,888.7 4101.6,881.9 4099.1,1411.2 6139.7,1395.0 6080.3,7357.6 29.9,7403.5\" /></svg>"
         }
       },
       "body": {
@@ -1206,8 +9963,8 @@
           "value": "36"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1226,7 +9983,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1442.4 396.8,1435.3 398.8,1629.0 6112.4,1567.7 6004.0,7201.7 5240.8,7416.5 -0.0,7425.2 -0.0,1442.4\" /></svg>"
+          "value": "<svg><polygon points=\"388.1,1435.4 378.9,-0.0 6086.4,-0.0 6136.5,4374.3 6038.9,4377.3 6037.8,7796.0 5918.6,7796.0 6003.0,7201.8 5240.0,7416.6 -0.0,7422.9 -0.0,1442.3 388.1,1435.4\" /></svg>"
         }
       },
       "body": {
@@ -1299,8 +10056,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1392,8 +10149,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1412,7 +10169,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6343.5,3006.8 6174.3,7795.0 457.1,7795.0 478.8,463.0 2034.9,462.4 2037.6,672.1 6109.9,651.9 6192.9,2519.4 6343.5,3006.8\" /></svg>"
+          "value": "<svg><polygon points=\"6343.5,3006.8 6153.7,6230.5 454.3,6169.6 478.8,463.0 2034.9,462.4 2037.6,672.1 6109.9,651.9 6122.2,2354.5 6343.5,3006.8\" /></svg>"
         }
       },
       "body": {
@@ -1468,564 +10225,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p467",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7390.6 0.0,0.0 6536.0,-0.0 6536.0,7516.2 -0.0,7390.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0467/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4008.0,
-                1975.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.566805,
-                39.068528
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                164.0,
-                5215.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.568683,
-                39.070411
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p468",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2115.8,7587.1 811.8,7605.6 683.8,56.9 1653.4,46.2 5821.7,-0.0 6021.9,7715.0 2121.1,7788.0 2115.8,7587.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0468/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6021.9,
-                7715.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.570498,
-                39.064991
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5929.9,
-                4071.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.568285,
-                39.064934
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p469",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6154.4,0.0 6197.7,7795.0 409.6,7795.0 259.4,0.0 6154.4,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0469/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2304.0,
-                3887.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5644585,
-                39.068454
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6172.0,
-                3887.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.562188,
-                39.068373
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p470",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5456.6,0.0 5524.3,7221.6 5929.9,7217.4 5934.4,7586.6 6386.0,7586.8 6386.0,7795.0 2157.9,7795.0 2148.7,7643.0 184.1,7643.0 118.8,0.0 5456.6,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0470/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2148.7,
-                7643.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.561095,
-                39.066513
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                184.1,
-                7643.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56228,
-                39.066558
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p471",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6536
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"392.6,7277.1 -0.0,7277.5 -0.0,287.4 373.1,290.9 372.8,179.9 -0.0,209.8 -0.0,-0.0 6536.0,0.0 6536.0,300.6 5972.0,297.3 5958.0,7610.6 393.6,7634.5 392.6,7277.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0471/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2268.0,
-                3931.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.55755,
-                39.06821
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2268.0,
-                7643.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5576415,
-                39.0664127
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p472",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6156.1,0.0 6188.4,7795.0 237.4,7795.0 207.2,0.0 6156.1,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0472/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2200.7,
-                3883.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5540884,
-                39.068094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6185.9,
-                3883.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.551758,
-                39.068012
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0473/georef",
       "type": "Annotation",
       "@context": [
@@ -2043,8 +10242,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2063,7 +10262,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"275.8,0.0 6254.5,0.0 6265.6,7796.0 253.6,7796.0 275.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5893.8,0.0 5759.6,7796.0 253.4,7796.0 275.0,0.0 5893.8,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2152,8 +10351,8 @@
           "value": "2841.6"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2201,8 +10400,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59874564521397,
-                39.06249183305151
+                -94.59874564521336,
+                39.062491833050885
               ]
             }
           },
@@ -2222,8 +10421,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59722787136232,
-                39.06242527769109
+                -94.59722787136245,
+                39.0624252776905
               ]
             }
           },
@@ -2243,8 +10442,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.59732187420326,
-                39.0611352001554
+                -94.59732187420335,
+                39.06113520015544
               ]
             }
           },
@@ -2264,8 +10463,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -94.5988396480549,
-                39.06120175551582
+                -94.59883964805424,
+                39.061201755515825
               ]
             }
           },
@@ -2327,8 +10526,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2347,7 +10546,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5278.9 -0.0,635.2 1216.4,650.7 1476.5,0.0 6338.9,0.0 6386.0,6709.9 4937.4,6724.0 4112.6,7598.0 296.1,7613.0 299.5,6186.0 -0.0,5278.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5278.9 -0.0,635.2 1198.2,650.5 1115.8,814.2 6334.9,756.5 6386.0,6709.9 6293.7,7795.0 294.9,7795.0 299.5,6186.0 -0.0,5278.9\" /></svg>"
         }
       },
       "body": {
@@ -2420,8 +10619,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2440,7 +10639,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6279.7,7568.9 1914.7,7587.1 1328.2,7294.5 377.4,7304.7 327.9,204.0 6230.7,181.2 6279.7,7568.9\" /></svg>"
+          "value": "<svg><polygon points=\"6279.7,7568.9 1914.7,7587.1 1328.2,7294.5 462.3,7303.8 327.9,204.0 6230.7,181.2 6279.7,7568.9\" /></svg>"
         }
       },
       "body": {
@@ -2496,192 +10695,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p476",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6386
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6041.7,55.0 6080.6,7795.0 182.4,7795.0 156.0,19.4 6041.7,55.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0476/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4185.3,
-                3867.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.588001,
-                39.063873
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6089.9,
-                3867.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.586882,
-                39.063831
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p477",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6531
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6261.7,7796.0 361.5,7796.0 330.5,263.5 2338.6,245.2 2336.6,0.0 4489.2,0.0 4541.0,1382.7 5898.9,1439.7 6389.4,1777.1 6257.4,2265.9 6261.6,7652.3 6531.0,7681.2 6261.7,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0477/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4339.3,
-                3976.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5844916,
-                39.0637457
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6263.0,
-                3976.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.583332,
-                39.063703
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0478/georef",
       "type": "Annotation",
       "@context": [
@@ -2699,8 +10712,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2719,7 +10732,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"333.0,1864.8 424.5,1703.4 -0.0,1413.3 -0.0,0.0 2305.6,0.0 2316.1,291.2 6247.8,103.5 6305.8,7795.0 309.7,7795.0 333.0,1864.8\" /></svg>"
+          "value": "<svg><polygon points=\"333.0,1865.3 424.6,1703.9 -0.0,1413.8 -0.0,-0.0 6247.9,104.4 6305.7,7795.0 309.7,7795.0 333.0,1865.3\" /></svg>"
         }
       },
       "body": {
@@ -2775,657 +10788,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p479",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6327.2,7795.0 326.1,7795.0 264.2,37.1 6247.2,0.0 6327.2,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0479/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2303.3,
-                3919.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.578691,
-                39.063518
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6310.1,
-                3919.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.576359,
-                39.063426
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p480",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6324.5,7795.0 190.4,7795.0 109.1,0.0 2938.1,0.0 6402.0,28.1 6324.5,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0480/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2184.7,
-                3911.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.575201,
-                39.06338
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4205.3,
-                3911.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574038,
-                39.063334
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p481",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1999.4,152.7 2489.7,0.0 6253.5,0.0 6291.1,3884.0 6491.9,3881.3 6494.0,7795.0 4523.9,7795.0 4523.6,7562.3 525.9,7571.3 631.4,22.5 1999.4,152.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0481/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2435.2,
-                3895.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.571723,
-                39.063246
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                391.9,
-                3895.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.572903,
-                39.063289
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p482",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6402.0,7601.4 6402.0,7795.0 2074.0,7795.0 2077.3,7365.2 350.7,7361.2 375.4,3887.0 200.7,3888.0 193.8,510.0 -0.0,411.4 5612.5,373.3 5633.3,7598.1 6402.0,7601.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0482/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                288.1,
-                3887.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.569438,
-                39.0631685
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1992.6,
-                3887.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5683065,
-                39.063134
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p483",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7588.7 -0.0,7623.9 255.6,7586.4 265.4,2083.3 335.1,2082.9 344.2,163.3 6494.0,147.0 6494.0,7588.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0483/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4094.7,
-                152.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5611903,
-                39.0647144
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4094.7,
-                7595.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.565786,
-                39.064872
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p484",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6402
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"984.1,98.0 6182.5,127.6 6204.9,5787.6 6402.0,5787.4 6402.0,7601.1 979.4,7609.9 984.1,98.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0484/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.7,
-                2011.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5624604,
-                39.0629423
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2376.7,
-                7607.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.565883,
-                39.063058
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p485",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6494
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"573.6,3411.2 368.5,3409.1 383.7,-0.0 5701.8,72.1 5640.2,7597.0 530.6,7575.1 573.6,3411.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0485/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4170.7,
-                5775.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5600759,
-                39.0646765
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4170.7,
-                1967.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5577442,
-                39.0646067
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0486/georef",
       "type": "Annotation",
       "@context": [
@@ -3443,8 +10805,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3463,7 +10825,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6152.2,5789.3 5753.3,5792.0 5754.2,7664.5 -0.0,7657.3 -0.0,95.7 6125.0,57.2 6152.2,5789.3\" /></svg>"
+          "value": "<svg><polygon points=\"6152.2,5789.3 5915.3,5790.9 5917.5,7665.4 -0.0,7657.7 -0.0,95.6 6125.0,57.2 6152.2,5789.3\" /></svg>"
         }
       },
       "body": {
@@ -3536,8 +10898,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3556,7 +10918,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"494.9,7597.1 489.0,175.7 5710.6,168.8 5690.3,7594.6 494.9,7597.1\" /></svg>"
+          "value": "<svg><polygon points=\"5587.9,7594.9 403.9,7584.8 407.1,5757.5 479.9,5757.5 489.0,175.7 5542.7,163.5 5587.9,7594.9\" /></svg>"
         }
       },
       "body": {
@@ -3612,99 +10974,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p488",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6430
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6082.0,7602.7 -0.0,7621.6 -0.0,93.9 6430.0,87.1 6279.0,1955.8 6085.5,1956.6 6082.0,7602.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0488/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2295.3,
-                5759.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5555349,
-                39.0627132
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2295.3,
-                7615.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5566761,
-                39.0627518
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0489/georef",
       "type": "Annotation",
       "@context": [
@@ -3722,8 +10991,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3742,7 +11011,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6494.0,7566.4 228.7,7548.7 195.4,7548.5 160.2,7548.2 170.5,1666.4 181.8,1666.4 192.2,-0.0 6494.0,-0.0 6494.0,7566.4\" /></svg>"
+          "value": "<svg><polygon points=\"6494.0,-0.0 6494.0,7566.4 228.7,7548.7 269.9,-0.0 6494.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -3815,8 +11084,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3835,7 +11104,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6298.3,-0.0 6430.0,5916.4 5971.0,5940.7 6000.5,7527.2 649.8,7546.6 614.7,-0.0 6298.3,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6430.0,5833.5 6012.1,5831.4 6035.3,7528.3 649.8,7546.6 614.7,-0.0 5500.2,-0.0 5476.3,4089.8 5610.2,3625.9 6430.0,3627.4 6430.0,5833.5\" /></svg>"
         }
       },
       "body": {
@@ -3908,8 +11177,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3984,99 +11253,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p492",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6414
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"167.9,7552.0 259.6,7400.5 -0.0,-0.0 6414.0,0.0 6158.4,7617.5 167.9,7552.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0492/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3990.8,
-                4992.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.601424,
-                39.058333
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                167.9,
-                7552.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6037473,
-                39.0572111
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0493__1/georef",
       "type": "Annotation",
       "@context": [
@@ -4110,8 +11286,8 @@
           "value": "3654.7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4219,8 +11395,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4239,7 +11415,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"619.7,3529.8 3755.1,3524.5 3738.7,-0.0 6328.9,-0.0 6332.0,7581.0 -0.0,7422.1 -0.0,7080.7 606.5,7083.0 619.7,3529.8\" /></svg>"
+          "value": "<svg><polygon points=\"619.7,3529.8 3755.1,3524.5 3743.8,1187.0 6325.3,1175.9 6332.0,7581.0 -0.0,7476.8 -0.0,7080.7 606.5,7083.0 619.7,3529.8\" /></svg>"
         }
       },
       "body": {
@@ -4295,192 +11471,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p494",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6430
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"160.6,7617.0 204.5,1309.9 4141.3,1320.0 4140.5,153.3 6430.0,-0.0 6430.0,4507.1 5394.8,4953.7 6430.0,7225.0 6430.0,7628.9 160.6,7617.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0494/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4434.6,
-                7655.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.600177,
-                39.05514
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                167.9,
-                4675.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.598328,
-                39.057024
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p495",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6452
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6248.0,7599.0 200.0,7599.0 202.9,927.2 3934.7,912.6 4799.2,0.0 6257.3,0.0 6248.0,7599.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0495/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                200.0,
-                7599.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.597687,
-                39.058193
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6248.0,
-                7599.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.594158,
-                39.058067
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0496/georef",
       "type": "Annotation",
       "@context": [
@@ -4498,8 +11488,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4518,7 +11508,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"275.8,7627.6 320.0,0.0 1269.6,0.0 1852.2,298.5 6211.4,327.3 6216.0,4942.0 6198.1,7623.0 275.8,7627.6\" /></svg>"
+          "value": "<svg><polygon points=\"275.8,7627.6 320.0,0.0 1269.6,0.0 1852.2,298.5 6211.4,327.3 6221.9,7795.0 6198.1,7623.0 275.8,7627.6\" /></svg>"
         }
       },
       "body": {
@@ -4591,8 +11581,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4611,7 +11601,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1172.4,6844.2 -0.0,6848.0 -0.0,2891.7 1206.9,2893.9 1218.3,236.0 5640.0,248.0 5673.0,6804.0 2118.6,6853.1 1343.5,7373.6 1172.4,6844.2\" /></svg>"
+          "value": "<svg><polygon points=\"1360.7,7191.7 1378.3,2901.6 -0.0,2885.0 -0.0,236.0 5640.0,248.0 5673.0,6804.0 1900.8,6850.9 1360.7,7191.7\" /></svg>"
         }
       },
       "body": {
@@ -4684,8 +11674,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4704,7 +11694,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3750.9,6746.3 1312.0,6790.7 1215.8,238.4 5156.1,178.2 5171.8,7795.0 4511.2,7791.4 4502.0,7795.0 3750.9,6746.3\" /></svg>"
+          "value": "<svg><polygon points=\"5156.1,178.2 5175.2,7795.0 4502.0,7795.0 3750.9,6746.3 1312.0,6790.7 1215.8,238.4 5156.1,178.2\" /></svg>"
         }
       },
       "body": {
@@ -4760,99 +11750,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p499",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,159.6 6500.0,7622.5 326.6,7664.7 302.7,79.1 5746.0,-0.0 6483.1,159.6 6500.0,159.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0499/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4056.0,
-                3895.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.588223,
-                39.060269
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4056.0,
-                168.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.585893,
-                39.06018
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0500/georef",
       "type": "Annotation",
       "@context": [
@@ -4870,8 +11767,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4890,7 +11787,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1023.4,65.8 6120.5,39.6 6158.6,7666.2 1035.5,7705.2 1023.4,65.8\" /></svg>"
+          "value": "<svg><polygon points=\"6159.1,7666.1 1133.2,7682.8 1020.5,40.6 6120.4,10.8 6159.1,7666.1\" /></svg>"
         }
       },
       "body": {
@@ -4946,564 +11843,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p501",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2863.8,7067.1 6100.4,7795.0 92.8,7795.0 3.6,0.0 4453.7,-0.0 2863.8,7067.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0501/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4124.0,
-                5871.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.584697,
-                39.060138
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4124.0,
-                1855.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.582355,
-                39.060063
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p502",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6431.8,-0.0 5698.1,976.3 6454.0,4456.5 6454.0,7036.1 3008.2,7795.0 979.0,7795.0 978.1,7795.0 -0.0,7795.0 -0.0,673.0 2075.4,211.9 2028.8,-0.0 6431.8,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0502/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6342.0,
-                3943.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.583775,
-                39.056491
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2399.3,
-                140.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.580176,
-                39.05817
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p503",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,5302.2 6500.0,6372.6 5850.6,6372.9 5850.8,6629.0 73.0,6642.7 58.5,269.3 5847.0,249.4 5849.5,4437.9 6500.0,5302.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0503/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                164.0,
-                2347.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574137,
-                39.061547
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                164.0,
-                6375.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.576466,
-                39.061634
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p504",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1871.4,7795.0 1869.3,6613.4 -0.0,6616.7 -0.0,6360.1 650.6,6360.2 588.5,5204.1 -0.0,4539.1 -0.0,0.0 6307.7,-0.0 6318.3,7795.0 1871.4,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0504/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6310.0,
-                2327.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574469,
-                39.056167
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6310.0,
-                6367.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5768,
-                39.056253
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p505",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,113.7 6500.0,7581.0 5799.9,7579.0 5799.3,7795.0 -0.0,7795.0 -0.0,3924.8 225.1,3925.0 229.4,2019.3 308.0,2019.4 302.1,100.2 6500.0,113.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0505/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4192.0,
-                3919.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.570725,
-                39.059615
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4192.0,
-                104.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.568447,
-                39.059536
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p506",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6278.1,160.0 6279.5,7321.8 1086.5,7307.1 1086.3,121.7 6278.1,160.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0506/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6278.1,
-                7615.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5733076,
-                39.0561255
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6278.1,
-                160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.568682,
-                39.055965
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0507/georef",
       "type": "Annotation",
       "@context": [
@@ -5521,8 +11860,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5541,7 +11880,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"917.8,7626.5 908.9,3007.3 702.1,3007.7 704.4,2044.0 510.5,2043.8 503.2,106.5 6477.0,128.6 6477.0,7657.9 917.8,7626.5\" /></svg>"
+          "value": "<svg><polygon points=\"5487.5,118.8 5505.0,7650.6 477.1,7624.0 506.1,3827.9 628.2,3828.0 503.2,106.5 5487.5,118.8\" /></svg>"
         }
       },
       "body": {
@@ -5597,192 +11936,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p508",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6152.2,334.4 5879.0,7778.6 827.0,7574.2 1046.9,134.4 6152.2,334.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0508/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2247.3,
-                7627.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.56856,
-                39.05774
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3630.9,
-                3851.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.566193,
-                39.057042
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p509",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3534.5,1172.3 6477.0,1234.3 6477.0,2353.0 5595.9,2356.9 5613.2,7665.3 423.3,7678.6 402.7,3973.7 -0.0,3971.4 -0.0,2097.9 399.2,2095.4 387.6,151.9 3535.3,160.4 3534.5,1172.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0509/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4192.6,
-                5843.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5626551,
-                39.0593451
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4192.6,
-                7663.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.563765,
-                39.059385
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0510/georef",
       "type": "Annotation",
       "@context": [
@@ -5800,8 +11953,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5820,7 +11973,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6227.9,4429.5 6263.3,7683.5 -0.0,7634.1 -0.0,2257.4 892.4,2256.3 896.1,1123.2 6401.0,1094.7 6401.0,4427.1 6227.9,4429.5\" /></svg>"
+          "value": "<svg><polygon points=\"6263.3,7683.5 -0.0,7634.1 -0.0,2257.4 927.1,2256.3 930.0,1123.1 6401.0,1094.7 6263.3,7683.5\" /></svg>"
         }
       },
       "body": {
@@ -5876,99 +12029,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p511",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6477.0,7795.0 3570.7,7795.0 3575.8,6717.5 224.0,6695.1 224.0,667.9 6477.0,600.4 6477.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0511/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                224.0,
-                6695.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5590804,
-                39.06102
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                224.0,
-                667.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5556314,
-                39.0609067
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0512/georef",
       "type": "Annotation",
       "@context": [
@@ -5986,8 +12046,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6006,7 +12066,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 476.5,7716.7 508.7,492.2 6210.6,542.8 6423.0,692.6 6423.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6358.3,7795.0 578.2,7778.8 682.7,492.8 6210.6,542.8 6423.0,692.6 6358.3,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -6062,192 +12122,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p513",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6477.0,7659.1 6199.5,7654.0 6196.7,7795.0 204.3,7742.1 294.1,3834.9 493.4,3838.2 544.5,2164.6 767.3,1922.1 -0.0,1876.0 -0.0,321.6 6477.0,98.6 6477.0,7659.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0513/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4176.6,
-                1975.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5522397,
-                39.0590036
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                236.0,
-                5783.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5544614,
-                39.0608714
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p514",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6423.0,7663.7 6113.4,7529.7 900.2,7661.8 528.7,187.6 1228.0,138.6 1216.3,-0.0 6423.0,-0.0 6423.0,7663.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0514/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2151.7,
-                7623.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.555698,
-                39.057409
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2151.7,
-                136.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.551183,
-                39.057155
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0515/georef",
       "type": "Annotation",
       "@context": [
@@ -6265,8 +12139,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6285,7 +12159,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6458.9 -0.0,-0.0 115.1,0.0 141.2,653.4 6274.9,591.9 6316.4,6106.2 -0.0,6458.9\" /></svg>"
+          "value": "<svg><polygon points=\"6089.1,7197.8 458.1,7266.1 490.7,7795.0 -0.0,7795.0 -0.0,-0.0 115.1,0.0 141.2,653.4 6274.9,591.9 6089.1,7197.8\" /></svg>"
         }
       },
       "body": {
@@ -6341,192 +12215,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p516",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1622.7,7795.0 1629.4,7137.3 -0.0,7129.3 52.9,557.7 6423.0,608.1 6380.3,7142.9 3519.2,7147.9 3517.3,7795.0 1622.7,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0516/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5443.2,
-                7155.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.600759,
-                39.054148
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1879.7,
-                571.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6026871,
-                39.0571745
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p517",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6477
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6477.0,4749.8 6477.0,6131.0 5479.4,6003.8 5250.9,7795.0 4036.8,7795.0 2259.0,7570.7 2230.2,7795.0 1177.4,7795.0 1221.2,7439.8 560.8,7356.4 915.9,4435.6 704.6,4408.1 757.6,3995.4 -0.0,1518.4 5063.5,56.4 6477.0,4749.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0517/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                916.1,
-                4435.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.600214,
-                39.054138
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5064.8,
-                56.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.597548,
-                39.052491
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0518__1/georef",
       "type": "Annotation",
       "@context": [
@@ -6560,8 +12248,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6580,7 +12268,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6241.3 363.5,4944.2 319.7,172.9 2155.7,188.6 2157.6,-0.0 2575.1,-0.0 2813.2,214.6 6438.0,195.9 6438.0,1532.6 6250.8,1497.3 5513.2,3167.9 5640.1,3323.2 3461.9,7746.4 -0.0,6241.3\" /></svg>"
+          "value": "<svg><polygon points=\"6147.0,1477.8 3438.2,7796.0 -0.0,6241.3 362.9,4883.7 319.7,172.9 2156.2,188.7 2158.1,-0.0 2575.1,-0.0 2813.2,214.6 6438.0,195.9 6438.0,1532.6 6147.0,1477.8\" /></svg>"
         }
       },
       "body": {
@@ -6653,8 +12341,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6673,7 +12361,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"459.5,1958.3 4654.6,3735.3 5008.5,2900.3 5858.5,7364.5 2879.5,7483.4 2873.5,6704.5 2002.9,6725.8 1059.2,7795.0 497.4,7795.0 459.5,1958.3\" /></svg>"
+          "value": "<svg><polygon points=\"459.5,1947.5 4664.1,3764.9 5136.0,2559.2 5880.1,7363.2 2879.7,7482.9 2873.7,6694.8 2026.7,6698.7 1059.1,7795.0 497.7,7795.0 459.5,1947.5\" /></svg>"
         }
       },
       "body": {
@@ -6729,564 +12417,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p520",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"142.3,5659.6 -0.0,5596.4 -0.0,5242.0 146.3,5244.1 178.2,1666.6 393.1,1434.6 398.9,1022.6 766.5,1031.6 1722.1,0.0 2580.5,0.0 2567.7,768.1 5924.0,767.2 5896.4,4094.3 4211.7,7789.2 139.9,5915.1 142.3,5659.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0520/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5918.2,
-                3036.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.593615,
-                39.051837
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                187.9,
-                1492.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5970813,
-                39.0515121
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p521",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,621.4 493.2,0.0 1421.7,0.0 6409.6,3265.2 6481.0,5814.7 6218.7,6570.7 6181.0,7557.0 29.6,7557.0 406.1,5314.5 -0.0,5201.9 -0.0,621.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0521/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6181.0,
-                7559.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.590533,
-                39.053295
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                28.0,
-                7559.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.593615,
-                39.051837
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p522",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1093.3,7796.0 1104.1,7420.5 511.8,7406.3 642.5,3263.5 246.1,2258.5 3846.7,0.0 6216.1,0.0 6438.0,356.4 6438.0,1042.5 5159.6,1844.0 6267.3,3583.4 6438.0,7796.0 1093.3,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0522/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2507.2,
-                868.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5923013,
-                39.0524461
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5806.2,
-                7516.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.59045,
-                39.0494522
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p523",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2300.7,5019.0 2287.4,4330.3 2057.3,3976.4 -0.0,4016.1 -0.0,3807.4 1322.7,2944.2 6481.0,2729.3 6481.0,6369.5 6301.4,6105.1 4302.1,7411.3 3723.5,6514.3 2167.4,7585.0 1030.6,5850.4 2300.7,5019.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0523/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4704.7,
-                3383.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.588629,
-                39.053039
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3052.5,
-                5479.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5896155,
-                39.0521293
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p524",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6438
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3685.8 1566.6,2717.0 2090.9,3625.2 4114.8,2439.8 4278.2,2707.9 4384.6,1384.5 6438.0,1501.4 6140.7,7796.0 46.1,7796.0 -0.0,3685.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0524/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                -12.0,
-                3692.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.590161,
-                39.051206
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1567.5,
-                2716.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.58925,
-                39.05166
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p525",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6481
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5879.3,5873.2 5707.5,7795.0 664.6,7795.0 241.0,6912.2 -0.0,6010.3 391.4,288.6 5980.4,594.9 5675.4,5864.5 5879.3,5873.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0525/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                280.0,
-                2247.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.590818,
-                39.055838
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4240.7,
-                5639.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5884497,
-                39.0542918
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0526__1/georef",
       "type": "Annotation",
       "@context": [
@@ -7320,8 +12450,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7340,7 +12470,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"206.7,5608.0 -0.0,5611.2 -0.0,260.7 2289.2,256.4 2288.0,0.0 4429.4,0.0 6438.0,251.2 6438.0,5524.9 2304.9,5554.9 2307.5,6795.6 201.5,6813.4 206.7,5608.0\" /></svg>"
+          "value": "<svg><polygon points=\"201.5,6813.4 183.7,5608.4 -0.0,5611.2 -0.0,260.7 4102.3,252.1 4121.2,5543.9 2304.9,5554.9 2307.5,6795.6 201.5,6813.4\" /></svg>"
         }
       },
       "body": {
@@ -7429,8 +12559,8 @@
           "value": "2832.8"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7449,7 +12579,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6323.5,4259.6 4290.3,4259.6 4290.3,1426.8 6341.8,1426.8 6323.5,4259.6\" /></svg>"
+          "value": "<svg><polygon points=\"6323.5,4259.6 4290.3,4259.6 4320.6,1426.8 6341.8,1426.8 6323.5,4259.6\" /></svg>"
         }
       },
       "body": {
@@ -7522,8 +12652,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7542,7 +12672,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"646.0,5189.0 653.5,1307.4 1878.6,242.2 774.6,-0.0 6481.0,-0.0 6481.0,1302.0 6000.9,1299.8 6024.9,5199.9 646.0,5189.0\" /></svg>"
+          "value": "<svg><polygon points=\"6481.0,1302.0 6000.9,1299.8 6039.5,7563.4 641.3,7571.7 652.7,1244.2 -0.0,1245.1 -0.0,0.0 6481.0,-0.0 6481.0,1302.0\" /></svg>"
         }
       },
       "body": {
@@ -7615,8 +12745,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7635,7 +12765,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"915.3,7605.1 921.3,138.8 1362.8,143.6 1363.7,-0.0 4962.5,-0.0 4957.9,7631.8 915.3,7605.1\" /></svg>"
+          "value": "<svg><polygon points=\"6456.0,-0.0 6456.0,188.2 5884.0,184.0 5874.3,7637.8 915.3,7605.1 921.3,138.8 1362.8,143.6 1363.7,-0.0 6456.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -7691,99 +12821,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p530",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6454
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5806.9,7682.8 -0.0,7738.5 0.0,0.0 6436.6,-0.0 6454.0,2075.5 5898.4,2077.5 5922.5,7683.4 6454.0,7683.1 6454.0,7796.0 5813.4,7796.0 5806.9,7682.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0530/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5894.2,
-                5832.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5853774,
-                39.0493156
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5894.2,
-                216.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5818691,
-                39.0492051
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0531/georef",
       "type": "Annotation",
       "@context": [
@@ -7801,8 +12838,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7821,7 +12858,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,6282.4 208.7,6281.7 183.3,850.6 6456.0,814.6 6456.0,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,6266.7 208.6,6264.6 183.3,850.6 6456.0,814.6 6456.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7894,8 +12931,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7987,8 +13024,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8080,8 +13117,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8173,8 +13210,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8193,7 +13230,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5168.9,7605.0 458.5,7577.4 502.8,296.9 5207.3,322.1 5168.9,7605.0\" /></svg>"
+          "value": "<svg><polygon points=\"5168.8,7605.0 458.9,7577.4 503.2,296.9 5207.2,322.1 5168.8,7605.0\" /></svg>"
         }
       },
       "body": {
@@ -8266,8 +13303,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8359,8 +13396,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8379,7 +13416,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5814.0,-0.0 5812.2,406.3 6456.0,418.3 6456.0,1875.3 5805.7,1873.5 5797.1,3846.5 6456.0,3847.2 6456.0,7795.0 193.1,7795.0 193.6,436.1 372.5,434.0 373.5,-0.0 5814.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5814.0,-0.0 5797.1,3846.5 6456.0,3847.2 6456.0,7795.0 193.1,7795.0 193.6,436.1 372.5,434.0 373.5,-0.0 5814.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -8452,8 +13489,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8472,7 +13509,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6472.0,522.7 6472.0,1943.6 6320.8,1944.4 6326.3,7795.0 677.8,7795.0 660.8,3945.0 -0.0,3947.1 -0.0,1968.3 652.2,1967.3 645.7,506.1 -0.0,496.8 0.0,-0.0 6082.0,-0.0 6082.1,523.4 6472.0,522.7\" /></svg>"
+          "value": "<svg><polygon points=\"6472.0,1943.6 6320.8,1944.4 6326.3,7795.0 677.8,7795.0 660.8,3945.0 -0.0,3947.1 0.0,-0.0 6082.0,-0.0 6082.1,523.4 6472.0,522.7 6472.0,1943.6\" /></svg>"
         }
       },
       "body": {
@@ -8528,1002 +13565,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p539",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5111.5,7344.1 5097.5,7740.6 276.7,7795.0 275.7,7601.9 160.0,7601.0 168.6,130.7 6456.0,168.7 6456.0,6050.1 5111.5,7344.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0539/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                160.0,
-                1991.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574781,
-                39.050789
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                160.0,
-                7599.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.578299,
-                39.050897
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p540",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6472.0,7795.0 -0.0,7795.0 -0.0,7398.6 1428.8,5922.3 1288.6,5829.8 1089.8,187.9 723.5,199.4 717.5,-0.0 5958.9,46.8 6038.7,1150.8 6472.0,730.5 6472.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0540/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2264.0,
-                2015.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574994,
-                39.047183
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                7900.0,
-                120.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5740706,
-                39.0443708
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p541",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"151.9,796.8 6456.0,768.7 6456.0,7094.1 148.0,7087.1 151.9,796.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0541/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                148.0,
-                5075.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57243,
-                39.050708
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                148.0,
-                7087.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.573614,
-                39.050749
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p543",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6456.0,278.3 6456.0,2213.4 5674.7,2212.8 5510.4,7566.1 287.0,7580.6 304.6,265.1 6456.0,278.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0543/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4104.0,
-                4119.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.567909,
-                39.048751
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4104.0,
-                2211.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.566751,
-                39.048713
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p544",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6262.2,7795.0 892.3,7795.0 886.2,7577.9 -0.0,7603.6 -0.0,2267.4 778.1,2244.1 718.9,317.0 6062.2,154.1 6072.2,480.7 6472.0,469.6 6472.0,3953.3 6150.2,3966.6 6262.2,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0544/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2256.0,
-                2199.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.566851,
-                39.046905
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6256.0,
-                7535.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.570272,
-                39.045201
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p545",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6456
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"338.5,7789.5 -0.0,6855.5 -0.0,3773.3 216.9,3774.8 271.8,76.0 6456.0,365.3 6456.0,3716.9 6282.0,3715.5 6209.5,7795.0 338.5,7789.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0545/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6280.0,
-                3715.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.575172,
-                39.043626
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2268.0,
-                1779.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.577457,
-                39.044544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p546",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"352.5,3736.2 515.7,3734.4 455.0,589.7 1483.9,617.9 1066.9,163.9 6189.0,0.0 6100.4,7088.8 6472.0,7087.5 6472.0,7203.6 6100.6,7201.1 6097.3,7628.7 3923.6,7633.9 3922.5,7795.0 -0.0,7795.0 -0.0,7571.7 358.1,7619.2 352.5,3736.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0546/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4160.0,
-                3719.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.572832,
-                39.043547
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2168.0,
-                3719.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.574056,
-                39.043592
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p547",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6433
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6433.0,496.4 6433.0,7795.0 156.1,7795.0 280.1,0.0 6281.0,144.0 6285.2,492.1 6433.0,496.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0547/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                280.0,
-                144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.571479,
-                39.045242
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6281.0,
-                144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5680985,
-                39.045127
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p548",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6472
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5428.9,6235.7 2766.6,6080.1 2666.3,7795.0 2605.9,7795.0 2724.8,5337.5 -0.0,5220.6 -0.0,3547.6 752.7,3577.7 571.8,3268.1 537.9,2909.7 712.0,2573.4 805.8,2512.8 857.7,433.8 -0.0,427.9 0.0,0.0 6472.0,-0.0 6472.0,7795.0 6230.7,7795.0 5428.9,6235.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0548/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4448.0,
-                6835.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5700359,
-                39.0401218
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4448.0,
-                1727.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.563748,
-                39.040144
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p551",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6167.4,0.0 6239.1,5305.9 6400.0,5308.1 6400.0,7795.0 -0.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0551/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5766301021538,
-                39.04070932697251
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57287954658062,
-                39.04059260988325
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6400.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57306282059868,
-                39.03704845359497
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.57681337617187,
-                39.03716517068424
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6168.0,
-                204.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5730203,
-                39.0405041
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0552__1/georef",
       "type": "Annotation",
       "@context": [
@@ -9557,8 +13598,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9577,7 +13618,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"383.6,7795.0 245.5,2724.6 -0.0,2728.0 -0.0,448.7 2181.8,429.2 2182.4,0.0 6472.0,0.0 6472.0,5355.8 3438.7,7146.0 3466.9,7629.8 6472.0,7454.2 6472.0,7795.0 383.6,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,446.7 6472.0,390.9 6472.0,5355.9 4718.3,6389.1 6472.0,6325.8 6472.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -9633,192 +13674,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p553",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2723.5,158.1 5535.9,300.1 5335.7,5679.6 6400.0,5690.8 6400.0,7795.0 -0.0,7795.0 -0.0,1611.1 1046.6,1651.6 1115.2,78.0 2730.4,-0.0 2723.5,158.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0553/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                800.0,
-                7299.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.607312,
-                39.0543593
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5300.0,
-                5679.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.6063331,
-                39.052261
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p554",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6512
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1029.1,238.1 5551.5,190.0 5533.3,7412.7 6512.0,7411.0 6512.0,7795.0 2284.3,7761.1 2176.8,5636.7 1065.7,5681.2 1029.1,238.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0554/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5520.0,
-                5579.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.606401,
-                39.050205
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5520.0,
-                755.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.603537,
-                39.050097
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0555__1/georef",
       "type": "Annotation",
       "@context": [
@@ -9852,8 +13707,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9872,7 +13727,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1264.7,0.0 3178.4,0.0 3181.8,1750.9 3332.6,2927.5 5097.8,2926.5 5100.3,7714.1 1260.2,7579.1 1264.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3178.4,0.0 3184.0,2927.6 5097.8,2926.5 5045.1,7712.2 1260.2,7579.1 1264.7,0.0 3178.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9928,99 +13783,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p556",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6512
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6512.0,4722.6 6512.0,7795.0 741.2,7795.0 601.4,0.0 4385.3,0.0 4745.0,2603.0 6512.0,4722.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0556/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                600.0,
-                3867.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.593243,
-                39.04786
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                600.0,
-                244.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.593204,
-                39.04869
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0557/georef",
       "type": "Annotation",
       "@context": [
@@ -10038,8 +13800,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10058,7 +13820,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6022.8,922.5 6069.5,4320.6 6400.0,4320.9 6400.0,7795.0 -0.0,7795.0 -0.0,953.1 6022.8,922.5\" /></svg>"
+          "value": "<svg><polygon points=\"6022.8,922.5 6069.5,4320.6 6400.0,4320.9 6400.0,7795.0 1128.6,7795.0 1112.1,5970.9 -0.0,5989.2 -0.0,953.1 6022.8,922.5\" /></svg>"
         }
       },
       "body": {
@@ -10131,8 +13893,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10224,8 +13986,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10244,7 +14006,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6048.3,6743.3 -0.0,6754.8 174.1,2239.2 5531.0,2254.9 6048.3,6743.3\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6754.8 162.0,2189.6 5520.2,2161.1 6048.3,6743.3 -0.0,6754.8\" /></svg>"
         }
       },
       "body": {
@@ -10333,8 +14095,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10353,7 +14115,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1967.0 850.2,2100.5 1159.1,1992.7 1257.4,1161.5 2674.2,1463.9 3002.2,1349.5 6522.0,1781.6 6522.0,2566.8 5484.9,4376.0 6037.4,4692.4 6522.0,4748.1 6522.0,6343.1 2473.0,5885.2 2380.7,6711.1 -0.0,6436.7 -0.0,1967.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1911.8 1141.5,1998.9 3002.2,1349.5 6522.0,1781.6 6522.0,2566.8 5484.9,4376.0 6037.4,4692.4 6522.0,4748.1 6522.0,6343.1 2473.0,5885.2 2380.7,6711.1 -0.0,6436.7 -0.0,1911.8\" /></svg>"
         }
       },
       "body": {
@@ -10442,8 +14204,8 @@
           "value": "1657.4"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10518,99 +14280,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p561",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6400
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6400.0,940.8 6400.0,7687.3 6174.6,7795.0 -0.0,7795.0 21.1,3801.1 177.8,2949.6 -0.0,2859.3 -0.0,1043.8 6400.0,940.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0561/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3932.0,
-                6879.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.600531,
-                39.048125
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3932.0,
-                951.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.597075,
-                39.048
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0562/georef",
       "type": "Annotation",
       "@context": [
@@ -10628,8 +14297,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10648,7 +14317,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6315.7,6939.7 2314.2,6898.1 2030.9,7051.0 560.2,6903.9 601.9,943.2 6484.8,974.8 6522.0,6390.9 6315.7,6939.7\" /></svg>"
+          "value": "<svg><polygon points=\"2314.2,6898.1 541.0,7746.8 585.5,943.1 6484.8,974.8 6522.0,6390.9 6315.7,6939.7 2314.2,6898.1\" /></svg>"
         }
       },
       "body": {
@@ -10721,8 +14390,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10741,7 +14410,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5755.2,2548.3 6400.0,2551.0 6400.0,5213.9 5738.8,5209.8 5726.4,7205.2 -0.0,7237.8 139.1,7196.7 -0.0,5799.7 237.8,5696.7 298.4,561.6 671.7,564.3 659.4,-0.0 2024.7,-0.0 2023.7,574.0 5767.9,506.8 5755.2,2548.3\" /></svg>"
+          "value": "<svg><polygon points=\"139.1,7196.7 -0.0,5799.7 237.8,5696.7 300.5,-0.0 2459.6,-0.0 2455.9,575.4 5767.8,506.8 5726.4,7205.2 -0.0,7241.0 139.1,7196.7\" /></svg>"
         }
       },
       "body": {
@@ -10814,8 +14483,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10834,7 +14503,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6413.2,-0.0 6522.0,7224.3 -0.0,7200.2 -0.0,5211.2 659.3,5211.3 642.8,2557.1 -0.0,2558.4 -0.0,523.5 222.6,525.0 220.2,-0.0 6413.2,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"630.3,527.7 4697.9,554.4 4698.0,-0.0 6413.2,-0.0 6522.0,7224.3 -0.0,7200.2 -0.0,588.4 630.6,583.8 630.3,527.7\" /></svg>"
         }
       },
       "body": {
@@ -10890,99 +14559,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p565",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6392
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3459.3,7522.9 2977.6,7795.0 729.2,7795.0 555.3,340.5 6331.8,184.8 6392.0,7795.0 5441.8,7795.0 4652.9,6466.9 4139.4,6685.5 3459.3,7522.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0565/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                608.0,
-                3159.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5866108,
-                39.0480113
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4408.0,
-                224.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5841981,
-                39.0492785
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0566__1/georef",
       "type": "Annotation",
       "@context": [
@@ -11016,8 +14592,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11036,7 +14612,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6517.0,0.0 6517.0,7796.0 6413.2,7560.2 579.7,7485.7 594.9,7796.0 -0.0,7796.0 -0.0,-0.0 6517.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6517.0,0.0 6517.0,6979.5 4617.4,7073.6 4637.8,7441.5 579.7,7485.7 594.9,7796.0 -0.0,7796.0 -0.0,-0.0 6517.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -11109,8 +14685,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11129,7 +14705,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"550.5,7795.0 545.3,4967.7 -0.0,4847.7 -0.0,9.8 6360.0,118.1 6360.0,7795.0 550.5,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,10.7 559.5,13.3 560.0,186.0 6360.0,208.0 6360.0,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -11185,192 +14761,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p568",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6517
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6517.0,7796.0 292.3,7796.0 245.3,0.0 6517.0,0.0 6517.0,7796.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0568/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2112.3,
-                3856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5472635,
-                39.0678799
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                256.0,
-                3856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5483382,
-                39.0679157
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p569",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6360
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4244.7,1035.7 5885.4,1132.8 5945.5,0.0 6360.0,0.0 6360.0,7795.0 -0.0,7795.0 -0.0,951.8 4242.7,1082.3 4244.7,1035.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0569/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4240.0,
-                1143.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5486956,
-                39.0606496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6072.0,
-                1143.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.5476177,
-                39.0606594
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0571/georef",
       "type": "Annotation",
       "@context": [
@@ -11388,8 +14778,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11481,8 +14871,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11590,8 +14980,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11610,7 +15000,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,5575.4 343.5,5518.0 316.3,2422.9 1517.3,2406.9 1507.0,1627.8 1051.7,1096.3 951.8,437.4 278.3,446.3 271.6,0.0 5688.6,0.0 5728.7,3397.3 5797.8,3398.2 5905.6,6997.8 5988.8,7491.6 5920.5,7494.6 5929.5,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"336.0,4660.8 3048.2,4637.7 3014.2,639.8 281.5,663.1 271.6,0.0 5688.6,0.0 5719.8,3370.7 6111.6,3368.8 6141.2,7760.6 -0.0,7795.0 -0.0,5575.4 343.5,5518.0 336.0,4660.8\" /></svg>"
         }
       },
       "body": {
@@ -11666,192 +15056,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p574 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "19"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6517
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6709.4 -0.0,3278.8 1015.3,3323.3 1255.0,3201.3 1625.9,2769.6 1855.0,2715.2 2208.9,3374.7 2668.9,3394.7 2794.8,0.0 6430.9,0.0 6249.1,3646.5 6434.0,3656.7 6394.7,5362.1 6294.7,5360.6 6283.0,6781.9 6435.6,7213.9 6517.0,7197.1 6517.0,7796.0 -0.0,7796.0 -0.0,7088.0 63.6,7087.2 -0.0,6709.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0574/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4604.7,
-                2128.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.580833,
-                39.046854
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1256.2,
-                3200.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.585052,
-                39.045875
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Kansas City, Mo. | 1951 | Vol. 4 p576",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6491
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6491.0,7704.2 -0.0,7795.0 0.0,0.0 6491.0,0.0 6491.0,7704.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0576/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1175.8,
-                3951.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.598676,
-                39.069691
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5939.1,
-                5735.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -94.595925,
-                39.068688
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd416m:g4164m:g4164km:g4164km_g04720195104:04720_04_1951-0577__1/georef",
       "type": "Annotation",
       "@context": [
@@ -11885,8 +15089,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:33:53Z",
-      "modified": "2026-07-18T02:33:53Z",
+      "created": "2026-07-30T22:41:58Z",
+      "modified": "2026-07-30T22:41:58Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11905,7 +15109,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,218.2 3442.8,271.4 3583.2,7795.0 -0.0,7795.0 -0.0,218.2\" /></svg>"
+          "value": "<svg><polygon points=\"5711.8,4520.9 5555.4,5545.7 4689.7,7795.0 -0.0,7795.0 -0.0,347.4 1206.8,351.6 1216.5,336.7 5706.6,306.4 5711.8,4520.9\" /></svg>"
         }
       },
       "body": {

--- a/gallery/los_angeles_ca_1949_vol_14.iiif.json
+++ b/gallery/los_angeles_ca_1949_vol_14.iiif.json
@@ -1,19 +1,19 @@
 {
-  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn01227_003/main-content//generated",
+  "id": "https://oldinsurancemaps.net/iiif/mosaic/sanborn00656_064/main-content//generated",
   "type": "AnnotationPage",
   "@context": [
     "http://www.w3.org/ns/anno.jsonld"
   ],
-  "label": "Mosaic of main content, Washington, D.C. | 1916 | Vol. 2",
+  "label": "Mosaic of main content, Los Angeles, Calif. | 1949 | Vol. 14",
   "items": [
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1467/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001660",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1467",
       "metadata": [
         {
           "label": "streets",
@@ -24,8 +24,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -34,21 +34,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1467/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1467/info.json",
           "type": "ImageService2",
-          "height": 8479,
-          "width": 6029
+          "height": 8149,
+          "width": 5510
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,8271.9 -0.0,0.0 6029.0,-0.0 6029.0,8158.4 5333.4,8159.3 4957.5,8276.5 0.0,8271.9\" /></svg>"
+          "value": "<svg><polygon points=\"42.9,7742.3 -0.0,0.0 2534.2,0.0 2895.5,327.3 5339.6,315.7 5173.7,8149.0 3967.9,8149.0 3968.3,7686.5 42.9,7742.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001660/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1467/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0033666,
-                38.9165978
+                -118.2070699,
+                34.0277423
               ]
             }
           },
@@ -82,7 +82,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6029.0,
+                5510.0,
                 0.0
               ],
               "creator": {
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0033605,
-                38.913301
+                -118.2056632,
+                34.0299798
               ]
             }
           },
@@ -103,8 +103,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6029.0,
-                8479.0
+                5510.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0093172,
-                38.9132944
+                -118.2016724,
+                34.0282564
               ]
             }
           },
@@ -125,7 +125,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8479.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -136,8 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0093232,
-                38.9165912
+                -118.2030791,
+                34.026019
               ]
             }
           }
@@ -145,3491 +145,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001260 [2]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499J",
       "metadata": [
         {
           "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "4624.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2090.2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
-          "type": "ImageService2",
-          "height": 8371,
-          "width": 5948
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4180.4,-0.0 4206.1,2090.2 0.0,2090.2 -0.0,0.0 4180.4,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01127565554683,
-                38.92149773744876
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4624.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01131201016932,
-                38.918931030913974
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4624.0,
-                2090.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01279410219111,
-                38.918943917812115
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                2090.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01275774756863,
-                38.921510624346894
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001270",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/info.json",
-          "type": "ImageService2",
-          "height": 8406,
-          "width": 6029
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8406.0 -0.0,1324.3 313.4,1317.1 306.0,689.8 5140.6,594.5 5204.1,3842.1 5965.3,4332.0 4266.5,6812.4 3759.1,7872.7 3665.0,8406.0 -0.0,8406.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001270/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0186371084626,
-                38.91945806621041
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6029.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01821221322352,
-                38.91618761198648
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6029.0,
-                8406.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02403027673533,
-                38.91572355189413
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8406.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02445517197441,
-                38.91899400611806
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001280",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/info.json",
-          "type": "ImageService2",
-          "height": 8414,
-          "width": 6002
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5621.9,828.3 5674.4,8414.0 336.9,8414.0 372.9,7890.0 762.8,6781.8 2183.3,4134.0 1374.0,3729.4 960.6,509.5 4359.1,77.0 3976.8,787.9 5621.9,828.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001280/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01832714191008,
-                38.91715882830143
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6002.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01835520613302,
-                38.91388481285555
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6002.0,
-                8414.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02421216493227,
-                38.91391563704486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8414.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02418410070932,
-                38.91718965249074
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001290",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/info.json",
-          "type": "ImageService2",
-          "height": 8403,
-          "width": 5961
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5705.0,548.6 5668.5,8403.0 -0.0,8403.0 -0.0,8068.9 278.0,8071.9 306.4,517.0 1059.4,520.1 1191.4,1909.2 2328.0,1865.5 2413.1,2039.1 3009.9,1981.5 3023.2,538.1 5705.0,548.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001290/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0185694586732,
-                38.914264187471254
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5961.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01855293622661,
-                38.910998102159105
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5961.0,
-                8403.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02442629902056,
-                38.910979858503254
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8403.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02444282146715,
-                38.9142459438154
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001300",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/info.json",
-          "type": "ImageService2",
-          "height": 8491,
-          "width": 6006
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6006.0,8491.0 655.2,8479.9 558.1,588.0 5260.6,509.5 5345.7,8388.3 6006.0,8381.5 6006.0,8491.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001300/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01852309656896,
-                38.91143728490927
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6006.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01857734537029,
-                38.90816305774664
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6006.0,
-                8491.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02448318198552,
-                38.90822314434919
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8491.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02442893318418,
-                38.911497371511814
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001320/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001320",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001320/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001320/info.json",
-          "type": "ImageService2",
-          "height": 8411,
-          "width": 5966
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"48.5,940.8 5758.2,907.3 5757.2,531.7 5966.0,530.3 5966.0,8377.8 5790.1,8379.3 5966.0,8411.0 98.4,8411.0 48.5,940.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001320/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0185300509108,
-                38.90567150777972
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5966.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01855931068457,
-                38.902404604770794
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5966.0,
-                8411.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02443508212251,
-                38.90243692565327
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8411.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02440582234874,
-                38.905703828662205
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001340/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001340",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001340/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001340/info.json",
-          "type": "ImageService2",
-          "height": 8427,
-          "width": 5979
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"656.1,566.6 5186.3,575.4 5178.1,4616.7 5332.5,4862.9 4992.5,4860.3 4355.4,4861.3 4356.2,7808.0 5288.4,7806.5 5158.8,8427.0 634.5,8427.0 656.1,566.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001340/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01853704559103,
-                38.90017524085084
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01853015560035,
-                38.8969106819386
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                8427.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02440057861197,
-                38.89690307131165
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8427.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02440746860266,
-                38.90016763022389
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001350/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001350",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001350/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001350/info.json",
-          "type": "ImageService2",
-          "height": 8454,
-          "width": 6027
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5486.0,7801.0 4951.3,7802.7 4955.2,8454.0 804.8,8412.0 935.0,7789.7 -0.0,7790.9 -0.0,4835.5 980.1,4837.4 825.3,4590.4 834.7,537.1 5498.5,552.8 5507.0,-0.0 6027.0,-0.0 6027.0,588.2 5711.4,590.1 6027.0,1529.4 6027.0,1963.1 5500.5,1959.5 5486.0,7801.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001350/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01855997902166,
-                38.89779792838284
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6027.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0185518181214,
-                38.894517182988444
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6027.0,
-                8454.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02442362766566,
-                38.8945082103101
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8454.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02443178856593,
-                38.8977889557045
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001360/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001360",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001360/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001360/info.json",
-          "type": "ImageService2",
-          "height": 8438,
-          "width": 5974
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8438.0 -0.0,7211.7 534.8,7213.1 583.6,1368.8 1110.2,1375.5 1112.8,941.7 800.4,-0.0 1995.2,-0.0 1981.6,2018.4 5974.0,2045.2 5974.0,8438.0 -0.0,8438.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001360/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01896644914763,
-                38.895125085809354
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5974.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01893403977317,
-                38.89187427811628
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5974.0,
-                8438.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02479161604545,
-                38.891838401812656
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8438.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0248240254199,
-                38.89508920950573
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001370",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/info.json",
-          "type": "ImageService2",
-          "height": 8487,
-          "width": 6101
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"752.7,790.9 6101.0,400.9 6101.0,7171.8 5587.2,7129.1 5272.0,7428.7 4959.6,7247.9 5017.5,6868.8 4924.9,7068.9 3523.3,6962.2 1219.9,7142.7 752.7,790.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001370/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01964474597902,
-                38.91966645482806
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6101.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01538752537543,
-                38.91982679692959
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6101.0,
-                8487.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01510296407628,
-                38.91518827532561
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8487.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01936018467985,
-                38.91502793322408
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001380",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/info.json",
-          "type": "ImageService2",
-          "height": 8394,
-          "width": 5924
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2074.7,1152.9 3695.4,1103.0 3589.7,0.0 4914.4,0.0 4864.8,1230.8 5924.0,1259.0 5924.0,8394.0 5562.2,8394.0 5576.8,7881.0 5036.7,7881.1 5585.0,7645.9 5636.6,5890.0 1308.5,5700.6 1207.0,338.5 2025.1,261.7 2074.7,1152.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001380/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01622744414315,
-                38.919774415682745
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5924.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01207322916392,
-                38.91986924016593
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5924.0,
-                8394.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01190170766327,
-                38.91525600446628
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8394.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0160559226425,
-                38.915161179983095
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001390",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/info.json",
-          "type": "ImageService2",
-          "height": 8472,
-          "width": 6024
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"735.1,7172.9 1097.3,7164.6 932.5,21.5 6024.0,0.0 6024.0,4760.9 4999.3,4756.1 4967.1,7979.6 731.0,7945.5 735.1,7172.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001390/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01270104435616,
-                38.91918601518032
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6024.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00847992703908,
-                38.91920608835063
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6024.0,
-                8472.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00844389808196,
-                38.914554581462376
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8472.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01266501539905,
-                38.91453450829207
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001400",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/info.json",
-          "type": "ImageService2",
-          "height": 8468,
-          "width": 5978
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5090.9,8241.7 4040.4,7656.1 683.1,7688.3 607.4,886.8 4888.1,850.7 4921.4,2582.7 5044.6,2959.7 5090.9,8241.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001400/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.012569752344,
-                38.915311083494665
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5978.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00842474648978,
-                38.91527726650848
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5978.0,
-                8468.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00848585853642,
-                38.91067795790708
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8468.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01263086439064,
-                38.91071177489326
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001410",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/info.json",
-          "type": "ImageService2",
-          "height": 8459,
-          "width": 6017
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"296.5,5447.9 349.9,3093.4 1072.0,3442.6 868.2,1585.2 3465.1,1306.8 4574.4,1364.1 4668.6,1611.5 4936.2,1710.5 4988.6,2298.5 4827.2,4955.9 4702.7,5461.9 5674.4,5995.2 5649.8,8459.0 262.8,8459.0 269.8,7417.9 1766.4,7433.2 1574.6,5349.4 296.5,5447.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001410/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01916855861526,
-                38.91665646704574
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6017.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01497333028068,
-                38.91668395141653
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6017.0,
-                8459.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01492403777178,
-                38.9120643104691
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8459.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01911926610636,
-                38.912036826098316
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001420",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/info.json",
-          "type": "ImageService2",
-          "height": 8439,
-          "width": 5994
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"313.8,4941.4 414.1,2279.1 348.3,1691.9 24.2,1530.6 58.4,1147.7 280.0,1033.2 149.0,0.0 5438.1,0.0 5463.5,1769.7 4922.2,2030.5 5465.6,2006.6 5564.2,8439.0 1219.3,8439.0 1185.4,5965.9 200.7,5450.5 313.8,4941.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001420/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01594229282082,
-                38.91667092923538
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5994.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01176721850867,
-                38.916623153961744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5994.0,
-                8439.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01185304134482,
-                38.91201819063837
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8439.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01602811565698,
-                38.912065965912014
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001430",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/info.json",
-          "type": "ImageService2",
-          "height": 8411,
-          "width": 5994
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"316.0,3297.5 5660.7,3253.6 5658.0,7657.8 322.6,7656.0 316.0,3297.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001430/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01915838518134,
-                38.91385351564644
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5994.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0149460708483,
-                38.91385395145471
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5994.0,
-                8411.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0149452905961,
-                38.909223146131964
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8411.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01915760492915,
-                38.90922271032369
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001440",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/info.json",
-          "type": "ImageService2",
-          "height": 8475,
-          "width": 6059
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"756.2,7762.3 787.5,3307.2 5145.8,3397.7 5113.2,7789.8 756.2,7762.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001440/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0157384688427,
-                38.913848820712516
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6059.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0115410446332,
-                38.913869088085875
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6059.0,
-                8475.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01150486888584,
-                38.9092686470723
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8475.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01570229309533,
-                38.909248379698944
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001450",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/info.json",
-          "type": "ImageService2",
-          "height": 8400,
-          "width": 5945
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"354.9,523.5 5945.0,507.0 5945.0,7026.8 5669.6,5889.1 5754.7,4891.8 5358.6,4893.1 4309.2,4896.0 4328.6,8400.0 379.0,8400.0 354.9,523.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001450/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01917807945179,
-                38.90992579644698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5945.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01502006206803,
-                38.90991550102121
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5945.0,
-                8400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01503861576421,
-                38.9053138166814
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01919663314797,
-                38.90532411210717
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001470/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001470",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001470/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001470/info.json",
-          "type": "ImageService2",
-          "height": 8382,
-          "width": 5995
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5995.0,7055.0 -0.0,7061.0 -0.0,1398.1 362.7,1397.8 364.0,1986.5 4285.2,1994.3 4294.7,2749.4 5995.0,2140.8 5995.0,7055.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001470/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0191863564318,
-                38.90642048014053
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5995.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01496300532337,
-                38.90641664671121
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5995.0,
-                8382.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01496984498345,
-                38.901788688582045
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8382.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01919319609188,
-                38.90179252201137
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001480",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/info.json",
-          "type": "ImageService2",
-          "height": 8439,
-          "width": 6046
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5008.8,7069.1 1034.7,7106.8 987.9,2203.5 1096.2,2168.3 1093.3,1890.9 4931.7,165.0 5008.8,7069.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001480/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01564576886213,
-                38.90645968904027
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6046.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01137624707228,
-                38.906423895275935
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6046.0,
-                8439.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01143998472914,
-                38.901754594575316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8439.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01570950651899,
-                38.90179038833965
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001490",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/info.json",
-          "type": "ImageService2",
-          "height": 8455,
-          "width": 6063
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5770.6,7904.7 416.9,7891.4 469.5,256.8 5816.9,293.2 5770.6,7904.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001490/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01926039359446,
-                38.9026604365208
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6063.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01500574146986,
-                38.90268371502156
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6063.0,
-                8455.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01496432287972,
-                38.89803390387276
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8455.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01921897500434,
-                38.898010625372
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001500",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/info.json",
-          "type": "ImageService2",
-          "height": 8442,
-          "width": 5996
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5996.0,7756.1 5996.0,7911.3 4869.5,7946.6 5010.8,8442.0 691.4,8442.0 718.0,291.5 5003.0,313.3 4993.9,4139.4 4300.5,4145.1 4323.9,6970.4 4340.5,6970.5 5996.0,7756.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001500/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01568299158794,
-                38.90268072993334
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5996.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01146433634678,
-                38.90269364200347
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5996.0,
-                8442.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01144113489559,
-                38.89803748128261
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8442.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01565979013675,
-                38.898024569212474
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001510/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001510",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001510/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001510/info.json",
-          "type": "ImageService2",
-          "height": 8453,
-          "width": 5966
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"386.9,976.0 5778.8,969.4 5744.5,7424.3 355.5,7417.4 386.9,976.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001510/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0192010098561,
-                38.8988545312596
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5966.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01504398580576,
-                38.89886514358693
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5966.0,
-                8453.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.015024800927,
-                38.89424871167376
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8453.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01918182497734,
-                38.89423809934643
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001520/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001520",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001520/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001520/info.json",
-          "type": "ImageService2",
-          "height": 8492,
-          "width": 6000
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"626.2,1508.9 4308.2,1486.9 4364.7,5443.5 4949.5,5435.2 4948.4,7430.1 626.6,7400.6 626.2,1508.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001520/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01560721464652,
-                38.898850373253474
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6000.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01142860953097,
-                38.89884358396393
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6000.0,
-                8492.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01144086964244,
-                38.89420827472196
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8492.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.015619474758,
-                38.894215064011505
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001540",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/info.json",
-          "type": "ImageService2",
-          "height": 8460,
-          "width": 6085
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5639.1 242.6,5641.8 251.1,4882.3 -0.0,4785.3 -0.0,4631.0 84.5,4485.8 254.9,4550.1 279.6,2351.8 -0.0,2349.6 -0.0,136.7 4828.0,180.7 4756.3,2354.9 4249.6,2420.6 4749.9,2481.9 4635.2,5955.5 4713.0,6180.8 4685.6,8063.4 6085.0,8071.2 6085.0,8460.0 -0.0,8460.0 -0.0,5639.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001540/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01853721126338,
-                38.89487596397049
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6085.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01430979688168,
-                38.894916915314624
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6085.0,
-                8460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01423719384606,
-                38.890312445388766
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8460.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01846460822777,
-                38.89027149404464
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001550",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
+          "value": "9"
         },
         {
           "label": "intersections",
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3638,21 +172,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/info.json",
           "type": "ImageService2",
-          "height": 8486,
-          "width": 6017
+          "height": 8150,
+          "width": 5607
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2890.5,8486.0 752.1,8486.0 802.0,641.6 4148.7,656.7 5187.5,1255.0 5031.9,7580.4 2890.5,8486.0\" /></svg>"
+          "value": "<svg><polygon points=\"5112.7,6942.7 2827.9,6937.0 2827.9,6929.0 196.4,6943.2 235.1,285.2 -0.0,282.6 -0.0,-0.0 4223.0,-0.0 5398.6,3913.1 5374.6,4553.5 5131.4,5493.6 5112.7,6942.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001550/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499J/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3677,8 +211,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01271113590713,
-                38.91147943301789
+                -118.1765205,
+                34.0407679
               ]
             }
           },
@@ -3686,7 +220,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6017.0,
+                5607.0,
                 0.0
               ],
               "creator": {
@@ -3698,8 +232,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00852549626772,
-                38.91149153119695
+                -118.1764584,
+                34.0356476
               ]
             }
           },
@@ -3707,8 +241,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6017.0,
-                8486.0
+                5607.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3719,8 +253,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00850372825714,
-                38.906866859980305
+                -118.1854403,
+                34.0355728
               ]
             }
           },
@@ -3729,7 +263,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8486.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3740,8 +274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01268936789654,
-                38.90685476180124
+                -118.1855024,
+                34.0406931
               ]
             }
           }
@@ -3749,13 +283,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1406/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001560",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1406",
       "metadata": [
         {
           "label": "streets",
@@ -3766,8 +300,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3776,21 +310,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1406/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1406/info.json",
           "type": "ImageService2",
-          "height": 8460,
-          "width": 6022
+          "height": 8150,
+          "width": 5676
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"930.3,6605.7 540.5,6775.2 655.3,441.0 4421.9,2431.3 6022.0,3477.9 6022.0,6983.5 929.1,7010.1 930.3,6605.7\" /></svg>"
+          "value": "<svg><polygon points=\"5145.9,396.3 5676.0,1004.5 5676.0,8150.0 515.9,8150.0 1963.1,7466.0 1183.2,56.6 4765.2,227.8 5145.9,396.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001560/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1406/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3815,8 +349,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00955377332095,
-                38.91104693387297
+                -118.22677656217134,
+                34.051848697121564
               ]
             }
           },
@@ -3824,7 +358,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6022.0,
+                5676.0,
                 0.0
               ],
               "creator": {
@@ -3836,8 +370,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00536967891223,
-                38.911037809721606
+                -118.2262014607297,
+                34.05447453669826
               ]
             }
           },
@@ -3845,8 +379,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6022.0,
-                8460.0
+                5676.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3857,8 +391,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00538603056603,
-                38.906433091359744
+                -118.22168154252827,
+                34.05378536784866
               ]
             }
           },
@@ -3867,7 +401,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8460.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3878,8 +412,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00957012497474,
-                38.906442215511106
+                -118.22225664396991,
+                34.05115952827196
               ]
             }
           }
@@ -3887,13 +421,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1409/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001570",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1409",
       "metadata": [
         {
           "label": "streets",
@@ -3904,8 +438,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3914,21 +448,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1409/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1409/info.json",
           "type": "ImageService2",
-          "height": 8419,
-          "width": 5996
+          "height": 8150,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"742.5,7317.9 762.6,1617.2 2907.1,1614.0 5056.3,701.8 5167.6,7355.2 742.5,7317.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3275.2 708.0,2872.3 1649.0,0.0 3392.9,0.0 3577.9,201.3 5615.0,128.6 5615.0,7771.2 807.6,7811.8 650.9,4844.3 -0.0,3275.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001570/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1409/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -3953,8 +487,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01269485202083,
-                38.90773338087194
+                -118.22142204516416,
+                34.04795147408372
               ]
             }
           },
@@ -3962,7 +496,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5996.0,
+                5615.0,
                 0.0
               ],
               "creator": {
@@ -3974,8 +508,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00854144234277,
-                38.907740507257905
+                -118.219934861475,
+                34.05021449464874
               ]
             }
           },
@@ -3983,8 +517,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5996.0,
-                8419.0
+                5615.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3995,8 +529,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00852867243071,
-                38.903169760719344
+                -118.21599806312207,
+                34.04841320278383
               ]
             }
           },
@@ -4005,7 +539,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8419.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4016,8 +550,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01268208210877,
-                38.90316263433338
+                -118.21748524681124,
+                34.04615018221881
               ]
             }
           }
@@ -4025,13 +559,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1417/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001580",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1417",
       "metadata": [
         {
           "label": "streets",
@@ -4042,8 +576,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4052,21 +586,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1417/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1417/info.json",
           "type": "ImageService2",
-          "height": 8494,
-          "width": 5986
+          "height": 8150,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"883.7,551.9 879.8,955.3 5962.2,963.1 5986.0,3849.3 5229.8,3885.1 5219.0,6616.1 581.6,6597.1 493.7,718.4 883.7,551.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8150.0 193.8,6661.9 -0.0,6634.6 -0.0,5948.6 1051.5,76.1 5031.7,743.4 4819.2,3484.9 5519.3,3491.9 5615.0,3894.0 5615.0,8150.0 -0.0,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001580/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1417/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4091,8 +625,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0095369996241,
-                38.90774930187307
+                -118.22525578881782,
+                34.04814642462687
               ]
             }
           },
@@ -4100,7 +634,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5986.0,
+                5615.0,
                 0.0
               ],
               "creator": {
@@ -4112,8 +646,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00536923118477,
-                38.90776225258139
+                -118.22496433943155,
+                34.04561682761321
               ]
             }
           },
@@ -4121,8 +655,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5986.0,
-                8494.0
+                5615.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4133,8 +667,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00534578396848,
-                38.90312809029665
+                -118.22936483720517,
+                34.0452638177636
               ]
             }
           },
@@ -4143,7 +677,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8494.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4154,8 +688,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00951355240781,
-                38.90311513958832
+                -118.22965628659144,
+                34.04779341477726
               ]
             }
           }
@@ -4163,13 +697,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1418/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001590",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1418",
       "metadata": [
         {
           "label": "streets",
@@ -4180,8 +714,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4190,21 +724,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1418/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1418/info.json",
           "type": "ImageService2",
-          "height": 8426,
-          "width": 5964
+          "height": 8150,
+          "width": 5631
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5052.0,3216.8 5064.2,7332.5 674.0,7354.1 643.7,865.5 5171.5,868.9 5179.3,3126.8 5052.0,3216.8\" /></svg>"
+          "value": "<svg><polygon points=\"892.0,5084.4 193.6,5056.2 544.4,1818.6 2274.7,1561.1 2311.1,531.1 2517.3,425.8 2538.2,94.9 5631.0,93.3 5631.0,8150.0 894.5,8150.0 975.4,5488.6 892.0,5084.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001590/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1418/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4229,8 +763,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01261486132798,
-                38.9042355588385
+                -118.22417561169331,
+                34.046199970107196
               ]
             }
           },
@@ -4238,7 +772,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5964.0,
+                5631.0,
                 0.0
               ],
               "creator": {
@@ -4250,8 +784,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00846091500776,
-                38.9042199447186
+                -118.22379055059561,
+                34.0436678506977
               ]
             }
           },
@@ -4259,8 +793,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5964.0,
-                8426.0
+                5631.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4271,8 +805,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00848906935114,
-                38.8996194263272
+                -118.22818279464447,
+                34.043202767753115
               ]
             }
           },
@@ -4281,7 +815,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8426.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4292,8 +826,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01264301567136,
-                38.8996350404471
+                -118.22856785574217,
+                34.04573488716261
               ]
             }
           }
@@ -4301,13 +835,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001610/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1419/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001610",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1419",
       "metadata": [
         {
           "label": "streets",
@@ -4318,8 +852,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4328,21 +862,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001610/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1419/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001610/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1419/info.json",
           "type": "ImageService2",
-          "height": 8222,
-          "width": 5722
+          "height": 8150,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1633.0,7773.5 1626.8,7751.6 586.4,7748.7 579.4,8222.0 -0.0,8222.0 -0.0,-0.0 693.9,0.0 672.7,344.5 5021.9,397.0 4985.7,5274.4 4759.3,5226.4 5017.5,5399.3 5002.2,7774.6 1633.0,7773.5\" /></svg>"
+          "value": "<svg><polygon points=\"607.4,199.4 5301.6,38.4 5448.7,8047.8 5615.0,8150.0 845.3,8150.0 607.4,199.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001610/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1419/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4367,8 +901,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01264585428981,
-                38.90040375082999
+                -118.22377975919314,
+                34.043944254308485
               ]
             }
           },
@@ -4376,7 +910,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
+                5615.0,
                 0.0
               ],
               "creator": {
@@ -4388,8 +922,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0086233062598,
-                38.900442198444985
+                -118.22348586812048,
+                34.04140544329667
               ]
             }
           },
@@ -4397,8 +931,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
-                8222.0
+                5615.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4409,8 +943,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00855282485884,
-                38.895912564901984
+                -118.22790215155504,
+                34.04104945643266
               ]
             }
           },
@@ -4419,7 +953,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8222.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4430,8 +964,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01257537288885,
-                38.895874117286986
+                -118.2281960426277,
+                34.04358826744448
               ]
             }
           }
@@ -4439,13 +973,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1420/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001620",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1420",
       "metadata": [
         {
           "label": "streets",
@@ -4456,8 +990,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4466,21 +1000,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1420/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1420/info.json",
           "type": "ImageService2",
-          "height": 8484,
-          "width": 6042
+          "height": 8150,
+          "width": 5631
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"751.7,5340.3 706.3,361.4 4983.7,229.9 5128.9,4058.9 6042.0,4309.5 6042.0,7398.8 1506.2,7579.2 810.7,7891.9 786.2,5467.2 519.8,5295.1 751.7,5340.3\" /></svg>"
+          "value": "<svg><polygon points=\"5095.8,2829.5 5631.0,5172.0 5631.0,8150.0 -0.0,8150.0 -0.0,171.6 5243.8,107.2 5458.0,-0.0 5095.8,2829.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001620/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1420/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4505,8 +1039,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0095975576047,
-                38.900415505339694
+                -118.22342989604024,
+                34.041554416624024
               ]
             }
           },
@@ -4514,7 +1048,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6042.0,
+                5631.0,
                 0.0
               ],
               "creator": {
@@ -4526,8 +1060,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00543547092877,
-                38.900401359579
+                -118.2230777781248,
+                34.03900293166051
               ]
             }
           },
@@ -4535,8 +1069,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6042.0,
-                8484.0
+                5631.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4547,8 +1081,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00546080598046,
-                38.89582238702399
+                -118.22750337529817,
+                34.038577615089245
               ]
             }
           },
@@ -4557,7 +1091,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8484.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4568,8 +1102,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0096228926564,
-                38.895836532784685
+                -118.22785549321362,
+                34.04112910005276
               ]
             }
           }
@@ -4577,13 +1111,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001630/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1421/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001630",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1421",
       "metadata": [
         {
           "label": "streets",
@@ -4594,8 +1128,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4604,21 +1138,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001630/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1421/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001630/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1421/info.json",
           "type": "ImageService2",
-          "height": 8503,
-          "width": 5967
+          "height": 8150,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4538.2,8403.9 745.7,8503.0 749.7,5214.6 1585.0,5171.2 750.6,4928.7 765.9,429.7 5269.5,417.3 5967.0,110.5 5967.0,8000.0 4543.9,7937.9 4538.2,8403.9\" /></svg>"
+          "value": "<svg><polygon points=\"4828.6,8150.0 977.8,8150.0 977.8,8150.0 369.9,8150.0 462.1,6240.6 38.7,3784.4 560.4,847.7 1371.5,703.7 1474.8,-0.0 5615.0,-0.0 5443.3,1891.9 5615.0,2053.5 4648.3,1902.2 4828.6,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001630/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1421/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4643,8 +1177,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01269627035283,
-                38.89636946072549
+                -118.22263254548781,
+                34.03939184863001
               ]
             }
           },
@@ -4652,7 +1186,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5967.0,
+                5615.0,
                 0.0
               ],
               "creator": {
@@ -4664,8 +1198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00858287277751,
-                38.89638101018086
+                -118.22214042933754,
+                34.03689268002896
               ]
             }
           },
@@ -4673,8 +1207,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5967.0,
-                8503.0
+                5615.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4685,8 +1219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856187597705,
-                38.89178693661133
+                -118.22648751319028,
+                34.03629655233236
               ]
             }
           },
@@ -4695,7 +1229,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8503.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4706,8 +1240,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01267527355236,
-                38.89177538715596
+                -118.22697962934055,
+                34.03879572093341
               ]
             }
           }
@@ -4715,13 +1249,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001640/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1422/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001640",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1422",
       "metadata": [
         {
           "label": "streets",
@@ -4732,8 +1266,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4742,21 +1276,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001640/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1422/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001640/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1422/info.json",
           "type": "ImageService2",
-          "height": 8456,
-          "width": 5994
+          "height": 8150,
+          "width": 5619
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5694.7,0.0 5747.3,376.7 5994.0,721.5 5286.1,563.2 5225.1,7949.6 4640.2,8456.0 -0.0,8456.0 -0.0,7870.6 1408.9,7914.8 1313.0,105.8 5694.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8150.0 -0.0,781.2 5619.0,1827.5 5619.0,8150.0 -0.0,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001640/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1422/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4781,8 +1315,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00949659098332,
-                38.89638529682648
+                -118.22281738978995,
+                34.03725220423969
               ]
             }
           },
@@ -4790,7 +1324,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
+                5619.0,
                 0.0
               ],
               "creator": {
@@ -4802,8 +1336,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00532124249891,
-                38.89635682540663
+                -118.22222782429867,
+                34.03471722106253
               ]
             }
           },
@@ -4811,8 +1345,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
-                8456.0
+                5619.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4823,8 +1357,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00537247084665,
-                38.8917415437954
+                -118.2266339505084,
+                34.03400353713771
               ]
             }
           },
@@ -4833,7 +1367,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8456.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4844,8 +1378,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00954781933106,
-                38.89177001521525
+                -118.22722351599968,
+                34.03653852031486
               ]
             }
           }
@@ -4853,13 +1387,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001650/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1423/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001650",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1423",
       "metadata": [
         {
           "label": "streets",
@@ -4870,8 +1404,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4880,21 +1414,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001650/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1423/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001650/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1423/info.json",
           "type": "ImageService2",
-          "height": 8428,
-          "width": 5973
+          "height": 8150,
+          "width": 5607
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"689.8,6305.9 785.9,2807.9 281.8,2749.0 791.5,2679.9 851.6,490.5 5212.9,558.9 5206.6,2558.8 5973.0,2790.1 5204.8,2844.6 5190.3,6131.1 5973.0,6133.6 5973.0,8428.0 752.4,8428.0 689.8,6305.9\" /></svg>"
+          "value": "<svg><polygon points=\"515.8,5404.8 1058.0,3344.5 3929.2,3757.4 5043.6,2034.0 5102.7,3921.4 5296.1,3953.9 5401.8,7837.9 5607.0,7827.4 5607.0,8150.0 4553.8,8150.0 209.3,7569.4 217.8,7507.6 -0.0,7473.7 -0.0,5333.0 515.8,5404.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001650/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1423/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -4919,8 +1453,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01577141262594,
-                38.89507211784681
+                -118.21989023451967,
+                34.047890728539876
               ]
             }
           },
@@ -4928,7 +1462,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5973.0,
+                5607.0,
                 0.0
               ],
               "creator": {
@@ -4940,8 +1474,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01164985482981,
-                38.89509404472665
+                -118.21969201621188,
+                34.04528411663397
               ]
             }
           },
@@ -4949,8 +1483,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5973.0,
-                8428.0
+                5607.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4961,8 +1495,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01161040177652,
-                38.89053802613005
+                -118.22423293304388,
+                34.04504368648634
               ]
             }
           },
@@ -4971,7 +1505,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8428.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4982,8 +1516,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01573195957265,
-                38.89051609925021
+                -118.22443115135165,
+                34.04765029839224
               ]
             }
           }
@@ -4991,13 +1525,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1424/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001680",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1424",
       "metadata": [
         {
           "label": "streets",
@@ -5008,8 +1542,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5018,21 +1552,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1424/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1424/info.json",
           "type": "ImageService2",
-          "height": 8380,
-          "width": 5969
+          "height": 8150,
+          "width": 5619
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2586.0,7799.0 1777.4,7796.8 1717.2,-0.0 5969.0,-0.0 5969.0,2482.4 5586.6,2482.7 4698.5,3843.7 2586.0,7799.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,99.4 5317.3,323.7 4859.1,7782.7 178.1,7908.0 -0.0,99.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001680/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1424/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5057,8 +1591,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00362038548339,
-                38.91221327171726
+                -118.21973318199913,
+                34.04557414782569
               ]
             }
           },
@@ -5066,7 +1600,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5969.0,
+                5619.0,
                 0.0
               ],
               "creator": {
@@ -5078,8 +1612,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00363528182757,
-                38.908929577345674
+                -118.21944023383055,
+                34.04299964213585
               ]
             }
           },
@@ -5087,8 +1621,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5969.0,
-                8380.0
+                5619.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5099,8 +1633,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0095153934345,
-                38.90894595702128
+                -118.2239155104737,
+                34.04264505704796
               ]
             }
           },
@@ -5109,7 +1643,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8380.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5120,8 +1654,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00950049709033,
-                38.91222965139288
+                -118.2242084586423,
+                34.045219562737806
               ]
             }
           }
@@ -5129,13 +1663,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1425/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001690",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1425",
       "metadata": [
         {
           "label": "streets",
@@ -5146,8 +1680,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5156,21 +1690,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1425/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1425/info.json",
           "type": "ImageService2",
-          "height": 8446,
-          "width": 5989
+          "height": 8150,
+          "width": 5607
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7679.6 -0.0,3768.5 181.7,3766.4 145.8,355.9 889.4,309.9 884.9,0.0 5576.1,0.0 5660.1,7410.3 14.8,7659.5 -0.0,7679.6\" /></svg>"
+          "value": "<svg><polygon points=\"3789.6,462.9 3674.5,7570.6 -0.0,7927.4 0.0,-0.0 151.1,-0.0 163.1,415.7 3789.6,462.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001690/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1425/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5195,8 +1729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00598549371617,
-                38.90583911491087
+                -118.21940389360117,
+                34.043130201360526
               ]
             }
           },
@@ -5204,7 +1738,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5989.0,
+                5607.0,
                 0.0
               ],
               "creator": {
@@ -5216,8 +1750,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00174856275673,
-                38.905804162764255
+                -118.21930135181131,
+                34.04056319399126
               ]
             }
           },
@@ -5225,8 +1759,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5989.0,
-                8446.0
+                5607.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5237,8 +1771,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00181144206142,
-                38.90112269851721
+                -118.22377304871372,
+                34.0404388089993
               ]
             }
           },
@@ -5247,7 +1781,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8446.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5258,8 +1792,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00604837302086,
-                38.901157650663826
+                -118.22387559050358,
+                34.04300581636856
               ]
             }
           }
@@ -5267,13 +1801,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001710/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1426/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001710",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1426",
       "metadata": [
         {
           "label": "streets",
@@ -5284,8 +1818,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5294,21 +1828,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001710/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1426/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001710/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1426/info.json",
           "type": "ImageService2",
-          "height": 8440,
-          "width": 5928
+          "height": 8150,
+          "width": 5619
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"405.1,251.5 2014.2,237.6 2282.4,101.0 2631.8,285.8 2640.6,0.0 5928.0,0.0 5928.0,8159.5 468.2,8208.5 405.1,251.5\" /></svg>"
+          "value": "<svg><polygon points=\"5619.0,-0.0 5619.0,6522.2 4860.3,6774.8 4657.6,6995.2 -0.0,7511.3 -0.0,500.0 2973.0,969.0 3490.4,-0.0 5619.0,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001710/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1426/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5333,8 +1867,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99872225949102,
-                38.905784227594886
+                -118.21931021909022,
+                34.04139214521893
               ]
             }
           },
@@ -5342,7 +1876,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5928.0,
+                5619.0,
                 0.0
               ],
               "creator": {
@@ -5354,8 +1888,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99461409785398,
-                38.90575696230314
+                -118.21925664025738,
+                34.03878184524242
               ]
             }
           },
@@ -5363,8 +1897,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5928.0,
-                8440.0
+                5619.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5375,8 +1909,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99466363138843,
-                38.90117314967064
+                -118.22379395349623,
+                34.03871699066758
               ]
             }
           },
@@ -5385,7 +1919,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8440.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5396,8 +1930,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99877179302547,
-                38.90120041496239
+                -118.22384753232906,
+                34.04132729064409
               ]
             }
           }
@@ -5405,13 +1939,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001720/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1428/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001720",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1428",
       "metadata": [
         {
           "label": "streets",
@@ -5422,8 +1956,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5432,21 +1966,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001720/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1428/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001720/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1428/info.json",
           "type": "ImageService2",
-          "height": 8475,
-          "width": 5982
+          "height": 8150,
+          "width": 5619
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"974.4,7831.8 983.4,0.0 5982.0,0.0 5982.0,2565.2 4581.7,2579.1 4592.5,3667.2 5458.7,4136.0 5474.5,7808.8 974.4,7831.8\" /></svg>"
+          "value": "<svg><polygon points=\"692.3,295.1 5619.0,-0.0 5619.0,7179.4 5417.0,6802.1 1171.0,8150.0 746.8,8150.0 -0.0,6484.0 -0.0,1375.4 474.9,1476.1 692.3,295.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001720/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1428/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5471,8 +2005,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99530083856429,
-                38.905604118607286
+                -118.21867590416392,
+                34.0360383501424
               ]
             }
           },
@@ -5480,7 +2014,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5982.0,
+                5619.0,
                 0.0
               ],
               "creator": {
@@ -5492,8 +2026,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99113362321376,
-                38.90558019211681
+                -118.21960619026423,
+                34.033527008741984
               ]
             }
           },
@@ -5501,8 +2035,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5982.0,
-                8475.0
+                5619.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5513,8 +2047,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99117686812183,
-                38.90095437249986
+                -118.22397121308468,
+                34.03465314639765
               ]
             }
           },
@@ -5523,7 +2057,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8475.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5534,8 +2068,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99534408347236,
-                38.90097829899034
+                -118.22304092698437,
+                34.037164487798066
               ]
             }
           }
@@ -5543,13 +2077,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001730",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1429 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -5560,8 +2094,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5570,21 +2104,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/info.json",
           "type": "ImageService2",
-          "height": 8426,
-          "width": 6022
+          "height": 8150,
+          "width": 5541
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5197.7,911.5 5193.8,7591.8 1552.2,7571.5 1078.9,8426.0 -0.0,8426.0 -0.0,0.0 4771.8,-0.0 4767.2,359.7 5184.1,595.5 5328.0,676.8 5197.7,911.5\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,288.1 5541.0,128.1 5541.0,6778.2 3287.0,8150.0 2152.0,8150.0 -0.0,4698.6 -0.0,288.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001730/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1429/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5609,8 +2143,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98620395205532,
-                38.904189990399644
+                -118.21850295422689,
+                34.04712808547204
               ]
             }
           },
@@ -5618,7 +2152,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6022.0,
+                5541.0,
                 0.0
               ],
               "creator": {
@@ -5630,8 +2164,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98619309936204,
-                38.90087479088172
+                -118.21580198914069,
+                34.04588454742293
               ]
             }
           },
@@ -5639,8 +2173,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6022.0,
-                8426.0
+                5541.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5651,8 +2185,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99211140687162,
-                38.90086289137934
+                -118.21799489471148,
+                34.04256814724185
               ]
             }
           },
@@ -5661,7 +2195,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8426.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5672,8 +2206,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9921222595649,
-                38.90417809089726
+                -118.22069585979769,
+                34.04381168529097
               ]
             }
           }
@@ -5681,13 +2215,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001750/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1433/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001750",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1433",
       "metadata": [
         {
           "label": "streets",
@@ -5698,8 +2232,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5708,21 +2242,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001750/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1433/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001750/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1433/info.json",
           "type": "ImageService2",
-          "height": 8489,
-          "width": 6001
+          "height": 8149,
+          "width": 5539
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"264.8,0.0 5854.8,0.0 5825.2,874.6 6001.0,880.7 6001.0,7186.7 5613.5,7167.7 5567.5,8489.0 786.7,8489.0 869.7,6301.2 -0.0,6026.7 -0.0,425.9 264.8,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5526.7,7919.1 69.4,7894.6 152.7,201.3 5464.2,178.0 5526.7,7919.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001750/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1433/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5747,8 +2281,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00622127724345,
-                38.901588509778946
+                -118.20861416266293,
+                34.043303251631336
               ]
             }
           },
@@ -5756,7 +2290,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6001.0,
+                5539.0,
                 0.0
               ],
               "creator": {
@@ -5768,8 +2302,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00193185537108,
-                38.90170145474254
+                -118.20593338098527,
+                34.04210782079319
               ]
             }
           },
@@ -5777,8 +2311,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6001.0,
-                8489.0
+                5539.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5789,8 +2323,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00172802565427,
-                38.89694660568858
+                -118.20804030125494,
+                34.03881763584329
               ]
             }
           },
@@ -5799,7 +2333,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8489.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5810,8 +2344,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00601744752665,
-                38.89683366072499
+                -118.21072108293261,
+                34.04001306668144
               ]
             }
           }
@@ -5819,13 +2353,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1434/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001800",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1434",
       "metadata": [
         {
           "label": "streets",
@@ -5836,8 +2370,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5846,21 +2380,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1434/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1434/info.json",
           "type": "ImageService2",
-          "height": 8492,
-          "width": 5976
+          "height": 8150,
+          "width": 5606
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"922.3,7775.9 839.9,476.1 2959.2,441.0 3197.4,569.3 3509.8,0.0 5976.0,0.0 5976.0,512.2 5976.0,584.7 5976.0,4835.0 4916.2,4847.9 4941.8,7736.9 922.3,7775.9\" /></svg>"
+          "value": "<svg><polygon points=\"162.8,7950.0 -0.0,294.6 5606.0,236.0 5606.0,7897.6 162.8,7950.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001800/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1434/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -5885,8 +2419,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98889357807202,
-                38.90158454737876
+                -118.20595642882616,
+                34.04218201746868
               ]
             }
           },
@@ -5894,7 +2428,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5976.0,
+                5606.0,
                 0.0
               ],
               "creator": {
@@ -5906,8 +2440,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98472959891413,
-                38.90155137911714
+                -118.20322430781918,
+                34.040940413880776
               ]
             }
           },
@@ -5915,8 +2449,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5976.0,
-                8492.0
+                5606.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5927,8 +2461,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98478973682136,
-                38.89691390242349
+                -118.20538709798625,
+                34.03762619768621
               ]
             }
           },
@@ -5937,7 +2471,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8492.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5948,8 +2482,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98895371597925,
-                38.896947070685115
+                -118.2081192189932,
+                34.038867801274115
               ]
             }
           }
@@ -5957,13 +2491,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1435/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001810",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1435",
       "metadata": [
         {
           "label": "streets",
@@ -5974,8 +2508,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5984,21 +2518,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1435/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1435/info.json",
           "type": "ImageService2",
-          "height": 8472,
-          "width": 5986
+          "height": 8150,
+          "width": 5500
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6635.1 -0.0,0.0 3241.5,-0.0 3241.5,-0.0 5618.6,-0.0 4459.8,4997.7 4254.2,5311.6 4248.5,6704.0 -0.0,6635.1\" /></svg>"
+          "value": "<svg><polygon points=\"631.0,146.5 1079.3,149.2 1078.4,-0.0 4750.0,-0.0 4685.7,7879.1 575.0,7863.6 631.0,146.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001810/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1435/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6023,8 +2557,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98011045988788,
-                38.901254022527276
+                -118.20266137363004,
+                34.040641851112035
               ]
             }
           },
@@ -6032,7 +2566,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5986.0,
+                5500.0,
                 0.0
               ],
               "creator": {
@@ -6044,8 +2578,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98008519585778,
-                38.89798398901327
+                -118.19998389149974,
+                34.03945788728337
               ]
             }
           },
@@ -6053,8 +2587,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5986.0,
-                8472.0
+                5500.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6065,8 +2599,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98598843316192,
-                38.89795597515656
+                -118.2020867420607,
+                34.03614612185821
               ]
             }
           },
@@ -6075,7 +2609,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8472.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6086,8 +2620,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98601369719202,
-                38.90122600867057
+                -118.204764224191,
+                34.037330085686875
               ]
             }
           }
@@ -6095,13 +2629,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1437/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001820",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1437",
       "metadata": [
         {
           "label": "streets",
@@ -6112,8 +2646,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6122,21 +2656,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1437/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1437/info.json",
           "type": "ImageService2",
-          "height": 8535,
-          "width": 6019
+          "height": 8150,
+          "width": 5510
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5855.0,2973.2 5855.4,3047.6 4857.1,3053.0 4862.6,5098.5 3317.0,5114.5 3317.6,5344.4 3498.3,5464.7 3656.9,5565.5 3663.2,7766.9 783.8,7778.6 765.8,5334.4 967.2,5019.2 2071.1,-0.0 4607.0,-0.0 5122.4,340.7 6019.0,299.7 6019.0,2409.4 5852.5,2409.9 5855.0,2973.2\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7959.4 0.0,-0.0 5510.0,-0.0 5510.0,7926.8 -0.0,7959.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001820/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1437/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6161,8 +2695,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98006157541505,
-                38.89931646612152
+                -118.19794245384178,
+                34.0385701261078
               ]
             }
           },
@@ -6170,7 +2704,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6019.0,
+                5510.0,
                 0.0
               ],
               "creator": {
@@ -6182,8 +2716,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98008407320172,
-                38.89601841545396
+                -118.19527548978976,
+                34.03737460171668
               ]
             }
           },
@@ -6191,8 +2725,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6019.0,
-                8535.0
+                5510.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6203,8 +2737,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98605074931257,
-                38.89604341778404
+                -118.19739420272826,
+                34.034082953552705
               ]
             }
           },
@@ -6213,7 +2747,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8535.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6224,8 +2758,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9860282515259,
-                38.8993414684516
+                -118.20006116678027,
+                34.03527847794383
               ]
             }
           }
@@ -6233,13 +2767,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001830/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1438/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001830",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1438",
       "metadata": [
         {
           "label": "streets",
@@ -6250,8 +2784,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6260,21 +2794,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001830/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1438/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001830/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1438/info.json",
           "type": "ImageService2",
-          "height": 8472,
-          "width": 5952
+          "height": 8150,
+          "width": 5671
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"721.0,2405.9 802.8,2313.7 800.1,1506.4 5708.9,1303.2 5758.2,7443.6 216.3,7436.1 290.3,2969.1 1043.3,3138.1 752.1,2782.9 721.0,2405.9\" /></svg>"
+          "value": "<svg><polygon points=\"5530.7,7860.9 653.5,7943.6 653.5,-0.0 1253.9,-0.0 1257.0,292.8 5421.5,324.0 5530.7,7860.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001830/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1438/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6299,8 +2833,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00600373487556,
-                38.897673494768725
+                -118.19559872636204,
+                34.03750139586034
               ]
             }
           },
@@ -6308,7 +2842,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5952.0,
+                5671.0,
                 0.0
               ],
               "creator": {
@@ -6320,8 +2854,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00186167327466,
-                38.89764820843333
+                -118.1928721887971,
+                34.036279141836594
               ]
             }
           },
@@ -6329,8 +2863,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5952.0,
-                8472.0
+                5671.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6341,8 +2875,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0019075946781,
-                38.89302723635606
+                -118.19497714059038,
+                34.03300884853647
               ]
             }
           },
@@ -6351,7 +2885,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8472.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6362,8 +2896,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00604965627899,
-                38.893052522691455
+                -118.19770367815534,
+                34.03423110256021
               ]
             }
           }
@@ -6371,13 +2905,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1439/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001840",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1439",
       "metadata": [
         {
           "label": "streets",
@@ -6388,8 +2922,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6398,21 +2932,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1439/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1439/info.json",
           "type": "ImageService2",
-          "height": 8481,
-          "width": 5994
+          "height": 8150,
+          "width": 5510
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"382.0,7554.1 265.9,0.0 4950.4,0.0 4957.1,550.1 5462.4,543.5 5573.2,8427.2 2513.3,8480.7 2494.2,7505.1 382.0,7554.1\" /></svg>"
+          "value": "<svg><polygon points=\"1452.5,-0.0 5510.0,7501.7 5510.0,7919.3 393.3,7860.2 393.7,7578.3 -0.0,7538.9 -0.0,-0.0 1452.5,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001840/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1439/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6437,8 +2971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00222039667341,
-                38.89768162663253
+                -118.19320647330808,
+                34.04049588420414
               ]
             }
           },
@@ -6446,7 +2980,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
+                5510.0,
                 0.0
               ],
               "creator": {
@@ -6458,8 +2992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99808045555831,
-                38.89763167840148
+                -118.19043678608656,
+                34.03928993854327
               ]
             }
           },
@@ -6467,8 +3001,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
-                8481.0
+                5510.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6479,8 +3013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9981706259309,
-                38.893040454390054
+                -118.19257399900236,
+                34.03587155648289
               ]
             }
           },
@@ -6489,7 +3023,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8481.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6500,8 +3034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.002310567046,
-                38.8930904026211
+                -118.19534368622388,
+                34.03707750214375
               ]
             }
           }
@@ -6509,13 +3043,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001860/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1440/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001860",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1440",
       "metadata": [
         {
           "label": "streets",
@@ -6526,8 +3060,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6536,21 +3070,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001860/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1440/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001860/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1440/info.json",
           "type": "ImageService2",
-          "height": 8429,
-          "width": 6000
+          "height": 8150,
+          "width": 5671
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"477.9,700.3 5414.5,716.1 5388.5,8429.0 460.2,8429.0 477.9,700.3\" /></svg>"
+          "value": "<svg><polygon points=\"1163.5,7903.0 -0.0,7768.6 284.5,7707.2 471.7,235.3 1615.8,174.9 1718.1,-0.0 5625.1,7853.4 1163.5,7903.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001860/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1440/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6575,8 +3109,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99529903071608,
-                38.89771473355204
+                -118.1932524370509,
+                34.03639494094025
               ]
             }
           },
@@ -6584,7 +3118,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6000.0,
+                5671.0,
                 0.0
               ],
               "creator": {
@@ -6596,8 +3130,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99112046509156,
-                38.89772283529742
+                -118.19044662310348,
+                34.035253941684374
               ]
             }
           },
@@ -6605,8 +3139,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6000.0,
-                8429.0
+                5671.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6617,8 +3151,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99110593855276,
-                38.89312024451019
+                -118.19241161272554,
+                34.031888517064246
               ]
             }
           },
@@ -6627,7 +3161,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8429.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6638,8 +3172,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99528450417729,
-                38.893112142764814
+                -118.19521742667295,
+                34.03302951632012
               ]
             }
           }
@@ -6647,13 +3181,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001880/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1441/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001880",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1441",
       "metadata": [
         {
           "label": "streets",
@@ -6664,8 +3198,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6674,21 +3208,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001880/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1441/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001880/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1441/info.json",
           "type": "ImageService2",
-          "height": 8452,
-          "width": 6026
+          "height": 8150,
+          "width": 5534
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7358.8 -0.0,469.5 6026.0,483.3 6026.0,7367.8 -0.0,7358.8\" /></svg>"
+          "value": "<svg><polygon points=\"2760.1,7817.9 467.8,7854.9 386.6,205.8 3568.0,103.8 5534.0,3613.4 5534.0,8150.0 2763.9,8150.0 2760.1,7817.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001880/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1441/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6713,8 +3247,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98892459761227,
-                38.897589118505095
+                -118.19403784294425,
+                34.02882468029807
               ]
             }
           },
@@ -6722,7 +3256,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6026.0,
+                5534.0,
                 0.0
               ],
               "creator": {
@@ -6734,8 +3268,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9847293497983,
-                38.89759409829451
+                -118.19134703583671,
+                34.027595590244125
               ]
             }
           },
@@ -6743,8 +3277,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6026.0,
-                8452.0
+                5534.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6755,8 +3289,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98472044131705,
-                38.89298371091936
+                -118.19351553545533,
+                34.024288522438525
               ]
             }
           },
@@ -6765,7 +3299,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8452.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6776,8 +3310,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98891568913102,
-                38.892978731129936
+                -118.19620634256287,
+                34.02551761249248
               ]
             }
           }
@@ -6785,13 +3319,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1443/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001900",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1443",
       "metadata": [
         {
           "label": "streets",
@@ -6802,8 +3336,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6812,21 +3346,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1443/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1443/info.json",
           "type": "ImageService2",
-          "height": 8398,
-          "width": 6024
+          "height": 8150,
+          "width": 5534
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6024.0,8398.0 590.5,8398.0 591.7,3802.3 1875.1,3119.9 594.9,3383.5 610.4,517.7 2810.0,526.2 4099.8,1008.4 5916.4,994.4 5921.3,0.0 6024.0,0.0 6024.0,8398.0\" /></svg>"
+          "value": "<svg><polygon points=\"5319.3,209.4 5326.1,8150.0 -0.0,8150.0 -0.0,228.0 5319.3,209.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001900/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1443/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6851,8 +3385,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9859285553357,
-                38.8938575681154
+                -118.21552755263438,
+                34.0424114007671
               ]
             }
           },
@@ -6860,7 +3394,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6024.0,
+                5534.0,
                 0.0
               ],
               "creator": {
@@ -6872,8 +3406,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98170348467364,
-                38.89386543632624
+                -118.21285753845027,
+                34.04120740186333
               ]
             }
           },
@@ -6881,8 +3415,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6024.0,
-                8398.0
+                5534.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6893,8 +3427,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98168948720132,
-                38.8892474888005
+                -118.21498210355581,
+                34.03792640515349
               ]
             }
           },
@@ -6903,7 +3437,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8398.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6914,8 +3448,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98591455786338,
-                38.88923962058966
+                -118.21765211773993,
+                34.03913040405725
               ]
             }
           }
@@ -6923,13 +3457,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001910/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1444/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001910",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1444",
       "metadata": [
         {
           "label": "streets",
@@ -6940,8 +3474,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6950,21 +3484,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001910/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1444/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001910/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1444/info.json",
           "type": "ImageService2",
-          "height": 8417,
-          "width": 5994
+          "height": 8150,
+          "width": 5636
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"287.4,6226.2 -0.0,6225.7 -0.0,3527.4 323.7,3255.0 358.6,389.5 5782.3,466.1 5746.7,7236.3 275.4,7214.5 287.4,6226.2\" /></svg>"
+          "value": "<svg><polygon points=\"5381.3,311.8 5151.1,8056.1 282.9,8029.3 429.4,236.1 5381.3,311.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001910/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1444/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -6989,8 +3523,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00614986362298,
-                38.893832665238676
+                -118.21316558727642,
+                34.041355874697324
               ]
             }
           },
@@ -6998,7 +3532,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
+                5636.0,
                 0.0
               ],
               "creator": {
@@ -7010,8 +3544,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0018880018208,
-                38.8938493809932
+                -118.21041921035561,
+                34.040174236700025
               ]
             }
           },
@@ -7019,8 +3553,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5994.0,
-                8417.0
+                5636.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7031,8 +3565,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00185805439108,
-                38.889158367006274
+                -118.21246730807144,
+                34.03685926146233
               ]
             }
           },
@@ -7041,7 +3575,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8417.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7052,8 +3586,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00611991619326,
-                38.88914165125175
+                -118.21521368499225,
+                34.03804089945963
               ]
             }
           }
@@ -7061,13 +3595,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1447/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001920",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1447",
       "metadata": [
         {
           "label": "streets",
@@ -7078,8 +3612,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7088,21 +3622,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1447/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1447/info.json",
           "type": "ImageService2",
-          "height": 8422,
-          "width": 5971
+          "height": 8149,
+          "width": 5605
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5505.2,7359.3 369.0,7336.4 400.3,436.7 2492.2,429.4 2492.1,1395.5 5522.3,1402.0 5505.2,7359.3\" /></svg>"
+          "value": "<svg><polygon points=\"257.5,239.4 234.2,-0.0 2106.9,-0.0 2105.9,240.0 5071.3,241.0 5114.3,7938.4 -0.0,7910.4 -0.0,239.7 257.5,239.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001920/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1447/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7127,8 +3661,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00231745285905,
-                38.893826905984724
+                -118.20537082070452,
+                34.03787613680936
               ]
             }
           },
@@ -7136,7 +3670,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5971.0,
+                5605.0,
                 0.0
               ],
               "creator": {
@@ -7148,8 +3682,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9981518198569,
-                38.89384087385003
+                -118.20264818375834,
+                34.03666330625101
               ]
             }
           },
@@ -7157,8 +3691,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5971.0,
-                8422.0
+                5605.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7169,8 +3703,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99812668319129,
-                38.88923512243598
+                -118.2047612268737,
+                34.0333597075001
               ]
             }
           },
@@ -7179,7 +3713,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8422.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7190,8 +3724,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00229231619343,
-                38.88922115457067
+                -118.20748386381987,
+                34.034572538058455
               ]
             }
           }
@@ -7199,13 +3733,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1448/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001930",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1448",
       "metadata": [
         {
           "label": "streets",
@@ -7216,8 +3750,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7226,21 +3760,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1448/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1448/info.json",
           "type": "ImageService2",
-          "height": 8399,
-          "width": 5988
+          "height": 8149,
+          "width": 5639
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5477.2,7363.4 500.5,7333.2 524.8,1220.3 511.3,1212.4 513.1,473.0 5514.7,509.2 5502.2,3370.9 5075.4,3365.8 5072.8,3644.1 5504.0,3874.9 5477.2,7363.4\" /></svg>"
+          "value": "<svg><polygon points=\"5515.0,7999.8 -0.0,7977.3 -0.0,256.8 5537.1,304.3 5515.0,7999.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001930/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1448/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7265,8 +3799,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99883299612362,
-                38.893844292900916
+                -118.20290422994162,
+                34.03678522810572
               ]
             }
           },
@@ -7274,7 +3808,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5988.0,
+                5639.0,
                 0.0
               ],
               "creator": {
@@ -7286,8 +3820,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99463463057387,
-                38.89386174672969
+                -118.20016416825811,
+                34.035580997862
               ]
             }
           },
@@ -7295,8 +3829,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5988.0,
-                8399.0
+                5639.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7307,8 +3841,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99460339361842,
-                38.88924541243084
+                -118.20224880941534,
+                34.03227743637358
               ]
             }
           },
@@ -7317,7 +3851,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8399.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7328,8 +3862,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99880175916817,
-                38.88922795860206
+                -118.20498887109885,
+                34.033481666617305
               ]
             }
           }
@@ -7337,13 +3871,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1451/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001950",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1451",
       "metadata": [
         {
           "label": "streets",
@@ -7354,8 +3888,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7364,21 +3898,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1451/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1451/info.json",
           "type": "ImageService2",
-          "height": 8433,
-          "width": 5976
+          "height": 8149,
+          "width": 5605
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"665.3,498.1 5299.3,489.4 5325.1,2664.8 5098.2,3359.0 5347.3,3361.6 5318.4,5879.9 4441.1,6364.8 694.0,6429.4 665.3,498.1\" /></svg>"
+          "value": "<svg><polygon points=\"2587.3,7482.8 601.4,7473.6 580.0,143.1 2255.0,287.0 5034.1,187.7 5027.0,7947.5 2582.5,7944.5 2587.3,7482.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001950/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1451/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7403,8 +3937,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99199539578501,
-                38.89384798609012
+                -118.19560012059038,
+                34.03349023813484
               ]
             }
           },
@@ -7412,7 +3946,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5976.0,
+                5605.0,
                 0.0
               ],
               "creator": {
@@ -7424,8 +3958,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98783542070906,
-                38.89384137830443
+                -118.19288911554794,
+                34.032304665982544
               ]
             }
           },
@@ -7433,8 +3967,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5976.0,
-                8433.0
+                5605.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7445,8 +3979,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98784732110565,
-                38.88923841822951
+                -118.19495455428925,
+                34.02901500015342
               ]
             }
           },
@@ -7455,7 +3989,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8433.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7466,8 +4000,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9920072961816,
-                38.8892450260152
+                -118.1976655593317,
+                34.030200572305716
               ]
             }
           }
@@ -7475,13 +4009,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1452/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001960",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1452",
       "metadata": [
         {
           "label": "streets",
@@ -7492,8 +4026,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7502,21 +4036,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1452/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1452/info.json",
           "type": "ImageService2",
-          "height": 8434,
-          "width": 5988
+          "height": 8149,
+          "width": 5639
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"777.4,6412.6 38.8,6309.0 910.8,5830.7 947.6,3332.1 700.5,3328.7 927.8,2640.5 909.1,482.0 4910.6,489.2 4898.4,3353.9 5988.0,3187.7 4895.8,3772.6 4899.9,8366.5 889.1,8434.0 888.8,6736.8 777.4,6412.6\" /></svg>"
+          "value": "<svg><polygon points=\"1695.7,225.8 5639.0,7613.2 5639.0,7993.8 5511.8,8029.2 -0.0,7986.9 -0.0,308.8 1695.7,225.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001960/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1452/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7541,8 +4075,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98894548908363,
-                38.893839539583965
+                -118.19313360045874,
+                34.032475541885624
               ]
             }
           },
@@ -7550,7 +4084,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5988.0,
+                5639.0,
                 0.0
               ],
               "creator": {
@@ -7562,8 +4096,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.984744047611,
-                38.89384350630201
+                -118.1903775282317,
+                34.03126754738606
               ]
             }
           },
@@ -7571,8 +4105,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5988.0,
-                8434.0
+                5639.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7583,8 +4117,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98473691800648,
-                38.88920397863581
+                -118.19246856577547,
+                34.0279444921996
               ]
             }
           },
@@ -7593,7 +4127,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8434.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7604,8 +4138,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9889383594791,
-                38.889200011917765
+                -118.19522463800251,
+                34.02915248669917
               ]
             }
           }
@@ -7613,13 +4147,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001970/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001970",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1458",
       "metadata": [
         {
           "label": "streets",
@@ -7630,8 +4164,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7640,21 +4174,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001970/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001970/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/info.json",
           "type": "ImageService2",
-          "height": 8401,
-          "width": 5943
+          "height": 8149,
+          "width": 5650
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5787.9,7849.6 329.3,7829.2 310.5,4884.0 -0.0,4884.8 0.0,0.0 296.0,0.0 285.7,998.1 5812.9,1009.7 5787.9,7849.6\" /></svg>"
+          "value": "<svg><polygon points=\"904.5,224.2 4792.3,248.6 4622.9,6037.2 5650.0,6072.3 5650.0,7961.6 4567.2,7938.5 4578.3,7559.4 1428.7,7559.5 1426.0,7926.8 869.9,7924.3 904.5,224.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001970/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1458/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7679,8 +4213,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00613170606293,
-                38.89036291491638
+                -118.20605002012553,
+                34.03415527493919
               ]
             }
           },
@@ -7688,7 +4222,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5943.0,
+                5650.0,
                 0.0
               ],
               "creator": {
@@ -7700,8 +4234,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0019487295359,
-                38.89037310957578
+                -118.20331116234364,
+                34.032959594598054
               ]
             }
           },
@@ -7709,8 +4243,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5943.0,
-                8401.0
+                5650.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7721,8 +4255,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00193034139355,
-                38.88573720190967
+                -118.2053780038218,
+                34.02966205464269
               ]
             }
           },
@@ -7731,7 +4265,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8401.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7742,8 +4276,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0061133179206,
-                38.88572700725027
+                -118.20811686160368,
+                34.030857734983826
               ]
             }
           }
@@ -7751,13 +4285,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1460/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001980",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1460",
       "metadata": [
         {
           "label": "streets",
@@ -7768,8 +4302,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7778,21 +4312,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1460/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1460/info.json",
           "type": "ImageService2",
-          "height": 8432,
-          "width": 6009
+          "height": 8149,
+          "width": 5650
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"411.3,1012.9 5567.7,998.8 5588.6,8432.0 429.7,8432.0 411.3,1012.9\" /></svg>"
+          "value": "<svg><polygon points=\"5387.2,137.1 5428.0,7897.6 -0.0,7954.4 -0.0,193.2 5387.2,137.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001980/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1460/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7817,8 +4351,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00232184126118,
-                38.89036784117962
+                -118.20152818067493,
+                34.03213329610476
               ]
             }
           },
@@ -7826,7 +4360,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6009.0,
+                5650.0,
                 0.0
               ],
               "creator": {
@@ -7838,8 +4372,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99814611696955,
-                38.890358259403925
+                -118.19882241510936,
+                34.03089156555655
               ]
             }
           },
@@ -7847,8 +4381,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6009.0,
-                8432.0
+                5650.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7859,8 +4393,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99816326118795,
-                38.88576751221049
+                -118.20096881752187,
+                34.027633805847756
               ]
             }
           },
@@ -7869,7 +4403,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8432.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7880,8 +4414,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00233898547958,
-                38.885777093986185
+                -118.20367458308743,
+                34.028875536395965
               ]
             }
           }
@@ -7889,13 +4423,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1463/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001990",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1463",
       "metadata": [
         {
           "label": "streets",
@@ -7906,8 +4440,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7916,21 +4450,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1463/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1463/info.json",
           "type": "ImageService2",
-          "height": 8381,
-          "width": 5962
+          "height": 8150,
+          "width": 5541
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5455.2,7791.9 471.4,7794.2 461.0,921.0 5442.8,915.8 5453.1,4408.9 4952.0,4671.9 4952.4,4939.2 5453.8,4936.2 5455.2,7791.9\" /></svg>"
+          "value": "<svg><polygon points=\"5181.4,7324.4 -0.0,7286.6 320.2,1804.4 5220.5,658.2 5181.4,7324.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001990/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1463/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -7955,8 +4489,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99877656897775,
-                38.89032132878359
+                -118.22057070702931,
+                34.03377100135399
               ]
             }
           },
@@ -7964,7 +4498,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5962.0,
+                5541.0,
                 0.0
               ],
               "creator": {
@@ -7976,8 +4510,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99460058909753,
-                38.890315438517646
+                -118.21919160855353,
+                34.03603758810228
               ]
             }
           },
@@ -7985,8 +4519,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5962.0,
-                8381.0
+                5541.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7997,8 +4531,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9946111525402,
-                38.88571377253926
+                -118.21519515795913,
+                34.03434402264163
               ]
             }
           },
@@ -8007,7 +4541,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8381.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8018,8 +4552,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99878713242042,
-                38.88571966280521
+                -118.21657425643491,
+                34.03207743589334
               ]
             }
           }
@@ -8027,13 +4561,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1464/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002010",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1464",
       "metadata": [
         {
           "label": "streets",
@@ -8044,8 +4578,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8054,21 +4588,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1464/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1464/info.json",
           "type": "ImageService2",
-          "height": 8449,
-          "width": 6055
+          "height": 8149,
+          "width": 5650
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"652.4,7873.9 712.1,1985.3 1330.8,1992.7 1355.0,0.0 5125.0,0.0 5331.0,410.3 5319.7,2122.2 6055.0,2127.2 6055.0,8449.0 5817.7,8449.0 5825.6,7883.6 5275.0,8062.1 5225.3,7837.2 652.4,7873.9\" /></svg>"
+          "value": "<svg><polygon points=\"171.5,8149.0 -0.0,8149.0 0.0,0.0 155.7,0.0 161.9,375.0 5362.5,330.7 5318.0,7785.4 177.0,7768.1 171.5,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002010/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1464/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8093,8 +4627,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99202638924116,
-                38.89033472217896
+                -118.21722204159643,
+                34.0322721290355
               ]
             }
           },
@@ -8102,7 +4636,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6055.0,
+                5650.0,
                 0.0
               ],
               "creator": {
@@ -8114,8 +4648,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98781487988279,
-                38.890361085348346
+                -118.21577605872872,
+                34.03455533026558
               ]
             }
           },
@@ -8123,8 +4657,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                6055.0,
-                8449.0
+                5650.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8135,8 +4669,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98776794141045,
-                38.88575370905938
+                -118.21182931448679,
+                34.03281440143417
               ]
             }
           },
@@ -8145,7 +4679,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8449.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8156,8 +4690,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99197945076884,
-                38.88572734589
+                -118.21327529735449,
+                34.03053120020409
               ]
             }
           }
@@ -8165,13 +4699,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1468/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002020",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1468",
       "metadata": [
         {
           "label": "streets",
@@ -8182,8 +4716,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8192,21 +4726,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1468/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1468/info.json",
           "type": "ImageService2",
-          "height": 8158,
-          "width": 5679
+          "height": 8149,
+          "width": 5629
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1371.5,6912.1 1161.3,7121.9 541.3,6807.7 514.9,1054.5 5129.6,950.5 5131.9,1178.6 5679.0,992.8 5679.0,6874.7 1371.5,6912.1\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,-0.0 199.2,0.0 191.3,443.5 4138.3,430.0 4135.6,896.6 5345.2,909.8 5265.0,7589.2 -0.0,7515.7 0.0,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002020/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1468/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8231,8 +4765,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99188337584418,
-                38.88662141831994
+                -118.20353070032562,
+                34.02613672946149
               ]
             }
           },
@@ -8240,7 +4774,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5679.0,
+                5629.0,
                 0.0
               ],
               "creator": {
@@ -8252,8 +4786,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98792663725219,
-                38.88660332181694
+                -118.20213107458203,
+                34.028422881330414
               ]
             }
           },
@@ -8261,8 +4795,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5679.0,
-                8158.0
+                5629.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8273,8 +4807,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98795980182061,
-                38.88214736150571
+                -118.19816548766717,
+                34.026731648543766
               ]
             }
           },
@@ -8283,7 +4817,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8158.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8294,8 +4828,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9919165404126,
-                38.88216545800871
+                -118.19956511341076,
+                34.02444549667484
               ]
             }
           }
@@ -8303,13 +4837,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002070",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1470 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -8320,8 +4854,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8330,21 +4864,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/info.json",
           "type": "ImageService2",
-          "height": 8193,
-          "width": 5699
+          "height": 8149,
+          "width": 5629
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3088.0 0.0,0.0 5699.0,0.0 5699.0,209.2 4669.8,189.1 4505.5,7399.4 1179.8,7325.7 1279.1,3117.6 -0.0,3088.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,3328.6 -0.0,1278.1 2632.8,67.0 4784.0,4456.5 4834.1,5266.4 443.6,5294.6 1081.7,4891.8 -0.0,3328.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002070/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1470/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8369,8 +4903,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02085873807863,
-                38.889282405614864
+                -118.22246791260763,
+                34.04624451394456
               ]
             }
           },
@@ -8378,7 +4912,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5699.0,
+                5629.0,
                 0.0
               ],
               "creator": {
@@ -8390,8 +4924,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01683323987949,
-                38.889350613959365
+                -118.22093081292904,
+                34.04853422388166
               ]
             }
           },
@@ -8399,8 +4933,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5699.0,
-                8193.0
+                5629.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8411,8 +4945,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0167081230461,
-                38.88481333386957
+                -118.21695810064996,
+                34.046677320739576
               ]
             }
           },
@@ -8421,7 +4955,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8193.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8432,8 +4966,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02073362124524,
-                38.88474512552507
+                -118.21849520032853,
+                34.044387610802474
               ]
             }
           }
@@ -8441,13 +4975,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1472/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002080",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1472",
       "metadata": [
         {
           "label": "streets",
@@ -8458,8 +4992,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8468,21 +5002,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1472/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1472/info.json",
           "type": "ImageService2",
-          "height": 8206,
-          "width": 5668
+          "height": 8150,
+          "width": 5662
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1100.8,8206.0 1118.5,0.0 5668.0,0.0 5668.0,154.1 4538.3,170.7 4540.2,8206.0 1100.8,8206.0\" /></svg>"
+          "value": "<svg><polygon points=\"688.1,-0.0 3538.8,-0.0 3550.8,492.6 4061.6,445.4 4554.2,2039.7 4981.5,7759.9 4775.9,8150.0 487.0,8108.0 714.1,7603.4 688.1,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002080/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1472/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8507,8 +5041,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01832645312265,
-                38.88923224619574
+                -118.18828147654435,
+                34.046399894871136
               ]
             }
           },
@@ -8516,7 +5050,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5668.0,
+                5662.0,
                 0.0
               ],
               "creator": {
@@ -8528,8 +5062,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01442937382211,
-                38.88923885512616
+                -118.18827478690822,
+                34.04379926659444
               ]
             }
           },
@@ -8537,8 +5071,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5668.0,
-                8206.0
+                5662.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8549,8 +5083,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0144171645278,
-                38.88481506136262
+                -118.1927604017457,
+                34.04379123243126
               ]
             }
           },
@@ -8559,7 +5093,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8206.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8570,8 +5104,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01831424382833,
-                38.884808452432196
+                -118.19276709138182,
+                34.04639186070795
               ]
             }
           }
@@ -8579,13 +5113,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1473/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002090",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1473",
       "metadata": [
         {
           "label": "streets",
@@ -8596,8 +5130,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8606,21 +5140,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1473/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1473/info.json",
           "type": "ImageService2",
-          "height": 8203,
-          "width": 5722
+          "height": 8150,
+          "width": 5595
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7444.5 -0.0,4067.1 784.0,4066.7 774.8,677.0 3641.2,671.0 3641.2,1379.4 5321.7,1412.1 5303.0,8151.6 721.8,8203.0 715.3,7445.6 -0.0,7444.5\" /></svg>"
+          "value": "<svg><polygon points=\"4952.2,8150.0 1110.3,8150.0 1261.9,7878.6 971.9,2112.7 657.0,998.4 2116.8,1026.9 2137.0,-0.0 4289.0,37.9 4760.2,2003.5 4952.2,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002090/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1473/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8645,8 +5179,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01472000241121,
-                38.885237357536994
+                -118.18825780208951,
+                34.04477490808127
               ]
             }
           },
@@ -8654,7 +5188,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
+                5595.0,
                 0.0
               ],
               "creator": {
@@ -8666,8 +5200,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01472216997004,
-                38.88210741656957
+                -118.18817685796962,
+                34.0422228086593
               ]
             }
           },
@@ -8675,8 +5209,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
-                8203.0
+                5595.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8687,8 +5221,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02044481211188,
-                38.882109851925854
+                -118.19263217173071,
+                34.042124412639645
               ]
             }
           },
@@ -8697,7 +5231,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8203.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8708,8 +5242,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02044264455304,
-                38.88523979289327
+                -118.1927131158506,
+                34.04467651206161
               ]
             }
           }
@@ -8717,13 +5251,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002100/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1474/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002100",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1474",
       "metadata": [
         {
           "label": "streets",
@@ -8734,8 +5268,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8744,21 +5278,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002100/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1474/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002100/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1474/info.json",
           "type": "ImageService2",
-          "height": 8177,
-          "width": 5675
+          "height": 8150,
+          "width": 5662
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5576.8,8177.0 -0.0,8177.0 -0.0,1429.6 2448.5,1470.5 2450.2,1365.4 5555.9,1328.7 5576.8,8177.0\" /></svg>"
+          "value": "<svg><polygon points=\"738.3,8150.0 489.5,2025.1 -0.0,63.1 5057.5,85.3 5023.3,7949.3 5652.2,7954.6 5545.9,8150.0 738.3,8150.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002100/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1474/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8783,8 +5317,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01471092908386,
-                38.88232421012997
+                -118.18818197903643,
+                34.0428185508572
               ]
             }
           },
@@ -8792,7 +5326,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
+                5662.0,
                 0.0
               ],
               "creator": {
@@ -8804,8 +5338,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0147240407419,
-                38.87922474457616
+                -118.18812871874283,
+                34.040235953258865
               ]
             }
           },
@@ -8813,8 +5347,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
-                8177.0
+                5662.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8825,8 +5359,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02042188075647,
-                38.87923955801917
+                -118.19258306743512,
+                34.040171985970574
               ]
             }
           },
@@ -8835,7 +5369,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8177.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8846,8 +5380,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02040876909844,
-                38.88233902357298
+                -118.19263632772872,
+                34.04275458356891
               ]
             }
           }
@@ -8855,13 +5389,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1475/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002110",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1475",
       "metadata": [
         {
           "label": "streets",
@@ -8872,8 +5406,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8882,21 +5416,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1475/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1475/info.json",
           "type": "ImageService2",
-          "height": 8209,
-          "width": 5675
+          "height": 8150,
+          "width": 5595
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"219.4,8209.0 184.1,631.6 5310.9,606.8 5338.7,7227.9 5028.8,8209.0 219.4,8209.0\" /></svg>"
+          "value": "<svg><polygon points=\"263.3,7938.1 221.2,108.8 5072.4,78.1 5079.5,7903.2 263.3,7938.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002110/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1475/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -8921,8 +5455,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01476920878234,
-                38.87938886091232
+                -118.18812219366609,
+                34.04061271711612
               ]
             }
           },
@@ -8930,7 +5464,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
+                5595.0,
                 0.0
               ],
               "creator": {
@@ -8942,8 +5476,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01478894988408,
-                38.87633385111721
+                -118.18809923525795,
+                34.03804944436296
               ]
             }
           },
@@ -8951,8 +5485,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
-                8209.0
+                5595.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8963,8 +5497,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02042687775996,
-                38.87635624232838
+                -118.19257385949106,
+                34.0380215348053
               ]
             }
           },
@@ -8973,7 +5507,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8209.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8984,8 +5518,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02040713665822,
-                38.87941125212349
+                -118.1925968178992,
+                34.04058480755846
               ]
             }
           }
@@ -8993,13 +5527,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1476/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002120",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1476",
       "metadata": [
         {
           "label": "streets",
@@ -9010,8 +5544,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9020,21 +5554,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1476/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1476/info.json",
           "type": "ImageService2",
-          "height": 8177,
-          "width": 5675
+          "height": 8150,
+          "width": 5662
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1334.4,715.4 1336.9,-0.0 5675.0,-0.0 5675.0,8177.0 858.8,8177.0 1143.2,7235.3 1092.8,716.9 1334.4,715.4\" /></svg>"
+          "value": "<svg><polygon points=\"5047.6,7924.0 -0.0,7954.3 -0.0,65.9 5002.3,76.1 5047.6,7924.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002120/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1476/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9059,8 +5593,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01469777699133,
-                38.87712567855194
+                -118.1881083705202,
+                34.038288864554325
               ]
             }
           },
@@ -9068,7 +5602,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
+                5662.0,
                 0.0
               ],
               "creator": {
@@ -9080,8 +5614,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0147317942853,
-                38.87402254419626
+                -118.18808252797099,
+                34.03571522080728
               ]
             }
           },
@@ -9089,8 +5623,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5675.0,
-                8177.0
+                5662.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9101,8 +5635,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02043596571221,
-                38.87406097943718
+                -118.19252119735494,
+                34.03568418144163
               ]
             }
           },
@@ -9111,7 +5645,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8177.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9122,8 +5656,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.02040194841824,
-                38.87716411379286
+                -118.19254703990416,
+                34.03825782518867
               ]
             }
           }
@@ -9131,13 +5665,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1478/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002150",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1478",
       "metadata": [
         {
           "label": "streets",
@@ -9148,8 +5682,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9158,21 +5692,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1478/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1478/info.json",
           "type": "ImageService2",
-          "height": 8205,
-          "width": 5691
+          "height": 8150,
+          "width": 5662
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5691.0,8205.0 5527.3,8205.0 5573.8,6944.6 571.8,6760.2 669.3,0.0 5691.0,0.0 5691.0,8205.0\" /></svg>"
+          "value": "<svg><polygon points=\"4780.3,7999.1 1271.5,7972.9 1320.2,217.8 1389.7,218.0 1391.5,-0.0 4920.5,-0.0 4780.3,7999.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002150/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1478/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9197,8 +5731,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01567419660985,
-                38.889139342778144
+                -118.18796474877732,
+                34.03454186657267
               ]
             }
           },
@@ -9206,7 +5740,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5691.0,
+                5662.0,
                 0.0
               ],
               "creator": {
@@ -9218,8 +5752,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01169195121251,
-                38.88919199880878
+                -118.18791584976759,
+                34.031912352868105
               ]
             }
           },
@@ -9227,8 +5761,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5691.0,
-                8205.0
+                5662.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9239,8 +5773,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01159508510085,
-                38.88469058247577
+                -118.1924506617992,
+                34.03185361772041
               ]
             }
           },
@@ -9249,7 +5783,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8205.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9260,8 +5794,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01557733049818,
-                38.88463792644513
+                -118.19249956080893,
+                34.03448313142497
               ]
             }
           }
@@ -9269,13 +5803,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002160/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002160",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1480",
       "metadata": [
         {
           "label": "streets",
@@ -9286,8 +5820,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9296,21 +5830,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002160/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002160/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/info.json",
           "type": "ImageService2",
-          "height": 8204,
+          "height": 8150,
           "width": 5684
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"713.4,4033.1 625.9,0.0 5684.0,0.0 5684.0,8204.0 -0.0,8204.0 -0.0,4047.0 713.4,4033.1\" /></svg>"
+          "value": "<svg><polygon points=\"4980.9,8005.1 -0.0,8039.5 -0.0,1048.8 656.5,1051.8 660.0,-0.0 5017.8,-0.0 4980.9,8005.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002160/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1480/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9335,8 +5869,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0156276517628,
-                38.88544266581856
+                -118.18798277655858,
+                34.03057326149523
               ]
             }
           },
@@ -9356,8 +5890,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01169200411816,
-                38.885380985661165
+                -118.18795943823976,
+                34.02798476915379
               ]
             }
           },
@@ -9366,7 +5900,7 @@
             "properties": {
               "resourceCoords": [
                 5684.0,
-                8204.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9377,8 +5911,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0118055695096,
-                38.88092792259915
+                -118.19240758270004,
+                34.027956833568616
               ]
             }
           },
@@ -9387,7 +5921,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8204.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9398,8 +5932,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01574121715424,
-                38.88098960275655
+                -118.19243092101885,
+                34.030545325910055
               ]
             }
           }
@@ -9407,13 +5941,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002180",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1481",
       "metadata": [
         {
           "label": "streets",
@@ -9424,8 +5958,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9434,21 +5968,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/info.json",
           "type": "ImageService2",
-          "height": 8188,
-          "width": 5707
+          "height": 8150,
+          "width": 5595
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"515.7,7273.5 574.5,115.9 5087.8,0.0 4962.6,8188.0 437.5,8105.4 494.7,7497.2 -0.0,7500.6 -0.0,7225.5 515.7,7273.5\" /></svg>"
+          "value": "<svg><polygon points=\"4981.4,7988.6 1260.2,8020.2 1194.2,8150.0 477.9,8022.5 628.8,8020.6 619.1,-0.0 4984.6,-0.0 4981.4,7988.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002180/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1481/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9473,8 +6007,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00946877245805,
-                38.887652265354944
+                -118.18795728861902,
+                34.02856995350342
               ]
             }
           },
@@ -9482,7 +6016,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5707.0,
+                5595.0,
                 0.0
               ],
               "creator": {
@@ -9494,8 +6028,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00546842515853,
-                38.88767028208356
+                -118.18795208883473,
+                34.026023108534666
               ]
             }
           },
@@ -9503,8 +6037,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5707.0,
-                8188.0
+                5595.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9515,8 +6049,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00543545563754,
-                38.88317197877145
+                -118.19239738595384,
+                34.02601678645487
               ]
             }
           },
@@ -9525,7 +6059,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8188.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9536,8 +6070,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00943580293705,
-                38.88315396204283
+                -118.19240258573812,
+                34.02856363142362
               ]
             }
           }
@@ -9545,13 +6079,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002190",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1487",
       "metadata": [
         {
           "label": "streets",
@@ -9562,8 +6096,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9572,21 +6106,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/info.json",
           "type": "ImageService2",
-          "height": 8203,
-          "width": 5722
+          "height": 8149,
+          "width": 5609
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2916.9,7478.4 615.7,7400.0 640.6,4170.1 -0.0,4163.3 -0.0,1054.6 4387.7,1179.7 4400.6,4207.5 3872.9,4205.8 2916.9,7478.4\" /></svg>"
+          "value": "<svg><polygon points=\"5138.2,561.0 5135.6,4879.2 4530.2,4876.7 4537.2,7004.9 3953.0,7009.3 3941.7,6973.4 1778.3,7019.3 -0.0,563.8 5138.2,561.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002190/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1487/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9611,8 +6145,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01567426922551,
-                38.88156387362174
+                -118.18436477305066,
+                34.04470104521507
               ]
             }
           },
@@ -9620,7 +6154,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
+                5609.0,
                 0.0
               ],
               "creator": {
@@ -9632,8 +6166,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01169082452573,
-                38.88159045101665
+                -118.1843485773223,
+                34.04212111019808
               ]
             }
           },
@@ -9641,8 +6175,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5722.0,
-                8203.0
+                5609.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9653,8 +6187,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01164223469729,
-                38.877114576629985
+                -118.18884066576409,
+                34.04210147447116
               ]
             }
           },
@@ -9663,7 +6197,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8203.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9674,8 +6208,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01562567939709,
-                38.87708799923507
+                -118.18885686149245,
+                34.04468140948814
               ]
             }
           }
@@ -9683,13 +6217,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002220",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1488",
       "metadata": [
         {
           "label": "streets",
@@ -9700,8 +6234,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9710,21 +6244,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/info.json",
           "type": "ImageService2",
-          "height": 8207,
-          "width": 5702
+          "height": 8149,
+          "width": 5636
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5367.1,8069.1 240.0,8107.1 240.3,8207.0 -0.0,8207.0 -0.0,653.8 214.6,652.4 214.0,580.3 213.3,520.8 196.2,374.3 5343.4,336.7 5349.8,1642.0 5193.0,1644.3 5244.4,7855.6 5367.1,8069.1\" /></svg>"
+          "value": "<svg><polygon points=\"621.9,537.0 4560.1,561.1 4532.8,6956.4 -0.0,6975.8 -0.0,4848.7 605.0,4853.2 621.9,537.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002220/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1488/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9749,8 +6283,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0017792617157,
-                38.87939181496334
+                -118.18436596634935,
+                34.04262464513394
               ]
             }
           },
@@ -9758,7 +6292,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5702.0,
+                5636.0,
                 0.0
               ],
               "creator": {
@@ -9770,8 +6304,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00180953661967,
-                38.876257239888645
+                -118.184339411218,
+                34.0400305854942
               ]
             }
           },
@@ -9779,8 +6313,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5702.0,
-                8207.0
+                5636.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9791,8 +6325,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00756306183594,
-                38.876291394007964
+                -118.18883351152262,
+                34.03999854894568
               ]
             }
           },
@@ -9801,7 +6335,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8207.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9812,8 +6346,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00753278693196,
-                38.87942596908266
+                -118.18886006665396,
+                34.04259260858542
               ]
             }
           }
@@ -9821,13 +6355,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002230",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1489",
       "metadata": [
         {
           "label": "streets",
@@ -9838,8 +6372,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9848,21 +6382,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/info.json",
           "type": "ImageService2",
-          "height": 8188,
-          "width": 5691
+          "height": 8149,
+          "width": 5605
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8188.0 -0.0,4215.7 550.5,4196.1 535.9,1017.8 645.6,756.0 2723.3,763.6 2723.8,0.0 4692.2,0.0 4692.4,885.6 5161.4,890.8 5156.6,4212.7 4846.1,4209.7 4835.4,4401.3 4845.5,7204.0 5107.8,7205.6 5106.6,7467.4 5106.6,8188.0 -0.0,8188.0\" /></svg>"
+          "value": "<svg><polygon points=\"112.1,7273.1 195.0,-0.0 5417.9,-0.0 5361.5,7282.3 112.1,7273.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002230/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1489/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -9887,8 +6421,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01256522326244,
-                38.87696352615946
+                -118.18417188105865,
+                34.04061455946168
               ]
             }
           },
@@ -9896,7 +6430,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5691.0,
+                5605.0,
                 0.0
               ],
               "creator": {
@@ -9908,8 +6442,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856313200248,
-                38.87696286317869
+                -118.18412386816185,
+                34.03803580805099
               ]
             }
           },
@@ -9917,8 +6451,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5691.0,
-                8188.0
+                5605.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9929,8 +6463,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00856434845302,
-                38.872449301876976
+                -118.18861685610547,
+                34.03797755241846
               ]
             }
           },
@@ -9939,7 +6473,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8188.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9950,8 +6484,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01256643971298,
-                38.87244996485774
+                -118.18866486900227,
+                34.04055630382915
               ]
             }
           }
@@ -9959,13 +6493,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002250",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1491",
       "metadata": [
         {
           "label": "streets",
@@ -9976,8 +6510,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9986,21 +6520,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/info.json",
           "type": "ImageService2",
-          "height": 8221,
-          "width": 5684
+          "height": 8149,
+          "width": 5605
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"106.7,8221.0 113.6,688.6 4286.2,695.3 4287.1,851.3 5684.0,856.8 5684.0,8221.0 106.7,8221.0\" /></svg>"
+          "value": "<svg><polygon points=\"5605.0,7226.9 987.1,7288.7 986.2,952.3 5605.0,938.4 5605.0,7226.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002250/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1491/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -10025,8 +6559,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00597966957578,
-                38.87692474460072
+                -118.18412104040117,
+                34.03649303625172
               ]
             }
           },
@@ -10034,7 +6568,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5684.0,
+                5605.0,
                 0.0
               ],
               "creator": {
@@ -10046,8 +6580,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00197563315439,
-                38.87692911465734
+                -118.18409798604793,
+                34.03391969209276
               ]
             }
           },
@@ -10055,8 +6589,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5684.0,
-                8221.0
+                5605.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10067,8 +6601,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00196756844316,
-                38.872387039399186
+                -118.18858134257098,
+                34.033891718172846
               ]
             }
           },
@@ -10077,7 +6611,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8221.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10088,8 +6622,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00597160486456,
-                38.87238266934258
+                -118.18860439692422,
+                34.03646506233181
               ]
             }
           }
@@ -10097,13 +6631,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002270/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1496/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002270",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1496",
       "metadata": [
         {
           "label": "streets",
@@ -10114,8 +6648,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -10124,1125 +6658,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002270/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1496/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002270/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1496/info.json",
           "type": "ImageService2",
-          "height": 8205,
-          "width": 5660
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"134.7,343.9 5616.1,377.2 5568.8,8205.0 -0.0,8205.0 -0.0,-0.0 95.5,0.0 134.7,343.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002270/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00597854360323,
-                38.886231706559165
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5660.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00201138678065,
-                38.886248662169486
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5660.0,
-                8205.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00198002005035,
-                38.88173877809228
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8205.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00594717687294,
-                38.881721822481964
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002280",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/info.json",
-          "type": "ImageService2",
-          "height": 8199,
-          "width": 5690
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5405.1,2235.5 5425.3,6868.5 244.5,6943.3 216.4,2246.8 5405.1,2235.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002280/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0021820237718,
-                38.88699365595285
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5690.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99825066205725,
-                38.886977926620446
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5690.0,
-                8199.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9982795686331,
-                38.882538216995044
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8199.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00221093034763,
-                38.88255394632745
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002290",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/info.json",
-          "type": "ImageService2",
-          "height": 8205,
-          "width": 5691
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"365.7,7086.2 338.8,1020.6 4450.4,1004.2 4483.3,7067.2 365.7,7086.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002290/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99868860422129,
-                38.886600249922644
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99472130143731,
-                38.88658361207975
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                8205.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99475190735731,
-                38.88209892815199
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8205.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99871921014129,
-                38.882115565994894
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002310",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/info.json",
-          "type": "ImageService2",
-          "height": 8180,
-          "width": 5691
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"274.8,3063.3 280.8,308.5 5452.0,254.3 5453.9,1237.4 5691.0,1237.3 5691.0,7833.1 4331.1,7385.7 -0.0,7373.2 -0.0,3065.2 274.8,3063.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002310/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00223170269487,
-                38.88340078843865
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99829216499148,
-                38.88339723219455
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                8180.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99829868421749,
-                38.87895892240898
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8180.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00223822192089,
-                38.87896247865308
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002320",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/info.json",
-          "type": "ImageService2",
-          "height": 8189,
-          "width": 5692
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1842.6,8189.0 546.0,7734.8 564.2,1190.5 5354.1,1201.9 5342.3,7532.0 3597.6,7527.3 3593.6,8189.0 1842.6,8189.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002320/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99868548560617,
-                38.88337238799304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5692.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99474119676773,
-                38.883377427625334
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5692.0,
-                8189.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99473194466495,
-                38.878927251326225
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8189.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99867623350339,
-                38.87892221169393
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002330",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/info.json",
-          "type": "ImageService2",
-          "height": 8212,
-          "width": 5729
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"429.2,7444.6 442.9,1074.8 2204.3,1081.5 2204.4,0.0 3197.2,0.0 3822.8,325.4 3823.9,0.0 3987.4,0.0 5729.0,908.2 5729.0,7466.0 429.2,7444.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002330/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99528070626549,
-                38.88330395770263
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5729.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9913320181659,
-                38.88330992354896
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5729.0,
-                8212.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99132111554732,
-                38.87887506684578
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8212.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9952698036469,
-                38.87886910099946
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002340/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002340",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002340/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002340/info.json",
-          "type": "ImageService2",
-          "height": 8157,
-          "width": 5664
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"748.7,900.0 1077.0,1069.7 1290.3,860.5 5624.8,858.8 5664.0,8157.0 5085.5,8157.0 5087.0,7434.0 745.2,7421.8 748.7,900.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002340/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9918507933676,
-                38.883307141002426
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5664.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98792888971396,
-                38.88331471735707
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5664.0,
-                8157.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98791496636444,
-                38.87888529270186
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8157.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99183687001809,
-                38.87887771634722
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002350",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/info.json",
-          "type": "ImageService2",
-          "height": 8180,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"223.7,7558.2 223.7,7834.9 -0.0,7832.1 -0.0,3771.9 1293.6,-0.0 5427.9,-0.0 5411.1,1463.5 5672.7,1465.5 5696.0,7524.1 5332.1,7452.3 5330.0,7618.1 223.7,7558.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002350/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99671614821368,
-                38.879449790576984
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5696.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99667018082965,
-                38.876301702664726
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5696.0,
-                8180.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00243686047209,
-                38.87624994943457
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8180.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00248282785611,
-                38.87939803734683
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002360",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "0"
-        },
-        {
-          "label": "intersections",
-          "value": "0"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/info.json",
-          "type": "ImageService2",
-          "height": 8157,
+          "height": 8150,
           "width": 5652
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5467.0,4570.5 1280.8,4586.8 927.1,5580.1 937.4,3838.1 278.7,3830.2 276.9,552.4 5652.0,592.2 5652.0,6052.6 5456.4,5979.3 5467.0,4570.5\" /></svg>"
+          "value": "<svg><polygon points=\"136.9,-0.0 5307.4,-0.0 5263.4,8150.0 82.7,8150.0 136.9,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002360/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1496/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11267,8 +6697,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99351770561232,
-                38.87945289746411
+                -118.18393933150243,
+                34.026375763928016
               ]
             }
           },
@@ -11288,8 +6718,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99348799938078,
-                38.87636776484572
+                -118.18390847384717,
+                34.02377232121798
               ]
             }
           },
@@ -11298,7 +6728,7 @@
             "properties": {
               "resourceCoords": [
                 5652.0,
-                8157.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11309,8 +6739,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9991694398241,
-                38.876334141652826
+                -118.18840739577598,
+                34.02373517398011
               ]
             }
           },
@@ -11319,7 +6749,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8157.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11330,8 +6760,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99919914605564,
-                38.87941927427122
+                -118.18843825343124,
+                34.02633861669013
               ]
             }
           }
@@ -11339,13 +6769,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1497/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002390 [2]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1497",
       "metadata": [
         {
           "label": "streets",
@@ -11354,26 +6784,10 @@
         {
           "label": "intersections",
           "value": "0"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5663.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8183.0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11382,21 +6796,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1497/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1497/info.json",
           "type": "ImageService2",
-          "height": 8183,
-          "width": 5663
+          "height": 8149,
+          "width": 5635
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5663.0,6045.8 5663.0,8183.0 -0.0,8183.0 0.0,-0.0 2052.8,-0.0 2250.8,584.3 2366.1,361.6 4840.8,465.3 5663.0,155.6 5663.0,5991.7 5571.2,6026.9 5663.0,6045.8\" /></svg>"
+          "value": "<svg><polygon points=\"799.7,6.9 5635.0,40.7 5635.0,4390.4 3866.2,4383.5 3765.4,8035.1 737.2,8030.9 799.7,6.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002390__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1497/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11421,8 +6835,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99238475658798,
-                38.86654275924968
+                -118.18374904603685,
+                34.024312139643975
               ]
             }
           },
@@ -11430,7 +6844,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5663.0,
+                5635.0,
                 0.0
               ],
               "creator": {
@@ -11442,8 +6856,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98911728876752,
-                38.86485505206009
+                -118.1837091003797,
+                34.02163509059947
               ]
             }
           },
@@ -11451,8 +6865,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5663.0,
-                8183.0
+                5635.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11463,8 +6877,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99222722915157,
-                38.861153012053045
+                -118.18834598270239,
+                34.02158688917249
               ]
             }
           },
@@ -11473,7 +6887,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8183.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11484,8 +6898,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99549469697203,
-                38.862840719242634
+                -118.18838592835955,
+                34.024263938217004
               ]
             }
           }
@@ -11493,13 +6907,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002400",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1498",
       "metadata": [
         {
           "label": "streets",
@@ -11510,8 +6924,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11520,21 +6934,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/info.json",
           "type": "ImageService2",
-          "height": 8156,
-          "width": 5649
+          "height": 8150,
+          "width": 5651
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5223.4,2614.9 5364.0,7479.3 2323.2,7582.7 179.7,6692.6 -0.0,6865.5 -0.0,-0.0 5649.0,0.0 5649.0,2107.7 5089.7,2122.7 5223.4,2614.9\" /></svg>"
+          "value": "<svg><polygon points=\"4964.6,547.0 5128.1,543.5 5218.3,6020.6 5007.0,6024.6 5047.4,8150.0 -0.0,8078.4 -0.0,4438.6 1762.6,4396.8 1642.9,64.4 1221.4,73.1 1399.2,-0.0 4952.9,-0.0 4964.6,547.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002400/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1498/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11559,8 +6973,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99010198434931,
-                38.8692246698385
+                -118.18368125304815,
+                34.022417423498176
               ]
             }
           },
@@ -11568,7 +6982,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5649.0,
+                5651.0,
                 0.0
               ],
               "creator": {
@@ -11580,8 +6994,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98630439330928,
-                38.86844607540161
+                -118.18373015602548,
+                34.019724094531405
               ]
             }
           },
@@ -11589,8 +7003,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5649.0,
-                8156.0
+                5651.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11601,8 +7015,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98773729072967,
-                38.86414918261663
+                -118.18838421144031,
+                34.01978296766989
               ]
             }
           },
@@ -11611,7 +7025,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8156.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11622,8 +7036,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9915348817697,
-                38.86492777705352
+                -118.18833530846298,
+                34.02247629663666
               ]
             }
           }
@@ -11631,13 +7045,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002420/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499C/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002420",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499C",
       "metadata": [
         {
           "label": "streets",
@@ -11648,8 +7062,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11658,21 +7072,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002420/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499C/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002420/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499C/info.json",
           "type": "ImageService2",
-          "height": 8184,
-          "width": 5697
+          "height": 8150,
+          "width": 5651
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,8184.0 0.0,3545.1 371.7,3541.6 373.1,3248.5 373.6,3121.9 354.5,290.1 5203.2,279.9 5697.0,159.7 5697.0,8184.0 0.0,8184.0\" /></svg>"
+          "value": "<svg><polygon points=\"257.1,7242.3 277.7,318.1 -0.0,318.9 0.0,-0.0 5421.3,-0.0 5393.7,7224.9 257.1,7242.3\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002420/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499C/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11697,8 +7111,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98806291299287,
-                38.86439226027777
+                -118.1799158967388,
+                34.026453724564846
               ]
             }
           },
@@ -11706,7 +7120,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5697.0,
+                5651.0,
                 0.0
               ],
               "creator": {
@@ -11718,8 +7132,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9871616897906,
-                38.86742463093909
+                -118.17989550735727,
+                34.023833522174805
               ]
             }
           },
@@ -11727,8 +7141,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5697.0,
-                8184.0
+                5651.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11739,8 +7153,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98160913526547,
-                38.86641001110334
+                -118.18442340862065,
+                34.02380897700852
               ]
             }
           },
@@ -11749,7 +7163,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8184.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11760,8 +7174,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98251035846775,
-                38.863377640442025
+                -118.18444379800216,
+                34.02642917939856
               ]
             }
           }
@@ -11769,13 +7183,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002620",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499F",
       "metadata": [
         {
           "label": "streets",
@@ -11786,8 +7200,8 @@
           "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11796,21 +7210,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5536
+          "height": 8149,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"331.4,5860.0 359.5,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0 -0.0,6425.5 331.4,5860.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7303.9 -0.0,788.7 5615.0,804.7 5615.0,7301.1 -0.0,7303.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002620/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499F/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11835,8 +7249,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98034535983035,
-                38.89995860921772
+                -118.18067769934393,
+                34.045200318951906
               ]
             }
           },
@@ -11844,7 +7258,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5536.0,
+                5615.0,
                 0.0
               ],
               "creator": {
@@ -11856,8 +7270,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.97657446100419,
-                38.89998905440422
+                -118.18066324335655,
+                34.042633415785154
               ]
             }
           },
@@ -11865,8 +7279,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5536.0,
-                8160.0
+                5615.0,
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11877,8 +7291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.97651720379626,
-                38.895632717017726
+                -118.18512628124195,
+                34.04261591431566
               ]
             }
           },
@@ -11887,7 +7301,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8160.0
+                8149.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11898,8 +7312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.98028810262242,
-                38.89560227183123
+                -118.18514073722933,
+                34.04518281748241
               ]
             }
           }
@@ -11907,41 +7321,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001250 [1]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499G",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5936.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8381.0"
+          "value": "0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -11950,21 +7348,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/info.json",
           "type": "ImageService2",
-          "height": 8381,
-          "width": 5936
+          "height": 8150,
+          "width": 5641
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5936.0,-0.0 5833.1,1621.0 4933.0,1585.3 4917.4,8381.0 3087.4,8381.0 3089.5,7566.2 3091.4,6661.7 -0.0,6704.8 -0.0,-0.0 5936.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5466.9,7301.0 932.3,7345.0 860.3,918.6 572.1,920.6 553.3,-0.0 5386.2,-0.0 5466.9,7301.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001250__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499G/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -11989,8 +7387,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01412648938415,
-                38.92243643110608
+                -118.18059232976354,
+                34.04302620446177
               ]
             }
           },
@@ -11998,7 +7396,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5936.0,
+                5641.0,
                 0.0
               ],
               "creator": {
@@ -12010,8 +7408,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01361351817464,
-                38.91922739365267
+                -118.1806126029695,
+                34.04042130603084
               ]
             }
           },
@@ -12019,8 +7417,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5936.0,
-                8381.0
+                5641.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12031,8 +7429,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01943840199678,
-                38.91866363234752
+                -118.18512451337946,
+                34.04044575850975
               ]
             }
           },
@@ -12041,7 +7439,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8381.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12052,29 +7450,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.01995137320631,
-                38.921872669800926
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1244.0,
-                5989.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018182,
-                38.921361
+                -118.18510424017352,
+                34.04305065694068
               ]
             }
           }
@@ -12082,13 +7459,151 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001260 [2]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499I",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5641
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5462.3,6846.7 615.4,6821.5 595.7,5524.7 -0.0,5535.3 0.0,0.0 5428.4,-0.0 5462.3,6846.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499I/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17682841567363,
+                34.04305000786749
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17683239842076,
+                34.04045267096704
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18133121548051,
+                34.04045747474384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18132723273338,
+                34.04305481164429
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1401 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -12096,7 +7611,7 @@
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "5"
         },
         {
           "label": "split_canvas_x",
@@ -12108,15 +7623,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "5948.0"
+          "value": "5672.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "8371.0"
+          "value": "8149.0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12125,119 +7640,32 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401/info.json",
           "type": "ImageService2",
-          "height": 8371,
-          "width": 5948
+          "height": 8149,
+          "width": 5672
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8371.0 0.0,-0.0 3190.5,-0.0 3174.3,1698.8 4688.6,1709.6 4496.8,8371.0 -0.0,8371.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,-0.0 5672.0,0.0 5672.0,933.8 5082.8,1292.6 4868.6,1610.2 3197.3,8149.0 -0.0,8149.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001260__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1401__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01879543833493,
-                38.92203891405352
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5948.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01825174323068,
-                38.918826346906265
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5948.0,
-                8371.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02406293996069,
-                38.91823087870072
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8371.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.02460663506494,
-                38.921443445847984
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1304.0,
-                3171.6
+                4456.0,
+                3144.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12248,8 +7676,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.020878,
-                38.921109
+                -118.2264214,
+                34.0532505
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4032.0,
+                4788.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2266838,
+                34.0524126
               ]
             }
           }
@@ -12257,13 +7706,231 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001310",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2750.9"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"622.9,3875.1 133.2,3838.9 756.3,0.0 2750.9,382.3 1918.3,5540.7 927.7,5540.7 622.9,3875.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                927.6,
+                5540.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2248614,
+                34.045088
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1919.2,
+                5540.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2243038,
+                34.0451302
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1402 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "1756.3"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "3932.7"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5689
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1888.1,8149.0 1756.3,8149.0 1756.3,-0.0 2075.5,0.0 2207.7,1738.0 5513.0,1486.6 5176.9,3544.4 5091.1,7466.7 3228.0,7585.6 3234.1,7769.8 1832.7,7829.8 1888.1,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1402__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5176.9,
+                3544.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2275305,
+                34.0497248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3248.6,
+                3544.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2286463,
+                34.0497959
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1404 [2]",
       "metadata": [
         {
           "label": "streets",
@@ -12271,104 +7938,27 @@
         },
         {
           "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/info.json",
-          "type": "ImageService2",
-          "height": 8423,
-          "width": 5966
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5780.9,8423.0 352.8,8423.0 349.5,525.1 5762.8,521.0 5780.9,8423.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001310/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2823.1,
-                7787.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.023969,
-                38.907247
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2823.1,
-                535.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018937,
-                38.9072367
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001330",
-      "metadata": [
-        {
-          "label": "streets",
           "value": "6"
         },
         {
-          "label": "intersections",
-          "value": "12"
+          "label": "split_canvas_x",
+          "value": "3217.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2472.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8149.0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12377,21 +7967,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404/info.json",
           "type": "ImageService2",
-          "height": 8450,
-          "width": 6035
+          "height": 8149,
+          "width": 5689
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5703.6,577.7 5694.9,8442.4 867.3,8449.7 923.0,575.9 5703.6,577.7\" /></svg>"
+          "value": "<svg><polygon points=\"5359.5,7696.7 3531.3,7703.0 3477.0,4184.5 3477.0,380.0 5322.2,363.0 5359.5,7696.7\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001330/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1404__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -12401,8 +7991,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                711.9,
-                1979.5
+                3477.0,
+                4184.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12413,8 +8003,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.019907,
-                38.902521
+                -118.204337,
+                34.0392855
               ]
             }
           },
@@ -12422,8 +8012,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                711.9,
-                575.9
+                3477.0,
+                380.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12434,8 +8024,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0189297,
-                38.902521
+                -118.203313,
+                34.0408511
               ]
             }
           }
@@ -12443,13 +8033,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001460",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1407",
       "metadata": [
         {
           "label": "streets",
@@ -12457,11 +8047,11 @@
         },
         {
           "label": "intersections",
-          "value": "14"
+          "value": "2"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12470,21 +8060,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/info.json",
           "type": "ImageService2",
-          "height": 8425,
-          "width": 5999
+          "height": 8149,
+          "width": 5650
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5034.0,6621.6 1100.0,8339.8 890.1,7117.4 927.6,496.3 5051.4,507.4 5034.0,6621.6\" /></svg>"
+          "value": "<svg><polygon points=\"2588.9,669.9 5650.0,1283.1 5650.0,5204.8 2344.5,6358.1 2632.4,7227.7 1809.7,6858.2 751.3,8005.0 331.0,8044.1 278.8,6290.9 410.6,5188.0 684.0,5187.5 527.9,4082.6 412.2,4081.0 463.2,622.7 2588.9,669.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001460/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1407/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -12494,8 +8084,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                707.9,
-                6381.7
+                2588.9,
+                668.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12506,8 +8096,1047 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0151644,
-                38.9064627
+                -118.2275305,
+                34.0497248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3441.2,
+                7664.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2199908,
+                34.0500061
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1408 [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "5676.0"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8150.0"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5676
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5676.0,0.0 5676.0,4413.2 2343.7,8150.0 -0.0,8150.0 -0.0,3468.9 1560.9,0.0 5676.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1408__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3824.0,
+                3863.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2201542,
+                34.0514148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                292.0,
+                6922.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2216392,
+                34.049668
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1410",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5676
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5676.0,0.0 5676.0,8150.0 5522.0,8150.0 5521.1,7841.2 1087.8,7830.2 1153.8,198.7 4119.4,204.2 4343.5,0.0 5676.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1410/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2840.0,
+                2767.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2181801,
+                34.0503049
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                700.0,
+                7822.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2162879,
+                34.048343
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1411",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1858.8,8150.0 1857.4,7819.1 570.1,7806.2 599.3,279.6 5027.4,255.6 5021.3,2578.1 4896.5,2775.5 4287.9,2784.6 4288.6,5301.3 5006.4,5290.8 5024.3,8046.4 5615.0,8046.3 5615.0,8150.0 1858.8,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1411/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2835.5,
+                5322.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.214393,
+                34.0463596
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2835.5,
+                271.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2168534,
+                34.0474547
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1412",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"727.4,5357.6 -0.0,5368.2 -0.0,2817.8 616.7,2808.7 743.3,2608.7 750.0,255.2 5631.0,292.3 5631.0,8150.0 744.9,8150.0 727.4,5357.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1412/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2895.5,
+                5358.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.213282,
+                34.0481058
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2891.5,
+                259.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2157324,
+                34.0491958
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1413",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3037.9,7694.5 -0.0,7698.9 -0.0,0.0 5263.1,-0.0 5258.2,7888.4 3038.2,7893.4 3037.9,7694.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1413/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2911.5,
+                4570.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2100721,
+                34.0455732
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                228.0,
+                4570.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2113887,
+                34.0461553
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1414",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"315.0,7906.7 335.0,-0.0 5631.0,96.0 5631.0,7904.7 315.0,7906.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1414/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                335.9,
+                4139.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2087915,
+                34.0452512
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5399.0,
+                4139.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2062938,
+                34.0441516
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1415",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "12"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5615
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5408.7,7938.4 587.3,7918.2 611.9,-0.0 5615.0,-0.0 5615.0,269.2 5413.5,267.2 5408.7,7938.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1415/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                363.9,
+                5998.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2067819,
+                34.0433845
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                363.9,
+                4099.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2062938,
+                34.0441516
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1416",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5631
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"288.1,263.7 487.5,267.1 395.6,-0.0 5631.0,-0.0 5631.0,7936.3 231.2,7858.1 288.1,263.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1416/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2727.5,
+                4095.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2026248,
+                34.0425377
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5239.1,
+                6002.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2018717,
+                34.0412233
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1430",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "3"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5628
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3406.0,8150.0 1195.6,7160.9 1258.3,420.4 5502.2,441.1 5534.8,6971.5 5281.4,8150.0 3406.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1430/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3008.0,
+                2623.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2155605,
+                34.0445658
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3008.0,
+                6974.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2166958,
+                34.0428103
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1431",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "3"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5640
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"293.1,7819.1 300.1,-0.0 5640.0,-0.0 5640.0,200.3 4726.3,201.0 4478.4,293.7 5404.2,210.9 5328.7,7850.7 293.1,7819.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1431/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2820.0,
+                3496.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2131108,
+                34.043468
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2820.0,
+                7841.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.214237,
+                34.0417129
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1432",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5591
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5270.7,7818.8 349.7,7839.1 351.0,199.7 5272.5,137.6 5270.7,7818.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1432/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                315.9,
+                5632.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2124494,
+                34.0420644
               ]
             }
           },
@@ -12516,7 +9145,7 @@
             "properties": {
               "resourceCoords": [
                 2887.5,
-                4954.2
+                3488.4
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12527,8 +9156,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.013655,
-                38.9072357
+                -118.2106349,
+                34.0423637
               ]
             }
           }
@@ -12536,25 +9165,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001530",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1436",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "7"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "10"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12563,21 +9192,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/info.json",
           "type": "ImageService2",
-          "height": 8420,
-          "width": 5966
+          "height": 8150,
+          "width": 5606
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5966.0,6861.1 5966.0,8420.0 -0.0,8420.0 -0.0,-0.0 5377.3,0.0 5396.0,1669.0 5966.0,1667.0 5966.0,6179.3 5617.3,6051.1 5303.9,6607.7 5966.0,6861.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7934.8 -0.0,0.0 4935.5,-0.0 4955.3,7950.4 -0.0,7934.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001530/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1436/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -12587,8 +9216,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1295.6,
-                4504.0
+                199.9,
+                2115.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12599,8 +9228,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0199136,
-                38.8928445
+                -118.2008004,
+                34.0387292
               ]
             }
           },
@@ -12608,8 +9237,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1295.6,
-                -1460.0
+                3374.8,
+                188.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12620,8 +9249,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0199158,
-                38.8944258
+                -118.198757,
+                34.0388192
               ]
             }
           }
@@ -12629,25 +9258,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001600",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1442 [1]",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "4"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12656,21 +9285,1695 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/info.json",
           "type": "ImageService2",
-          "height": 8110,
-          "width": 5610
+          "height": 8150,
+          "width": 5669
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"558.5,743.0 432.4,743.3 418.3,0.0 5028.6,0.0 5028.7,735.1 4845.2,735.3 4804.2,4713.7 4565.6,5194.7 4629.6,7104.4 421.9,7216.8 428.3,3003.5 555.8,3003.3 558.5,743.0\" /></svg>"
+          "value": "<svg><polygon points=\"3971.8,257.6 5669.0,219.3 5669.0,8150.0 3105.4,8150.0 1999.9,5052.4 402.4,2162.1 752.3,1953.1 679.6,1822.9 321.3,2023.2 98.5,1641.7 1215.5,1676.3 2797.1,731.3 3971.8,257.6\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001600/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1442/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2000.4,
+                5050.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2195761,
+                34.0415167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5292.9,
+                219.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2166958,
+                34.0428103
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1445",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,218.1 5421.0,252.0 5421.0,7969.0 -0.0,8024.4 -0.0,218.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1445/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5421.0,
+                252.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2079868,
+                34.0389131
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5421.0,
+                7969.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2099804,
+                34.0358305
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1446/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1446",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "16"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1446/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1446/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5669
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"72.6,249.9 5306.5,251.0 5340.1,7919.6 71.1,7778.7 72.6,249.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1446/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3408.6,
+                5334.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2076891,
+                34.0361326
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3408.6,
+                243.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2063573,
+                34.0381929
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1449",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4167.8,7998.4 489.2,7966.2 466.1,250.2 5217.4,260.6 5173.2,7516.0 4167.8,7998.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1449/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3228.6,
+                5896.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2004047,
+                34.0326129
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                500.1,
+                5896.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2017317,
+                34.0331962
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1450",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5639
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7940.9 184.8,119.4 5639.0,168.0 5639.0,7559.7 2182.5,7513.5 2176.9,7981.0 -0.0,7943.8 -0.0,7940.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1450/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2199.6,
+                6092.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1985014,
+                34.0316469
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                192.0,
+                2116.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1984781,
+                34.0336569
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1453",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,293.7 4858.9,258.0 5049.6,7767.1 -0.0,7883.7 -0.0,293.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1453/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2687.0,
+                4348.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2172998,
+                34.0368489
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5078.2,
+                2592.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2156753,
+                34.0370221
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1454",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5639
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5639.0,173.2 5639.0,7784.3 -0.0,7762.5 -0.0,150.0 152.2,153.2 154.2,153.2 5639.0,173.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1454/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2811.5,
+                6184.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2152831,
+                34.0350028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2811.5,
+                192.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2137451,
+                34.0374491
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1455",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"611.6,7772.0 639.3,56.5 5582.0,80.6 5582.0,7867.1 611.6,7772.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1455/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1143.6,
+                4400.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2131941,
+                34.0349968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2923.0,
+                7817.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2131859,
+                34.0332484
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1456",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1540.2,7939.3 1304.3,-0.0 5650.0,-0.0 5650.0,7933.1 1540.2,7939.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1456/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2252.8,
+                5668.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.210974,
+                34.0334196
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5137.8,
+                3788.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2091083,
+                34.0335439
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1457",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5582
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"840.6,7811.0 948.5,86.1 5582.0,174.9 5582.0,7871.0 840.6,7811.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1457/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3794.6,
+                152.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.206535,
+                34.034262
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                399.9,
+                1856.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2086276,
+                34.0342936
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1459",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1013.2,6002.8 -0.0,5991.7 -0.0,260.2 4515.1,191.7 4579.8,7865.5 1067.7,7872.2 1013.2,6002.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1459/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5279.0,
+                2159.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2017404,
+                34.0310929
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2295.6,
+                7898.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2047403,
+                34.0294518
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1461",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5555
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5283.7,657.8 5228.8,7999.7 250.0,8026.0 282.3,-0.0 5555.0,-0.0 5538.3,450.3 5283.7,657.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1461/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5275.1,
+                2947.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1971658,
+                34.0287702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                252.0,
+                8026.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2010089,
+                34.0277831
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1462",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"383.3,499.9 595.9,370.3 5650.0,372.9 5650.0,8082.0 5312.9,8074.1 5313.7,7796.8 261.8,7801.2 383.3,499.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1462/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                320.1,
+                2912.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1971658,
+                34.0287702
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5309.9,
+                2912.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1947282,
+                34.0276999
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1465",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5272.6,8149.0 -0.0,8149.0 36.9,537.4 205.3,534.8 207.0,162.1 5251.5,101.7 5272.6,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1465/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                239.9,
+                4304.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2113656,
+                34.0297758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5262.1,
+                2204.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2110518,
+                34.0322948
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1466",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5650
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7355.0 -0.0,2257.1 5287.7,2330.5 5280.5,3886.6 5650.0,3887.2 5650.0,7041.9 5268.7,7033.0 5263.3,7650.3 2695.4,7653.9 2427.7,7344.2 -0.0,7355.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1466/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2953.0,
+                3900.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2079557,
+                34.0297096
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5249.9,
+                5772.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.2064637,
+                34.0302359
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1469",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "6"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 13.7,456.5 5510.0,446.1 5510.0,5506.5 5232.3,5505.5 5221.4,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1469/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2663.0,
+                5468.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.196744,
+                34.0245773
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2663.0,
+                432.1
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1992025,
+                34.0256545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1471",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5510
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 -0.0,308.1 4499.7,288.2 4532.2,7512.2 4298.9,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1471/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1411.5,
+                4552.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1907731,
+                34.0474846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4530.4,
+                4552.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1907697,
+                34.0460662
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1477",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5595
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5595.0,8064.8 1017.2,8042.1 978.5,210.8 5595.0,157.7 5595.0,8064.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1477/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                959.8,
+                6082.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1913317,
+                34.0359985
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                959.8,
+                2187.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1892059,
+                34.0360149
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1479/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1479",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1479/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1479/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5595
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"529.5,-0.0 2702.1,-0.0 2702.1,-0.0 4870.5,-0.0 4874.5,1110.1 4214.7,1112.7 4273.3,8011.7 520.4,8021.8 529.5,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1479/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -12695,8 +10998,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00940686911068,
-                38.904151337355245
+                -118.18793774531693,
+                34.03249916174941
               ]
             }
           },
@@ -12704,7 +11007,7 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5610.0,
+                5595.0,
                 0.0
               ],
               "creator": {
@@ -12716,8 +11019,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00547781980924,
-                38.90415090820911
+                -118.18794057302289,
+                34.02993712693514
               ]
             }
           },
@@ -12725,8 +11028,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5610.0,
-                8110.0
+                5595.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12737,8 +11040,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0054786170153,
-                38.89973171841948
+                -118.19244775465734,
+                34.029940537977744
               ]
             }
           },
@@ -12747,7 +11050,7 @@
             "properties": {
               "resourceCoords": [
                 0.0,
-                8110.0
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12758,8 +11061,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00940766631673,
-                38.899732147565615
+                -118.19244492695137,
+                34.03250257279202
               ]
             }
           },
@@ -12767,8 +11070,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                555.8,
-                3003.3
+                4903.1,
+                8010.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12779,8 +11082,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0091072,
-                38.9025147
+                -118.19237,
+                34.0302573
               ]
             }
           },
@@ -12788,8 +11091,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                555.8,
-                3003.3
+                4903.1,
+                8010.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12800,29 +11103,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0091072,
-                38.9025147
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.8,
-                3003.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090179,
-                38.9025148
+                -118.1923547,
+                34.0299325
               ]
             }
           }
@@ -12830,25 +11112,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1482/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001670",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1482",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "6"
         },
         {
           "label": "intersections",
           "value": "6"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12857,21 +11139,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1482/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1482/info.json",
           "type": "ImageService2",
-          "height": 8421,
-          "width": 6002
+          "height": 8150,
+          "width": 5684
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2310.3,7697.6 2331.6,-0.0 6002.0,-0.0 6002.0,1605.8 6002.0,1605.8 6002.0,7718.3 2310.3,7697.6\" /></svg>"
+          "value": "<svg><polygon points=\"283.9,7995.5 269.6,968.4 5496.3,913.4 5520.9,7441.8 5280.2,8149.0 939.5,8150.0 656.0,7996.3 283.9,7995.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001670/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1482/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -12881,8 +11163,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2227.3,
-                7697.3
+                2444.0,
+                4251.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12893,8 +11175,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.009092,
-                38.9133406
+                -118.1902474,
+                34.0253088
               ]
             }
           },
@@ -12902,8 +11184,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                4926.4,
-                1367.5
+                2444.0,
+                755.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12914,8 +11196,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00458,
-                38.911861
+                -118.1883215,
+                34.0253077
               ]
             }
           }
@@ -12923,13 +11205,292 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1483/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001700",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "7"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1483/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5595
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5595.0,679.9 5595.0,8150.0 493.4,8150.0 727.0,7442.6 642.0,758.7 5595.0,679.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                3851.3,
+                5874.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1911571,
+                34.0224675
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                683.9,
+                4263.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1902498,
+                34.0239107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1485/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1485",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1485/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1485/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5609
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5609.0,7389.1 174.1,7410.3 174.4,8149.0 -0.0,8149.0 -0.0,0.0 4514.1,-0.0 4514.0,55.3 5609.0,49.5 5609.0,7389.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1485/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4636.8,
+                4936.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1870723,
+                34.0460858
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4636.8,
+                7388.9
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1884298,
+                34.046084
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1486/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1486",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "10"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1486/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1486/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5636
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5636.0,7117.6 5636.0,8149.0 4159.8,8149.0 4006.5,7647.9 3486.4,7693.2 3476.6,7195.3 1562.5,7186.2 1600.4,-0.0 2614.4,-0.0 2613.2,579.4 3687.7,582.6 5489.7,7120.4 5636.0,7117.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1486/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2540.0,
+                4944.6
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1870552,
+                34.045205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4228.0,
+                2768.3
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1858638,
+                34.0444497
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1490/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1490",
       "metadata": [
         {
           "label": "streets",
@@ -12940,8 +11501,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12950,21 +11511,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1490/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1490/info.json",
           "type": "ImageService2",
-          "height": 8452,
-          "width": 6013
+          "height": 8149,
+          "width": 5636
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"368.0,30.5 3984.2,0.0 3982.0,320.0 5493.4,317.7 5500.4,8232.8 5016.3,8233.5 5015.9,8452.0 385.9,8452.0 368.0,30.5\" /></svg>"
+          "value": "<svg><polygon points=\"5054.5,-0.0 5044.0,7281.5 486.6,7272.5 484.8,-0.0 5054.5,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001700/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1490/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -12974,8 +11535,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3982.0,
-                6044.0
+                492.0,
+                5232.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -12986,8 +11547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9995097,
-                38.9025203
+                -118.1870172,
+                34.0381004
               ]
             }
           },
@@ -12995,7 +11556,472 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3982.0,
+                492.0,
+                3068.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1858248,
+                34.0381079
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "7"
+        },
+        {
+          "label": "intersections",
+          "value": "18"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1492/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5636
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1156.6,7017.1 1141.8,969.2 2609.4,1047.3 2623.4,-0.0 4035.1,-0.0 4110.4,3109.8 4742.0,3112.4 4738.9,6980.1 1156.6,7017.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4744.0,
+                6036.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1874015,
+                34.0322575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4744.0,
+                3112.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1857872,
+                34.0322643
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1493/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1493",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "2"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1493/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1493/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5605.0,7108.7 634.9,7022.3 630.2,3135.3 -0.0,3134.0 -0.0,833.0 2801.6,842.6 2808.3,269.2 3891.2,304.0 4951.8,683.8 5605.0,1088.0 5605.0,7108.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1493/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                636.1,
+                6052.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1874015,
+                34.0322575
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4952.9,
+                6052.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1873942,
+                34.0302781
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "8"
+        },
+        {
+          "label": "intersections",
+          "value": "9"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1494/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5636
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1236.6,1126.0 714.5,803.0 1232.1,799.9 1234.6,-0.0 4881.7,-0.0 4888.0,4060.5 5636.0,4063.6 5636.0,6203.8 4912.1,6208.3 4911.7,7112.1 1238.5,7129.5 1236.6,1126.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                588.0,
+                6076.7
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1873942,
+                34.0302781
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                4888.0,
+                4060.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1862688,
+                34.0283029
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1495/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1495",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "11"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1495/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1495/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5605
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"940.3,7233.7 943.0,6336.3 1669.6,6333.6 1675.0,4185.5 924.2,4180.5 928.2,-0.0 5289.9,-0.0 5277.4,7249.1 940.3,7233.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1495/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                924.2,
+                4180.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1862688,
+                34.0283029
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5260.9,
+                4180.5
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1862562,
+                34.0263159
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "9"
+        },
+        {
+          "label": "intersections",
+          "value": "13"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5635
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2865.3,7580.4 2860.7,8149.0 -0.0,8149.0 -0.0,361.9 1657.7,321.4 1658.3,-0.0 4260.2,-0.0 4330.7,7735.5 2865.3,7580.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2851.5,
+                6360.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.183517,
+                34.0312758
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                1743.7,
                 320.0
               ],
               "creator": {
@@ -13007,8 +12033,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.999504,
-                38.9056457
+                -118.1801461,
+                34.0317872
               ]
             }
           }
@@ -13016,106 +12042,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499A/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001740",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/info.json",
-          "type": "ImageService2",
-          "height": 8432,
-          "width": 5983
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5983.0,8432.0 -0.0,8432.0 0.0,-0.0 5983.0,0.0 5983.0,8432.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001740/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4999.2,
-                7892.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9808896,
-                38.9039887
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4999.2,
-                1252.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9782803,
-                38.9081126
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001770",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499A",
       "metadata": [
         {
           "label": "streets",
@@ -13123,11 +12056,11 @@
         },
         {
           "label": "intersections",
-          "value": "5"
+          "value": "4"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13136,21 +12069,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499A/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499A/info.json",
           "type": "ImageService2",
-          "height": 8438,
-          "width": 5946
+          "height": 8150,
+          "width": 5651
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5491.5,340.7 5509.8,7707.9 -0.0,7708.4 -0.0,362.3 5491.5,340.7\" /></svg>"
+          "value": "<svg><polygon points=\"1315.6,7350.5 1308.4,8150.0 761.3,8150.0 -0.0,7813.3 0.0,-0.0 5651.0,-0.0 5651.0,344.6 4992.8,344.9 4961.8,7372.4 1315.6,7350.5\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001770/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499A/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -13160,8 +12093,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3766.7,
-                2419.4
+                915.8,
+                2859.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13172,8 +12105,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.996167,
-                38.9002024
+                -118.1815297,
+                34.0301904
               ]
             }
           },
@@ -13181,8 +12114,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                487.8,
-                2419.4
+                2831.5,
+                2859.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13193,8 +12126,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9984507,
-                38.9002082
+                -118.1815204,
+                34.0293091
               ]
             }
           }
@@ -13202,106 +12135,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499B/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001780",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/info.json",
-          "type": "ImageService2",
-          "height": 8476,
-          "width": 5996
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5453.1,401.3 5461.0,7791.7 503.9,7793.2 501.8,395.4 5453.1,401.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001780/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2240.0,
-                2476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.993757,
-                38.900202
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                504.0,
-                2476.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.994961,
-                38.900203
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001790",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499B",
       "metadata": [
         {
           "label": "streets",
@@ -13312,8 +12152,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13322,21 +12162,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499B/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499B/info.json",
           "type": "ImageService2",
-          "height": 8464,
-          "width": 6032
+          "height": 8149,
+          "width": 5635
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"736.7,418.4 5320.7,421.7 5323.1,8464.0 1051.4,8464.0 1051.2,8464.0 739.0,8464.0 736.7,418.4\" /></svg>"
+          "value": "<svg><polygon points=\"612.0,7323.8 615.9,395.2 4967.1,376.0 4957.8,7322.2 612.0,7323.8\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001790/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499B/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -13346,8 +12186,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5328.0,
-                3664.0
+                2783.5,
+                4852.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13358,8 +12198,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.988305,
-                38.89955
+                -118.1825808,
+                34.0273181
               ]
             }
           },
@@ -13367,8 +12207,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2568.0,
-                1440.0
+                4967.1,
+                376.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13379,8 +12219,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.990242,
-                38.900763
+                -118.1800916,
+                34.026324
               ]
             }
           }
@@ -13388,199 +12228,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499D/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001850",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/info.json",
-          "type": "ImageService2",
-          "height": 8492,
-          "width": 5995
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5436.1,7627.4 427.9,7582.6 502.0,689.5 5483.7,740.7 5436.1,7627.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001850/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5463.1,
-                4216.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949624,
-                38.8954393
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                487.9,
-                1828.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9984577,
-                38.8967215
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001870",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/info.json",
-          "type": "ImageService2",
-          "height": 8444,
-          "width": 5999
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4408.6,1205.0 4405.6,7361.4 669.3,7353.3 697.9,1200.1 4408.6,1205.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001870/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2515.6,
-                3944.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.990245,
-                38.895435
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5279.1,
-                3944.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.98831,
-                38.895438
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001890",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499D",
       "metadata": [
         {
           "label": "streets",
@@ -13588,284 +12242,11 @@
         },
         {
           "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/info.json",
-          "type": "ImageService2",
-          "height": 8478,
-          "width": 6021
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2773.7,7254.4 1799.9,7259.2 1771.9,341.9 2865.3,341.8 3087.7,0.0 3318.1,0.0 3329.9,1560.1 5379.4,1560.4 5382.0,2568.0 6021.0,2566.9 6021.0,7721.2 4194.9,7744.5 2773.7,7254.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001890/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                667.7,
-                3903.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9855056,
-                38.8953987
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5389.3,
-                3767.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.982211,
-                38.895466
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb001940",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/info.json",
-          "type": "ImageService2",
-          "height": 8424,
-          "width": 5979
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,3671.5 -0.0,3390.6 427.4,3391.7 417.2,1363.1 5318.6,1330.9 5354.4,6436.6 5979.0,6429.1 5979.0,8424.0 5364.3,8424.0 5362.9,7700.6 5183.8,7462.9 439.9,7420.0 433.9,3900.2 -0.0,3671.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb001940/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99525226930017,
-                38.89385625130697
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99106561217467,
-                38.89384296976025
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5979.0,
-                8424.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99108965696159,
-                38.88925384922644
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8424.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.99527631408709,
-                38.88926713077316
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                439.9,
-                7420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949654,
-                38.8898131
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                439.9,
-                7420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9949654,
-                38.8898131
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002000",
-      "metadata": [
-        {
-          "label": "streets",
           "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13874,21 +12255,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499D/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499D/info.json",
           "type": "ImageService2",
-          "height": 8404,
-          "width": 5995
+          "height": 8149,
+          "width": 5615
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3809.0,7824.0 499.6,7835.3 501.8,4956.6 -0.0,4959.0 -0.0,4689.6 501.8,4425.1 495.9,904.0 5242.0,963.7 5420.3,1202.1 5407.0,6406.2 3799.3,6408.2 3809.0,7824.0\" /></svg>"
+          "value": "<svg><polygon points=\"821.9,7404.9 814.9,-0.0 4558.0,-0.0 4556.5,668.4 5615.0,671.5 5615.0,7386.1 821.9,7404.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002000/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499D/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -13898,8 +12279,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2215.6,
-                904.0
+                823.9,
+                7404.9
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13910,8 +12291,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9937618,
-                38.8898126
+                -118.1837473,
+                34.0239322
               ]
             }
           },
@@ -13919,8 +12300,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                495.9,
-                904.0
+                819.9,
+                696.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -13931,8 +12312,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9949654,
-                38.8898131
+                -118.1800647,
+                34.0239368
               ]
             }
           }
@@ -13940,851 +12321,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499E/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002030",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499E",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/info.json",
-          "type": "ImageService2",
-          "height": 8228,
-          "width": 5702
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5702.0,1931.7 5702.0,8228.0 -0.0,8228.0 -0.0,2381.5 561.8,2370.0 565.6,1416.3 564.5,1281.8 4773.9,1294.2 4778.5,1930.3 5702.0,1931.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002030/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1623.4,
-                1288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199119,
-                38.886887
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4470.4,
-                1288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199096,
-                38.8850455
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002130 [2]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5691.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "5763.5"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130/info.json",
-          "type": "ImageService2",
-          "height": 8241,
-          "width": 5691
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5763.5 -0.0,4791.1 -0.0,4791.1 1358.3,1479.6 2764.8,120.5 5613.5,342.5 5624.0,1682.0 3565.1,5763.5 -0.0,5763.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002130__1/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01694460187657,
-                38.879246902181755
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00899659845653,
-                38.878785242214924
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                5763.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00959740741719,
-                38.872522536256255
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                5763.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01754541083724,
-                38.872984196223086
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2355.6,
-                2315.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0138948,
-                38.8765394
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2355.6,
-                2315.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0138866,
-                38.8763961
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002140",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/info.json",
-          "type": "ImageService2",
-          "height": 8189,
-          "width": 5723
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"447.8,411.1 1491.0,502.5 3536.3,-0.0 4234.0,-0.0 4910.2,1894.6 447.8,1913.4 447.8,411.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002140/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.9,
-                6017.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.018937,
-                38.9072367
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                447.9,
-                7449.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0199003,
-                38.9072369
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002170",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/info.json",
-          "type": "ImageService2",
-          "height": 8204,
-          "width": 5683
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1219.4,8204.0 1113.9,6647.3 1276.6,6630.3 582.6,0.0 5683.0,0.0 5683.0,870.0 4409.7,1011.7 5023.2,8204.0 1219.4,8204.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002170/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01207964667257,
-                38.88834954843369
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5683.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00811543530693,
-                38.888078755222494
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5683.0,
-                8204.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00861773678868,
-                38.88362656942112
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8204.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01258194815432,
-                38.883897362632304
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5023.1,
-                7856.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090568,
-                38.8838463
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002200",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/info.json",
-          "type": "ImageService2",
-          "height": 8203,
-          "width": 5691
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7730.1 -0.0,4697.8 1152.3,4735.6 1306.4,0.0 5088.1,0.0 5026.5,612.9 5691.0,605.1 5691.0,7803.2 -0.0,7730.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002200/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01265443352801,
-                38.883499881569605
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00866969516916,
-                38.88353919172689
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5691.0,
-                8203.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.00859688020397,
-                38.87907024202878
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8203.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0125816185628,
-                38.8790309318715
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5007.1,
-                2223.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0091288,
-                38.8823232
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5007.1,
-                2223.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0090025,
-                38.882288
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002210",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
           "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14793,21 +12348,180 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499E/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499E/info.json",
           "type": "ImageService2",
-          "height": 8217,
-          "width": 5692
+          "height": 8150,
+          "width": 5641
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"71.9,304.0 5184.6,49.0 5312.0,2591.1 2951.0,2703.8 1776.0,2591.1 1881.1,4722.7 5287.4,4551.7 5478.9,8217.0 1198.9,8217.0 471.7,8051.5 71.9,304.0\" /></svg>"
+          "value": "<svg><polygon points=\"5116.7,-0.0 4945.8,312.3 4995.7,7340.3 1295.6,7287.5 1280.6,692.6 228.0,691.8 228.0,28.2 5116.7,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002210/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499E/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17966260197477,
+                34.0223410442182
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.17966498164024,
+                34.0197588644148
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5641.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18417216384466,
+                34.019761712594644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.18416978417919,
+                34.02234389239804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                228.0,
+                691.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1800453,
+                34.0222369
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499H/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499H",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499H/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499H/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5089.8,-0.0 5005.0,5538.6 5607.0,5537.1 5607.0,7766.4 -0.0,7699.0 0.0,0.0 5089.8,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499H/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -14817,8 +12531,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1776.0,
-                2591.1
+                2623.5,
+                2067.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14829,8 +12543,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0091405,
-                38.8784194
+                -118.1779939,
+                34.0441604
               ]
             }
           },
@@ -14838,8 +12552,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5312.0,
-                2591.1
+                2507.6,
+                7726.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14850,8 +12564,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0092655,
-                38.8764748
+                -118.1811047,
+                34.0441771
               ]
             }
           }
@@ -14859,25 +12573,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002240",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499K [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "11"
         },
         {
           "label": "intersections",
           "value": "8"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14886,21 +12600,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/info.json",
           "type": "ImageService2",
-          "height": 8205,
-          "width": 5692
+          "height": 8150,
+          "width": 5587
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"426.9,7255.0 427.7,4199.9 742.4,4203.0 747.4,813.6 5124.8,678.7 5129.2,8205.0 691.6,8205.0 692.9,7256.7 426.9,7255.0\" /></svg>"
+          "value": "<svg><polygon points=\"4087.2,6828.4 4084.1,7339.1 1108.0,7334.5 1109.9,5459.4 1335.5,4541.5 1329.5,3848.5 160.8,122.8 -0.0,124.7 0.0,0.0 5587.0,-0.0 5587.0,3355.7 4769.7,3377.0 4775.7,6823.5 4087.2,6828.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002240/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499K/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -14910,8 +12624,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2868.0,
-                4202.5
+                1951.7,
+                2015.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14922,8 +12636,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.007465,
-                38.8746408
+                -118.1786209,
+                34.035235
               ]
             }
           },
@@ -14931,8 +12645,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2868.0,
-                807.7
+                4003.3,
+                7326.2
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14943,8 +12657,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0074646,
-                38.8764749
+                -118.1846384,
+                34.0333206
               ]
             }
           }
@@ -14952,25 +12666,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499L/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002300",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499L [3]",
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "9"
         },
         {
           "label": "intersections",
-          "value": "3"
+          "value": "6"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -14979,21 +12693,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499L/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499L/info.json",
           "type": "ImageService2",
-          "height": 8199,
-          "width": 5707
+          "height": 8150,
+          "width": 5607
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3401.9,1664.1 3394.7,517.9 4696.3,517.1 4691.7,6333.2 3406.4,5660.3 3405.9,5989.9 2906.6,5729.7 2115.1,5731.2 2116.5,6599.2 -0.0,6595.8 -0.0,1670.5 3401.9,1664.1\" /></svg>"
+          "value": "<svg><polygon points=\"4723.0,7374.2 1403.1,7332.5 1398.3,8150.0 -0.0,8150.0 -0.0,0.0 5607.0,-0.0 5607.0,570.0 4573.4,576.8 4598.5,4420.4 4731.1,4420.8 4723.0,7374.2\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002300/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499L/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -15003,8 +12717,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2111.6,
-                5315.4
+                3675.3,
+                6878.3
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15015,8 +12729,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9937643,
-                38.8835872
+                -118.1838248,
+                34.0461454
               ]
             }
           },
@@ -15024,8 +12738,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2111.6,
-                3799.5
+                4855.1,
+                1603.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15036,8 +12750,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9937644,
-                38.8846064
+                -118.178006,
+                34.0451047
               ]
             }
           }
@@ -15045,199 +12759,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002370",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/info.json",
-          "type": "ImageService2",
-          "height": 8182,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5642.0,8182.0 224.4,8182.0 266.6,196.3 987.5,196.2 987.1,-0.0 5642.0,-0.0 5642.0,8182.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002370/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1863.3,
-                2959.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.990248,
-                38.8784074
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1863.3,
-                196.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9883153,
-                38.8784076
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002380",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/info.json",
-          "type": "ImageService2",
-          "height": 8170,
-          "width": 5664
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,546.5 5664.0,509.4 5664.0,8170.0 -0.0,8170.0 -0.0,546.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002380/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                380.0,
-                307.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9937667,
-                38.8764942
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5392.0,
-                307.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9902047,
-                38.876463
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002410",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499M [1]",
       "metadata": [
         {
           "label": "streets",
@@ -15246,99 +12774,6 @@
         {
           "label": "intersections",
           "value": "4"
-        }
-      ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/info.json",
-          "type": "ImageService2",
-          "height": 8155,
-          "width": 5696
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,862.2 5382.9,2948.8 5353.1,8155.0 0.0,8155.0 0.0,862.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002410/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1876.0,
-                7391.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.986656,
-                38.862381
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3760.0,
-                3863.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -76.9887945,
-                38.8638066
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002440 [3]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "2"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
         },
         {
           "label": "split_canvas_x",
@@ -15350,15 +12785,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "5664.0"
+          "value": "2784.3"
         },
         {
           "label": "split_canvas_h",
-          "value": "8224.0"
+          "value": "8150.0"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15367,21 +12802,348 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M/info.json",
           "type": "ImageService2",
-          "height": 8224,
-          "width": 5664
+          "height": 8150,
+          "width": 5587
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1984.7 -0.0,-0.0 5664.0,0.0 5664.0,2141.7 5664.0,2141.7 2160.4,7965.8 647.0,8034.6 -0.0,1984.7\" /></svg>"
+          "value": "<svg><polygon points=\"2784.3,-0.0 2784.3,6664.7 2563.5,6663.6 2547.2,8150.0 -0.0,8150.0 -0.0,514.5 286.2,-0.0 2784.3,-0.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002440__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__1/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2568.3,
+                3183.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1812961,
+                34.0188994
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2568.3,
+                895.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1800381,
+                34.018906
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499M [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "2781.5"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2805.5"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "8150.0"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5587
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5157.0,7175.4 2781.5,7181.5 2781.5,1497.3 5153.4,1485.4 5162.3,-0.0 5587.0,-0.0 5587.0,8150.0 5162.2,8150.0 5157.0,7175.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499M__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5155.4,
+                7286.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1872204,
+                34.0188903
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5155.4,
+                927.8
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1837208,
+                34.0188941
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__2/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499N [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "5"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "0.0"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "1613.2"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2857.9"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "6536.8"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__2/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2857.9,5442.6 2660.0,5443.1 2662.0,7346.4 647.2,7367.5 653.4,8150.0 -0.0,8150.0 -0.0,1613.2 2653.5,1613.2 2656.8,2609.0 2857.9,2609.5 2857.9,5442.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__2/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2662.0,
+                3704.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1882858,
+                34.0188822
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2662.0,
+                7346.4
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1902479,
+                34.0188759
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__3/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499N [2]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "2"
+        },
+        {
+          "label": "intersections",
+          "value": "1"
+        },
+        {
+          "label": "split_canvas_x",
+          "value": "2852.7"
+        },
+        {
+          "label": "split_canvas_y",
+          "value": "1588.8"
+        },
+        {
+          "label": "split_canvas_w",
+          "value": "2754.3"
+        },
+        {
+          "label": "split_canvas_h",
+          "value": "6561.2"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__3/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5607.0,8150.0 2852.7,8150.0 2852.7,1588.8 3915.9,1588.8 3905.0,3085.0 4223.4,3087.4 4223.2,2706.3 5205.2,2703.2 5211.0,1776.4 5307.4,1776.8 5308.8,1588.8 5607.0,1588.8 5607.0,8150.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499N__3/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -15394,8 +13156,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                0.0
+                2852.7,
+                1588.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15406,8 +13168,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00080423769572,
-                38.906902338032275
+                -118.18904423748303,
+                34.021042628502684
               ]
             }
           },
@@ -15415,8 +13177,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5664.0,
-                0.0
+                5607.0,
+                1588.8
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15427,8 +13189,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99684178027763,
-                38.90678237823993
+                -118.18901023573243,
+                34.018519207699924
               ]
             }
           },
@@ -15436,8 +13198,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5664.0,
-                8224.0
+                5607.0,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15448,8 +13210,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.99706562696241,
-                38.9023055610475
+                -118.19626816290538,
+                34.018452148700554
               ]
             }
           },
@@ -15457,8 +13219,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                0.0,
-                8224.0
+                2852.7,
+                8150.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15469,8 +13231,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0010280843805,
-                38.90242552083984
+                -118.19630216465598,
+                34.020975569503314
               ]
             }
           },
@@ -15478,8 +13240,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                428.0,
-                2292.0
+                5203.2,
+                3596.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15490,8 +13252,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0005672,
-                38.9056456
+                -118.1912355,
+                34.0188686
               ]
             }
           }
@@ -15499,41 +13261,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002600 [1]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499O",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "6"
         },
         {
           "label": "intersections",
-          "value": "3"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "0.0"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "5551.0"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "8160.0"
+          "value": "8"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15542,21 +13288,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5551
+          "height": 8150,
+          "width": 5587
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8160.0 -0.0,0.0 5551.0,0.0 5551.0,8160.0 -0.0,8160.0\" /></svg>"
+          "value": "<svg><polygon points=\"4291.0,5508.1 4823.5,6294.1 5587.0,5804.4 5587.0,7864.3 4249.7,7864.5 4262.7,8150.0 -0.0,8150.0 0.0,0.0 5587.0,0.0 5587.0,3776.3 4049.2,3451.3 4147.2,5607.4 4291.0,5508.1\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499O/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -15566,8 +13312,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3767.3,
-                2288.0
+                2755.5,
+                7834.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15578,8 +13324,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -76.9995279,
-                38.9201209
+                -118.190306,
+                34.056387
               ]
             }
           },
@@ -15587,8 +13333,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                204.0,
-                204.0
+                4291.2,
+                5506.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15599,8 +13345,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.00203,
-                38.921298
+                -118.1885932,
+                34.0584906
               ]
             }
           }
@@ -15608,41 +13354,25 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499P/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002600 [1]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499P",
       "metadata": [
         {
           "label": "streets",
-          "value": "2"
+          "value": "11"
         },
         {
           "label": "intersections",
-          "value": "1"
-        },
-        {
-          "label": "split_canvas_x",
-          "value": "2636.7"
-        },
-        {
-          "label": "split_canvas_y",
-          "value": "6037.6"
-        },
-        {
-          "label": "split_canvas_w",
-          "value": "2914.3"
-        },
-        {
-          "label": "split_canvas_h",
-          "value": "2122.4"
+          "value": "14"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15651,119 +13381,32 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499P/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499P/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5551
+          "height": 8150,
+          "width": 5607
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2636.7,7247.4 2817.3,7178.8 2882.8,6037.6 5551.0,6037.6 5551.0,8151.1 2636.7,7850.0 2636.7,7247.4\" /></svg>"
+          "value": "<svg><polygon points=\"156.7,5137.9 -0.0,5235.9 -0.0,2953.6 1608.8,3370.7 1762.0,0.0 4469.9,0.0 4582.7,559.4 3584.9,692.1 3800.7,1445.7 4359.0,1536.8 5170.8,3687.9 5607.0,3595.7 5607.0,8150.0 -0.0,8150.0 -0.0,7625.1 1412.7,7689.0 1511.5,5513.0 681.5,5993.8 156.7,5137.9\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002600__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499P/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2636.7,
-                6037.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.0200721541108,
-                38.91359392711383
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5551.0,
-                6037.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01804070463531,
-                38.91375165274088
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5551.0,
-                8160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01789305772614,
-                38.91260027477598
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2636.7,
-                8160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -77.01992450720164,
-                38.912442549148935
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2804.6,
-                7064.8
+                4359.2,
+                1535.6
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15774,8 +13417,29 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0198837,
-                38.9130461
+                -118.1843599,
+                34.0617167
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                2887.5,
+                7522.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1856691,
+                34.0565202
               ]
             }
           }
@@ -15783,17 +13447,17 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__1/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002610 [4]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499Q [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "4"
+          "value": "6"
         },
         {
           "label": "intersections",
@@ -15809,15 +13473,15 @@
         },
         {
           "label": "split_canvas_w",
-          "value": "3399.2"
+          "value": "5587.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "5302.0"
+          "value": "4672.9"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15826,21 +13490,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__1/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5536
+          "height": 8150,
+          "width": 5587
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5302.0 -0.0,0.0 3399.2,-0.0 3399.2,3806.3 2763.3,3373.1 1546.3,5159.2 1756.2,5302.0 -0.0,5302.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,4273.4 814.6,4608.2 2514.6,469.4 5473.1,769.6 5587.0,1732.6 5587.0,4672.9 -0.0,4672.9 -0.0,4273.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__1/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__1/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -15850,8 +13514,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1939.5,
-                5601.9
+                2103.6,
+                3004.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15862,8 +13526,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0090875,
-                38.9251261
+                -118.1822797,
+                34.0578091
               ]
             }
           },
@@ -15871,8 +13535,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                911.8,
-                4898.2
+                3075.4,
+                512.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15883,8 +13547,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0090823,
-                38.9258397
+                -118.1824292,
+                34.0601503
               ]
             }
           }
@@ -15892,21 +13556,21 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Washington, D.C. | 1916 | Vol. 2 psb002610 [4]",
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499Q [2]",
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "12"
+          "value": "2"
         },
         {
           "label": "split_canvas_x",
@@ -15914,19 +13578,19 @@
         },
         {
           "label": "split_canvas_y",
-          "value": "0.0"
+          "value": "4627.3"
         },
         {
           "label": "split_canvas_w",
-          "value": "5536.0"
+          "value": "5587.0"
         },
         {
           "label": "split_canvas_h",
-          "value": "8160.0"
+          "value": "3522.7"
         }
       ],
-      "created": "2026-07-31T00:22:00Z",
-      "modified": "2026-07-31T00:22:00Z",
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15935,21 +13599,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q/info.json",
           "type": "ImageService2",
-          "height": 8160,
-          "width": 5536
+          "height": 8150,
+          "width": 5587
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8160.0 0.0,-0.0 3116.1,0.0 3267.0,458.2 3266.8,0.0 5536.0,0.0 5536.0,8160.0 -0.0,8160.0\" /></svg>"
+          "value": "<svg><polygon points=\"992.7,4959.0 1160.4,4627.3 5587.0,4627.3 5587.0,8150.0 -0.0,8150.0 67.2,5956.1 -0.0,4806.6 992.7,4959.0\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd385m:g3851m:g3851gm:g01227003:sb002610__2/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499Q__2/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "helmert"
@@ -15959,8 +13623,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3264.0,
-                5668.0
+                5523.0,
+                6766.5
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15971,8 +13635,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.0089892,
-                38.922372
+                -118.1748294,
+                34.0613624
               ]
             }
           },
@@ -15980,8 +13644,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3264.0,
-                1728.0
+                2207.6,
+                5087.1
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -15992,8 +13656,101 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -77.008984,
-                38.9245149
+                -118.1781304,
+                34.0613647
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Los Angeles, Calif. | 1949 | Vol. 14 p1499R",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "6"
+        },
+        {
+          "label": "intersections",
+          "value": "4"
+        }
+      ],
+      "created": "2026-07-31T00:17:49Z",
+      "modified": "2026-07-31T00:17:49Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5607
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3113.7,7658.5 2896.7,8150.0 2128.8,8150.0 2270.1,7193.5 1723.6,7149.7 1437.2,8150.0 -0.0,8150.0 -0.0,-0.0 4548.5,39.4 5025.0,3208.2 5315.1,3302.4 5316.5,4126.1 5316.5,4141.9 5315.1,7477.6 3113.7,7658.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd436m:g4364m:g4364lm:g4364lm_g00656194914:00656_14_1949-1499R/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "helmert"
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5315.1,
+                3303.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1791423,
+                34.0610455
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5315.1,
+                7478.2
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "gcp"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -118.1834386,
+                34.0598898
               ]
             }
           }

--- a/gallery/nashville_tn_1957_vol1a.iiif.json
+++ b/gallery/nashville_tn_1957_vol1a.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,7 +44,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6732.3 0.0,0.0 4016.2,0.0 5109.2,733.6 5609.4,765.5 5681.8,6161.9 5250.0,6155.3 5281.9,6684.5 4704.1,6708.0 -0.0,6732.3\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6902.4 -0.0,0.0 4467.0,0.0 4478.0,460.3 5085.3,858.2 5593.5,893.0 5668.6,6356.2 5229.8,6347.4 5261.7,6873.0 -0.0,6902.4\" /></svg>"
         }
       },
       "body": {
@@ -73,8 +73,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78418395211922,
-                36.168499104831575
+                -86.78415274197828,
+                36.1685593903496
               ]
             }
           },
@@ -94,8 +94,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78073249285357,
-                36.16992610190361
+                -86.78076499811696,
+                36.16997749166741
               ]
             }
           },
@@ -115,8 +115,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77858027872998,
-                36.1665301261288
+                -86.77864011795216,
+                36.1666223751157
               ]
             }
           },
@@ -136,29 +136,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.78203173799562,
-                36.16510312905676
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5620.0,
-                2136.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7806732,
-                36.168812
+                -86.78202786181348,
+                36.16520427379789
               ]
             }
           }
@@ -176,15 +155,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "4"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -203,34 +182,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1457.8,6606.5 1376.9,1950.8 945.3,1925.2 -0.0,1299.8 -0.0,0.0 6600.0,0.0 6600.0,8040.0 4084.1,8040.0 3987.5,6536.1 1457.8,6606.5\" /></svg>"
+          "value": "<svg><polygon points=\"1035.7,6776.4 1095.9,1598.6 592.7,1552.1 -0.0,1143.2 -0.0,0.0 6600.0,0.0 6600.0,8040.0 4034.8,8040.0 3988.3,6778.3 3933.3,6773.9 1035.7,6776.4\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0011/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3024.0,
-                3124.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7796837,
-                36.1692225
+                -86.78205117467492,
+                36.16980436758476
               ]
             }
           },
@@ -238,20 +220,62 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                3024.0,
-                1200.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.780276,
-                36.1701663
+                -86.778678677953,
+                36.171299880459415
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77643777187346,
+                36.16795991278198
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77981026859538,
+                36.166464399907326
               ]
             }
           }
@@ -269,15 +293,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "5"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "6"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -296,34 +320,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1770.9,6475.6 1778.2,8040.0 -0.0,8040.0 -0.0,352.1 4988.7,771.8 2439.3,6478.0 1770.9,6475.6\" /></svg>"
+          "value": "<svg><polygon points=\"1796.2,8040.0 -0.0,8040.0 -0.0,416.1 4951.9,854.8 4974.2,5881.2 3994.3,5876.6 3991.6,6475.6 1785.4,6458.8 1796.2,8040.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0013/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                1756.0,
-                3508.0
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7989413,
-                36.1569371
+                -86.80089728511139,
+                36.15793168761354
               ]
             }
           },
@@ -331,20 +358,2960 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                5000.0,
-                5876.0
+                6600.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7966284,
-                36.156783
+                -86.79761095710356,
+                36.159566916161545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79516106531472,
+                36.15631179848918
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79844739332255,
+                36.154676569941174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p15",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"746.8,1717.0 6600.0,1456.7 6600.0,7050.2 5672.1,7043.3 3044.5,8040.0 -0.0,8040.0 -0.0,6758.1 746.8,1717.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79677431413279,
+                36.15638987767294
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79336412130294,
+                36.157876222405555
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79113732703736,
+                36.15449835484699
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79454751986721,
+                36.15301201011438
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p16",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"937.7,6971.4 907.7,1319.6 5605.7,1028.3 5896.2,3233.4 5936.7,6982.0 937.7,6971.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79378425822718,
+                36.157614166146054
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79039969005568,
+                36.159070560486825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78821773690925,
+                36.1557181201732
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79160230508074,
+                36.15426172583243
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p17",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6177.1,6991.6 486.5,6992.7 443.0,3254.2 151.6,1055.1 6160.6,717.1 6177.1,6991.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79099514726114,
+                36.15883024193177
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78760000843698,
+                36.16028826189029
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7854155883564,
+                36.15692539968641
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78881072718056,
+                36.15546737972789
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p18",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6963.7 -0.0,642.0 6169.3,462.5 6180.4,6994.4 -0.0,6963.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78780520761408,
+                36.16015739636004
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78444001931277,
+                36.16161173515242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78226107727853,
+                36.158278595514105
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78562626557984,
+                36.15682425672173
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p19",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6046.3,7526.7 1001.1,7478.8 989.7,5730.3 -0.0,5727.2 -0.0,5124.7 985.7,5124.9 942.0,0.0 3950.8,0.0 3939.4,261.6 4689.7,305.2 6046.3,7526.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79865869644998,
+                36.15861048074028
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79538249034111,
+                36.16022412724172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79296490780558,
+                36.15697906872079
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79624111391443,
+                36.155365422219354
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p20",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1818.8,7560.6 451.0,390.0 5448.1,618.5 5171.5,1839.4 5118.2,2982.5 5455.3,7555.4 1818.8,7560.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79658222687506,
+                36.15968214661709
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79327891481304,
+                36.16129888112253
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79085667333538,
+                36.15802701819849
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7941599853974,
+                36.15641028369305
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p21",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1778.7,7244.6 1350.4,2629.1 1382.3,1472.8 1638.4,233.5 5356.9,340.1 5921.3,7137.5 1778.7,7244.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79455678867687,
+                36.16047562211533
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79125235799279,
+                36.16202421781651
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7889321808438,
+                36.15875127982871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79223661152788,
+                36.15720268412752
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0022/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p22",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0022/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0022/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"526.5,341.8 6600.0,573.9 6600.0,7190.5 916.3,7073.0 526.5,341.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0022/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79214162286007,
+                36.16160240770952
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7888639685691,
+                36.163228187245764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78642811077088,
+                36.15998182415089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78970576506185,
+                36.15835604461465
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p23",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"398.1,8040.0 -0.0,8040.0 -0.0,0.0 6600.0,0.0 6600.0,6766.7 5418.5,6811.3 5419.4,6881.7 339.2,6647.3 398.1,8040.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.8027813371755,
+                36.1603831738826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79948865515921,
+                36.16186987346257
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79726121468786,
+                36.15860857060842
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.80055389670416,
+                36.15712187102845
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p25",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7034.3 0.0,0.0 4597.7,0.0 4600.0,672.7 6600.0,709.3 6600.0,5021.1 5967.5,7071.6 -0.0,7034.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7985265727976,
+                36.16229084737991
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7952690755616,
+                36.16374185263215
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79309506598244,
+                36.16051547042905
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79635256321843,
+                36.15906446517681
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p5",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5641.6,7028.1 2088.0,7144.4 1669.7,538.6 728.5,575.4 790.5,0.0 6135.2,0.0 6129.8,533.4 5656.1,522.1 5641.6,7028.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0005/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7896951831479,
+                36.16285406783172
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78629889282593,
+                36.16430763094927
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78412103177862,
+                36.160943810848416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7875173221006,
+                36.159490247730865
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p51",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,13.7 6600.0,204.6 6600.0,5893.4 6323.1,6465.9 5915.2,6884.2 4849.8,7337.3 3733.4,7340.8 3723.0,8040.0 -0.0,8040.0 -0.0,13.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0051/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79329146762969,
+                36.1541657732566
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78990145219171,
+                36.1556837341907
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78762735155678,
+                36.152325764145246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79101736699475,
+                36.150807803211144
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p52",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1455.8,5857.2 1326.8,305.8 5887.1,248.8 5929.4,6732.9 1071.4,6745.5 1455.8,5857.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.79060455850825,
+                36.15542653466902
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78719471961662,
+                36.15687035443674
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78503164279596,
+                36.15349282512756
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78844148168758,
+                36.152049005359835
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p54",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3060.3,4950.7 1815.5,4948.4 1796.5,3915.8 1488.7,3715.6 1394.5,3006.9 1094.9,2722.8 1089.5,797.8 1353.3,187.4 5613.0,178.8 5608.3,7515.8 3051.5,7556.3 3060.3,4950.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78505149828197,
+                36.15775813279745
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78163401528484,
+                36.15919175066449
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77948617922166,
+                36.15580671800082
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7829036622188,
+                36.154373100133775
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p55",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1337.7,290.1 5576.1,333.7 5618.8,7381.8 1409.4,6219.3 1262.0,6753.0 1337.7,290.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78287099587006,
+                36.15872558754309
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77944699088175,
+                36.160200233047306
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7772376436656,
+                36.15680880761794
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7806616486539,
+                36.155334162113725
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p57",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5372.5,3443.8 5270.7,7278.0 1377.0,7271.8 1458.8,3843.8 3834.6,3894.1 3849.9,3418.0 5372.5,3443.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77810866356944,
+                36.16089800409347
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77477047862313,
+                36.16241367157428
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77249962827506,
+                36.15910731233055
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77583781322139,
+                36.15759164484974
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p6",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,3471.4 3067.4,7162.7 1110.9,7167.6 0.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0006/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78737751251822,
+                36.16395270635226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7839376138141,
+                36.16538281593041
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78179489016763,
+                36.16197580887204
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78523478887175,
+                36.1605456992939
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p62",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 5104.8,0.0 5519.4,630.2 6600.0,0.0 6600.0,372.4 5732.6,959.3 6418.6,2019.0 4198.6,3451.8 5646.3,5603.2 4384.4,6530.5 4018.6,7319.5 3517.4,7561.9 3203.8,8040.0 2506.2,8040.0 2381.5,7126.6 716.5,7446.7 801.5,4789.6 1193.1,4271.6 1364.2,1344.3 0.0,1261.6 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78366733089771,
+                36.15344922677333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78328806024476,
+                36.156517141942246
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77869185842962,
+                36.15614146224729
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77907112908258,
+                36.15307354707838
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p63",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1353.7,3500.7 745.9,2968.6 404.7,2100.7 -0.0,573.0 0.0,0.0 4547.8,0.0 5870.0,4575.4 6600.0,4390.3 6600.0,7564.0 5930.7,7341.4 5561.6,7521.4 3870.7,6210.9 3791.9,5593.5 1568.2,5183.7 1789.0,4512.5 1428.3,4059.6 1353.7,3500.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.78043080656627,
+                36.15641706608818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77677492209116,
+                36.15707449885936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77578998573546,
+                36.15345323750067
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77944587021057,
+                36.15279580472949
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p65",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"792.7,6673.2 811.0,1219.6 4662.2,1126.5 6148.1,1294.6 6177.1,4280.4 6401.2,4932.6 6082.6,5494.9 6074.1,6508.5 6600.0,6503.5 6600.0,8040.0 3139.1,8040.0 -0.0,8040.0 -0.0,6984.1 791.0,6990.3 791.5,6912.1 792.7,6673.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77611066256533,
+                36.15855835502053
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77268930739761,
+                36.160019079532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.7705008298791,
+                36.15663025865463
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77392218504681,
+                36.15516953414316
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p66",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/info.json",
+          "type": "ImageService2",
+          "height": 8040,
+          "width": 6600
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"455.5,6438.2 465.8,5364.6 804.0,4769.5 567.5,4078.4 548.1,1672.1 4992.0,1708.2 4996.0,0.0 6600.0,0.0 6600.0,8040.0 1010.4,8040.0 1012.4,6433.6 455.5,6438.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77307164162464,
+                36.15962433124804
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.76984356325477,
+                36.161006781043376
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6600.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.76777233797814,
+                36.157809429953154
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8040.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -86.77100041634802,
+                36.15642698015782
               ]
             }
           }
@@ -369,8 +3336,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -389,7 +3356,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1677.1,0.0 4900.3,0.0 5224.6,1357.5 6159.9,1764.9 5321.4,1763.0 6600.0,7114.9 6600.0,8040.0 -0.0,8040.0 -0.0,1567.6 1677.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,1615.5 1677.0,0.0 4900.3,0.0 6600.0,7115.0 6600.0,8040.0 -0.0,8040.0 -0.0,1615.5\" /></svg>"
         }
       },
       "body": {
@@ -445,537 +3412,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p15",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2614.0,6893.4 886.8,6617.9 895.4,1612.0 4604.2,1613.3 5303.2,0.0 5617.9,0.0 5891.0,1634.4 6600.0,1631.0 6600.0,4109.2 5705.3,4110.2 5394.3,8040.0 -0.0,8040.0 -0.0,7802.5 2576.7,7797.7 2614.0,6893.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0015/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3664.0,
-                4112.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7937625,
-                36.1554997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3664.0,
-                1620.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7945183,
-                36.1565114
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p16",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8040.0 -0.0,3995.7 891.4,3924.5 696.0,1455.8 5490.1,1034.9 5821.2,3216.3 5936.0,6936.0 2427.6,7004.1 2455.9,8040.0 -0.0,8040.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0016/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7937869688246,
-                36.15769588165345
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.79031942007504,
-                36.15909720095
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78820593348084,
-                36.15568539433569
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.79167348223041,
-                36.15428407503914
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5936.0,
-                6936.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.788845,
-                36.1560129
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p17",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6056.4,6991.6 478.3,7048.0 418.8,3269.1 116.1,1049.0 2330.0,903.1 2217.8,0.0 6600.0,0.0 6600.0,629.0 6002.7,653.4 6056.4,6991.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0017/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2720.0,
-                3720.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7885815,
-                36.1578752
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3136.0,
-                6988.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7874961,
-                36.1566099
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p18",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6935.5 -0.0,753.7 582.7,734.8 587.9,121.4 -0.0,116.4 0.0,0.0 6600.0,0.0 6600.0,566.2 6172.0,548.0 6172.0,6940.0 -0.0,6935.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0018/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6172.0,
-                6940.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7827584,
-                36.1586196
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6172.0,
-                548.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7845343,
-                36.1613251
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p19",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,1523.5 0.0,0.0 3464.4,0.0 6600.0,4638.2 6600.0,7029.0 4284.6,8040.0 2874.9,8040.0 2377.5,6908.6 -0.0,7944.0 -0.0,1627.7 -0.0,1523.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0019/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3632.0,
-                300.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.796239,
-                36.1596339
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5716.0,
-                7420.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7945183,
-                36.1565114
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0001__1/georef",
       "type": "Annotation",
       "@context": [
@@ -1009,8 +3445,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1029,7 +3465,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2643.2,1022.4 2702.7,6484.4 516.1,7024.0 516.1,932.0 2643.2,1022.4\" /></svg>"
+          "value": "<svg><polygon points=\"516.1,7024.0 510.9,2798.9 516.1,932.0 2643.2,1022.4 2702.7,6484.4 516.1,7024.0\" /></svg>"
         }
       },
       "body": {
@@ -1118,8 +3554,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1138,7 +3574,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6212.3,7378.0 3370.4,7197.2 3742.1,668.0 6600.0,143.0 6212.3,7378.0\" /></svg>"
+          "value": "<svg><polygon points=\"6600.0,143.0 6212.3,7378.0 3370.4,7197.2 3742.1,668.0 6600.0,143.0\" /></svg>"
         }
       },
       "body": {
@@ -1211,8 +3647,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1231,7 +3667,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1056.5,7406.9 841.4,1024.0 5560.4,894.2 5652.0,7116.0 1056.5,7406.9\" /></svg>"
+          "value": "<svg><polygon points=\"5560.4,894.1 5652.0,7116.0 1056.5,7407.0 841.4,1024.1 5560.4,894.1\" /></svg>"
         }
       },
       "body": {
@@ -1287,292 +3723,13 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/georef",
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0026/georef",
       "type": "Annotation",
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
         "http://iiif.io/api/presentation/3/context.json"
       ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p20",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1573.1,5857.3 1297.6,5853.3 1496.7,5411.5 650.0,467.6 5484.5,748.8 5194.8,1931.5 5122.7,3041.2 5367.0,7487.4 1845.7,7449.3 1573.1,5857.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0020/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3244.0,
-                7468.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.792671,
-                36.1574039
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2204.0,
-                584.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7954035,
-                36.1599861
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p21",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1531.4,2372.4 1657.8,1228.1 2020.7,0.0 6600.0,0.0 6600.0,6401.5 5680.5,6287.3 5680.6,7189.3 1576.2,6981.8 1531.4,2372.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0021/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5680.0,
-                3736.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7906744,
-                36.1602998
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5680.0,
-                7156.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7895437,
-                36.1589722
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p23",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "5"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,5510.7 5953.0,5272.5 5446.0,6753.5 514.8,6640.7 620.7,8040.0 -0.0,8040.0 0.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0023/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3720.0,
-                3608.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7999356,
-                36.1597506
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5360.0,
-                3608.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.799082,
-                36.1601152
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p25",
+      "label": "Nashville, Tenn. | 1957 | Vol. 1a p26",
       "metadata": [
         {
           "label": "streets",
@@ -1583,8 +3740,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1593,21 +3750,21 @@
       ],
       "motivation": "georeferencing",
       "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/selector",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0026/selector",
         "type": "SpecificResource",
         "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/info.json",
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0026/info.json",
           "type": "ImageService2",
           "height": 8040,
           "width": 6600
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 6600.0,0.0 6600.0,7557.2 716.0,7072.0 702.6,6739.1 -0.0,6385.2 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"2179.8,3952.4 1225.9,4058.4 1184.9,3737.0 -0.0,3890.7 0.0,0.0 6600.0,0.0 6600.0,6466.5 2256.0,7032.0 2435.4,6013.0 2179.8,3952.4\" /></svg>"
         }
       },
       "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0025/gcps",
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0026/gcps",
         "type": "FeatureCollection",
         "transformation": {
           "type": "polynomial",
@@ -1632,8 +3789,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79893369887475,
-                36.16221053479578
+                -86.79916021110624,
+                36.16618900075175
               ]
             }
           },
@@ -1653,8 +3810,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7957346975129,
-                36.163980178380484
+                -86.79194643642806,
+                36.168482427785534
               ]
             }
           },
@@ -1674,8 +3831,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7930656998034,
-                36.160832602154805
+                -86.78848746222953,
+                36.16138461721713
               ]
             }
           },
@@ -1695,8 +3852,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.79626470116524,
-                36.159062958570104
+                -86.79570123690772,
+                36.15909119018335
               ]
             }
           },
@@ -1704,8 +3861,8 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                716.0,
-                7072.0
+                2256.0,
+                7032.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1716,8 +3873,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.796239,
-                36.1596339
+                -86.7936691,
+                36.160765
               ]
             }
           }
@@ -1742,8 +3899,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1762,7 +3919,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5895.8,664.0 5896.0,7276.0 818.5,7348.9 1009.6,590.4 5895.8,664.0\" /></svg>"
+          "value": "<svg><polygon points=\"5895.8,664.0 5896.0,7276.0 818.7,7349.2 1009.8,590.7 5895.8,664.0\" /></svg>"
         }
       },
       "body": {
@@ -1835,8 +3992,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1855,7 +4012,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5796.0,6924.0 1087.3,7287.6 796.9,915.9 5576.9,684.8 5796.0,6924.0\" /></svg>"
+          "value": "<svg><polygon points=\"5576.9,684.9 5796.0,6924.0 1087.3,7287.5 796.9,915.9 5576.9,684.9\" /></svg>"
         }
       },
       "body": {
@@ -1928,8 +4085,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1948,7 +4105,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"629.8,7175.1 849.2,641.2 3966.6,797.0 6048.2,814.8 5696.0,7264.0 629.8,7175.1\" /></svg>"
+          "value": "<svg><polygon points=\"629.7,7175.3 849.2,641.1 6048.4,814.5 5696.0,7264.0 629.7,7175.3\" /></svg>"
         }
       },
       "body": {
@@ -2021,8 +4178,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2041,7 +4198,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"412.0,7704.0 804.0,1699.8 -0.0,1684.2 -0.0,643.3 6600.0,916.2 6600.0,8040.0 1374.1,8040.0 1389.5,7757.1 412.0,7704.0\" /></svg>"
+          "value": "<svg><polygon points=\"412.0,7704.0 804.0,1699.7 -0.0,1684.2 -0.0,643.3 845.3,706.9 852.3,234.9 6600.0,416.1 6600.0,8040.0 1374.2,8040.0 1389.6,7757.1 412.0,7704.0\" /></svg>"
         }
       },
       "body": {
@@ -2114,8 +4271,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2134,7 +4291,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5648.8,7118.6 -0.0,7139.4 0.0,0.0 4507.6,0.0 4516.1,710.0 5667.3,691.3 5648.8,7118.6\" /></svg>"
+          "value": "<svg><polygon points=\"5648.7,7118.5 914.8,7172.2 729.5,6009.9 1008.6,766.9 5667.2,691.2 5648.7,7118.5\" /></svg>"
         }
       },
       "body": {
@@ -2207,8 +4364,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2227,7 +4384,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5782.4,7334.5 1064.0,7284.0 1160.4,807.0 -0.0,815.6 0.0,0.0 5106.5,0.0 5102.4,781.4 5868.0,784.0 5782.4,7334.5\" /></svg>"
+          "value": "<svg><polygon points=\"5782.3,7334.5 1064.0,7284.0 1160.5,807.1 -0.0,815.6 0.0,0.0 5106.5,0.0 5102.4,781.4 5868.0,784.0 5782.3,7334.5\" /></svg>"
         }
       },
       "body": {
@@ -2300,8 +4457,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2320,7 +4477,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"852.0,7228.0 852.0,621.4 5614.6,661.3 5684.5,7192.9 852.0,7228.0\" /></svg>"
+          "value": "<svg><polygon points=\"852.0,7228.0 852.0,621.4 5614.5,661.1 5684.4,7192.7 852.0,7228.0\" /></svg>"
         }
       },
       "body": {
@@ -2393,8 +4550,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2413,7 +4570,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1095.2,865.0 5924.0,796.0 5924.0,7332.0 1116.9,7408.7 1095.2,865.0\" /></svg>"
+          "value": "<svg><polygon points=\"1095.3,865.3 5924.0,796.0 5924.0,7332.0 1117.0,7408.9 1095.3,865.3\" /></svg>"
         }
       },
       "body": {
@@ -2486,8 +4643,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2506,7 +4663,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"740.0,732.0 6600.0,603.6 6600.0,7092.3 807.7,7242.4 740.0,732.0\" /></svg>"
+          "value": "<svg><polygon points=\"740.0,732.0 6600.0,603.2 6600.0,7092.1 807.7,7242.6 740.0,732.0\" /></svg>"
         }
       },
       "body": {
@@ -2579,8 +4736,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2599,7 +4756,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"788.0,974.0 5549.8,887.7 5611.7,7067.4 788.0,7092.0 788.0,974.0\" /></svg>"
+          "value": "<svg><polygon points=\"788.0,974.0 5549.7,887.6 5611.6,7067.3 788.0,7092.0 788.0,974.0\" /></svg>"
         }
       },
       "body": {
@@ -2672,8 +4829,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2692,7 +4849,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5856.0,940.0 5856.0,7028.0 1251.1,6967.4 1299.6,1013.0 5856.0,940.0\" /></svg>"
+          "value": "<svg><polygon points=\"5856.0,940.0 5856.0,7028.0 1251.2,6967.6 1299.7,1013.2 5856.0,940.0\" /></svg>"
         }
       },
       "body": {
@@ -2765,8 +4922,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2785,7 +4942,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2578.0,5175.7 3343.8,5172.4 3378.0,3765.1 2590.3,3774.4 2621.3,1825.6 2097.4,1827.8 2101.4,0.0 6600.0,0.0 6600.0,8040.0 6375.3,8040.0 6377.5,6568.9 5403.1,6567.5 5392.3,7545.5 3298.6,7521.8 3298.3,7164.1 2557.7,7076.6 2578.0,5175.7\" /></svg>"
+          "value": "<svg><polygon points=\"444.7,5681.0 441.3,0.0 6600.0,0.0 6600.0,8040.0 2519.1,8040.0 2541.0,5671.9 444.7,5681.0\" /></svg>"
         }
       },
       "body": {
@@ -2814,8 +4971,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77995615129157,
-                36.16389474770452
+                -86.77767191782623,
+                36.16444151458576
               ]
             }
           },
@@ -2835,8 +4992,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7731165594021,
-                36.16684653120118
+                -86.77596251394706,
+                36.16517924722262
               ]
             }
           },
@@ -2856,8 +5013,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.76866464407878,
-                36.16011688829404
+                -86.7748498567233,
+                36.16349732264631
               ]
             }
           },
@@ -2877,8 +5034,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77550423596826,
-                36.15716510479738
+                -86.77655926060247,
+                36.16275959000945
               ]
             }
           },
@@ -2924,8 +5081,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2944,7 +5101,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"938.8,7012.0 950.8,782.9 6600.0,705.7 6600.0,5728.9 5622.5,5733.2 5620.0,7012.0 938.8,7012.0\" /></svg>"
+          "value": "<svg><polygon points=\"938.8,7012.0 951.1,782.8 6600.0,705.6 6600.0,5729.0 5622.6,5733.3 5620.0,7012.0 938.8,7012.0\" /></svg>"
         }
       },
       "body": {
@@ -3033,8 +5190,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3053,7 +5210,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6600.0,0.0 6456.1,6988.0 3713.5,6988.0 3831.3,0.0 6600.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3713.5,6988.0 3831.5,0.0 6600.0,0.0 6456.1,6988.0 3713.5,6988.0\" /></svg>"
         }
       },
       "body": {
@@ -3126,8 +5283,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3219,8 +5376,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3239,7 +5396,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4158.5,7410.8 992.0,7436.0 1220.1,827.5 4982.7,729.7 4158.5,7410.8\" /></svg>"
+          "value": "<svg><polygon points=\"6600.0,7432.5 992.0,7436.0 1220.1,827.5 6600.0,713.6 6600.0,7432.5\" /></svg>"
         }
       },
       "body": {
@@ -3312,8 +5469,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3332,7 +5489,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5658.0,148.5 6462.3,6639.6 6204.9,6724.8 -0.0,7434.5 -0.0,817.6 5658.0,148.5\" /></svg>"
+          "value": "<svg><polygon points=\"6462.4,6639.7 2384.4,7161.8 1578.7,630.9 5658.1,148.6 6462.4,6639.7\" /></svg>"
         }
       },
       "body": {
@@ -3405,8 +5562,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3425,7 +5582,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"672.0,7488.3 679.2,665.6 5636.0,728.0 5636.0,7444.0 672.0,7488.3\" /></svg>"
+          "value": "<svg><polygon points=\"672.0,7488.4 679.3,665.7 5636.0,728.0 5636.0,7444.0 672.0,7488.4\" /></svg>"
         }
       },
       "body": {
@@ -3498,8 +5655,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3518,7 +5675,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5884.0,1592.0 5382.0,8040.0 528.3,8040.0 1093.3,1263.3 5884.0,1592.0\" /></svg>"
+          "value": "<svg><polygon points=\"5884.0,1592.0 5382.0,8040.0 526.9,8040.0 1091.9,1263.2 5884.0,1592.0\" /></svg>"
         }
       },
       "body": {
@@ -3547,8 +5704,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77889671037964,
-                36.16059562237369
+                -86.77889621631175,
+                36.160595746418025
               ]
             }
           },
@@ -3568,8 +5725,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77725995712858,
-                36.16143482418925
+                -86.77725993601794,
+                36.16143470573729
               ]
             }
           },
@@ -3589,8 +5746,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77599426287075,
-                36.15982438235518
+                -86.77599460749595,
+                36.15982472925752
               ]
             }
           },
@@ -3610,8 +5767,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.77763101612183,
-                36.158985180539624
+                -86.77763088778975,
+                36.158985769938255
               ]
             }
           },
@@ -3678,8 +5835,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3698,7 +5855,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5576.0,7448.0 737.9,7416.1 677.5,6907.1 800.0,708.0 5719.0,741.3 5576.0,7448.0\" /></svg>"
+          "value": "<svg><polygon points=\"5576.0,7448.0 737.8,7416.2 677.5,6907.2 800.0,708.0 5719.0,741.2 5576.0,7448.0\" /></svg>"
         }
       },
       "body": {
@@ -3771,8 +5928,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3791,7 +5948,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1116.0,1452.0 5828.0,1452.0 5814.0,8040.0 1093.9,8040.0 1116.0,1452.0\" /></svg>"
+          "value": "<svg><polygon points=\"1116.0,1452.0 5828.0,1452.0 5813.9,8040.0 1093.8,8040.0 1116.0,1452.0\" /></svg>"
         }
       },
       "body": {
@@ -3864,8 +6021,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3884,7 +6041,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"784.0,7144.0 759.5,699.3 6600.0,869.0 6600.0,7166.8 784.0,7144.0\" /></svg>"
+          "value": "<svg><polygon points=\"784.0,3968.0 -0.0,3949.7 -0.0,666.7 6600.0,869.0 6600.0,7181.1 784.0,7144.0 784.0,3968.0\" /></svg>"
         }
       },
       "body": {
@@ -3940,99 +6097,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p52",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"946.3,6912.4 -0.0,7339.2 -0.0,406.6 5941.6,405.9 5895.5,6674.6 1218.0,6648.7 946.3,6912.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0052/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5888.0,
-                5008.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7862099,
-                36.1546124
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5888.0,
-                7352.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7855402,
-                36.1536013
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0053/georef",
       "type": "Annotation",
       "@context": [
@@ -4050,8 +6114,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4070,7 +6134,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"528.0,7240.0 582.2,222.8 6600.0,252.6 6341.2,845.8 6313.2,2726.2 6600.0,3007.2 6600.0,4910.6 5218.4,4906.3 3702.1,8040.0 2754.6,8040.0 2642.0,7264.1 528.0,7240.0\" /></svg>"
+          "value": "<svg><polygon points=\"2642.0,7264.2 528.0,7240.0 582.2,222.8 6600.0,252.9 6341.4,846.0 6313.4,2726.4 6600.0,3007.4 6600.0,4903.7 5876.2,4899.0 3770.5,8040.0 2754.7,8040.0 2642.0,7264.2\" /></svg>"
         }
       },
       "body": {
@@ -4126,192 +6190,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p54",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1894.5,4912.8 1833.4,3090.6 1408.0,2983.9 1150.8,2725.2 1116.4,820.3 1367.1,210.8 5564.9,114.0 5671.0,7375.0 3152.0,7468.0 3126.2,5312.2 1894.5,4912.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0054/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3152.0,
-                2612.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7827243,
-                36.1573212
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3152.0,
-                7468.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7814528,
-                36.1552396
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p55",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "2"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1112.1,6027.4 1083.2,444.8 5632.0,388.0 5791.6,7154.3 1198.7,5745.1 1112.1,6027.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0055/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3468.0,
-                388.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7809449,
-                36.1593996
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5632.0,
-                388.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7798865,
-                36.1598307
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/georef",
       "type": "Annotation",
       "@context": [
@@ -4322,15 +6200,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "3"
+          "value": "4"
         },
         {
           "label": "intersections",
-          "value": "1"
+          "value": "3"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4349,103 +6227,16 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3537.8,8040.0 3568.9,4931.7 768.0,4908.0 772.8,171.0 3611.0,142.0 3571.0,3541.8 5991.7,3368.7 5938.0,8040.0 3537.8,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"5959.9,8040.0 3553.3,8040.0 3576.6,4923.8 768.0,4908.0 760.9,157.1 3606.7,119.9 3575.2,3528.9 6002.0,3348.4 5959.9,8040.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0056/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
+          "type": "helmert"
         },
         "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.78033383005426,
-                36.159728182840766
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77692038205161,
-                36.16121363047895
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77468001208211,
-                36.15785505492193
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77809346008476,
-                36.15636960728376
-              ]
-            }
-          },
           {
             "type": "Feature",
             "properties": {
@@ -4466,85 +6257,13 @@
                 36.1578508
               ]
             }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p57",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5273.1,7211.3 1465.7,7297.7 1483.9,3931.0 3808.0,3923.9 3814.4,3456.2 5303.7,3445.3 5273.1,7211.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0057/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3788.0,
-                5400.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7746692,
-                36.1595482
-              ]
-            }
           },
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2584.0,
-                7312.0
+                5988.0,
+                4908.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4555,8 +6274,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -86.7747683,
-                36.1584689
+                -86.7758725,
+                36.1590163
               ]
             }
           }
@@ -4581,8 +6300,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4601,7 +6320,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0,8040 0,0 6600,0 6600,8040 0,8040\" /></svg>"
+          "value": "<svg><polygon points=\"974.2,3408.4 -0.0,3423.7 -0.0,3423.7 2490.8,3384.6 2538.1,141.7 2090.5,240.1 970.9,257.7 1037.6,0.0 6600.0,0.0 6600.0,8040.0 2452.6,8040.0 2444.2,7331.4 975.3,7174.7 974.2,3408.4\" /></svg>"
         }
       },
       "body": {
@@ -4690,8 +6409,8 @@
           "value": "8040.0"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4710,7 +6429,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5017.1,263.2 6446.9,1313.9 6502.0,2804.0 6600.0,2655.5 6600.0,8040.0 -0.0,8040.0 -0.0,624.1 5017.1,263.2\" /></svg>"
+          "value": "<svg><polygon points=\"754.2,8040.0 -0.0,5540.7 -0.0,1077.6 -0.0,624.1 5017.1,263.2 6446.9,1314.0 6600.0,8040.0 754.2,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -4783,8 +6502,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4803,7 +6522,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,8040.0 315.6,2121.9 2124.0,944.3 3463.8,1002.1 6600.0,3087.9 6600.0,4750.9 6106.9,7315.8 6600.0,7357.2 6600.0,8040.0 -0.0,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,8040.0 315.6,2121.9 2124.1,944.4 3521.9,963.5 6600.0,3087.9 6600.0,4751.0 6106.9,7315.7 6600.0,7357.2 6600.0,8040.0 -0.0,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -4876,8 +6595,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4896,7 +6615,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,8040.0 0.0,2184.7 127.7,2176.8 138.5,1679.8 2717.4,1511.3 2740.6,2014.3 4407.9,1910.7 4519.3,1615.3 4115.0,1161.0 4067.5,0.0 6600.0,0.0 6600.0,2881.3 6243.6,3412.0 6312.9,6022.8 21.1,7311.9 241.1,8040.0 0.0,8040.0\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,8040.0 0.0,2184.7 127.8,2176.7 138.6,1679.8 2717.3,1511.3 2740.5,2014.3 4407.8,1910.6 4519.1,1615.4 4114.8,1161.1 4067.3,0.0 6600.0,0.0 6600.0,2880.9 6243.2,3412.2 6312.5,6023.0 21.2,7311.9 241.2,8040.0 0.0,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -4952,192 +6671,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p62",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 5701.8,0.0 6300.9,1248.0 6600.0,1103.2 6600.0,1521.7 6466.8,1586.2 6600.0,2859.9 4661.4,3748.4 5756.4,5988.3 4423.9,6524.5 3884.0,6504.5 4129.0,6889.3 4067.2,7264.1 3830.8,7501.7 3453.7,7563.0 3055.9,8040.0 2420.3,8040.0 2425.2,6990.0 2224.1,7085.1 788.0,7076.0 1228.7,4562.0 1676.1,4120.1 2232.7,1363.4 0.0,910.7 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0062/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2000.0,
-                7076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7793984,
-                36.1540195
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                788.0,
-                7076.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7793691,
-                36.1534343
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p63",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1584.2,3881.5 1238.9,3777.6 846.6,3961.2 931.4,3455.2 0.0,0.0 4175.5,0.0 5728.3,4788.7 6600.0,4519.6 6600.0,7440.4 5978.0,7265.4 5653.7,7444.8 4077.8,6334.1 3980.9,5778.7 2113.5,5527.3 2191.2,4929.1 1584.2,3881.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0063/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5728.0,
-                4788.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7766648,
-                36.1549221
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3532.0,
-                6504.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7778472,
-                36.1538731
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0064/georef",
       "type": "Annotation",
       "@context": [
@@ -5155,8 +6688,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5175,7 +6708,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"803.8,7412.7 716.0,7412.0 682.0,443.6 3481.1,423.0 3498.2,3530.1 5896.5,3492.1 5883.8,8040.0 1496.5,8040.0 1694.0,7421.4 803.8,7412.7\" /></svg>"
+          "value": "<svg><polygon points=\"3481.0,423.0 3498.2,3528.8 5896.6,3497.6 5884.0,8040.0 1365.0,8040.0 1531.6,7419.8 803.8,7412.7 681.8,443.6 3481.0,423.0\" /></svg>"
         }
       },
       "body": {
@@ -5231,258 +6764,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p65",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "6"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"770.6,6647.0 840.9,1115.1 4732.9,1034.5 6232.5,1210.4 6233.5,4239.2 6453.7,4901.6 6126.5,5470.8 6108.3,6498.9 6600.0,6496.0 6600.0,8040.0 -0.0,8040.0 -0.0,6960.0 765.9,6968.8 767.1,6889.4 770.6,6647.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0065/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3160.0,
-                6536.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77269,
-                36.1564939
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1984.0,
-                1132.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7747683,
-                36.1584689
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "Nashville, Tenn. | 1957 | Vol. 1a p66",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/info.json",
-          "type": "ImageService2",
-          "height": 8040,
-          "width": 6600
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"665.3,4844.9 459.6,4334.5 445.2,1914.9 4632.6,1956.2 4651.3,0.0 6600.0,0.0 6600.0,8040.0 812.7,7944.4 811.3,6419.5 325.5,6422.7 342.6,5407.3 665.3,4844.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0066/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77313232728623,
-                36.15977690541481
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.76970981906221,
-                36.16124868986296
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6600.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.76749005608002,
-                36.15788119973101
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                8040.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.77091256430404,
-                36.15640941528286
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1632.0,
-                6412.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -86.7705151,
-                36.1574555
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd396m:g3964m:g3964nm:g3964nm_g08356195701A:08356_01A_1957-0067/georef",
       "type": "Annotation",
       "@context": [
@@ -5500,8 +6781,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5520,7 +6801,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3263.1,0.0 3446.9,580.4 5293.8,1542.1 5615.1,1303.4 6306.1,1401.0 6117.4,0.0 6600.0,0.0 6600.0,8040.0 290.1,8040.0 249.7,205.7 151.2,0.0 3263.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"290.0,8040.0 249.6,205.7 157.4,0.0 3263.1,0.0 3446.9,580.4 5293.8,1542.1 5615.1,1303.4 6294.1,1398.9 6038.8,0.0 6600.0,0.0 6600.0,8040.0 290.0,8040.0\" /></svg>"
         }
       },
       "body": {
@@ -5593,8 +6874,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:42:26Z",
-      "modified": "2026-07-18T02:42:26Z",
+      "created": "2026-07-30T23:53:33Z",
+      "modified": "2026-07-30T23:53:33Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5613,7 +6894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5866.6,717.9 5677.1,7299.3 -0.0,7221.4 -0.0,0.0 3949.8,0.0 3937.6,736.2 5866.6,717.9\" /></svg>"
+          "value": "<svg><polygon points=\"5866.4,717.7 5676.9,7299.1 -0.0,7221.5 0.0,0.0 4164.2,0.0 4151.9,733.8 5866.4,717.7\" /></svg>"
         }
       },
       "body": {

--- a/gallery/new_orleans_la_1896_vol_2.iiif.json
+++ b/gallery/new_orleans_la_1896_vol_2.iiif.json
@@ -7,6 +7,4422 @@
   "label": "Mosaic of main content, New Orleans, La. | 1896 | Vol. 2",
   "items": [
     {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p176",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "4"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6421
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3622.1,7795.0 3371.0,7795.0 3368.9,6857.4 3113.6,6760.5 3092.6,7795.0 2769.3,7795.0 2780.7,6796.7 953.1,6782.2 622.3,7795.0 0.0,7795.0 -0.0,0.0 4839.1,-0.0 4858.9,7423.2 3589.8,6941.3 3622.1,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0868982,
+                29.9511613
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6421.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08408,
+                29.9495891
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6421.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0862835,
+                29.9466239
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0891016,
+                29.9481961
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p181",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "5"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6537
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1468.2,678.7 1414.8,-0.0 6537.0,0.0 6537.0,833.5 5695.6,827.3 5590.5,7196.4 3072.7,7191.1 515.5,7795.0 462.3,6564.5 0.0,6542.6 -0.0,797.7 1468.2,678.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.090521,
+                29.9565668
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08845,
+                29.9589254
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0852029,
+                29.9567852
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0872738,
+                29.9544266
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p103",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6428
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3723.5,235.5 6428.0,1849.2 6428.0,7795.0 3922.7,7795.0 1943.4,7494.4 1814.8,176.3 3723.5,235.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07271764000629,
+                29.95174357352089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07183802721453,
+                29.954587309324793
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.067885328406,
+                29.953656460865357
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06876494119777,
+                29.95081272506145
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p104",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6428
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"828.5,212.9 6428.0,241.4 6428.0,7581.5 814.3,7519.0 828.5,212.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07332239067429,
+                29.949703529902724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07250252086044,
+                29.95255223802675
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0685429886857,
+                29.951684595362547
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06936285849956,
+                29.948835887238523
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p105",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6428
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1325.1,1852.5 1032.3,151.9 5438.4,185.4 5514.8,0.0 6095.9,202.2 6099.5,0.0 6428.0,0.0 6428.0,7795.0 5315.3,7784.3 2181.9,7336.5 1653.3,3851.9 1732.3,2823.0 1565.7,1863.8 1325.1,1852.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07588251678054,
+                29.95450146786338
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07386378247014,
+                29.95683874685537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6428.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07061497696351,
+                29.954702468048744
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07263371127391,
+                29.952365189056753
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p106",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6496
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1109.0,709.2 6457.2,1579.6 6332.0,3312.9 5866.5,4230.7 5023.5,7642.7 0.0,7631.1 897.9,1995.4 519.7,1498.2 1017.6,1433.4 1109.0,709.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07667018538183,
+                29.951937583960692
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6496.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07581895733179,
+                29.954809041021242
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6496.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07186949544315,
+                29.95391766293403
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07272072349319,
+                29.951046205873478
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p112",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6340
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2653.6,145.1 2916.3,128.3 2893.5,0.0 6340.0,0.0 6340.0,7795.0 3558.4,7795.0 3346.2,7007.1 869.7,6997.6 869.1,6372.5 -0.0,3238.6 -0.0,485.0 2781.0,417.7 2653.6,145.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06547313155258,
+                29.94861447275941
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6340.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06221545301645,
+                29.947879325614856
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6340.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06325140549758,
+                29.944383837648537
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0665090840337,
+                29.94511898479309
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p115",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6349
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"246.5,7546.7 291.6,4453.4 949.9,4447.2 942.4,2689.6 331.8,2679.3 658.0,1453.5 759.6,218.5 6330.5,194.9 6327.4,6793.8 3954.2,7732.6 3596.0,7529.5 246.5,7546.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0718281473983,
+                29.941345686488752
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0709878992975,
+                29.944135316929884
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06706193550824,
+                29.94323482930641
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06790218360904,
+                29.940445198865277
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p132",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6444
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6229.1,2266.4 4568.9,3369.4 4695.7,6303.7 3117.9,7333.4 136.0,7352.8 429.8,1326.2 5755.8,1526.5 6229.1,2266.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07505412803248,
+                29.93106795620108
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0725809381829,
+                29.93302017091396
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6444.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0698747642347,
+                29.930408839907788
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07234795408428,
+                29.928456625194908
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p137",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6349
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"949.7,6618.5 2221.6,2773.4 2889.5,2938.9 2891.9,3730.5 3215.2,2894.4 3177.7,773.3 2020.6,394.4 3008.1,380.1 3164.4,22.6 4407.1,118.5 5641.5,440.3 5712.7,7149.6 6349.0,7143.3 6349.0,7796.0 3027.4,7796.0 3014.5,6375.4 3266.5,6372.3 3263.7,6108.8 2912.7,5996.0 2858.8,7222.4 949.7,6618.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07319689523322,
+                29.94203437970515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0700221580739,
+                29.941291367095403
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6349.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07106780146002,
+                29.937888929335397
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07424253861934,
+                29.938631941945147
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0138/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p138",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0138/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0138/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6453
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"0.1,7284.6 35.1,0.0 1795.5,0.0 1796.0,659.1 4893.4,730.8 4904.7,3386.1 6147.9,6458.5 4900.5,6461.5 4856.8,7297.8 0.1,7284.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0138/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07036774522206,
+                29.94144972284913
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06711564581396,
+                29.940729726125472
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.06811256361952,
+                29.937300548959826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07136466302762,
+                29.938020545683482
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p139",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6340
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"161.2,3964.4 1329.4,3973.0 1327.8,3664.7 159.9,3663.6 147.1,901.5 6340.0,885.8 6340.0,7175.8 4498.6,7795.0 3475.1,7795.0 4217.7,7549.3 4167.8,6871.3 165.7,6859.8 161.2,3964.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07666707906294,
+                29.9406866035912
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6340.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07485058986832,
+                29.943113876270036
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6340.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07143033484807,
+                29.94116466891053
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0732468240427,
+                29.938737396231694
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p144",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6426
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5713.4,575.9 6426.0,365.0 6426.0,1278.3 6212.8,1429.9 6426.0,1774.3 3877.7,3639.1 4046.0,5810.3 5396.0,7795.0 93.1,7795.0 119.7,863.3 3681.2,758.1 5469.8,229.5 5713.4,575.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07707167476477,
+                29.93343952029559
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6426.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07451038795374,
+                29.935313431145495
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6426.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07190461451758,
+                29.93260072292906
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07446590132861,
+                29.93072681207915
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p145",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6372
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"36.3,7795.0 259.3,1228.8 -0.0,1231.2 0.0,-0.0 345.8,1220.7 6114.5,678.8 6268.2,2451.7 6299.5,7795.0 36.3,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07764892142448,
+                29.936127436721648
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6372.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07567636676161,
+                29.933798502873024
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6372.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07894135010355,
+                29.931692313792542
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08091390476642,
+                29.934021247641166
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p147",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6396
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"438.3,0.0 441.0,1027.3 4595.1,1323.7 6396.0,1144.3 6396.0,7192.7 -0.0,6910.5 -0.0,-0.0 438.3,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08299213573694,
+                29.936561071601297
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6396.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08033525460087,
+                29.93830843125807
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6396.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07789473811351,
+                29.935482253757886
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0805516192496,
+                29.933734894101114
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p148",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6453
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1916.9,929.5 3610.9,275.5 5527.4,5358.4 4556.6,5735.2 4610.4,5879.6 2104.0,6744.9 2124.6,6955.0 575.5,6971.4 567.9,1185.6 1916.9,929.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0805827590362,
+                29.938171027088565
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07789133491306,
+                29.93992288394818
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6453.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07546573685933,
+                29.937084854701524
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07815716098247,
+                29.935332997841908
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p152",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6443
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"414.8,116.5 6069.7,0.0 6120.6,2335.6 5757.1,2321.9 5681.3,3303.5 6443.0,4317.0 6443.0,4904.2 6148.2,4998.8 6190.2,5129.4 5969.4,5112.9 5750.9,7658.2 345.8,7647.3 387.0,2228.1 -0.0,2223.4 -0.0,2049.7 389.3,2054.0 414.8,116.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0785816015944,
+                29.943781656245946
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07677308288788,
+                29.946282133424404
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6443.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07330642792955,
+                29.944372861088205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07511494663606,
+                29.941872383909747
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p157",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6425
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"333.5,7795.0 433.6,333.3 6352.6,745.8 6425.0,3954.7 6205.2,6835.0 5909.7,6760.1 5822.4,7795.0 333.5,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07992178520578,
+                29.95362438647968
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6425.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07858520814204,
+                29.956275185104897
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6425.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07489833101567,
+                29.954859897597526
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07623490807941,
+                29.95220909897231
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p158",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6373
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5720.7,446.6 5729.7,0.0 6373.0,0.0 6373.0,7424.2 5935.5,7380.1 5716.5,7136.0 5710.0,7419.1 1572.5,7463.9 1075.0,4619.2 379.3,2380.5 234.1,456.9 5720.7,446.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0789440149846,
+                29.95646082279879
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6373.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07691221165875,
+                29.958728367047048
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6373.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07373257706962,
+                29.956559403009333
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07576438039547,
+                29.954291858761074
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p159",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6424
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6424.0,0.0 6424.0,7795.0 393.3,7795.0 363.7,6702.0 -0.0,6791.0 -0.0,1369.1 6424.0,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08336308879453,
+                29.955233215476238
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6424.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08180608523556,
+                29.957817080188153
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6424.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07821224908251,
+                29.956168410325724
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07976925264148,
+                29.953584545613804
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p160",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6423
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,972.0 3892.7,999.9 3885.8,649.2 6240.3,646.5 6230.1,0.0 6423.0,0.0 6320.1,7231.1 948.1,7305.9 -0.0,2745.1 -0.0,972.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08201001858514,
+                29.958182907006176
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07988676205784,
+                29.960494603481227
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6423.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07667139678723,
+                29.95824640029806
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07879465331453,
+                29.955934703823008
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p168",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6442
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,385.5 348.8,255.3 834.8,1506.7 2960.3,1213.2 5545.6,223.2 5996.7,3365.9 5730.6,7514.5 4704.7,7524.6 4706.6,7795.0 -0.0,7795.0 -0.0,385.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08112236116695,
+                29.940437514332356
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6442.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.07912231273873,
+                29.938086332348956
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6442.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08238381591731,
+                29.935973422941185
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08438386434553,
+                29.938324604924585
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p172",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6476
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"214.7,311.2 6152.7,356.3 6135.3,2179.6 6476.0,2182.6 6476.0,7795.0 134.4,6346.5 214.7,311.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08408424097672,
+                29.94606701212936
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6476.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08124486486062,
+                29.944500314587117
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6476.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08340619012067,
+                29.941517557141296
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08624556623678,
+                29.943084254683537
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p175",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6467
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,772.4 1673.5,152.2 2010.9,1091.1 2313.7,976.2 1972.7,-0.0 2245.6,-0.0 2574.4,877.2 2809.6,787.9 2481.8,-0.0 4427.0,-0.0 5387.6,2522.1 4850.4,2716.5 4998.3,3113.4 5361.8,2972.6 5363.0,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08805454711295,
+                29.948545648678444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6467.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0860486395935,
+                29.94619054435439
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6467.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08930174943833,
+                29.944080818783892
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09130765695778,
+                29.94643592310795
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p179 [1]",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6537
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5931.3,7314.8 5923.8,7398.0 5888.0,7795.0 166.8,7795.0 693.2,4654.6 409.5,4605.3 1771.3,0.0 4443.0,0.0 6537.0,600.4 5931.3,7314.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08740181912817,
+                29.953834224583545
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08614561248513,
+                29.956593591883248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6537.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08237348586457,
+                29.955286205641386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0836296925076,
+                29.952526838341683
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p180",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6461
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6155.9,2199.5 6132.9,279.1 4502.3,0.0 6383.3,0.0 6318.3,6653.6 777.2,7795.0 252.0,7795.0 190.7,1119.0 6155.9,2199.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08642042100858,
+                29.956649934765554
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6461.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08486672531504,
+                29.959271422039752
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6461.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08124082971952,
+                29.957635445596534
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08279452541306,
+                29.955013958322333
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p182",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6408
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7145.3 -0.0,738.1 4860.6,747.2 4863.6,764.3 5964.3,767.3 6004.1,4775.9 3743.6,5233.0 4464.1,5239.1 5412.4,5205.3 5793.9,7105.2 -0.0,7145.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08867376219392,
+                29.95860050675978
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6408.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08662604177574,
+                29.960886343317092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6408.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08343869478047,
+                29.958712715699917
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08548641519864,
+                29.956426879142604
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p185",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6542
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"664.4,7380.7 665.6,7566.0 134.9,7570.8 136.3,7795.0 -0.0,7795.0 -0.0,-0.0 6015.5,-0.0 6090.2,7339.5 664.4,7380.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08985634059802,
+                29.967351662042013
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6542.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08716373447474,
+                29.965495153857738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6542.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08969879369484,
+                29.962696567790434
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09239139981811,
+                29.96455307597471
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p186",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6490
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"6490.0,-0.0 6490.0,426.7 6072.8,426.8 6098.4,7795.0 484.2,7795.0 488.3,7179.2 -0.0,7175.9 -0.0,-0.0 6490.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0873623410709,
+                29.96566508947098
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6490.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08467348309809,
+                29.963860641979092
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6490.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08715867742288,
+                29.96104178048379
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08984753539569,
+                29.962846227975678
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p188",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/info.json",
+          "type": "ImageService2",
+          "height": 7796,
+          "width": 6483
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"205.9,49.1 5913.2,102.4 5900.0,7796.0 1157.1,7777.9 1152.0,4899.7 205.9,49.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09162136559011,
+                29.960596501320023
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6483.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08950330482624,
+                29.962947393417654
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6483.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08626359443325,
+                29.96072550333379
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7796.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08838165519713,
+                29.958374611236163
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p189",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,437.4 533.7,436.1 533.7,249.7 5990.5,243.6 6010.7,-0.0 6500.0,-0.0 6423.6,6400.4 -0.0,7575.1 -0.0,437.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09212265586498,
+                29.9647522894218
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08944887373637,
+                29.962933151936248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09194966340016,
+                29.960135257522087
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09462344552877,
+                29.961954395007638
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1896 | Vol. 2 p191",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/info.json",
+          "type": "ImageService2",
+          "height": 7795,
+          "width": 6500
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 6500.0,0.0 6500.0,7795.0 -0.0,7795.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09491461054813,
+                29.95634038238849
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09312738310669,
+                29.95878050053719
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                6500.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08977314661223,
+                29.95691018902551
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                7795.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09156037405367,
+                29.95447007087681
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0101__1/georef",
       "type": "Annotation",
       "@context": [
@@ -40,8 +4456,8 @@
           "value": "7795.0"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -60,7 +4476,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"299.5,4279.2 514.0,1763.6 -0.0,1539.5 -0.0,936.2 543.7,1166.9 748.9,0.0 6387.0,0.0 6387.0,7002.3 6149.2,7019.0 6288.0,7311.8 3221.2,7402.7 3229.7,7795.0 2622.7,7795.0 2532.7,7477.0 301.4,7489.2 299.5,4279.2\" /></svg>"
+          "value": "<svg><polygon points=\"1177.2,0.0 6387.0,0.0 6387.0,7002.3 6149.2,7019.0 6288.0,7311.8 3313.4,7492.0 1258.3,7460.9 1177.2,0.0\" /></svg>"
         }
       },
       "body": {
@@ -133,8 +4549,8 @@
           "value": "22"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -153,7 +4569,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5530.0,7442.9 833.3,7434.2 858.2,1901.6 1134.9,0.0 6428.0,0.0 6428.0,428.0 6026.1,423.6 5821.7,1515.9 5314.1,1294.0 5307.9,1859.8 5787.7,2075.2 5560.9,4432.3 5530.0,7442.9\" /></svg>"
+          "value": "<svg><polygon points=\"833.2,7434.3 858.1,1901.6 1134.8,0.0 6428.0,0.0 6428.0,7425.9 833.2,7434.3\" /></svg>"
         }
       },
       "body": {
@@ -209,378 +4625,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p103",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6428
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1966.5,0.0 4152.9,220.6 6428.0,1750.7 6428.0,7795.0 3597.0,7795.0 1702.9,7402.6 173.6,7318.5 1966.5,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0103/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                772.0,
-                4883.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.070038,
-                29.951481
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2448.0,
-                5039.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.069797,
-                29.9522091
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p104",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6428
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"845.7,7502.1 779.9,238.7 6136.0,178.6 4893.1,7500.1 845.7,7502.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0104/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3040.0,
-                5083.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0703357,
-                29.9504786
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3040.0,
-                228.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0728094,
-                29.9510458
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p105",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6428
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1670.6,2635.5 642.3,283.5 941.6,281.6 893.4,0.0 6428.0,0.0 6428.0,7795.0 2255.7,7421.0 1610.7,3732.0 1670.6,2635.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0105/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5604.0,
-                1587.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.073362,
-                29.955948
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5604.0,
-                7799.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0709689,
-                29.9543008
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p106",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6496
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1337.5,0.0 4272.3,0.0 6048.6,788.0 6496.0,0.0 6496.0,3096.6 5950.6,4242.7 5033.1,7651.1 0.0,7558.5 605.5,3846.9 619.4,3847.1 979.9,1920.3 607.9,1415.4 1111.7,1358.4 1337.5,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0106/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1548.0,
-                7579.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0726001,
-                29.9517601
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2108.0,
-                3867.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0744161,
-                29.9523963
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0107/georef",
       "type": "Annotation",
       "@context": [
@@ -598,8 +4642,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -618,7 +4662,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1815.3,7795.0 1553.9,7656.5 338.1,7649.5 295.3,0.0 3964.5,511.4 3990.3,2849.4 6423.8,2834.2 6428.0,7654.3 1815.3,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"6428.0,7654.2 1815.3,7795.0 1553.9,7656.5 -0.0,7649.0 -0.0,6071.4 333.7,6069.2 295.3,0.0 3980.0,592.8 3990.3,2849.4 6423.8,2834.2 6428.0,7654.2\" /></svg>"
         }
       },
       "body": {
@@ -691,8 +4735,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -784,8 +4828,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -804,7 +4848,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5733.3,7279.3 847.7,7279.1 846.8,6934.4 339.1,6769.0 846.0,6592.2 830.2,529.7 5735.9,562.3 5733.3,7279.3\" /></svg>"
+          "value": "<svg><polygon points=\"5733.3,7279.3 847.7,7279.1 834.9,2309.5 248.5,627.8 5735.9,562.3 5733.3,7279.3\" /></svg>"
         }
       },
       "body": {
@@ -877,8 +4921,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -897,7 +4941,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"704.0,7255.1 704.0,503.9 5589.6,513.4 5615.2,7271.7 704.0,7255.1\" /></svg>"
+          "value": "<svg><polygon points=\"5615.2,7271.7 704.0,7255.1 704.0,503.9 5589.6,513.4 5615.2,7271.7\" /></svg>"
         }
       },
       "body": {
@@ -970,8 +5014,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -990,7 +5034,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4733.7,648.9 6350.0,6579.0 6350.0,7251.9 373.9,7214.2 348.6,623.1 4733.7,648.9\" /></svg>"
+          "value": "<svg><polygon points=\"348.6,623.1 5474.0,670.3 5471.3,3395.8 6350.0,6579.0 6350.0,7239.6 373.9,7214.2 348.6,623.1\" /></svg>"
         }
       },
       "body": {
@@ -1046,99 +5090,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p112",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6340
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2740.6,154.6 3003.2,141.9 2980.0,0.0 6340.0,0.0 6340.0,7795.0 3528.3,7795.0 3342.7,7063.2 868.9,7025.1 876.5,6385.4 -0.0,3036.4 -0.0,453.4 2864.2,430.6 2740.6,154.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0112/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1084.0,
-                3019.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0653441,
-                29.9471396
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2184.0,
-                7047.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0652822,
-                29.9452167
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0113/georef",
       "type": "Annotation",
       "@context": [
@@ -1156,8 +5107,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1176,7 +5127,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4077.3,6851.0 580.1,7795.0 590.7,232.8 5711.8,227.7 5706.0,7557.8 4850.7,7795.0 4073.7,7795.0 4077.3,6851.0\" /></svg>"
+          "value": "<svg><polygon points=\"5711.8,227.7 5707.3,7795.0 4073.7,7795.0 4076.8,6972.1 3646.0,6971.2 580.1,7795.0 590.7,232.8 5711.8,227.7\" /></svg>"
         }
       },
       "body": {
@@ -1249,8 +5200,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1269,7 +5220,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"808.8,3241.6 797.4,819.9 3579.0,68.9 4251.6,0.0 4250.3,816.2 5021.0,814.6 5868.9,577.6 5877.6,1749.3 5141.9,1951.1 5197.4,4790.9 6305.0,4769.2 6305.0,7795.0 0.0,7795.0 0.0,3474.9 808.8,3241.6\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,3474.9 808.8,3241.6 797.4,823.3 3824.3,0.0 4251.6,0.0 4249.9,1030.1 5021.0,814.6 5870.7,812.9 5877.6,1749.3 5077.9,1968.7 5086.7,4775.8 6305.0,4767.9 6305.0,7795.0 0.0,7795.0 0.0,3474.9\" /></svg>"
         }
       },
       "body": {
@@ -1325,99 +5276,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p115",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6349
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"7.4,3670.0 606.4,2039.4 820.7,228.5 6349.0,192.5 6349.0,6816.2 4026.4,7737.1 3666.2,7534.7 0.0,7565.5 7.4,3670.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0115/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2228.4,
-                2688.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0701922,
-                29.9419857
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2228.4,
-                7552.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0677425,
-                29.9414266
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0116/georef",
       "type": "Annotation",
       "@context": [
@@ -1435,8 +5293,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1528,8 +5386,8 @@
           "value": "3"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1548,7 +5406,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,1035.4 416.8,0.0 6336.0,0.0 5972.0,878.9 6248.0,986.7 6141.7,5330.9 5702.6,5331.1 5704.5,7795.0 0.0,7795.0 0.0,2636.5 156.2,2577.5 0.0,2516.6 0.0,1035.4\" /></svg>"
+          "value": "<svg><polygon points=\"156.2,2577.5 0.0,2516.6 0.0,1035.1 416.8,0.0 3759.3,0.0 6248.0,986.7 6141.7,5330.9 5702.6,5331.1 5704.5,7795.0 0.0,7795.0 8.6,2636.4 156.2,2577.5\" /></svg>"
         }
       },
       "body": {
@@ -1621,8 +5479,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1641,7 +5499,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1070.0,3071.6 1238.1,3138.8 2483.6,0.0 6288.0,0.0 6288.0,7796.0 3148.2,7796.0 3212.0,6198.1 286.3,5043.0 1070.0,3071.6\" /></svg>"
+          "value": "<svg><polygon points=\"1070.0,3071.6 1237.6,3138.7 2483.1,0.0 6288.0,0.0 6288.0,7796.0 3223.6,7796.0 3212.0,6198.1 286.3,5043.0 1070.0,3071.6\" /></svg>"
         }
       },
       "body": {
@@ -1714,8 +5572,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1734,7 +5592,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1304.1,7795.0 1312.2,543.9 4753.6,550.5 5529.1,2783.8 5517.5,7281.7 5307.2,7280.1 5302.1,7795.0 1304.1,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"5302.1,7795.0 1304.1,7795.0 1312.2,543.9 4753.6,550.5 5404.8,2174.3 5529.1,2783.8 5517.5,7281.7 5307.2,7280.1 5302.1,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -1807,8 +5665,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1827,7 +5685,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"594.1,7276.5 536.1,2799.6 269.5,2068.8 3131.7,894.2 2764.6,0.0 6481.0,0.0 6481.0,6840.6 3221.1,6859.2 3228.5,7255.1 594.1,7276.5\" /></svg>"
+          "value": "<svg><polygon points=\"594.1,7276.5 536.1,2799.6 338.3,2040.6 3131.7,894.2 2764.6,0.0 6481.0,0.0 6481.0,6840.6 3221.1,6859.2 3228.5,7255.1 594.1,7276.5\" /></svg>"
         }
       },
       "body": {
@@ -1900,8 +5758,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1920,7 +5778,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4302.0,5643.3 4318.4,7796.0 -0.0,7796.0 372.1,3286.4 -0.0,3063.3 -0.0,433.6 6245.0,406.4 6245.0,6836.9 4302.0,5643.3\" /></svg>"
+          "value": "<svg><polygon points=\"4317.7,7796.0 -0.0,7796.0 -0.0,3063.2 -0.0,3063.2 -0.0,433.6 6245.0,407.0 6245.0,6838.1 4301.3,5643.7 4317.7,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -1993,8 +5851,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2086,8 +5944,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2106,7 +5964,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6146.0,1134.6 6146.0,7796.0 -0.0,7796.0 -0.0,-0.0 188.9,0.0 137.2,798.6 6146.0,1134.6\" /></svg>"
+          "value": "<svg><polygon points=\"6146.0,5737.1 6146.0,7796.0 -0.0,7796.0 -0.0,-0.0 188.9,0.0 137.2,798.6 6146.0,1104.0 6146.0,5737.1 6146.0,5737.1\" /></svg>"
         }
       },
       "body": {
@@ -2179,8 +6037,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2272,8 +6130,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2292,7 +6150,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7408.6 -0.0,374.9 5904.5,342.0 6051.1,3488.2 5370.3,3752.2 5457.7,4757.5 6126.8,4752.6 6239.5,7343.4 5828.2,7354.0 5871.4,7796.0 5641.8,7796.0 5613.5,7359.3 -0.0,7408.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,374.9 6335.0,296.5 6335.0,7320.7 -0.0,7408.6 -0.0,374.9\" /></svg>"
         }
       },
       "body": {
@@ -2365,8 +6223,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2385,7 +6243,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"663.9,4808.7 -0.0,4755.9 -0.0,3751.7 697.8,3548.6 823.9,416.7 3912.7,325.0 3506.5,550.1 4629.5,2233.4 5464.4,1667.1 5504.4,2734.9 6444.0,2108.1 6444.0,6887.4 5708.0,7395.6 5670.2,6914.3 3120.0,7007.7 552.2,7387.1 663.9,4808.7\" /></svg>"
+          "value": "<svg><polygon points=\"3788.1,362.2 3506.5,550.1 4629.6,2233.3 5464.4,1667.1 5504.4,2735.5 6444.0,2108.7 6444.0,6887.4 5708.0,7395.6 5670.2,6914.3 3120.0,7007.7 552.2,7387.1 1254.6,408.8 3788.1,362.2\" /></svg>"
         }
       },
       "body": {
@@ -2458,8 +6316,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2478,7 +6336,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5819.0,608.9 6032.7,7247.4 168.7,7216.7 162.4,7795.0 -0.0,7795.0 55.2,606.3 5819.0,608.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,605.6 682.4,614.2 839.6,615.3 3127.6,593.6 5819.0,608.9 6032.7,7247.4 168.7,7216.7 162.4,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -2534,99 +6392,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p132",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "23"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6444
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"470.5,638.1 4352.9,673.0 4950.1,353.1 6013.5,1984.3 6444.0,1704.2 6444.0,6799.5 5652.0,5583.6 4617.4,6251.1 4624.0,6454.1 3343.9,7231.3 77.4,7278.1 470.5,638.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0132/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5748.0,
-                5728.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0708129,
-                29.930899
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4624.0,
-                6456.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0709895,
-                29.9303133
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0133/georef",
       "type": "Annotation",
       "@context": [
@@ -2644,8 +6409,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2664,7 +6429,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1527.1,4277.4 4308.7,0.0 6015.6,0.0 6016.5,317.2 6358.0,317.0 6358.0,5555.8 6032.2,5557.1 6037.8,7437.1 981.4,7436.7 984.2,7795.0 0.0,7795.0 0.0,5746.4 1528.0,5752.1 1527.1,4277.4\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,5746.9 1528.0,5752.6 1526.2,2824.2 293.4,2819.7 1805.7,318.8 3794.8,310.0 3794.5,0.0 6015.6,0.0 6016.5,317.2 6358.0,317.0 6358.0,5555.8 6032.2,5557.1 6037.8,7437.1 0.0,7429.9 0.0,5746.9\" /></svg>"
         }
       },
       "body": {
@@ -2737,8 +6502,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2757,7 +6522,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1261.0,5613.2 1280.0,337.0 5505.3,349.5 5498.0,1440.7 4944.3,1441.0 4948.9,7796.0 3192.5,7796.0 3191.4,7464.1 931.6,7506.8 932.8,5613.4 1261.0,5613.2\" /></svg>"
+          "value": "<svg><polygon points=\"1280.0,337.0 936.0,336.0 936.2,16.5 5504.9,0.0 5505.3,349.5 5498.0,1440.9 4944.4,1441.2 4948.6,7796.0 3192.5,7796.0 3191.4,7464.1 931.6,7506.8 932.8,5613.4 1261.0,5613.2 1280.0,337.0\" /></svg>"
         }
       },
       "body": {
@@ -2830,8 +6595,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2850,7 +6615,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"182.8,7278.5 185.3,6745.7 -0.0,6745.3 -0.0,3954.2 1061.8,804.5 3769.6,816.5 3754.3,0.0 6321.0,0.0 6321.0,7263.5 182.8,7278.5\" /></svg>"
+          "value": "<svg><polygon points=\"217.4,2963.0 213.5,3320.8 852.5,1425.4 3287.9,1455.9 3293.8,805.9 6321.0,813.8 6321.0,7263.5 182.8,7278.5 185.3,6745.6 -0.0,6745.3 -0.0,3954.2 217.4,2963.0\" /></svg>"
         }
       },
       "body": {
@@ -2920,11 +6685,11 @@
         },
         {
           "label": "intersections",
-          "value": "7"
+          "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2943,7 +6708,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6443.0,7429.1 6263.9,7428.6 6263.7,7796.0 -0.0,7796.0 -0.0,7250.0 318.0,7252.4 344.2,19.8 6443.0,0.0 6443.0,7429.1\" /></svg>"
+          "value": "<svg><polygon points=\"341.1,830.2 1506.9,832.7 1549.4,0.0 5600.1,0.0 6443.0,2029.7 6443.0,7428.8 6264.4,7428.4 6264.2,7796.0 -0.0,7796.0 -0.0,7250.1 317.9,7252.5 341.1,830.2\" /></svg>"
         }
       },
       "body": {
@@ -2999,192 +6764,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p137",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6349
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2845.4,6272.2 2816.8,7796.0 2662.8,7796.0 2679.7,7054.8 932.2,6438.4 2206.0,2901.9 2818.6,3075.0 2796.7,4118.8 3115.7,3264.2 3139.3,1128.7 1945.0,683.2 2994.1,700.6 3147.7,372.9 4824.6,614.0 6349.0,1218.3 6349.0,7100.2 3065.3,7021.4 3078.2,6276.5 2845.4,6272.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0137/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1496.2,
-                4844.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0730958,
-                29.9397251
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3120.5,
-                3044.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0719774,
-                29.9403949
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p139",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6340
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1388.3,3923.5 1384.3,3617.7 222.5,3633.2 188.1,893.1 6340.0,789.6 6340.0,7050.1 4211.9,7795.0 3245.7,7795.0 4289.7,7430.2 4234.6,6758.4 253.3,6804.0 226.1,3931.6 1388.3,3923.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0139/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1972.0,
-                859.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.075719,
-                29.941206
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                224.0,
-                3755.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0749595,
-                29.9398011
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0140/georef",
       "type": "Annotation",
       "@context": [
@@ -3202,8 +6781,8 @@
           "value": "23"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3222,7 +6801,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4341.9,2508.4 4677.1,2687.9 5821.3,0.0 6031.2,0.0 6001.1,7411.1 357.9,7400.1 0.0,7239.7 0.0,6103.3 1670.3,1390.8 4436.7,2272.6 4341.9,2508.4\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,6251.5 1678.8,1393.6 4800.6,2393.7 5821.3,0.0 6031.2,0.0 6001.1,7411.1 357.9,7400.1 0.0,7239.7 0.0,6251.5\" /></svg>"
         }
       },
       "body": {
@@ -3295,8 +6874,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3315,7 +6894,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"339.9,7795.0 -0.0,7795.0 0.0,0.0 310.0,-0.0 302.5,1177.5 5203.2,1179.5 5454.3,1934.6 5609.9,1878.9 5087.4,328.8 5324.2,249.0 5580.7,1006.4 6353.0,753.0 6353.0,4083.1 6353.0,7795.0 6172.4,7795.0 6163.1,6768.9 330.8,6750.3 339.9,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"339.9,7795.0 -0.0,7795.0 0.0,0.0 310.0,-0.0 302.5,1177.5 5203.2,1179.5 4873.6,-0.0 5239.9,-0.0 5580.7,1006.4 6353.0,748.4 6353.0,7795.0 6172.4,7795.0 6163.1,6768.9 330.8,6750.3 339.9,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -3388,8 +6967,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3408,7 +6987,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"446.5,6062.4 404.5,2999.4 73.2,2783.2 -0.0,2782.6 -0.0,-0.0 820.7,0.0 819.2,534.6 5570.9,505.2 5579.5,5044.0 5262.2,5045.3 5265.1,7267.8 2309.3,7194.7 446.5,6062.4\" /></svg>"
+          "value": "<svg><polygon points=\"403.1,2893.0 -0.0,2865.5 -0.0,-0.0 820.7,0.0 819.2,534.6 5223.8,507.3 5265.1,7267.8 2309.3,7194.7 446.5,6062.4 403.1,2893.0\" /></svg>"
         }
       },
       "body": {
@@ -3481,8 +7060,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3501,7 +7080,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7200.0 -0.0,-0.0 114.5,0.0 109.4,877.8 5507.0,877.5 5896.7,7163.2 -0.0,7200.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7200.0 -0.0,-0.0 159.0,0.0 148.0,877.8 5507.0,877.5 5793.2,7172.3 -0.0,7200.0\" /></svg>"
         }
       },
       "body": {
@@ -3557,192 +7136,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p144",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6426
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7109.0 202.5,775.6 3796.0,807.4 5622.4,343.6 5852.0,702.4 6426.0,556.3 6426.0,1998.9 3862.1,3720.7 3932.3,5917.0 4420.6,6808.4 3818.1,7133.0 -0.0,7109.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0144/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1976.6,
-                2615.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0754149,
-                29.9330997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3817.2,
-                2615.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0747115,
-                29.9336558
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p145",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6372
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6221.0,7795.0 -0.0,7795.0 -0.0,1258.4 6037.8,733.8 6189.8,2484.2 6221.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0145/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3316.0,
-                4851.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0786481,
-                29.9335828
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6204.0,
-                4851.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0777357,
-                29.9325206
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0146/georef",
       "type": "Annotation",
       "@context": [
@@ -3760,8 +7153,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3780,7 +7173,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,5908.1 171.5,4358.4 -0.0,4314.6 -0.0,1659.4 185.5,1658.4 170.5,616.7 5985.2,602.5 6000.2,1625.5 6180.3,1624.5 6171.2,-0.0 6432.0,-0.0 6432.0,3695.0 6032.5,3827.3 6031.6,5688.1 5586.1,7405.1 -0.0,5908.1\" /></svg>"
+          "value": "<svg><polygon points=\"5586.1,7405.1 -0.0,5908.1 171.5,4358.4 -0.0,4314.6 -0.0,1659.4 185.5,1658.4 170.5,616.7 5985.2,602.5 6000.2,1625.5 6180.3,1624.5 6171.2,-0.0 6432.0,-0.0 6432.0,3695.0 6032.5,3827.3 6031.6,5688.1 5586.1,7405.1\" /></svg>"
         }
       },
       "body": {
@@ -3836,192 +7229,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p147",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "17"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6396
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"450.2,0.0 441.1,1017.6 4608.3,1336.0 6396.0,1101.3 6396.0,3973.2 6385.1,3974.3 6330.1,6995.0 -0.0,6934.4 0.0,-0.0 450.2,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0147/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                376.0,
-                4751.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0813341,
-                29.9349573
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2732.0,
-                1203.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0814841,
-                29.9368699
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p148",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6453
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1983.0,0.0 3719.6,0.0 5718.4,5237.7 1788.9,6916.1 1809.7,7119.7 44.0,7349.3 -0.0,484.9 1983.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0148/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3808.6,
-                6187.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0770518,
-                29.9369759
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1788.3,
-                6919.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0775951,
-                29.936274
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0149/georef",
       "type": "Annotation",
       "@context": [
@@ -4039,8 +7246,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4059,7 +7266,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"892.9,-0.0 5776.6,-0.0 5769.4,1966.5 6380.0,1968.3 6380.0,2093.1 5769.7,2090.8 5756.7,7795.0 765.3,7795.0 931.6,7099.7 901.3,2241.1 -0.0,2240.8 -0.0,1818.5 899.7,1829.2 892.9,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"931.6,7099.7 901.3,2241.1 -0.0,2240.8 -0.0,1818.5 899.7,1829.2 892.9,-0.0 5776.6,-0.0 5769.4,1966.5 6380.0,1968.3 6380.0,2093.1 5769.7,2090.8 5803.7,7579.6 3029.7,7584.5 931.6,7099.7\" /></svg>"
         }
       },
       "body": {
@@ -4132,8 +7339,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4152,7 +7359,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5842.0,6511.2 970.2,6485.7 385.6,7795.0 416.7,2822.7 1026.0,2827.4 1026.5,2702.9 416.9,2698.6 437.5,-0.0 3136.2,-0.0 3132.9,903.9 5912.9,931.0 5842.0,6511.2\" /></svg>"
+          "value": "<svg><polygon points=\"412.2,6482.2 416.7,2822.7 1026.0,2827.4 1026.5,2702.9 416.9,2698.6 437.5,-0.0 3136.2,-0.0 3132.9,903.9 5912.9,931.0 5842.0,6511.2 412.2,6482.2\" /></svg>"
         }
       },
       "body": {
@@ -4225,8 +7432,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4245,7 +7452,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1447.7,5046.9 1396.3,206.2 5267.5,158.8 5272.5,2101.9 4771.5,2107.5 4773.9,2281.4 5273.0,2276.5 5317.1,7710.5 2217.5,7721.1 2178.5,5041.9 1447.7,5046.9\" /></svg>"
+          "value": "<svg><polygon points=\"1396.3,206.2 5267.5,158.8 5272.5,2101.9 4880.9,2106.2 4883.7,2280.3 5273.0,2276.5 5317.1,7710.5 2217.5,7721.1 2178.4,5041.9 1447.7,5046.9 1396.3,206.2\" /></svg>"
         }
       },
       "body": {
@@ -4301,99 +7508,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p152",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6443
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1889.6,197.2 1862.5,0.0 6104.1,0.0 5972.3,168.3 6088.2,164.6 6091.6,2362.1 5736.2,2351.8 5664.1,3309.3 6443.0,4333.1 6443.0,4853.4 6124.1,4958.2 6165.4,5085.1 5949.6,5070.8 5721.9,7796.0 5358.6,7796.0 5373.9,7553.1 455.9,7588.0 485.2,2304.6 -0.0,2302.8 -0.0,2133.6 487.0,2134.8 508.0,245.8 1889.6,197.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0152/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                455.9,
-                4944.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0762884,
-                29.9427094
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                455.9,
-                7588.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.075084,
-                29.942043
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0153/georef",
       "type": "Annotation",
       "@context": [
@@ -4411,8 +7525,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4520,8 +7634,8 @@
           "value": "7796.0"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4540,7 +7654,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"325.5,5264.9 -0.0,5726.6 -0.0,2145.4 778.4,0.0 2935.6,0.0 4538.0,606.0 4822.5,920.7 6443.0,1273.9 6443.0,3358.8 4905.3,7796.0 2860.8,7796.0 2049.9,7076.6 2302.1,6764.2 325.5,5264.9\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,5726.6 -0.0,2145.3 778.4,0.0 2853.6,0.0 4538.1,606.0 4822.6,920.7 6443.0,1273.9 6443.0,3359.0 4905.4,7796.0 2860.9,7796.0 2049.9,7076.6 2302.2,6764.2 293.5,5310.3 -0.0,5726.6\" /></svg>"
         }
       },
       "body": {
@@ -4613,8 +7727,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4633,7 +7747,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"52.4,44.6 1263.4,0.0 1230.1,267.4 5891.2,1149.1 5894.2,4061.1 6283.9,4149.7 6261.9,4448.6 6378.0,4461.4 6189.2,7796.0 -0.0,7796.0 52.4,44.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7796.0 -0.0,32.6 5891.1,1149.1 5898.1,7796.0 -0.0,7796.0\" /></svg>"
         }
       },
       "body": {
@@ -4706,8 +7820,8 @@
           "value": "4"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4726,7 +7840,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"271.5,7795.0 526.7,3929.2 368.0,3911.6 390.4,3611.8 -0.0,3522.7 -0.0,603.2 3297.7,1138.6 3363.4,1645.4 3866.1,1262.1 5814.2,1593.6 5811.7,7795.0 271.5,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"271.5,7795.0 291.7,7267.4 -0.0,7267.1 -0.0,603.2 3297.7,1138.6 3363.5,1645.4 3866.2,1262.1 5814.2,1593.6 5811.7,7795.0 271.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -4782,444 +7896,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p157",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "1"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6425
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5891.0,0.0 6124.9,0.0 6425.0,1626.5 6425.0,7795.0 1530.8,7795.0 349.2,2510.3 6043.3,896.1 5891.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0157/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "polynomial",
-          "options": {
-            "order": 1
-          }
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.08078122497382,
-                29.95428830802305
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6425.0,
-                0.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07873927963189,
-                29.956601551217997
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6425.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07549937538832,
-                29.95445438419847
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                0.0,
-                7795.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "corner"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07754132073026,
-                29.952141141003526
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6169.0,
-                332.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.078683,
-                29.956417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p158",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6373
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"363.5,476.2 5767.6,439.8 5777.3,0.0 6373.0,0.0 6373.0,7563.8 1396.7,7532.3 1440.0,7795.0 1161.0,7795.0 785.8,6976.2 643.9,2527.4 363.5,476.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0158/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3408.5,
-                6087.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.07536,
-                29.955929
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3408.5,
-                471.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.077693,
-                29.957514
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p159",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6424
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6346.7,6949.3 6120.1,6885.0 6077.8,7224.4 6021.4,7795.0 354.9,7795.0 182.3,6545.2 161.4,6600.6 -0.0,6622.3 -0.0,3416.9 1255.1,3787.0 1158.1,1156.6 6424.0,551.4 6424.0,6234.1 6346.7,6949.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0159/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                328.0,
-                4835.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.081006,
-                29.954323
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6296.0,
-                7283.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.078683,
-                29.956417
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p160",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "26"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6423
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1019.2,7316.1 358.5,4777.3 301.1,4782.0 -0.0,3336.7 -0.0,1186.8 3884.2,1193.6 3878.0,854.0 6161.7,839.0 6149.7,0.0 6423.0,0.0 6423.0,6788.8 6233.8,6791.1 6229.8,7215.5 1019.2,7316.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0160/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1735.7,
-                2715.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0803989,
-                29.9580493
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3955.4,
-                7275.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.077693,
-                29.957514
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0161/georef",
       "type": "Annotation",
       "@context": [
@@ -5237,8 +7913,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5257,7 +7933,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"266.8,4916.1 -0.0,4912.2 -0.0,-0.0 6414.0,0.0 6414.0,7795.0 224.5,7795.0 266.8,4916.1\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,-0.0 6414.0,0.0 6414.0,7795.0 224.5,7795.0 266.8,4916.1 -0.0,4912.2 -0.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -5330,8 +8006,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5350,7 +8026,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"637.6,0.0 3165.2,0.0 2765.6,1191.2 5841.6,1304.6 6355.2,7795.0 4030.2,7795.0 4258.0,6712.8 833.3,5991.6 833.3,5991.6 415.8,5903.7 1042.1,4140.0 1161.0,3085.5 841.3,3049.0 637.6,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5806.7,1502.0 6355.2,7795.0 4030.2,7795.0 4258.0,6712.8 850.3,5995.2 1037.5,794.7 5806.7,1502.0\" /></svg>"
         }
       },
       "body": {
@@ -5423,8 +8099,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5443,7 +8119,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3587.1,6454.5 -0.0,6811.3 -0.0,1974.6 2995.7,1672.4 4421.6,5031.1 5699.6,4488.7 3587.1,6454.5\" /></svg>"
+          "value": "<svg><polygon points=\"4421.6,5031.1 5699.7,4488.6 3479.8,6554.5 740.5,6914.0 242.3,1950.2 2995.7,1672.4 4421.6,5031.1\" /></svg>"
         }
       },
       "body": {
@@ -5516,8 +8192,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5536,7 +8212,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"445.8,1447.4 6053.5,1428.3 6090.3,6655.1 4385.1,6669.3 4391.5,5774.9 3971.8,5776.8 3975.7,6672.8 487.6,6702.1 493.9,3795.9 -0.0,3858.2 -0.0,3126.9 444.8,1171.5 445.8,1447.4\" /></svg>"
+          "value": "<svg><polygon points=\"6053.5,1428.0 6053.5,1428.0 6090.3,6655.1 4385.1,6669.3 4391.5,5774.9 3971.8,5776.8 3975.7,6672.8 487.6,6702.1 493.9,3795.9 -0.0,3858.2 -0.0,3126.9 475.3,1037.8 470.3,1513.2 6053.5,1428.0\" /></svg>"
         }
       },
       "body": {
@@ -5609,8 +8285,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5629,7 +8305,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6659.7 10.5,1180.1 5326.5,1115.8 5316.7,1560.3 6185.1,1559.9 5697.4,6420.4 5309.4,6420.1 5336.8,6620.3 -0.0,6659.7\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6659.7 10.6,1180.1 5326.5,1115.8 5316.7,1560.3 6431.0,1559.7 6431.0,6598.3 -0.0,6659.7\" /></svg>"
         }
       },
       "body": {
@@ -5702,8 +8378,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5722,7 +8398,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5401.6,7795.0 1908.3,7795.0 1910.6,7533.2 1216.4,7535.0 1184.0,3399.7 1036.6,3404.3 875.0,2148.2 2625.2,1949.3 3315.6,1702.3 3089.9,1257.1 5490.6,404.2 5401.6,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"5417.5,7795.0 1908.3,7795.0 1910.6,7533.2 1216.4,7535.0 1184.0,3399.7 1036.6,3404.3 875.0,2148.2 2625.2,1949.3 3315.6,1702.3 3089.9,1257.1 5485.5,406.0 5417.5,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5778,99 +8454,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p168",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6442
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,360.3 345.5,231.9 841.9,1490.4 933.5,2201.2 5612.3,425.1 5847.0,1554.7 5785.2,1583.8 6051.1,3366.1 5805.7,7535.8 4788.1,7544.4 4792.5,7795.0 -0.0,7795.0 -0.0,360.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0168/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                264.1,
-                7555.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0842066,
-                29.93831
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5953.8,
-                5243.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0814841,
-                29.9368699
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0169/georef",
       "type": "Annotation",
       "@context": [
@@ -5888,8 +8471,8 @@
           "value": "22"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5908,7 +8491,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,1229.6 753.0,1238.9 4170.0,1215.5 4161.9,782.7 5334.8,353.9 6119.2,6711.1 4862.7,6884.0 4868.7,7031.4 727.7,7100.4 735.7,7795.0 -0.0,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 0.0,0.0 125.3,0.0 125.8,1231.2 4170.0,1215.5 4161.9,782.7 5334.8,353.9 6119.2,6711.1 4862.7,6884.0 4868.7,7031.4 727.7,7100.4 735.7,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -5981,8 +8564,8 @@
           "value": "25"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6001,7 +8584,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"632.5,814.9 1959.0,821.3 4048.5,6437.7 4056.4,6866.2 -0.0,6880.3 -0.0,0.0 633.0,0.0 632.5,814.9\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,0.0 5285.1,0.0 5350.5,172.3 3773.0,694.2 3774.1,983.5 2020.0,985.5 4048.5,6437.7 4056.4,6866.2 -0.0,6880.3 0.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -6074,8 +8657,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6094,7 +8677,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"539.2,469.1 5988.2,518.7 5973.7,7795.0 -0.0,7795.0 623.7,6097.6 512.0,6056.6 572.8,4401.8 -0.0,4405.6 -0.0,3981.8 570.2,3990.8 539.2,469.1\" /></svg>"
+          "value": "<svg><polygon points=\"546.4,1288.7 -0.0,1081.1 49.4,465.3 5988.2,518.7 5973.7,7795.0 174.6,7795.0 782.6,6156.0 512.0,6056.6 572.8,4401.8 -0.0,4405.6 -0.0,3981.8 570.2,3990.8 546.4,1288.7\" /></svg>"
         }
       },
       "body": {
@@ -6150,99 +8733,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p172",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6476
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"218.2,6360.3 226.7,339.9 6132.7,352.6 6136.9,2171.4 6476.0,2172.5 6476.0,7795.0 218.2,6360.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0172/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2008.0,
-                332.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0832916,
-                29.945462
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                228.0,
-                5923.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0856569,
-                29.94377
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0173/georef",
       "type": "Annotation",
       "@context": [
@@ -6260,8 +8750,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6280,7 +8770,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7519.0 0.0,-0.0 6474.0,-0.0 6474.0,2531.7 5749.0,2453.8 5734.4,5415.2 5734.4,5415.2 5723.5,7627.3 -0.0,7519.0\" /></svg>"
+          "value": "<svg><polygon points=\"5898.1,7630.6 -0.0,7519.0 0.0,0.0 6474.0,-0.0 6474.0,2531.7 5749.0,2453.8 5734.4,5415.2 5910.7,5416.1 5898.1,7630.6\" /></svg>"
         }
       },
       "body": {
@@ -6353,8 +8843,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6373,7 +8863,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6039.6,7637.0 -0.0,7588.8 -0.0,2421.5 724.4,2495.7 712.1,-0.0 4763.5,-0.0 4945.0,584.7 6421.0,126.8 6421.0,4078.8 5971.4,4068.6 6039.6,7637.0\" /></svg>"
+          "value": "<svg><polygon points=\"6039.6,7637.0 174.3,7591.2 176.0,5379.3 -0.0,5379.3 -0.0,2421.5 724.4,2495.7 712.1,-0.0 4763.5,-0.0 4945.0,584.7 6421.0,126.8 6421.0,4078.8 5971.4,4068.6 6039.6,7637.0\" /></svg>"
         }
       },
       "body": {
@@ -6429,192 +8919,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p175",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "36"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6467
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6467.0,7765.5 -0.0,7795.0 -0.0,530.0 1773.6,-0.0 2146.8,1041.2 2996.5,731.1 2693.1,-0.0 4726.3,-0.0 5642.6,2416.6 5077.4,2616.5 5232.7,3034.3 5795.7,2820.7 6341.9,4474.2 6467.0,4473.8 6467.0,7765.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0175/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1379.8,
-                5367.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0898782,
-                29.9466074
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4335.3,
-                5367.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0889983,
-                29.9455901
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p176",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "3"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6421
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3166.4,7795.0 2449.4,7795.0 637.9,7795.0 -0.0,7795.0 -0.0,923.3 29.8,-0.0 6421.0,-0.0 6421.0,489.4 4653.1,7720.6 3166.4,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0176/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3124.5,
-                6831.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0872464,
-                29.947698
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                932.1,
-                6831.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.088397,
-                29.948348
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0177/georef",
       "type": "Annotation",
       "@context": [
@@ -6632,8 +8936,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6652,7 +8956,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6344.3,1460.3 6537.0,1425.4 6360.6,1643.4 6537.0,7749.0 -0.0,7795.0 0.0,0.0 6211.4,0.0 6344.3,1460.3\" /></svg>"
+          "value": "<svg><polygon points=\"6211.4,0.0 6537.0,3646.1 6537.0,7749.1 -0.0,7795.0 -0.0,-0.0 6211.4,0.0\" /></svg>"
         }
       },
       "body": {
@@ -6708,378 +9012,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p179 [1]",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "10"
-        },
-        {
-          "label": "intersections",
-          "value": "57"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6537
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1453.6,0.0 4866.2,0.0 6489.2,191.4 6457.5,325.7 6263.0,286.0 6067.9,6988.6 3401.8,7466.3 3401.3,7795.0 2316.8,7795.0 352.7,7337.5 1453.6,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0179/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2880.4,
-                1743.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0859187,
-                29.9548331
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6265.0,
-                288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0858303,
-                29.9565209
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p180",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6461
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6190.8,2370.6 6247.7,478.3 4028.9,0.0 6461.0,95.9 6461.0,7012.5 6187.6,7795.0 5688.3,7795.0 5626.9,6797.5 122.7,7775.7 410.0,1106.3 6190.8,2370.6\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0180/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3232.5,
-                3895.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0838491,
-                29.9571531
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                260.0,
-                4231.5
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.084359,
-                29.9558475
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p181",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6537
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2886.8,0.0 6537.0,654.3 6537.0,5758.3 6233.8,7795.0 296.3,7795.0 416.2,6445.6 -0.0,6370.2 0.0,0.0 2886.8,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0181/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                356.1,
-                4895.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0882572,
-                29.9552086
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                352.1,
-                7159.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.087376,
-                29.954773
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p182",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6408
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,801.4 4608.7,690.7 4826.9,697.3 4860.6,870.2 5942.1,852.8 6045.0,4717.8 5456.7,5163.1 5872.4,7062.8 -0.0,7241.0 -0.0,801.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0182/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2400.0,
-                4831.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.085948,
-                29.958111
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1608.0,
-                759.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.087843,
-                29.958988
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0183/georef",
       "type": "Annotation",
       "@context": [
@@ -7097,8 +9029,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7117,7 +9049,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6469.0,-0.0 6449.5,7795.0 304.6,7795.0 244.0,312.0 663.0,312.7 661.3,-0.0 6469.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"6469.0,-0.0 6449.5,7795.0 304.6,7795.0 244.0,312.0 661.2,312.7 659.7,-0.0 6469.0,-0.0\" /></svg>"
         }
       },
       "body": {
@@ -7190,8 +9122,8 @@
           "value": "21"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7210,7 +9142,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5321.0,325.1 6135.1,312.0 6153.5,2528.1 6483.0,2521.5 6483.0,6215.5 148.9,7774.0 -0.0,0.0 5320.6,59.8 5321.0,325.1\" /></svg>"
+          "value": "<svg><polygon points=\"6483.0,2521.5 6483.0,6509.5 149.1,7724.1 -0.0,0.0 6483.0,-0.0 6483.0,139.9 5526.4,140.2 5527.7,321.7 6135.1,312.0 6153.0,2467.7 6483.0,2521.5\" /></svg>"
         }
       },
       "body": {
@@ -7266,192 +9198,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p185",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6542
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"610.1,7373.2 609.8,7560.8 35.8,7557.7 -0.0,0.0 6372.0,-0.0 6375.7,301.9 6122.7,300.8 6152.2,4987.7 6427.0,4988.4 6454.3,7593.9 6096.6,7591.4 6092.4,7410.9 610.1,7373.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0185/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4354.7,
-                4991.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0896826,
-                29.9643308
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2655.2,
-                288.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0888853,
-                29.9664772
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p186",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "8"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6490
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"274.9,5005.7 -0.0,5003.3 -0.0,317.4 253.0,320.1 251.2,-0.0 6490.0,-0.0 6490.0,421.0 6068.0,418.0 6089.4,7795.0 285.3,7795.0 274.9,5005.7\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0186/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3565.1,
-                5039.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.087477,
-                29.962849
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3565.1,
-                372.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0860036,
-                29.964523
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0187/georef",
       "type": "Annotation",
       "@context": [
@@ -7469,8 +9215,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7489,7 +9235,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6529.0,4852.4 6529.0,7627.6 5464.0,7638.4 5517.7,7795.0 1324.5,7677.6 848.0,326.9 5627.4,214.6 6529.0,4852.4\" /></svg>"
+          "value": "<svg><polygon points=\"761.5,403.3 5627.4,214.6 6529.0,4852.4 6529.0,7627.6 6257.4,7630.3 6243.6,6840.5 1389.6,6925.5 761.5,403.3\" /></svg>"
         }
       },
       "body": {
@@ -7545,192 +9291,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p188",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/info.json",
-          "type": "ImageService2",
-          "height": 7796,
-          "width": 6483
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5795.7,5580.4 5646.5,5581.6 5669.9,7796.0 4651.9,7796.0 4622.8,7632.8 4417.6,7623.2 1091.4,7648.0 1092.5,4875.2 183.7,174.7 5882.1,37.1 5707.9,91.0 5795.7,5580.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0188/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1235.8,
-                5620.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.088838,
-                29.959452
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4519.3,
-                7628.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.086852,
-                29.960089
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p189",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,6471.8 -0.0,7513.7 -0.0,187.3 586.3,199.0 589.3,7.4 6188.7,126.7 6190.4,311.2 6500.0,317.8 6500.0,6471.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0189/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                6168.0,
-                3367.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0907352,
-                29.9618496
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2592.0,
-                7103.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.093336,
-                29.961476
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0190/georef",
       "type": "Annotation",
       "@context": [
@@ -7748,8 +9308,8 @@
           "value": "5"
         }
       ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
+      "created": "2026-07-31T00:04:23Z",
+      "modified": "2026-07-31T00:04:23Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7768,7 +9328,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6026.2,7795.0 -0.0,7795.0 -0.0,-0.0 179.5,-0.0 176.9,1036.8 6053.5,109.8 6026.2,7795.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7795.0 -0.0,-0.0 127.7,-0.0 108.6,1047.4 6053.5,109.8 6084.3,4853.3 6306.3,7795.0 -0.0,7795.0\" /></svg>"
         }
       },
       "body": {
@@ -7805,99 +9365,6 @@
               "resourceCoords": [
                 6132.0,
                 6095.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.093526,
-                29.9582782
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1896 | Vol. 2 p191",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "7"
-        }
-      ],
-      "created": "2026-07-18T02:34:29Z",
-      "modified": "2026-07-18T02:34:29Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/info.json",
-          "type": "ImageService2",
-          "height": 7795,
-          "width": 6500
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"6500.0,7795.0 -0.0,7795.0 -0.0,-0.0 6500.0,14.0 6500.0,7795.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376189502:03376_02_1895-0191/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3484.0,
-                7655.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.090733,
-                29.95573
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5072.0,
-                140.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",

--- a/gallery/new_orleans_la_1951_vol_5.iiif.json
+++ b/gallery/new_orleans_la_1951_vol_5.iiif.json
@@ -17,15 +17,15 @@
       "metadata": [
         {
           "label": "streets",
-          "value": "7"
+          "value": "0"
         },
         {
           "label": "intersections",
-          "value": "8"
+          "value": "0"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -44,34 +44,37 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 4534.4,242.7 4533.0,2730.0 3727.0,5782.4 3760.2,7565.1 5700.0,7529.0 5700.0,8150.0 -0.0,8150.0 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,0.0 4593.8,280.7 4567.1,2767.6 3725.0,5813.8 3740.2,7596.5 5700.0,7574.1 5700.0,8150.0 -0.0,8150.0 -0.0,0.0\" /></svg>"
         }
       },
       "body": {
         "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0425/gcps",
         "type": "FeatureCollection",
         "transformation": {
-          "type": "helmert"
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
         },
         "features": [
           {
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                976.0,
-                2771.3
+                0.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1202085,
-                29.9167667
+                -90.1203951390393,
+                29.918123461955773
               ]
             }
           },
@@ -79,20 +82,4616 @@
             "type": "Feature",
             "properties": {
               "resourceCoords": [
-                2812.0,
-                419.9
+                5700.0,
+                0.0
               ],
               "creator": {
                 "id": "https://oldinsurancemaps.net/profile/danvk",
                 "type": "Person"
               },
-              "type": "gcp"
+              "type": "corner"
             },
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.118969,
-                29.917632
+                -90.1174483610522,
+                29.917544686085694
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5700.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11839666662581,
+                29.913866038698384
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.12134344461292,
+                29.914444814568462
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p427",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5681
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1076.3,3675.7 237.5,3908.9 128.5,1332.8 5155.8,0.0 5377.6,2474.3 4341.5,2766.6 5249.3,6069.4 5681.0,5925.6 5681.0,8150.0 1259.5,8150.0 1076.3,3675.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11579560224256,
+                29.9181709414871
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11297139975255,
+                29.917531778332847
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11402233751058,
+                29.91399374241219
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11684654000058,
+                29.914632905566442
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p429",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5681
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,3886.9 -0.0,689.7 3758.5,402.8 4369.4,5602.7 5681.0,5448.8 5681.0,8150.0 1948.8,8150.0 1632.1,3683.0 -0.0,3886.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11165942591865,
+                29.916822097065964
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10873713223062,
+                29.91667824948222
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5681.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10897365090673,
+                29.91301730905008
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11189594459476,
+                29.913161156633823
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p430",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5637
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5637.0,8149.0 271.6,8149.0 253.0,-0.0 5637.0,-0.0 5637.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1056545972698,
+                29.916881514481652
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10548303111379,
+                29.914411237359285
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5637.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10957443028892,
+                29.91419473356308
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10974599644494,
+                29.91666501068545
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p438",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5655
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,8149.0 334.6,6519.9 99.4,1348.7 -0.0,1350.9 -0.0,0.0 5655.0,-0.0 5655.0,8149.0 -0.0,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0438/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08656412273209,
+                29.918781934658945
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08606041034359,
+                29.9176036344617
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0880051299103,
+                29.916970253744026
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0885088422988,
+                29.918148553941272
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p440",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5655
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"2336.6,8149.0 1549.6,7949.6 1540.5,8149.0 -0.0,8149.0 -0.0,7412.2 503.3,7575.1 1118.5,0.0 5655.0,104.0 5655.0,8149.0 2336.6,8149.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09087765015666,
+                29.92120210906162
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08816279829666,
+                29.922211297348465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5655.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08649714969806,
+                29.918797653619787
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.08921200155805,
+                29.91778846533294
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p443",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5686
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"1300.3,0.0 5118.9,233.5 5026.4,7879.8 602.8,7729.1 1300.3,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09622087719985,
+                29.92670179964042
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5686.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09339883613328,
+                29.927547643895398
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5686.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09201057116726,
+                29.92401935421515
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09483261223384,
+                29.923173509960172
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p446",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5643
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"568.9,7254.7 580.5,884.6 2733.3,917.1 4334.6,720.3 5259.1,7115.0 3550.1,7288.6 568.9,7254.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09769904692433,
+                29.92645296047387
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09475859556312,
+                29.926697754252725
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5643.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09435349318319,
+                29.922990913629825
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0972939445444,
+                29.922746119850967
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p454",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5597
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5296.8,0.0 5294.3,202.8 4567.7,190.0 4506.8,8110.9 3017.0,8150.0 3035.0,6003.4 1040.7,5975.0 1100.9,128.8 420.6,116.8 422.5,0.0 5296.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10286310257715,
+                29.91971746551573
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0999664870703,
+                29.919978567015416
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5597.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09953072114921,
+                29.916295412959414
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10242733665606,
+                29.91603431145973
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p455",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5710
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"459.7,614.1 5297.2,671.8 5230.8,7182.3 368.4,7193.3 459.7,614.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10321243197266,
+                29.92297680307052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10024939950624,
+                29.92323799550444
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5710.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0998225300724,
+                29.919548834685315
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10278556253881,
+                29.919287642251394
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p458",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5647
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"318.9,931.6 5061.3,874.1 5127.7,7234.4 -0.0,7287.5 -0.0,1956.9 328.7,1951.9 318.9,931.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10229654779083,
+                29.926113307188476
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09934790298831,
+                29.926315536844438
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5647.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09901364093562,
+                29.922602810909208
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10196228573814,
+                29.922400581253246
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p472",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5673
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5437.1,6852.0 440.3,8077.9 328.6,644.1 4893.0,438.0 5437.1,6852.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11515805067982,
+                29.921187281606738
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11229115446925,
+                29.920593910749975
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5673.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11326772674626,
+                29.916999204656857
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11613462295685,
+                29.91759257551362
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p478",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5687
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"940.0,4275.4 759.8,4278.9 714.8,982.3 2216.6,971.0 2216.1,0.0 4132.2,0.0 4809.5,8150.0 934.8,8150.0 940.0,4275.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11381379063282,
+                29.92709591901383
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11091039879668,
+                29.9265042132993
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11188202283206,
+                29.92287240989053
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11478541466822,
+                29.92346411560506
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p481",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5668
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,-0.0 4537.9,0.0 4540.3,7093.4 949.3,7154.2 949.0,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11709686217168,
+                29.930293139230567
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11420379411989,
+                29.929700349738052
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5668.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11518018431003,
+                29.92607058818289
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11807325236184,
+                29.926663377675403
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p482",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5687
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4878.9,1411.1 4950.9,1871.0 5687.0,2047.3 5687.0,2422.5 4961.7,2215.1 4991.4,5216.5 4749.8,5221.7 4876.5,6407.5 934.7,6463.9 868.9,1203.3 1835.6,1461.0 2781.1,1446.8 2785.9,1311.2 4878.9,1411.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11520318022406,
+                29.929960053230715
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11230625995223,
+                29.929335635463644
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5687.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11333163106619,
+                29.925712038536712
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.116228551338,
+                29.926336456303783
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p483",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5705
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"-0.0,6800.2 111.6,5595.9 1365.5,304.5 5705.0,800.1 5705.0,7409.2 3408.5,7425.5 -0.0,6800.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11337284138372,
+                29.929647732747146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11041923874511,
+                29.929536025749613
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1106020709852,
+                29.925853696031112
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11355567362381,
+                29.925965403028645
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p484",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3144.6,5498.7 1275.5,5524.5 1199.9,800.9 4597.3,729.8 4700.0,6237.2 3144.6,5498.7\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1110322074182,
+                29.9295676631141
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10809251891241,
+                29.92941532931705
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10834249291848,
+                29.925740803605205
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11128218142427,
+                29.925893137402255
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p488",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5176.2,930.8 5201.5,7120.2 1294.3,7142.4 1231.6,945.7 5176.2,930.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10263742094514,
+                29.92892816194465
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09967726052075,
+                29.9291478470885
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09931676591829,
+                29.925447727766247
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10227692634268,
+                29.925228042622397
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p490",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5693
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"966.9,7152.0 885.1,986.6 3802.4,771.9 4719.5,6913.5 3121.3,7142.0 966.9,7152.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09813876634095,
+                29.92929982241345
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09516924999957,
+                29.929495547782846
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5693.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09484807209728,
+                29.925783737736854
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09781758843866,
+                29.92558801236746
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p491",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5707
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5707.0,654.6 5707.0,7328.1 4472.6,7327.6 4471.6,7634.0 680.4,7439.7 1348.5,458.8 5707.0,654.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09712518647713,
+                29.930029559751347
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09428813062965,
+                29.930852744276727
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5707.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09294108466062,
+                29.927316493309853
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09577814050809,
+                29.926493308784472
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p492",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5717
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5550.3,882.2 5555.6,0.0 5717.0,0.0 5717.0,7802.1 1628.9,7493.5 2129.3,829.0 5550.3,882.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09537450806846,
+                29.930543228041234
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09261613492573,
+                29.931549347674764
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0909720307945,
+                29.92811600445386
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09373040393724,
+                29.92710988482033
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p493",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5688
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4560.6,7280.8 325.1,6570.8 868.6,3187.6 886.6,56.0 5688.0,-0.0 5688.0,132.3 5161.0,129.6 5114.3,3155.4 4560.6,7280.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09432178685182,
+                29.93510158026023
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09318848116581,
+                29.932728692927576
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5688.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.097085264859,
+                29.93131117991939
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09821857054501,
+                29.933684067252045
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p494",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5717
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4662.0,7784.2 408.1,7105.4 937.3,3005.4 968.3,-0.0 5194.7,-0.0 5159.6,3430.3 4662.0,7784.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09354728266666,
+                29.93333352654992
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09241463133307,
+                29.930927489880744
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5717.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.096346437175,
+                29.929517713206046
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.0974790885086,
+                29.931923749875224
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p500",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5670
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4607.9,7151.6 1300.5,7187.2 1224.3,882.0 4569.8,836.2 4607.9,7151.6\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10439492823859,
+                29.93458962039224
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1014190664957,
+                29.93479291255893
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5670.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10108427681295,
+                29.931060262925147
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10406013855585,
+                29.93085697075846
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p502",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5705
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5351.7,813.8 5354.5,7163.5 514.3,7168.2 507.9,819.9 5351.7,813.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10412536163781,
+                29.931665788880643
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10115089142072,
+                29.93189383399089
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5705.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10077763873824,
+                29.92818557158206
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10375210895533,
+                29.92795752647181
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p507",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3563.2,180.9 3499.6,6947.8 -0.0,6902.8 -0.0,-0.0 3563.2,180.9\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11627230851734,
+                29.933342368269823
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11340789307542,
+                29.93278922105266
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11432353975992,
+                29.92917767927014
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11718795520184,
+                29.929730826487305
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p508",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5708
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5105.6,98.2 5079.7,8149.0 2904.2,8012.4 2897.3,8149.0 1944.4,8149.0 -0.0,7599.2 -0.0,6.0 5105.6,98.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11448293111346,
+                29.93291549218923
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11158718589434,
+                29.93233134314826
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5708.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11254262862471,
+                29.928723783941482
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11543837384383,
+                29.92930793298245
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p515",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5642
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"276.0,7225.2 276.4,5120.7 704.9,5122.1 728.6,848.5 2940.0,871.1 2937.8,1860.0 5060.9,1861.2 5045.0,7244.7 276.0,7225.2\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10345420755176,
+                29.937556890752713
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10052569727308,
+                29.93779025850146
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5642.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10013937518286,
+                29.934098086880525
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10306788546154,
+                29.933864719131776
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p518",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"119.9,7180.8 939.4,2892.9 953.0,35.9 5173.4,-0.0 5151.0,3110.7 4318.7,7933.5 119.9,7180.8\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09521343672981,
+                29.936893637466532
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09406207183704,
+                29.9344929574022
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09798250805846,
+                29.933060937149033
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09913387295124,
+                29.935461617213367
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p520",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"13.7,6789.5 1151.7,0.0 5719.0,0.0 5719.0,7216.9 3472.2,7329.8 13.7,6789.5\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10047646294723,
+                29.940343982653353
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09770707808887,
+                29.94132511131513
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09610477276956,
+                29.93788081675066
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.09887415762792,
+                29.93689968808888
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p522",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5719
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"699.7,88.1 5337.4,50.7 5361.2,7225.3 810.9,7230.1 699.7,88.1\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10498286528683,
+                29.94034555220114
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10201935491705,
+                29.940565091020666
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5719.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10166082230828,
+                29.93687934505248
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10462433267806,
+                29.936659806232953
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p524",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5750
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"5750.0,1967.4 5729.1,8149.0 3549.3,8149.0 3672.3,7154.0 543.2,7064.7 623.4,3231.4 246.5,2208.2 362.2,1051.2 0.0,973.2 0.0,767.1 5750.0,1967.4\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11076237407615,
+                29.93858612580457
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5750.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11070003249594,
+                29.941193033439458
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5750.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10646838320066,
+                29.94111596828226
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10653072478087,
+                29.938509060647373
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p525",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/info.json",
+          "type": "ImageService2",
+          "height": 8149,
+          "width": 5634
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"3786.8,0.0 3759.9,3072.4 4536.0,3120.2 4684.6,1270.0 5634.0,1348.0 5634.0,7182.4 4514.8,7187.9 4517.5,6548.0 1883.1,7058.0 1949.5,7400.1 686.6,7407.4 678.7,3337.5 439.5,3335.8 659.4,0.0 3786.8,0.0\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11477013510421,
+                29.93660095851229
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5634.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11409181510896,
+                29.939112130333058
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5634.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10992878969799,
+                29.938255726238477
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8149.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11060710969322,
+                29.93574455441771
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/georef",
+      "type": "Annotation",
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json"
+      ],
+      "label": "New Orleans, La. | 1951 | Vol. 5 p526",
+      "metadata": [
+        {
+          "label": "streets",
+          "value": "0"
+        },
+        {
+          "label": "intersections",
+          "value": "0"
+        }
+      ],
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
+      "creator": [
+        {
+          "id": "https://oldinsurancemaps.net/profile/danvk",
+          "type": "Person"
+        }
+      ],
+      "motivation": "georeferencing",
+      "target": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/selector",
+        "type": "SpecificResource",
+        "source": {
+          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/info.json",
+          "type": "ImageService2",
+          "height": 8150,
+          "width": 5736
+        },
+        "selector": {
+          "type": "SvgSelector",
+          "value": "<svg><polygon points=\"4886.3,7172.3 1913.6,7213.0 1862.5,1367.8 910.6,1297.9 777.9,3152.9 0.0,3111.8 0.0,-0.0 5736.0,0.0 5736.0,1821.9 4959.3,1844.7 4886.3,7172.3\" /></svg>"
+        }
+      },
+      "body": {
+        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/gcps",
+        "type": "FeatureCollection",
+        "transformation": {
+          "type": "polynomial",
+          "options": {
+            "order": 1
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1143312139927,
+                29.938292433504486
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5736.0,
+                0.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.11361637529329,
+                29.940838808329772
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                5736.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.10946944333699,
+                29.939952237301362
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "resourceCoords": [
+                0.0,
+                8150.0
+              ],
+              "creator": {
+                "id": "https://oldinsurancemaps.net/profile/danvk",
+                "type": "Person"
+              },
+              "type": "corner"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -90.1101842820364,
+                29.937405862476076
               ]
             }
           }
@@ -117,8 +4716,8 @@
           "value": "6"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -137,7 +4736,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"860.9,3337.8 908.5,855.4 4817.9,0.0 4822.2,2406.7 5637.0,2216.8 5637.0,8149.0 -0.0,8149.0 -0.0,3338.7 860.9,3337.8\" /></svg>"
+          "value": "<svg><polygon points=\"860.9,3337.8 908.5,855.4 4819.0,0.0 4822.2,2406.7 5637.0,2216.8 5637.0,8149.0 -0.0,8149.0 -0.0,3338.7 860.9,3337.8\" /></svg>"
         }
       },
       "body": {
@@ -193,99 +4792,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p427",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "4"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5681
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1049.6,3482.2 250.7,3665.5 256.0,1221.5 5041.4,174.0 5146.8,2537.6 4159.8,2767.9 4875.5,5935.7 5681.0,5707.5 5681.0,8150.0 1033.0,8150.0 1049.6,3482.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0427/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3296.6,
-                2967.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1144781,
-                29.9164744
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                256.0,
-                1219.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1159036,
-                29.9175779
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0428__1/georef",
       "type": "Annotation",
       "@context": [
@@ -319,8 +4825,8 @@
           "value": "8149.0"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -339,7 +4845,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,303.4 4232.5,299.0 4262.0,3353.6 -0.0,3584.7 -0.0,303.4\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,303.4 4286.0,299.0 4070.2,3364.0 5637.0,3279.0 5637.0,8149.0 -0.0,8149.0 -0.0,5145.0 432.0,3561.2 -0.0,3584.6 -0.0,303.4\" /></svg>"
         }
       },
       "body": {
@@ -395,192 +4901,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p429",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5681
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,462.8 3468.0,458.2 3407.9,5800.0 5681.0,5825.6 5681.0,8150.0 -0.0,8150.0 -0.0,462.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0429/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2792.5,
-                479.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1102415,
-                29.9165346
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4588.8,
-                479.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1092981,
-                29.9165542
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p430",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "4"
-        },
-        {
-          "label": "intersections",
-          "value": "3"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5637
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5637.0,8149.0 290.9,8149.0 -0.0,0.0 5637.0,-0.0 5637.0,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0430/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                300.1,
-                4904.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1081822,
-                29.9165665
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                300.1,
-                7028.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1092981,
-                29.9165542
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0431/georef",
       "type": "Annotation",
       "@context": [
@@ -598,8 +4918,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -618,7 +4938,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"999.7,419.9 5681.0,325.9 5681.0,8150.0 -0.0,8150.0 -0.0,5990.1 559.4,6033.9 999.7,419.9\" /></svg>"
+          "value": "<svg><polygon points=\"5681.0,325.9 5681.0,3082.5 4713.8,3163.5 4707.4,8150.0 -0.0,8150.0 -0.0,5489.5 776.4,5512.7 935.7,351.2 5681.0,325.9\" /></svg>"
         }
       },
       "body": {
@@ -647,8 +4967,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1061529192984,
-                29.916880652948837
+                -90.10615291951072,
+                29.916880652944066
               ]
             }
           },
@@ -668,8 +4988,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10317808645232,
-                29.917115608359854
+                -90.10317808642955,
+                29.91711560837365
               ]
             }
           },
@@ -689,8 +5009,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10278878928706,
-                29.91341733977371
+                -90.10278878923353,
+                29.913417339495247
               ]
             }
           },
@@ -710,8 +5030,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10576362213314,
-                29.913182384362695
+                -90.1057636223147,
+                29.913182384065664
               ]
             }
           },
@@ -757,8 +5077,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -777,7 +5097,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"963.5,300.8 5148.9,284.0 5154.2,2681.2 5637.0,2557.7 5637.0,8149.0 973.6,8127.8 963.5,300.8\" /></svg>"
+          "value": "<svg><polygon points=\"963.5,300.8 5148.9,284.0 5157.8,2425.1 5637.0,2405.7 5637.0,8149.0 -0.0,8149.0 -0.0,3140.7 967.1,3058.4 963.5,300.8\" /></svg>"
         }
       },
       "body": {
@@ -806,8 +5126,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10368128882298,
-                29.917064902415945
+                -90.10368128903714,
+                29.91706490240954
               ]
             }
           },
@@ -827,8 +5147,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10072915764675,
-                29.91729475784229
+                -90.10072915762763,
+                29.917294757854048
               ]
             }
           },
@@ -848,8 +5168,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10034552571247,
-                29.913597874619295
+                -90.10034552566302,
+                29.913597874338905
               ]
             }
           },
@@ -869,8 +5189,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.1032976568887,
-                29.91336801919295
+                -90.10329765707253,
+                29.913368018894396
               ]
             }
           },
@@ -937,8 +5257,8 @@
           "value": "1"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -986,8 +5306,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10130437042137,
-                29.916633694445874
+                -90.10130437063073,
+                29.916633694449086
               ]
             }
           },
@@ -1007,8 +5327,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.0983219758494,
-                29.91677999871837
+                -90.09832197582307,
+                29.91677999873314
               ]
             }
           },
@@ -1028,8 +5348,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.09807956458378,
-                29.913072329505443
+                -90.0980795645383,
+                29.913072329227216
               ]
             }
           },
@@ -1049,8 +5369,8 @@
             "geometry": {
               "type": "Point",
               "coordinates": [
-                -90.10106195915576,
-                29.91292602523295
+                -90.10106195934596,
+                29.91292602494316
               ]
             }
           },
@@ -1096,8 +5416,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1205,8 +5525,8 @@
           "value": "8149.0"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1298,8 +5618,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1318,7 +5638,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 3959.2,736.1 4434.4,8149.0 665.1,8149.0 1825.7,2158.0 -0.0,1907.1 -0.0,-0.0\" /></svg>"
+          "value": "<svg><polygon points=\"3959.2,736.1 4434.4,8149.0 665.1,8149.0 1825.7,2158.0 -0.0,1907.1 -0.0,-0.0 3959.2,736.1\" /></svg>"
         }
       },
       "body": {
@@ -1391,8 +5711,8 @@
           "value": "2"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1484,8 +5804,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1504,7 +5824,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"895.8,388.0 4626.7,346.5 4671.2,7993.2 4169.1,7879.5 4194.3,8149.0 3425.4,8149.0 3412.0,7707.1 919.8,7140.8 895.8,388.0\" /></svg>"
+          "value": "<svg><polygon points=\"4156.7,7876.3 4180.4,8149.0 3425.4,8149.0 3412.0,7707.1 919.8,7140.8 829.0,386.0 4626.9,365.6 4671.2,7993.2 4156.7,7876.3\" /></svg>"
         }
       },
       "body": {
@@ -1560,99 +5880,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p440",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5655
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"483.8,7546.5 1144.4,15.8 5655.0,146.3 5655.0,8149.0 -0.0,8149.0 -0.0,7388.3 483.8,7546.5\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0440/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2607.5,
-                2336.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0891468,
-                29.9206984
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5031.1,
-                144.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0884285,
-                29.9220625
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0441/georef",
       "type": "Annotation",
       "@context": [
@@ -1670,8 +5897,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1690,7 +5917,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"714.2,571.5 5671.0,458.9 5453.2,526.4 5455.0,7256.9 152.1,7293.8 714.2,571.5\" /></svg>"
+          "value": "<svg><polygon points=\"5671.0,513.1 5671.0,7243.9 650.5,7290.3 1318.3,565.8 5671.0,513.1\" /></svg>"
         }
       },
       "body": {
@@ -1763,8 +5990,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1783,7 +6010,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4939.5,0.0 5655.0,0.0 5655.0,8149.0 5451.2,8149.0 5445.8,7513.9 856.8,7420.4 1402.3,653.4 1626.8,603.2 4938.6,723.5 4939.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"4939.5,0.0 5655.0,0.0 5655.0,8149.0 5411.0,8149.0 5410.0,7513.8 1075.0,7424.8 1622.4,657.8 4938.6,723.5 4939.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -1839,99 +6066,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p443",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5686
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1310.8,31.0 5073.6,202.7 5130.2,7777.0 771.2,7731.6 1310.8,31.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0443/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2667.1,
-                3040.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.094402,
-                29.9257763
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5130.2,
-                7777.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0923838,
-                29.9240378
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0444/georef",
       "type": "Annotation",
       "@context": [
@@ -1949,8 +6083,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -1969,7 +6103,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"301.7,0.0 5643.0,0.0 5587.9,7690.8 266.3,7901.4 301.7,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5643.0,0.0 5587.9,7690.8 266.3,7901.4 301.7,0.0 5643.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -2042,8 +6176,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2118,99 +6252,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p446",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "18"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5643
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"620.0,7294.4 557.9,873.8 2713.1,879.0 4313.7,660.0 5313.0,7093.5 3604.4,7290.4 620.0,7294.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0446/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2691.5,
-                5458.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.096042,
-                29.924085
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                555.9,
-                871.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0973526,
-                29.9260758
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0447/georef",
       "type": "Annotation",
       "@context": [
@@ -2228,8 +6269,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2248,7 +6289,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"685.6,7347.5 642.0,700.7 4845.3,669.7 4919.8,7321.3 685.6,7347.5\" /></svg>"
+          "value": "<svg><polygon points=\"685.6,7347.5 642.0,700.7 4845.2,669.7 4919.8,7321.3 685.6,7347.5\" /></svg>"
         }
       },
       "body": {
@@ -2321,8 +6362,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2341,7 +6382,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"28.9,7272.5 870.5,626.5 5044.1,739.0 5148.8,7461.9 1764.8,7508.5 28.9,7272.5\" /></svg>"
+          "value": "<svg><polygon points=\"870.5,626.5 5643.0,673.7 5643.0,7409.4 1764.8,7508.5 28.9,7272.5 870.5,626.5\" /></svg>"
         }
       },
       "body": {
@@ -2414,8 +6455,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2507,8 +6548,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2527,7 +6568,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"896.7,7014.6 966.2,1038.0 4208.7,882.3 4753.5,7548.8 896.7,7014.6\" /></svg>"
+          "value": "<svg><polygon points=\"966.2,1038.0 4208.7,882.3 4753.5,7548.8 896.7,7014.6 966.2,1038.0\" /></svg>"
         }
       },
       "body": {
@@ -2600,8 +6641,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2620,7 +6661,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4364.0,239.6 4303.3,8104.9 -0.0,8149.0 -0.0,215.5 4364.0,239.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,215.5 4364.0,239.6 4303.3,8104.9 -0.0,8149.0 -0.0,215.5\" /></svg>"
         }
       },
       "body": {
@@ -2693,8 +6734,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2786,8 +6827,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -2806,7 +6847,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5710.0,6961.4 780.0,6980.2 783.1,1131.8 5710.0,1144.2 5710.0,6961.4\" /></svg>"
+          "value": "<svg><polygon points=\"5710.0,1144.2 5710.0,6970.5 780.0,6980.2 783.1,1131.8 5710.0,1144.2\" /></svg>"
         }
       },
       "body": {
@@ -2862,192 +6903,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p454",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5597
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3265.3,8150.0 1782.1,8143.1 2364.9,5886.9 507.0,5401.7 1901.8,0.0 5151.2,767.7 3265.3,8150.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0454/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2796.5,
-                4215.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1010572,
-                29.9179517
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2796.5,
-                2383.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1013917,
-                29.9187595
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p455",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5710
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5025.4,7326.9 240.7,7312.5 258.8,677.3 5019.2,675.0 5025.4,7326.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0455/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2859.0,
-                2936.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1014626,
-                29.9217926
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2859.0,
-                676.1
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1015689,
-                29.9228264
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0456/georef",
       "type": "Annotation",
       "@context": [
@@ -3065,8 +6920,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3158,8 +7013,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3178,7 +7033,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"593.1,7272.6 621.3,898.3 2723.0,904.1 2719.5,1942.3 4914.2,1940.2 4911.2,2439.1 5344.2,2441.0 5322.7,7291.2 593.1,7272.6\" /></svg>"
+          "value": "<svg><polygon points=\"621.3,898.3 2723.0,904.1 2719.5,1942.3 4586.7,1940.5 4504.1,7288.0 593.1,7272.6 621.3,898.3\" /></svg>"
         }
       },
       "body": {
@@ -3234,99 +7089,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p458",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5647
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1009.0,7276.4 1001.2,2423.6 567.9,2424.3 567.8,900.9 5295.7,882.6 5301.8,7267.4 1009.0,7276.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0458/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                567.9,
-                5448.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1018835,
-                29.9236378
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                567.9,
-                2424.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.102022,
-                29.9250094
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0459/georef",
       "type": "Annotation",
       "@context": [
@@ -3344,8 +7106,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3364,7 +7126,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1044.9,546.0 3166.1,851.9 5332.2,820.0 5338.5,7166.5 2339.6,7124.2 233.5,6867.1 1044.9,546.0\" /></svg>"
+          "value": "<svg><polygon points=\"233.5,6867.1 1044.9,545.9 3166.1,851.8 5332.2,820.0 5338.5,7166.5 2339.6,7124.2 233.5,6867.1\" /></svg>"
         }
       },
       "body": {
@@ -3437,8 +7199,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3530,8 +7292,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3550,7 +7312,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"696.2,7385.7 705.1,683.9 4994.0,684.9 4981.9,7384.0 696.2,7385.7\" /></svg>"
+          "value": "<svg><polygon points=\"4994.0,684.9 4981.9,7384.0 -0.0,7389.0 -0.0,612.3 4994.0,684.9\" /></svg>"
         }
       },
       "body": {
@@ -3623,8 +7385,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3716,8 +7478,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3736,7 +7498,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2242.1,1005.9 4347.8,1134.0 4404.3,6946.5 1534.2,6865.7 2242.1,1005.9\" /></svg>"
+          "value": "<svg><polygon points=\"437.3,6834.8 1202.6,867.5 4347.8,1134.0 4404.3,6946.5 437.3,6834.8\" /></svg>"
         }
       },
       "body": {
@@ -3809,8 +7571,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3829,7 +7591,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4991.2,1135.3 4987.9,6994.9 -0.0,6971.3 -0.0,1128.4 4991.2,1135.3\" /></svg>"
+          "value": "<svg><polygon points=\"4987.9,6994.9 2971.9,7008.8 -0.0,6971.3 -0.0,1128.4 4991.2,1135.3 4987.9,6994.9\" /></svg>"
         }
       },
       "body": {
@@ -3902,8 +7664,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -3995,8 +7757,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4015,7 +7777,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"960.0,868.1 5664.0,863.8 5664.0,6833.7 928.6,7152.0 960.0,868.1\" /></svg>"
+          "value": "<svg><polygon points=\"4558.8,6935.7 929.2,7152.2 960.0,868.1 4602.7,850.6 4558.8,6935.7\" /></svg>"
         }
       },
       "body": {
@@ -4088,8 +7850,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4181,8 +7943,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4201,7 +7963,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"798.2,7399.4 795.8,666.9 3793.0,576.7 4656.5,7178.1 2912.0,7416.9 798.2,7399.4\" /></svg>"
+          "value": "<svg><polygon points=\"795.8,666.9 3089.8,597.9 3971.8,7271.8 798.2,7399.4 795.8,666.9\" /></svg>"
         }
       },
       "body": {
@@ -4274,8 +8036,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4294,7 +8056,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"727.8,7262.0 887.8,5081.1 897.5,706.7 4695.3,710.1 5252.1,7082.6 727.8,7262.0\" /></svg>"
+          "value": "<svg><polygon points=\"727.8,7262.0 883.4,7030.1 895.6,1578.3 4772.0,1587.3 5252.1,7082.6 727.8,7262.0\" /></svg>"
         }
       },
       "body": {
@@ -4367,8 +8129,8 @@
           "value": "11"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4460,8 +8222,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4480,7 +8242,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"857.1,7085.1 838.2,931.1 4743.2,884.0 4816.5,6142.1 857.1,7085.1\" /></svg>"
+          "value": "<svg><polygon points=\"838.2,931.1 4743.2,884.0 4817.6,6142.1 857.1,7085.1 838.2,931.1\" /></svg>"
         }
       },
       "body": {
@@ -4536,99 +8298,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p472",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5673
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5280.9,6855.2 332.7,7879.6 479.6,530.0 4968.1,497.1 5280.9,6855.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0472/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5180.9,
-                5036.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1130958,
-                29.9184222
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                432.1,
-                2744.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1153223,
-                29.9198776
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0473/georef",
       "type": "Annotation",
       "@context": [
@@ -4646,8 +8315,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4739,8 +8408,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4759,7 +8428,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4604.4,7130.1 -0.0,7153.7 13.7,1963.1 974.4,1963.3 970.7,981.3 4566.0,916.8 4604.4,7130.1\" /></svg>"
+          "value": "<svg><polygon points=\"4604.4,7130.1 -0.0,7153.7 24.2,1984.3 974.5,1983.4 970.7,981.3 4566.0,916.8 4604.4,7130.1\" /></svg>"
         }
       },
       "body": {
@@ -4832,8 +8501,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4925,8 +8594,8 @@
           "value": "30"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -4945,7 +8614,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"699.5,4051.2 711.8,0.0 4824.0,0.0 4816.0,3098.7 4470.3,3099.4 4480.9,8137.0 1258.9,8125.9 1214.9,4055.1 699.5,4051.2\" /></svg>"
+          "value": "<svg><polygon points=\"4470.3,3099.4 4480.9,8137.0 1258.9,8125.9 1214.9,4055.1 699.5,4051.2 711.9,15.1 4824.0,0.0 4816.0,3098.7 4470.3,3099.4\" /></svg>"
         }
       },
       "body": {
@@ -5018,8 +8687,8 @@
           "value": "26"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5094,99 +8763,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p478",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5687
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1017.2,4289.4 839.1,4292.4 766.1,0.0 4166.1,0.0 4770.3,7286.4 1017.1,7283.0 1017.2,4289.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0478/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2551.6,
-                4271.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1130497,
-                29.9249415
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5071.1,
-                5774.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.111928,
-                29.9240055
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0479/georef",
       "type": "Annotation",
       "@context": [
@@ -5204,8 +8780,8 @@
           "value": "18"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5297,8 +8873,8 @@
           "value": "19"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5317,7 +8893,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4536.2,7250.2 387.2,7243.0 422.8,1180.2 3759.9,1545.5 3812.2,5405.7 5687.0,5405.1 5687.0,5703.9 4539.1,8150.0 4137.6,8150.0 4536.2,7250.2\" /></svg>"
+          "value": "<svg><polygon points=\"422.8,1180.2 3759.9,1545.5 3787.5,3585.3 5687.0,3586.9 5687.0,5703.9 5342.6,6437.8 387.2,7243.0 422.8,1180.2\" /></svg>"
         }
       },
       "body": {
@@ -5373,378 +8949,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p481",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "9"
-        },
-        {
-          "label": "intersections",
-          "value": "22"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5668
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 921.3,0.0 4550.0,924.1 4576.1,7096.1 961.9,7161.7 965.8,8149.0 -0.0,8149.0 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0481/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4576.0,
-                3516.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1151982,
-                29.9282313
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4576.0,
-                6356.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1155403,
-                29.9269835
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p482",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5687
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2832.3,1750.9 2847.5,1504.0 3715.6,1762.6 4933.7,1778.6 4927.9,2112.1 5687.0,2319.2 5687.0,2690.2 4929.4,2447.5 4879.8,5371.2 4645.9,5369.3 4660.5,6526.9 921.7,6468.0 997.5,1351.3 2832.3,1750.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0482/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2847.5,
-                1503.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.113949,
-                29.9290712
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                907.8,
-                7178.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1156293,
-                29.9266587
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p483",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "11"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5705
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"123.6,5827.8 144.4,5653.0 388.2,5690.2 879.0,2647.1 1633.1,3014.0 1688.8,2627.0 927.9,2296.8 1258.4,252.1 3992.2,675.9 5705.0,634.2 5705.0,7344.8 3516.3,7418.5 3579.6,6479.6 123.6,5827.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0483/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                792.1,
-                2424.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1129911,
-                29.9285324
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                88.0,
-                6880.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1135133,
-                29.9265722
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p484",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3146.4,5385.4 2855.6,5389.3 2878.6,7227.3 1225.4,7282.1 1300.8,749.5 4567.8,682.4 4670.1,6114.5 3146.4,5385.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0484/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4648.8,
-                4966.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.108772,
-                29.9271541
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1040.2,
-                2899.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1106098,
-                29.9281978
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0485/georef",
       "type": "Annotation",
       "@context": [
@@ -5762,8 +8966,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5782,7 +8986,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"300.2,6788.1 686.4,4246.4 1516.8,4766.8 1573.7,4371.1 738.2,3865.2 1207.5,535.4 3340.3,855.8 4688.1,833.5 4642.2,7102.5 2447.0,7116.3 300.2,6788.1\" /></svg>"
+          "value": "<svg><polygon points=\"1207.5,535.4 3340.3,855.8 4688.1,833.5 4642.2,7102.5 2447.0,7116.3 300.2,6788.1 118.2,8149.0 -0.0,8149.0 -0.0,3336.5 743.8,3825.5 1207.5,535.4\" /></svg>"
         }
       },
       "body": {
@@ -5855,8 +9059,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -5948,8 +9152,8 @@
           "value": "20"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6024,99 +9228,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p488",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5169.4,1052.9 5168.1,6983.2 1450.2,6993.1 1415.9,1055.5 5169.4,1052.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0488/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                644.1,
-                3099.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1022777,
-                29.9275459
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5168.9,
-                3099.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0998058,
-                29.927736
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0489/georef",
       "type": "Annotation",
       "@context": [
@@ -6134,8 +9245,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6210,471 +9321,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p490",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5693
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1052.9,7210.1 811.1,1023.8 3713.4,729.9 4787.3,6870.0 3200.2,7142.2 1052.9,7210.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0490/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2520.4,
-                3091.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.09669,
-                29.927979
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                3200.6,
-                7142.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0962292,
-                29.9261544
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p491",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5707
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1501.5,395.0 5707.0,748.5 5707.0,7488.2 4342.1,7436.0 4328.2,7744.7 503.8,7371.5 1501.5,395.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0491/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2471.6,
-                4854.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0950809,
-                29.9282903
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2735.5,
-                2703.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0953489,
-                29.9292443
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p492",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5717
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5302.9,0.0 5717.0,0.0 5717.0,7674.4 2101.2,7696.9 1798.1,887.1 5344.7,667.7 5302.9,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0492/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2616.5,
-                3007.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0935147,
-                29.9297593
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                672.1,
-                863.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0948129,
-                29.9304011
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p493",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5688
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4825.4,7119.0 518.9,6712.4 807.2,3294.7 589.5,203.6 -0.0,245.5 0.0,0.0 4889.1,-0.0 5054.0,4330.9 4825.4,7119.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0493/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                740.0,
-                4330.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.096193,
-                29.9340671
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5056.0,
-                4330.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0954874,
-                29.9322306
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p494",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5717
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"401.7,7131.4 789.9,4362.8 873.9,32.4 5154.7,-0.0 5059.2,4660.3 4719.3,7778.8 401.7,7131.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0494/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                880.2,
-                2995.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0948115,
-                29.9324192
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                880.2,
-                551.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0936364,
-                29.9328246
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0495/georef",
       "type": "Annotation",
       "@context": [
@@ -6692,8 +9338,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6785,8 +9431,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6878,8 +9524,8 @@
           "value": "8"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -6898,7 +9544,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4984.0,7168.2 734.3,7209.4 704.9,848.4 4961.0,835.2 4984.0,7168.2\" /></svg>"
+          "value": "<svg><polygon points=\"4984.0,7168.2 -0.0,7213.8 -0.0,854.7 4961.0,835.2 4984.0,7168.2\" /></svg>"
         }
       },
       "body": {
@@ -6971,8 +9617,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7064,8 +9710,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7084,7 +9730,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"665.9,819.2 4948.5,830.0 4928.4,7182.7 646.4,7220.9 665.9,819.2\" /></svg>"
+          "value": "<svg><polygon points=\"665.9,819.2 5703.0,827.8 5703.0,7182.8 646.4,7220.9 665.9,819.2\" /></svg>"
         }
       },
       "body": {
@@ -7140,99 +9786,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p500",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5670
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"712.3,7192.2 737.2,855.4 5533.9,845.2 5520.2,7196.2 712.3,7192.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0500/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.0,
-                2967.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1028671,
-                29.9333256
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2915.0,
-                839.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1029684,
-                29.9342947
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0501/georef",
       "type": "Annotation",
       "@context": [
@@ -7250,8 +9803,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7270,7 +9823,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"644.8,828.4 5703.0,786.4 5703.0,7184.0 649.1,7185.4 644.8,828.4\" /></svg>"
+          "value": "<svg><polygon points=\"649.1,7185.4 644.8,828.4 4950.7,786.9 4945.2,7184.2 649.1,7185.4\" /></svg>"
         }
       },
       "body": {
@@ -7326,99 +9879,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p502",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "12"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5705
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5135.3,7184.2 1095.2,7185.6 1095.3,860.0 5144.2,857.4 5135.3,7184.2\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0502/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2952.5,
-                2984.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1023527,
-                29.930449
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2952.5,
-                7184.9
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1021555,
-                29.9285309
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0503/georef",
       "type": "Annotation",
       "@context": [
@@ -7436,8 +9896,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7456,7 +9916,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3366.6,840.0 5230.0,834.7 5116.3,8149.0 174.3,8149.0 1290.9,538.0 3366.6,840.0\" /></svg>"
+          "value": "<svg><polygon points=\"3366.6,840.0 5230.0,834.7 5116.3,8149.0 175.7,8149.0 1290.9,538.0 3366.6,840.0\" /></svg>"
         }
       },
       "body": {
@@ -7529,8 +9989,8 @@
           "value": "16"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7549,7 +10009,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5649.1,1870.8 5585.1,7220.8 2109.9,7210.4 18.3,6886.6 738.1,1875.5 5649.1,1870.8\" /></svg>"
+          "value": "<svg><polygon points=\"5649.1,1870.8 5585.1,7220.8 2109.9,7210.4 18.3,6886.6 412.7,4081.3 735.0,1875.5 5649.1,1870.8\" /></svg>"
         }
       },
       "body": {
@@ -7622,8 +10082,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7642,7 +10102,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1206.4,57.8 5703.0,913.3 5703.0,7636.4 709.9,7622.9 714.4,2699.5 1206.4,57.8\" /></svg>"
+          "value": "<svg><polygon points=\"709.9,7622.8 714.4,2699.5 1206.4,57.8 5703.0,913.3 5703.0,5857.6 4981.0,5855.3 4966.5,7636.5 709.9,7622.8\" /></svg>"
         }
       },
       "body": {
@@ -7715,8 +10175,8 @@
           "value": "13"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -7735,7 +10195,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"1426.2,322.0 5348.7,1012.0 4996.7,2952.1 5002.7,7048.0 1485.1,7079.1 1426.2,322.0\" /></svg>"
+          "value": "<svg><polygon points=\"1469.5,5291.3 1426.2,322.0 5348.7,1012.0 4997.4,3415.1 5002.7,7048.0 744.7,7085.6 743.6,5295.3 1469.5,5291.3\" /></svg>"
         }
       },
       "body": {
@@ -7791,192 +10251,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p507",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,-0.0 4544.1,176.5 4504.9,8149.0 766.1,7149.2 -0.0,7139.9 -0.0,-0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0507/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4521.6,
-                4560.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1144924,
-                29.930901
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4521.6,
-                7829.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1148543,
-                29.9295066
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p508",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5708
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2815.1,8149.0 954.8,7769.3 952.0,162.0 4955.5,167.2 4939.9,8149.0 3708.2,8149.0 2827.2,7899.1 2815.1,8149.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0508/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                952.0,
-                2280.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1142511,
-                29.9318113
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                952.0,
-                160.0
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1139956,
-                29.9327704
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0509/georef",
       "type": "Annotation",
       "@context": [
@@ -7994,8 +10268,8 @@
           "value": "7"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8014,7 +10288,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"784.1,0.0 5642.0,0.0 5642.0,3684.3 4971.2,3684.9 4946.3,7834.4 3596.1,7833.7 2798.6,7988.8 2799.0,7833.3 617.8,7832.2 784.1,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"892.8,0.0 4101.1,0.0 4065.2,7834.0 2798.6,7988.8 2799.0,7833.3 617.8,7832.2 628.2,3680.5 892.8,0.0\" /></svg>"
         }
       },
       "body": {
@@ -8087,8 +10361,8 @@
           "value": "10"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8107,7 +10381,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"0.0,0.0 5724.0,0.0 5724.0,334.3 5057.9,328.0 4826.3,3677.3 5063.8,3678.9 5060.4,7696.6 2962.8,7723.1 2964.3,7483.3 857.9,7491.1 862.0,3684.1 1514.0,3680.5 1497.6,98.5 0.0,105.4 0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"5082.0,0.0 4826.3,3677.3 5063.8,3678.9 5060.4,7696.6 2962.8,7723.1 2964.3,7483.3 857.9,7491.1 856.4,7718.5 0.0,7722.0 0.0,0.0 5082.0,0.0\" /></svg>"
         }
       },
       "body": {
@@ -8180,8 +10454,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8200,7 +10474,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"666.7,2246.7 1025.0,0.0 1878.1,0.0 3136.9,255.3 3183.6,28.9 5285.0,439.5 4953.9,2285.3 4901.2,8085.7 2734.9,8047.5 2752.6,5934.6 615.4,5903.0 666.7,2246.7\" /></svg>"
+          "value": "<svg><polygon points=\"656.2,2312.3 1025.0,0.0 1878.1,0.0 3136.9,255.3 3183.6,28.9 5285.0,439.5 4953.9,2285.3 4901.2,8085.7 2734.9,8047.4 2752.6,5934.6 615.4,5903.0 656.2,2312.3\" /></svg>"
         }
       },
       "body": {
@@ -8273,8 +10547,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8293,7 +10567,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"770.1,1765.3 1038.3,175.7 5185.6,945.3 4950.2,2205.8 4981.7,7494.8 755.2,7496.1 770.1,1765.3\" /></svg>"
+          "value": "<svg><polygon points=\"1038.3,175.7 4349.0,778.5 4349.5,7495.0 755.2,7496.1 770.1,1765.3 1038.3,175.7\" /></svg>"
         }
       },
       "body": {
@@ -8366,8 +10640,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8459,8 +10733,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8479,7 +10753,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5724.0,826.7 5724.0,7223.9 625.2,7230.7 648.5,856.2 5724.0,826.7\" /></svg>"
+          "value": "<svg><polygon points=\"648.5,856.2 5377.9,824.8 5369.4,5107.5 4943.1,5108.2 4950.2,7217.1 625.2,7230.7 648.5,856.2\" /></svg>"
         }
       },
       "body": {
@@ -8535,99 +10809,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p515",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "5"
-        },
-        {
-          "label": "intersections",
-          "value": "9"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5642
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"3044.2,940.1 3041.1,1887.9 5062.3,1888.6 5041.8,7049.0 1242.3,7034.1 1270.2,922.2 3044.2,940.1\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0515/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                508.2,
-                2996.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1031668,
-                29.936202
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                5057.8,
-                2996.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1006861,
-                29.9363992
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0516/georef",
       "type": "Annotation",
       "@context": [
@@ -8645,8 +10826,8 @@
           "value": "9"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8738,8 +10919,8 @@
           "value": "14"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8758,7 +10939,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"4284.0,7005.5 3915.0,8149.0 1689.4,8047.4 2096.4,6811.7 -0.0,6451.1 0.0,-0.0 5057.6,-0.0 5052.5,2879.4 4284.0,7005.5\" /></svg>"
+          "value": "<svg><polygon points=\"5052.5,2879.4 4284.0,7005.5 3915.0,8149.0 1689.4,8047.4 2096.4,6811.7 -0.0,6451.1 558.9,2316.0 451.2,689.5 -0.0,683.8 -0.0,-0.0 5057.6,-0.0 5052.5,2879.4\" /></svg>"
         }
       },
       "body": {
@@ -8814,99 +10995,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p518",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "10"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5148.7,3091.3 4338.8,7943.6 89.6,7192.7 890.0,2878.5 885.1,-0.0 5150.8,-0.0 5148.7,3091.3\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0518/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                831.9,
-                3107.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0965375,
-                29.9359766
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                351.9,
-                5746.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0978975,
-                29.9357212
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0519/georef",
       "type": "Annotation",
       "@context": [
@@ -8924,8 +11012,8 @@
           "value": "12"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -8944,7 +11032,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"317.5,0.0 5650.0,0.0 4669.8,308.0 5552.6,7214.0 2400.8,7168.9 2397.2,8149.0 288.0,8149.0 317.5,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"317.5,0.0 5650.0,0.0 4678.4,367.4 5552.6,7213.9 2400.8,7168.9 2397.2,8149.0 288.0,8149.0 317.5,0.0\" /></svg>"
         }
       },
       "body": {
@@ -9000,99 +11088,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p520",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "14"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5719.0,0.0 5719.0,6693.4 17.7,6771.4 1138.0,0.0 5719.0,0.0\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0520/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                1403.8,
-                7002.3
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.0983983,
-                29.9376056
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                715.9,
-                2591.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.099619,
-                29.939381
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0521/georef",
       "type": "Annotation",
       "@context": [
@@ -9110,8 +11105,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9130,7 +11125,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"2221.1,150.7 5074.8,61.3 4957.3,7193.4 6.9,7189.6 1062.3,0.0 2221.1,150.7\" /></svg>"
+          "value": "<svg><polygon points=\"2047.4,128.1 2062.9,0.0 5664.0,0.0 5664.0,7204.3 6.9,7189.6 1062.3,0.0 2047.4,128.1\" /></svg>"
         }
       },
       "body": {
@@ -9186,99 +11181,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p522",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "6"
-        },
-        {
-          "label": "intersections",
-          "value": "15"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5719
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,7179.9 -0.0,234.8 2939.8,194.2 2861.1,0.0 5719.0,0.0 5719.0,134.9 5069.7,142.5 5099.8,7164.9 -0.0,7179.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0522/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2947.5,
-                5154.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.103127,
-                29.938132
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2947.5,
-                907.8
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1033161,
-                29.9400995
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0523/georef",
       "type": "Annotation",
       "@context": [
@@ -9296,8 +11198,8 @@
           "value": "17"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9316,7 +11218,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"837.8,512.6 3556.7,1007.6 3595.3,817.0 4504.0,1190.8 4411.1,2328.0 4802.8,3324.5 4794.8,7086.3 633.0,7067.2 601.9,1774.0 837.8,512.6\" /></svg>"
+          "value": "<svg><polygon points=\"0.0,345.6 0.0,0.0 2679.7,0.0 2555.2,622.4 4140.6,919.0 4144.4,1121.3 4504.0,1190.8 4411.1,2328.0 4802.8,3324.5 4794.8,7086.3 0.0,7067.3 0.0,357.1 0.0,345.6\" /></svg>"
         }
       },
       "body": {
@@ -9372,285 +11274,6 @@
       }
     },
     {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p524",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "25"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5750
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"5750.0,7365.9 5427.2,7346.1 5480.9,8149.0 3309.7,8149.0 3478.7,7205.1 352.6,6971.3 610.2,3167.1 280.5,2133.3 449.8,989.2 0.0,871.2 0.0,664.5 2083.6,1198.1 2022.8,1452.2 5750.0,2345.2 5750.0,7365.9\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0524/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2431.2,
-                4992.6
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1081488,
-                29.9396836
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                2495.1,
-                1416.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1100178,
-                29.9396709
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p525",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "8"
-        },
-        {
-          "label": "intersections",
-          "value": "16"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/info.json",
-          "type": "ImageService2",
-          "height": 8149,
-          "width": 5634
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"419.6,3408.8 623.1,0.0 5634.0,0.0 5634.0,1360.1 4695.0,1292.6 4557.1,3151.9 3814.7,3113.7 3812.2,3367.8 4553.6,3348.4 4563.0,7236.4 5634.0,7220.7 5634.0,7417.6 696.4,7494.6 661.2,3408.2 419.6,3408.8\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0525/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                488.2,
-                2000.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1137188,
-                29.9366287
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4553.6,
-                3348.4
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1125306,
-                29.9382721
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/georef",
-      "type": "Annotation",
-      "@context": [
-        "http://iiif.io/api/extension/georef/1/context.json",
-        "http://iiif.io/api/presentation/3/context.json"
-      ],
-      "label": "New Orleans, La. | 1951 | Vol. 5 p526",
-      "metadata": [
-        {
-          "label": "streets",
-          "value": "7"
-        },
-        {
-          "label": "intersections",
-          "value": "13"
-        }
-      ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
-      "creator": [
-        {
-          "id": "https://oldinsurancemaps.net/profile/danvk",
-          "type": "Person"
-        }
-      ],
-      "motivation": "georeferencing",
-      "target": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/selector",
-        "type": "SpecificResource",
-        "source": {
-          "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/info.json",
-          "type": "ImageService2",
-          "height": 8150,
-          "width": 5736
-        },
-        "selector": {
-          "type": "SvgSelector",
-          "value": "<svg><polygon points=\"865.5,1318.4 1808.7,1376.8 1795.3,11.7 5736.0,0.0 5736.0,1792.7 4967.9,1823.5 4935.4,7183.7 791.9,7285.4 744.0,3383.2 0.0,3409.9 0.0,3154.9 745.6,3185.9 865.5,1318.4\" /></svg>"
-        }
-      },
-      "body": {
-        "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0526/gcps",
-        "type": "FeatureCollection",
-        "transformation": {
-          "type": "helmert"
-        },
-        "features": [
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                744.0,
-                3383.2
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1125306,
-                29.9382721
-              ]
-            }
-          },
-          {
-            "type": "Feature",
-            "properties": {
-              "resourceCoords": [
-                4892.0,
-                5246.7
-              ],
-              "creator": {
-                "id": "https://oldinsurancemaps.net/profile/danvk",
-                "type": "Person"
-              },
-              "type": "gcp"
-            },
-            "geometry": {
-              "type": "Point",
-              "coordinates": [
-                -90.1110562,
-                29.9398784
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
       "id": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd401m:g4014m:g4014nm:g03376195105:03376_05_1951-0527/georef",
       "type": "Annotation",
       "@context": [
@@ -9668,8 +11291,8 @@
           "value": "15"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9688,7 +11311,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,0.0 5634.0,0.0 5634.0,8149.0 5371.0,8149.0 5378.0,7694.9 4015.9,7670.8 -0.0,7456.9 -0.0,0.0\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,7456.9 -0.0,0.0 5634.0,0.0 5634.0,4249.7 5431.0,4288.4 5378.0,7694.9 -0.0,7456.9\" /></svg>"
         }
       },
       "body": {
@@ -9761,8 +11384,8 @@
           "value": "40"
         }
       ],
-      "created": "2026-07-18T02:39:50Z",
-      "modified": "2026-07-18T02:39:50Z",
+      "created": "2026-07-31T00:10:43Z",
+      "modified": "2026-07-31T00:10:43Z",
       "creator": [
         {
           "id": "https://oldinsurancemaps.net/profile/danvk",
@@ -9781,7 +11404,7 @@
         },
         "selector": {
           "type": "SvgSelector",
-          "value": "<svg><polygon points=\"-0.0,6469.6 -0.0,6062.9 481.8,4506.1 -0.0,4357.0 -0.0,-0.0 5660.0,0.0 5660.0,7870.8 2662.8,7939.9 2733.3,6858.6 2332.0,6859.4 2352.3,6699.2 99.5,6552.3 -0.0,6469.6\" /></svg>"
+          "value": "<svg><polygon points=\"-0.0,6062.9 481.8,4506.1 -0.0,4357.0 -0.0,-0.0 5660.0,0.0 5660.0,7870.8 2690.9,7863.0 2803.2,6858.5 2332.0,6859.4 2340.0,6796.0 89.0,6543.5 -0.0,6469.6 -0.0,6062.9\" /></svg>"
         }
       },
       "body": {


### PR DESCRIPTION
Replaces the ten-column RMSE-distribution table with the metric the project is actually steered by, and refreshes every gallery IIIF from the 2026-07-30 twelve-volume run.

## Why replace the table

The old table gave median/mean/max RMSE plus five distribution buckets per volume — a lot of detail about the *shape* of the error and very little about whether a volume is usable. The new one reports pages placed, share within 25ft, share at 200ft or worse, and the land-weighted score that is their difference.

## The numbers

| Volume | Pages Placed | ≤25ft | ≥200ft | Score |
|---|---|---|---|---|
| Champaign, Ill. 1915 | 29/33 (88%) | 98.0% | 0.2% | **97.8%** |
| New Orleans 1951 Vol 5 | 104/109 (95%) | 93.1% | 0.9% | **92.2%** |
| Los Angeles 1949 Vol 14 | 123/129 (95%) | 84.2% | 1.6% | **82.6%** |
| Brooklyn 1939 Vol 1 | 54/62 (87%) | 82.8% | 2.9% | **80.0%** |
| Washington DC 1916 Vol 2 | 121/134 (90%) | 83.8% | 4.5% | **79.3%** |
| Chicago 1950 Vol 1 | 100/111 (90%) | 78.9% | 0.0% | **78.9%** |
| Kansas City 1951 Vol 4 | 128/142 (90%) | 79.5% | 3.6% | **75.9%** |
| New Orleans 1896 Vol 2 | 86/91 (95%) | 72.0% | 2.3% | **69.7%** |
| Detroit 1929 Vol 11 | 86/103 (83%) | 72.2% | 3.9% | **68.2%** |
| Grand Rapids 1953 Vol 7 | 64/83 (77%) | 72.6% | 4.5% | **68.1%** |
| Nashville 1957 Vol 1A | 60/71 (85%) | 66.0% | 4.4% | **61.6%** |
| Hudson County 1950 Vol 9 | 70/95 (74%) | 50.6% | 0.0% | **50.6%** |
| **All 12 volumes** | **1025/1163 (88%)** | **78.0%** | **2.7%** | **75.3%** |

Produced by `mapsnap fit --tag 2026-07-30-full` across all twelve truth volumes, on truth repaired for OIM#402 (#190), with multi-scale key-map segmentation (#186) and the street channel wired into `fit` (#189).

**Los Angeles 1949 Vol 14 appears for the first time**, in both the table and the gallery, at 82.6%.

Rows are sorted by score, and an aggregate row carries the headline number.

## What the table says

The corpus gap is **coverage, not correctness**. Disaster share is 2.7% overall, and the weakest volume — Hudson at 50.6% — has *zero* disasters; it simply leaves 25 of 95 pages unplaced. Chicago likewise has none. Raising placement rates would move the headline far more than reducing error on already-placed pages.

## Gallery

All twelve `gallery/*.iiif.json` files are refreshed from each volume's **tagged run output** (`data/<vol>/2026-07-30-full.iiif.json`) rather than the archived copy under `artifacts/`, which flattens split panels. Annotation counts move accordingly — DC 84 → 120 and Hudson 60 → 70 are the largest gains. Every `gallery%2F…` link in the README resolves to a file in the directory.

## On the OIM#402 truth repair

These scores are computed against truth repaired for OIM#402 (#190), but that repair does **not** meaningfully move the numbers, so they remain comparable to previously published ones.

Worth recording why, since the two paths differ. `mapsnap compare` (per-page RMSE) is structurally immune to OIM#402 — it pairs and grades splits via the template-matched `oim/pN.panels.json` regions and never reads the selector. `mapsnap score` is not: it calls `truth_polygon_world`, projecting the selector to get each page's footprint for land weighting, which a frame-mixed selector displaces.

Measured against the pre-repair backups, though, the effect is negligible — land weighting needs a footprint's area and rough location, not its exact placement:

| volume | pre-repair | repaired | Δ |
|---|---|---|---|
| Grand Rapids 1953 Vol 7 | 68.5% | 68.1% | −0.4 |
| Hudson County 1950 Vol 9 | 50.3% | 50.6% | +0.3 |
| New Orleans 1951 Vol 5 | 91.9% | 92.2% | +0.3 |
| Detroit 1929 Vol 11 | 68.3% | 68.2% | −0.1 |
| other 7 volumes | — | — | identical |

Land-weighted aggregate shift: **−0.003 points**. The headline is 75.3% either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
