### PR TITLE
snap: rung-flip arbitration — adopt doubled-scale candidates over half-scale fits

### DIFF
--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1713,6 +1713,89 @@ def arbitrate_challenge(record: dict, arbitrate_gate: float) -> dict | None:
     }
 
 
+# Rung-flip arbitration: a fit published at HALF its true scale. Ten of the
+# 2026-07-30 corpus's 39 disasters were exact half/double-scale fits with
+# near-perfect rotation, and for several the correct pose already sat in the
+# candidate list — trapped between refinement (needs <100 ft agreement; a rung
+# variant disagrees by 200-700 ft) and arbitration (needs an indefensible
+# incumbent; half-scale fits chamfer well on a gridiron and verify >= 0.1).
+RUNG_UP_BAND = (1.7, 2.3)
+"""Candidate/incumbent scale ratios treated as an up-rung challenge.
+
+UP only, never down: verification carries a small-footprint bias. A half-scale
+candidate explains 1/4 the ground and matches dense OSM cheaply — calibrating
+over every rung-band candidate pair in the twelve truth volumes, every
+would-be DOWN flip that passed any margin was a break (23-98 ft incumbents sent
+to 340-11000 ft: NO-1951 p433/p434/p436, Chicago p61w, Detroit p21, Nashville
+p44, LA p1499o/r), while every fix but one was an up flip. A doubled candidate
+must explain 4x the ground, so verification preferring it is hard-won evidence.
+"""
+RUNG_VER_MARGIN = 0.1
+RUNG_NAME_FLOOR = -0.10
+RUNG_SELECT_MIN = 0.9
+
+
+def rung_flip(record: dict) -> dict | None:
+    """Adopt a double-scale candidate over a half-scale incumbent, or None.
+
+    Calibrated offline over all 1228 rung-band candidate pairs in the twelve
+    truth volumes: these gates flip five pages — four disasters to <=25 ft
+    (Brooklyn p14 403->15, KC p556 289->13, Nashville p4 396->26, DC p153
+    306->12), one disaster to a different disaster (NO-1896 p125), and break
+    nothing. Family/scale priors were tried as the referee first and rejected:
+    the family-rung prior endorses the wrong rung on exactly the contested
+    pages (it was derived from the bad fits), and the volume median breaks
+    legitimate second scale families (Nashville) and oversize sheets (LA
+    p1499*). Direction + verification margin + name parity is the whole rule.
+    """
+    incumbent = record.get("incumbent")
+    candidates = record.get("candidates") or []
+    if not incumbent or not incumbent.get("world_affine") or not candidates:
+        return None
+    inc_affine = incumbent["world_affine"]
+    inc_scale = math.hypot(inc_affine[1][0], inc_affine[1][1])
+    incumbent_verification = incumbent.get("verification")
+    if inc_scale <= 0 or incumbent_verification is None:
+        return None
+    incumbent_name = (incumbent.get("name") or {}).get("score")
+    best_index = None
+    best_margin = 0.0
+    for index, candidate in enumerate(candidates):
+        affine = candidate.get("world_affine")
+        verification = candidate.get("verification")
+        score = candidate.get("select_score")
+        if not affine or verification is None or score is None:
+            continue
+        ratio = math.hypot(affine[1][0], affine[1][1]) / inc_scale
+        if not (RUNG_UP_BAND[0] <= ratio <= RUNG_UP_BAND[1]):
+            continue
+        if score < RUNG_SELECT_MIN:
+            continue
+        margin = verification - incumbent_verification
+        if margin < RUNG_VER_MARGIN:
+            continue
+        candidate_name = (candidate.get("name") or {}).get("score")
+        if (
+            incumbent_name is not None
+            and candidate_name is not None
+            and candidate_name - incumbent_name < RUNG_NAME_FLOOR
+        ):
+            continue
+        if best_index is None or margin > best_margin:
+            best_index, best_margin = index, margin
+    if best_index is None:
+        return None
+    return {
+        "target": record["target"],
+        "chosen": best_index,
+        "reason": "rung",
+        "rung": True,
+        "select_score": candidates[best_index].get("select_score"),
+        "incumbent_verification": incumbent_verification,
+        "challenger_verification": candidates[best_index].get("verification"),
+    }
+
+
 # Sheet-agreement gate for split panels. The GEOMETRY is exact: a panel jpg
 # is a bbox crop of the base jpg (pure translation), so one panel's pose
 # determines the whole base image's implied placement. The original intent
