### PR TITLE
Consume the printed scale note: rung authority + misscale demotion

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -1655,6 +1655,17 @@ def _finalize_georef(
     }
     if keymap:
         result["keymap"] = keymap
+    # The page's own printed scale note (#196), recorded whether or not any
+    # check acts on it: a reader of this sidecar judging the fit's scale
+    # should see what the sheet itself declares.
+    from mapsnap.printed_scale import printed_scale_ft
+
+    note = printed_scale_ft(Path(labels_path))
+    if note is not None:
+        result["printed_scale"] = {
+            "ft_per_inch": note[0],
+            "confidence": round(note[1], 4),
+        }
     if truth_polygons:
         result["truth"] = truth_polygons
     if gcp_pair_records is not None:
@@ -2483,6 +2494,14 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     ):
         nofit_path = output_path.replace(".georef.json", ".georef-nofit.json")
         nofit: dict = {"keymap": keymap, "streets": [], "intersections": []}
+        from mapsnap.printed_scale import printed_scale_ft as _note_read
+
+        _note = _note_read(Path(derive_paths(image_path)[0]))
+        if _note is not None:
+            nofit["printed_scale"] = {
+                "ft_per_inch": _note[0],
+                "confidence": round(_note[1], 4),
+            }
         if truth_polygons:
             nofit["truth"] = truth_polygons
         with open(nofit_path, "w") as f:

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -404,6 +404,67 @@ def region_relative_scale(
     return 1.0
 
 
+NOTE_SCALE_BAND = (0.80, 1.25)
+"""A fit within this ratio of its page's printed-note scale is confirmed; outside, condemned."""
+
+
+def printed_scale_verdicts(
+    scale_records: list[tuple[str, float]],
+) -> dict[str, tuple[str, float]]:
+    """Per-page verdicts from printed scale notes: img_path -> (verdict, ratio).
+
+    Pages whose OCR read a printed scale note (#196) get an ABSOLUTE scale
+    check instead of the relative half/double-band heuristic: the volume's
+    px-per-paper-inch is calibrated from the fitted note-bearing pages
+    themselves, so "N ft to one inch" converts to an expected px/ft. A fit
+    within NOTE_SCALE_BAND of its note is "keep" (even where the band test
+    would drop it -- a genuine 300 ft sheet sits at 6x the volume reference,
+    outside every band). A rung-shaped contradiction (~half or ~double the
+    note) is left published for snap's note-informed rung flip to repair,
+    which beats demotion. Only scattered contradictions no rung explains are
+    dropped -- and dropped unconditionally, with no neighbor-corroboration
+    escape: neighbours alias, print does not. Pages without a note are absent
+    from the result and face the usual checks.
+    """
+    from mapsnap.printed_scale import (
+        expected_px_per_ft,
+        printed_scale_ft,
+        volume_px_per_paper_inch,
+    )
+
+    notes: dict[str, int] = {}
+    for img_path, _px_per_ft in scale_records:
+        stem = os.path.splitext(img_path)[0]
+        note = printed_scale_ft(Path(stem + ".streets.json"))
+        if note is not None:
+            notes[img_path] = note[0]
+    calibration = volume_px_per_paper_inch(
+        [(px, notes[img]) for img, px in scale_records if img in notes]
+    )
+    if calibration is None:
+        return {}
+    verdicts: dict[str, tuple[str, float]] = {}
+    for img_path, px_per_ft in scale_records:
+        if img_path not in notes:
+            continue
+        ratio = px_per_ft / expected_px_per_ft(calibration, notes[img_path])
+        if NOTE_SCALE_BAND[0] <= ratio <= NOTE_SCALE_BAND[1]:
+            verdict = "keep"
+        elif (
+            HALF_SCALE_BAND[0] <= ratio <= HALF_SCALE_BAND[1]
+            or DOUBLE_SCALE_BAND[0] <= ratio <= DOUBLE_SCALE_BAND[1]
+        ):
+            # Rung-shaped contradiction: left published on purpose. Snap's
+            # note-informed rung flip (#195) repairs these to a correct fit,
+            # which beats demotion -- a demoted page faces the higher rescue
+            # gate its known-good candidate cannot clear.
+            verdict = "keep"
+        else:
+            verdict = "drop"
+        verdicts[img_path] = (verdict, ratio)
+    return verdicts
+
+
 def is_scale_outlier(ratio: float) -> bool:
     """Whether a fitted-scale / reference-scale ratio should be dropped as a scale outlier.
 
@@ -3829,8 +3890,29 @@ def main() -> None:
         and not args.geocode_keymaps
     ):
         centers_by_path = dict(location_records)
+        note_verdicts = printed_scale_verdicts(scale_records)
         n_dropped = 0
         for img_path, px_per_ft in scale_records:
+            note = note_verdicts.get(img_path)
+            if note is not None:
+                verdict, note_ratio = note
+                if verdict == "keep":
+                    continue  # the printed note confirms this scale outright
+                _, out_path, _ = derive_paths(img_path)
+                misscale_path = out_path.replace(
+                    ".georef.json", ".georef-misscale.json"
+                )
+                if os.path.exists(out_path):
+                    os.rename(out_path, misscale_path)
+                    n_success -= 1
+                    n_dropped += 1
+                    print(
+                        f"Dropped scale outlier {img_path}: {px_per_ft:.4f} px/ft is "
+                        f"{note_ratio:.2f}x the page's PRINTED scale note "
+                        f"-> {misscale_path}",
+                        file=sys.stderr,
+                    )
+                continue
             ratio = px_per_ft / ref_scale_px_per_ft
             if is_scale_outlier(ratio):
                 center = centers_by_path.get(img_path)

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1735,7 +1735,39 @@ RUNG_NAME_FLOOR = -0.10
 RUNG_SELECT_MIN = 0.9
 
 
-def rung_flip(record: dict) -> dict | None:
+def printed_note_ratios(volume: Path, records: list[dict]) -> dict[str, float]:
+    """expected/incumbent scale ratio per fitted page whose printed note read.
+
+    Calibrates metres-per-pixel-per-printed-ft from the volume's own fitted
+    note-bearing pages (the scan resolution, measured), then converts each
+    page's note into an expected scale. See mapsnap.printed_scale.
+    """
+    from mapsnap.printed_scale import printed_scale_ft
+
+    notes: dict[str, int] = {}
+    inc_scale: dict[str, float] = {}
+    for record in records:
+        incumbent = record.get("incumbent") or {}
+        affine = incumbent.get("world_affine")
+        if not affine:
+            continue
+        note = printed_scale_ft(volume / f"{record['target']}.streets.json")
+        if note is None:
+            continue
+        notes[record["target"]] = note[0]
+        inc_scale[record["target"]] = math.hypot(affine[1][0], affine[1][1])
+    samples = sorted(inc_scale[t] / notes[t] for t in notes)
+    if len(samples) < 3:
+        return {}
+    unit = samples[len(samples) // 2]  # median deg-per-px per printed ft
+    return {target: (unit * notes[target]) / inc_scale[target] for target in notes}
+
+
+RUNG_NOTE_BAND = (0.80, 1.25)
+"""How closely a scale must match the page's printed note to claim its authority."""
+
+
+def rung_flip(record: dict, note_ratio: float | None = None) -> dict | None:
     """Adopt a double-scale candidate over a half-scale incumbent, or None.
 
     Calibrated offline over all 1228 rung-band candidate pairs in the twelve
@@ -1758,6 +1790,14 @@ def rung_flip(record: dict) -> dict | None:
     if inc_scale <= 0 or incumbent_verification is None:
         return None
     incumbent_name = (incumbent.get("name") or {}).get("score")
+    # The printed scale note (#196), where read, is authority rather than
+    # inference: note_ratio is expected/incumbent scale. An incumbent that
+    # contradicts its own page's note by ~a rung forfeits the up-only
+    # protection, so a note-matching candidate may flip DOWN as well -- the
+    # direction verification alone cannot referee (small-footprint bias).
+    note_condemns = note_ratio is not None and not (
+        1 / RUNG_NOTE_BAND[1] <= note_ratio <= 1 / RUNG_NOTE_BAND[0]
+    )
     best_index = None
     best_margin = 0.0
     for index, candidate in enumerate(candidates):
@@ -1767,7 +1807,14 @@ def rung_flip(record: dict) -> dict | None:
         if not affine or verification is None or score is None:
             continue
         ratio = math.hypot(affine[1][0], affine[1][1]) / inc_scale
-        if not (RUNG_UP_BAND[0] <= ratio <= RUNG_UP_BAND[1]):
+        in_up_band = RUNG_UP_BAND[0] <= ratio <= RUNG_UP_BAND[1]
+        in_down_band = 1 / RUNG_UP_BAND[1] <= ratio <= 1 / RUNG_UP_BAND[0]
+        note_endorses = (
+            note_condemns
+            and note_ratio is not None
+            and RUNG_NOTE_BAND[0] <= ratio / note_ratio <= RUNG_NOTE_BAND[1]
+        )
+        if not (in_up_band or (in_down_band and note_endorses)):
             continue
         if score < RUNG_SELECT_MIN:
             continue
@@ -2053,6 +2100,7 @@ def cmd_select(
     elif mode == "arbitrate":
         # The union rescue selection, plus challenges to placed RANSAC fits.
         selections = select_union(volume, rescue, gate_score, gate_margin, allowed)
+        note_ratios = printed_note_ratios(volume, records)
         challenged = refined = flipped = 0
         for record in records:
             if record.get("fit_state") != "fitted":
@@ -2069,7 +2117,7 @@ def cmd_select(
                 selections.append(refinement)
                 refined += 1
                 continue
-            flip = rung_flip(record)
+            flip = rung_flip(record, note_ratio=note_ratios.get(record["target"]))
             if flip is not None:
                 selections.append(flip)
                 flipped += 1

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -361,3 +361,17 @@ def test_rung_flip_requires_margin_parity_and_confidence():
     assert rung_flip(rung_record(2.0, incumbent_name=0.5, challenger_name=0.2)) is None
     # An unconfident candidate keeps the incumbent.
     assert rung_flip(rung_record(2.0, select=0.5)) is None
+
+
+def test_rung_flip_note_authority_unlocks_down_flips():
+    # A doubled-scale incumbent whose page prints the standard note
+    # (note_ratio = expected/incumbent = 0.5): the matching half-scale
+    # candidate may flip down.
+    record = rung_record(0.5, incumbent_ver=0.3, challenger_ver=0.9)
+    assert rung_flip(record) is None  # no note: down stays blocked
+    flip = rung_flip(record, note_ratio=0.5)
+    assert flip is not None and flip["rung"]
+    # A note that ENDORSES the incumbent changes nothing.
+    assert rung_flip(record, note_ratio=1.0) is None
+    # A condemning note only admits candidates that MATCH it.
+    assert rung_flip(rung_record(0.5), note_ratio=2.0) is None

--- a/mapsnap/printed_scale.py
+++ b/mapsnap/printed_scale.py
@@ -1,0 +1,77 @@
+"""Read the printed scale note from a page's OCR output, and calibrate it.
+
+Most Sanborn sheets print their scale ("Scale 50 Ft. to One Inch."), and #196
+taught the constrained OCR decoder to emit it (173/173 parsed numbers correct
+against truth across the twelve-volume corpus). This module turns those reads
+into a per-page scale *authority*: parse the note, then calibrate the volume's
+pixels-per-paper-inch from pages that have both a fit and a note, so a printed
+"N ft to one inch" converts to an absolute expected scale for any page.
+
+The calibration constant is the scan resolution in disguise (LOC scans are
+uniform within a volume), measured rather than assumed: fitted pages with notes
+give ``px_per_paper_inch = px_per_ft * printed_ft`` directly.
+"""
+
+import json
+import re
+import statistics
+from pathlib import Path
+
+NOTE_PATTERN = re.compile(r"\b([0-9IO]{2,3})\s*FT\.?\s*TO\s*ONE\s*INCH", re.IGNORECASE)
+MIN_NOTE_CONFIDENCE = 0.2
+"""Reads below this are the decoder emitting a vocab string over noise. The
+corpus sweep found full-phrase reads at >=0.2 were correct 173/173 times while
+sub-0.1 reads are junk-box conversions."""
+
+MIN_CALIBRATION_PAGES = 3
+"""Fewest (fit, note) pages that anchor a volume's px-per-paper-inch."""
+
+VALID_PRINTED_FT = (25, 50, 100, 200, 300, 400, 600)
+"""Scales Sanborn actually printed; a parse outside this list is a misread."""
+
+
+def printed_scale_ft(streets_path: Path) -> tuple[int, float] | None:
+    """(printed ft-per-inch, confidence) from a page's OCR sidecar, or None.
+
+    The best-confidence full-phrase read wins; single tokens ("SCALE", "50")
+    are never trusted alone — "50" is also a street number and a house number.
+    """
+    if not streets_path.exists():
+        return None
+    best: tuple[int, float] | None = None
+    for street in json.loads(streets_path.read_text()).get("streets", []):
+        text = street.get("text") or ""
+        match = NOTE_PATTERN.search(text)
+        if not match:
+            continue
+        confidence = float(street.get("confidence") or 0.0)
+        if confidence < MIN_NOTE_CONFIDENCE:
+            continue
+        digits = match.group(1).upper().replace("I", "1").replace("O", "0")
+        try:
+            feet = int(digits)
+        except ValueError:
+            continue
+        if feet not in VALID_PRINTED_FT:
+            continue
+        if best is None or confidence > best[1]:
+            best = (feet, confidence)
+    return best
+
+
+def volume_px_per_paper_inch(pairs: list[tuple[float, int]]) -> float | None:
+    """Median px-per-paper-inch from (fitted px_per_ft, printed ft) pairs.
+
+    Each fitted page with a note measures the scan resolution directly:
+    ``px_per_ft * printed_ft`` pixels rendered one paper inch. The median over
+    at least MIN_CALIBRATION_PAGES pages rejects the occasional wrong fit.
+    """
+    samples = [px_per_ft * feet for px_per_ft, feet in pairs if px_per_ft > 0]
+    if len(samples) < MIN_CALIBRATION_PAGES:
+        return None
+    return float(statistics.median(samples))
+
+
+def expected_px_per_ft(px_per_paper_inch: float, printed_ft: int) -> float:
+    """The absolute scale a printed note implies, in the fitter's px/ft units."""
+    return px_per_paper_inch / printed_ft

--- a/mapsnap/printed_scale_test.py
+++ b/mapsnap/printed_scale_test.py
@@ -1,0 +1,60 @@
+import json
+
+from mapsnap.printed_scale import (
+    expected_px_per_ft,
+    printed_scale_ft,
+    volume_px_per_paper_inch,
+)
+
+
+def sidecar(tmp_path, streets):
+    path = tmp_path / "p1.streets.json"
+    path.write_text(json.dumps({"streets": streets}))
+    return path
+
+
+def test_printed_scale_parses_the_note_with_ocr_confusions(tmp_path):
+    path = sidecar(
+        tmp_path,
+        [
+            {"text": "SCALE IOO FT. TO ONE INCH", "confidence": 0.86},
+            {"text": "MAIN ST", "confidence": 0.9},
+        ],
+    )
+    assert printed_scale_ft(path) == (100, 0.86)
+
+
+def test_printed_scale_best_confidence_wins(tmp_path):
+    path = sidecar(
+        tmp_path,
+        [
+            {"text": "SCALE 50 FT TO ONE INCH", "confidence": 0.3},
+            {"text": "SCALE 100 FT. TO ONE INCH", "confidence": 0.7},
+        ],
+    )
+    assert printed_scale_ft(path) == (100, 0.7)
+
+
+def test_printed_scale_rejects_junk(tmp_path):
+    # Low confidence, lone tokens, and non-Sanborn numbers never parse.
+    path = sidecar(
+        tmp_path,
+        [
+            {"text": "SCALE 50 FT TO ONE INCH", "confidence": 0.05},
+            {"text": "SCALE", "confidence": 1.0},
+            {"text": "50", "confidence": 1.0},
+            {"text": "SCALE 70 FT TO ONE INCH", "confidence": 0.9},
+        ],
+    )
+    assert printed_scale_ft(path) is None
+    assert printed_scale_ft(tmp_path / "absent.streets.json") is None
+
+
+def test_calibration_and_expected_scale():
+    # Three fitted 50ft pages at ~6.1 px/ft -> ~305 px per paper inch.
+    pairs = [(6.1, 50), (6.05, 50), (6.2, 50), (3.1, 100)]
+    px_per_inch = volume_px_per_paper_inch(pairs)
+    assert px_per_inch is not None and 305 <= px_per_inch <= 312
+    # A 100ft note then implies half the px/ft of a 50ft page.
+    assert abs(expected_px_per_ft(px_per_inch, 100) - px_per_inch / 100) < 1e-9
+    assert volume_px_per_paper_inch([(6.1, 50)]) is None  # too few to calibrate


### PR DESCRIPTION
The third PR of the printed-scale arc (#195 rung inference → #196 note reads → this: note **consumers**). Closes the loop on #12's original goal: the sheet's own printed scale as a direct input to fitting decisions.

## `mapsnap/printed_scale.py`

Parse the best full-phrase note read (≥0.2 confidence — the corpus threshold below which reads are junk-box conversions; Sanborn-valid numbers only), then calibrate the volume's **px-per-paper-inch from its own fitted note-bearing pages** — the scan resolution measured rather than assumed (~62–63 px/paper-inch at 25% working scale, i.e. ~250 DPI full-res, uniform across LOC volumes). A printed "N ft to one inch" then converts to an absolute expected scale for any page. Volumes with <3 note+fit pages skip calibration and are untouched.

## Two consumers, partitioned to compose

**1. Note authority in `rung_flip`** — an incumbent contradicting its own page's printed note by ~a rung forfeits #195's up-only protection, so a note-matching candidate may flip **down** — the direction verification alone cannot referee (small-footprint bias). This is exactly the case #195 documented as unreachable.

**2. Absolute scale check in georef's outlier pass** — where a note read:
- within 0.8–1.25× of the note: **confirmed outright** (protects genuine odd sheets the half/double bands can't — a 300 ft sheet sits at 6× the volume reference, outside every band);
- a **scattered** contradiction: demoted to `georef-misscale`, unconditionally — no neighbour-corroboration escape (neighbours alias; print does not);
- a **rung-shaped** contradiction: deliberately left published, because snap's rung flip repairs those to a correct fit, which beats demotion — a demoted page faces the 1.25 rescue gate its known-good candidate (select ~1.1–1.2) cannot clear. This partition came out of validation: the naive drop-everything version would have regressed p14's fix to unplaced.

## Validation (`mapsnap fit`, both affected volumes)

Land-weighted score (`mapsnap score`):

| volume | before | after |
|---|---|---|
| **Brooklyn** | 80.0% (82.8% ≤25 ft − 2.9% disasters) | **87.9%** (87.9% − **0.0%**) — first clean volume |
| **DC** | 79.3% (83.8% − 4.5%) | **81.4%** (84.4% − 3.0%) |

Page counts: Brooklyn 45 → 48 ≤25 ft, 2 → 0 disasters; DC 110 → 111, 6 → 4.

Page level: Brooklyn p57 (doubled-scale fit over a printed 50 ft note) **1706 → 12 ft** via the note-informed down-flip; p14 56 → 14; p50 234 → demoted (see below); p45 bonus placement at 23 ft. DC p153 306 → 11; **p174 259 → demoted → snap rescued it to 23 ft** (the demote-then-rescue path outperforming expectations); p226/p227/p247 note-drops match pages the old band check already dropped. One minor regression: DC p175 18 → 33 ft (refit jitter).

Safety precheck across all note-bearing fitted pages: Brooklyn 42/45 inside the note band with the 3 outliers being *exactly its three disasters*; DC 80/82, both outliers disasters; **zero good fits outside the band** on either volume.

## Sidecar provenance

Every `georef.json` (and nofit doc) whose page read a note now records `printed_scale: {ft_per_inch, confidence}`, whether or not any check acts on it — a reader judging a fit's scale sees what the sheet itself declares. Demoted `georef-misscale` sidecars inherit the field through the rename.

## Deferred (the user's broader-uses list)

- **In-RANSAC scale prior** — imposing the printed scale during model selection so pages like p50 get *fixed* rather than demoted. Needs fitting-loop surgery; p50's demotion (+disaster removed) is this PR's floor for that page, not its ceiling.
- **Streets-fitter prior** — same idea for `street_solve`'s `sigma_log_scale`.
- Bar-only volumes (GR/KC/LA) still have no note to consume; geometric tick-spacing remains their path (#12).

820 tests (9 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
