### PR TITLE
snap: collapse the outer search grid — local challenges + clustered centers

### DIFF
--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -197,6 +197,41 @@ class PageContext:
         return self.orientation_cache
 
 
+def cluster_search_centers(
+    centers: list[tuple[float, float]], link_m: float
+) -> list[tuple[float, float]]:
+    """Merge search centers whose discs largely overlap (single linkage, centroid).
+
+    A page whose key-map number is printed many times (LA's lettered p1499
+    sheets inherit ~20 detections of "1499") searches every center with a full
+    NCC+refine pass; centers closer than ``link_m`` cover mostly the same
+    ground, so one centroid search suffices. Corpus timing showed center
+    multiplicity is the strongest cost correlate (r=+0.62) while sheet size is
+    not (r=+0.08); see issue #155.
+    """
+    if len(centers) <= 1:
+        return list(centers)
+    kx = 111_320.0 * math.cos(math.radians(centers[0][1]))
+    clusters: list[list[tuple[float, float]]] = []
+    for lon, lat in centers:
+        for cluster in clusters:
+            if any(
+                math.hypot((lon - a) * kx, (lat - b) * 110_540.0) <= link_m
+                for a, b in cluster
+            ):
+                cluster.append((lon, lat))
+                break
+        else:
+            clusters.append([(lon, lat)])
+    return [
+        (
+            sum(c[0] for c in cluster) / len(cluster),
+            sum(c[1] for c in cluster) / len(cluster),
+        )
+        for cluster in clusters
+    ]
+
+
 def frame_around(
     center_lonlat: tuple[float, float], *, half_m: float, res_m: float = OSM_RES_M
 ) -> FrameSpec:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -50,6 +50,7 @@ from mapsnap.osm_snap import (
     adjacency_keymap_rotations,
     affine_theta_deg,
     calibrated_radius_m,
+    cluster_search_centers,
     evaluate_pose,
     frame_around,
     label_osm_rotations,
@@ -61,6 +62,10 @@ from mapsnap.streets import Block, build_block_index
 from mapsnap.utils import default_centerlines, haversine_m
 
 # Pages the rescue channel may place: everything the iiif glob does not see.
+LOCAL_CHALLENGE_RADIUS_M = 150.0
+"""Search radius when challenging a defensible incumbent: covers refinement
+(<100 ft agreement) and rung flips (co-located) with margin, nothing more."""
+
 RESCUE_STATES = {"nofit", "misscale", "1gcp", "outlier", "none"}
 
 
@@ -615,6 +620,8 @@ def build_page_context(
         scales = page_scale_priors(
             vctx.volume_m_per_px, regions, unit.width, unit.height
         )
+    # Overlapping discs are one search; see cluster_search_centers.
+    centers = cluster_search_centers(centers, 0.75 * radius)
     ctx = PageContext(
         stem=unit.stem,
         number=unit.number,
@@ -735,6 +742,34 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
             if unit.rmse_ft is not None:
                 incumbent["rmse_ft"] = round(unit.rmse_ft, 1)
             record["incumbent"] = incumbent
+            # A defensible incumbent can only be improved LOCALLY: refinement
+            # requires <100 ft agreement and a rung flip is co-located by
+            # construction, while arbitration (the only rule that moves a page
+            # far) demands an indefensible incumbent. So the challenge search
+            # collapses to one center at the incumbent with a small radius --
+            # the 29-center hunts on LA's lettered sheets were 87% of corpus
+            # snap time spent challenging healthy fits (issue #155).
+            if (
+                incumbent.get("verification") is not None
+                and incumbent["verification"] >= INCUMBENT_DEFENSIBLE_VERIFICATION
+            ):
+                lon_c = float(
+                    unit.gen_affine[0, 0] * unit.width / 2
+                    + unit.gen_affine[0, 1] * unit.height / 2
+                    + unit.gen_affine[0, 2]
+                )
+                lat_c = float(
+                    unit.gen_affine[1, 0] * unit.width / 2
+                    + unit.gen_affine[1, 1] * unit.height / 2
+                    + unit.gen_affine[1, 2]
+                )
+                ctx.search_centers = [(lon_c, lat_c)]
+                ctx.radius_m = min(ctx.radius_m, LOCAL_CHALLENGE_RADIUS_M)
+                record["search"] = {
+                    "centers": [[round(lon_c, 7), round(lat_c, 7)]],
+                    "radius_m": round(ctx.radius_m, 1),
+                    "radius_source": "local-challenge",
+                }
     candidates = snap_page(ctx, vctx.feature_index)
     if not candidates:
         record["status"] = "no_candidates"

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -375,3 +375,22 @@ def test_rung_flip_note_authority_unlocks_down_flips():
     assert rung_flip(record, note_ratio=1.0) is None
     # A condemning note only admits candidates that MATCH it.
     assert rung_flip(rung_record(0.5), note_ratio=2.0) is None
+
+
+def test_cluster_search_centers_merges_overlapping_discs():
+    from mapsnap.osm_snap import cluster_search_centers
+
+    # Three centers within 100m of each other and one 2km away.
+    base = (-74.0, 40.0)
+    kx = 111_320.0 * 0.766
+    near = [
+        base,
+        (base[0] + 80 / kx, base[1]),
+        (base[0], base[1] + 80 / 110_540.0),
+    ]
+    far = [(base[0] + 2000 / kx, base[1])]
+    merged = cluster_search_centers(near + far, link_m=120.0)
+    assert len(merged) == 2
+    # Singletons and empties pass through untouched.
+    assert cluster_search_centers(far, 120.0) == far
+    assert cluster_search_centers([], 120.0) == []


### PR DESCRIPTION
Implements the two viable optimization ideas from the #155 timing analysis, and documents that the third was a phantom. Speed measured by full `--recompute` against stashed baselines; outcomes verified end-to-end on the published fits.

## The two changes

**1. Local challenge search.** A defensible incumbent (verification ≥ 0.1) can only be improved *locally*: refinement requires <100 ft agreement, a rung flip (#195) is co-located by construction, and arbitration — the only rule that moves a page far — demands an indefensible incumbent. So the challenge pass on a healthy fit collapses to **one search center at the incumbent, 150 m radius**; the full multi-center hunt runs only when the incumbent is indefensible. This attacks the structural finding that 87% of all snap compute was the challenge pass on already-fitted pages.

**2. Clustered search centers.** Centers whose discs largely overlap (single linkage at 0.75× radius) merge to their centroid. LA's lettered p1499 sheets inherit ~20 key-map detections of "1499" and were running ~29 full NCC+refine passes apiece — the strongest cost correlate in the corpus (r = +0.62 for center count vs +0.08 for sheet size).

## The phantom (idea 4)

Capping the rotation-prior ladder does nothing: `frame_thetas` already dedupes and caps at 8 per center. The 141–174-rung ladders in Grand Rapids' records are *display* of the raw prior list, not work performed. GR's true cost is its 831 m calibrated radius (frame area), which is not safely shrinkable. Recorded so nobody re-derives this.

## Measurements

| volume | per-page compute | speedup | published-outcome delta |
|---|---|---|---|
| **LA** | 90.9 → 16.7 min | **5.4×** | identical counts (one mid-tier move, 78→104 ft) |
| **Grand Rapids** | 13.5 → 4.8 min | 2.8× | **+1 good** (p701 26→5 ft) |
| **Hudson** | 4.5 → 3.6 min | 1.3× | **+1 good** (p68 30→14 ft) |

Net: **+2 pages ≤25 ft, zero disaster-count change.** Corpus projection: ~152 → ~55 min of snap compute, without touching the chamfer inner loop that previously looked like the mandatory target.

## Honest notes

- Three pages flipped `ok → no_keymap` in the raw records — **cache relics, not regressions**: they carry `prior_source` from an unmerged experiment (adjacency search priors, `7fdeffb`) and `elapsed_s: None`, predating the timing instrumentation; any `--recompute` on unmodified main loses them identically. (They're also an argument for reviving that adjacency-prior idea via #194's region graph.)
- The remaining LA tail (p1499j at 339 s) is indefensible-incumbent pages keeping the full clustered search **by design** — that's arbitration's search budget, spent where arbitration is actually possible.
- Rank-1 diagnostics moved on several pages (clustering changes which candidate ranks first); the published-fit comparison above is the meaningful check, and it only improved.

821 tests (1 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