@@ -1970,7 +2053,7 @@ def cmd_select(
     elif mode == "arbitrate":
         # The union rescue selection, plus challenges to placed RANSAC fits.
         selections = select_union(volume, rescue, gate_score, gate_margin, allowed)
-        challenged = refined = 0
+        challenged = refined = flipped = 0
         for record in records:
             if record.get("fit_state") != "fitted":
                 continue
@@ -1985,7 +2068,15 @@ def cmd_select(
             if refinement is not None:
                 selections.append(refinement)
                 refined += 1
-        print(f"{challenged} challenges, {refined} refinements accepted")
+                continue
+            flip = rung_flip(record)
+            if flip is not None:
+                selections.append(flip)
+                flipped += 1
+        print(
+            f"{challenged} challenges, {refined} refinements, "
+            f"{flipped} rung flips accepted"
+        )
     else:
         selections = select_argmax(rescue, gate_score, gate_margin, allowed)
     accepted = sum(1 for s in selections if s.get("chosen") is not None)

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -25,6 +25,7 @@ from mapsnap.osm_snap_experiment import (
     refine_adoption,
     refine_eligible_features,
     refine_rule_outcome,
+    rung_flip,
     snap_one_page,
 )
 
@@ -309,3 +310,54 @@ def test_append_snap_logs_is_idempotent(tmp_path):
     assert text.count(SNAP_LOG_BEGIN) == 1
     assert text.count(SNAP_LOG_END) == 1
     assert "refine: candidate #1 accepted" in text
+
+
+def rung_record(
+    scale_ratio: float,
+    incumbent_ver: float = 0.3,
+    challenger_ver: float = 0.9,
+    select: float = 1.2,
+    incumbent_name: float = 0.3,
+    challenger_name: float = 0.3,
+) -> dict:
+    """A fitted record whose sole candidate differs from the incumbent by scale_ratio."""
+    record = fitted_record(
+        incumbent_ver=incumbent_ver,
+        challenger_ver=challenger_ver,
+        shift_m=15.0,
+        incumbent_name=incumbent_name,
+        challenger_name=challenger_name,
+        select=select,
+    )
+    candidate = record["candidates"][0]
+    candidate["world_affine"] = [
+        [v * scale_ratio for v in row[:2]] + [row[2]]
+        for row in candidate["world_affine"]
+    ]
+    return record
+
+
+def test_rung_flip_adopts_a_doubled_candidate():
+    # The calibrated signature: half-scale incumbent, doubled candidate that
+    # wins verification with name parity and a confident select score.
+    flip = rung_flip(rung_record(2.0))
+    assert flip is not None and flip["rung"] and flip["reason"] == "rung"
+    assert flip["chosen"] == 0
+
+
+def test_rung_flip_never_flips_down():
+    # Verification has a small-footprint bias: every would-be down flip in the
+    # twelve-volume calibration was a break. Direction is the load-bearing gate.
+    assert rung_flip(rung_record(0.5)) is None
+    assert rung_flip(rung_record(0.5, challenger_ver=5.0)) is None
+
+
+def test_rung_flip_requires_margin_parity_and_confidence():
+    # Same-scale candidates are not rung disputes.
+    assert rung_flip(rung_record(1.0)) is None
+    # Verification margin below RUNG_VER_MARGIN keeps the incumbent.
+    assert rung_flip(rung_record(2.0, incumbent_ver=0.85, challenger_ver=0.9)) is None
+    # A name regression beyond the floor keeps the incumbent.
+    assert rung_flip(rung_record(2.0, incumbent_name=0.5, challenger_name=0.2)) is None
+    # An unconfident candidate keeps the incumbent.
+    assert rung_flip(rung_record(2.0, select=0.5)) is None


### PR DESCRIPTION
Closes the structural dead zone that let half-scale fits survive arbitration, using only candidates snap already generates. Follows the disaster characterization and rung-sweep prototype discussed on the 2026-07-30 run.

## The dead zone

Ten of the corpus's 39 disasters are fits at **exactly half or double their true scale** with near-perfect rotation. For several, the correct pose already sits in snap's candidate list — trapped between the two existing selection rules:

- **Refinement** requires <100 ft agreement with the incumbent; a correct-rung candidate disagrees by 200–700 ft.
- **Arbitration** requires an indefensible incumbent (verification < 0.1); a half-scale fit on a gridiron chamfer-matches well and verifies 0.14–0.89.

`rung_flip()` is a third rule for exactly this dispute: adopt a candidate at **1.7–2.3× the incumbent's scale** when it beats the incumbent's verification by **0.1**, doesn't lose the name head-to-head by more than 0.10, and carries a select score ≥ 0.9.

## The load-bearing gate is direction

**Up-flips only, never down.** Verification has a small-footprint bias — a half-scale candidate explains ¼ the ground and matches dense OSM cheaply. Calibrating over all **1228 rung-band candidate pairs in the twelve truth volumes**: every would-be down flip that passed any margin was a break (23–98 ft incumbents sent to 340–11,000 ft: NO-1951 p433/p434/p436, Chicago p61w, Detroit p21, Nashville p44, LA p1499o/r), while every fix but one was an up flip. A doubled candidate must explain 4× the ground, so verification preferring it is hard-won evidence.

Two referees were tried first and rejected with data:
- the **family-rung prior** endorses the wrong rung on exactly the contested pages (it was derived from the bad fits);
- the **volume median** breaks legitimate second scale families (Nashville's dual-scale corpus) and oversize sheets (LA p1499*).

## Validation (full snap → street-solve → iiif → compare on the five affected volumes)

| page | before | after |
|---|---|---|
| KC p556 | 406 ft | **13 ft** |
| DC p153 | 306 ft | **12 ft** |
| Nashville p4 | 396 ft | **26 ft** |
| Brooklyn p14 | 56 ft (streets rescue) | **15 ft** |
| NO-1896 p125 | 772 ft | 842 ft (disaster → disaster, neutral) |

Exactly one flip per volume — the calibrated set and nothing else — and **no other page moved anywhere**. A pleasing composition detail: Brooklyn p14's rung pose supersedes its street-channel rescue, and `street-solve`'s referee then correctly adopts nothing.

Corpus effect: ≥200 ft disasters −3, ≤25 ft +3 (~+0.5 land-weighted points). Brooklyn p57 (a *doubled*-scale fit at 1706 ft) is left untouched by design — fixing the down direction needs a verifier without the footprint bias (per-area normalization is the obvious candidate; noted for a follow-up).

815 tests (4 new, pinning the direction gate and each margin), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
