### PR TITLE
compare: land-area columns and a land-weighted score footer

### DIFF
--- a/app/server/compareTxt.test.ts
+++ b/app/server/compareTxt.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseCompareFooter, parseCompareTxt } from './compareTxt.ts';
+import {
+  parseCompareFooter,
+  parseCompareTxt,
+  parseLandByPage,
+} from './compareTxt.ts';
 
 const HEADER =
   'Page          n_t n_g  str  int  t.px/ft  g.px/ft   rmse_ft    max_ft   trans_ft   rot_err  scale_%   skew°   aniso';
@@ -86,5 +90,33 @@ describe('parseCompareFooter', () => {
     const noFooter = [HEADER, RULE, TABLE.split('\n')[2]].join('\n');
     expect(parseCompareFooter(noFooter)).toBe('');
     expect(parseCompareFooter('unrelated text file')).toBe('');
+  });
+});
+
+describe('land columns', () => {
+  const header =
+    'Page          n_t n_g  str  int  t.px/ft  g.px/ft   rmse_ft    max_ft   trans_ft   rot_err  scale_%   skew\u00b0   aniso   area_km2   land_km2';
+  const row =
+    'p57             3   2    3    2     4.89     2.64      12.3      20.1        9.4     +0.72   +1.36   -0.56   1.017     0.0622     0.0497';
+  const missingRow =
+    'p50             4   \u2014   \u2014   \u2014  \u2014  \u2014  \u2014  \u2014  \u2014  \u2014  \u2014  +0.78   1.008     0.0622     0.0497  (no fit)';
+
+  it('parses areaKm2/landKm2 from a paired row', () => {
+    const pages = parseCompareTxt([header, '-'.repeat(120), row].join('\n'));
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.areaKm2).toBeCloseTo(0.0622);
+    expect(pages[0]!.landKm2).toBeCloseTo(0.0497);
+  });
+
+  it('collects land for placed and no-fit rows, gated on the header', () => {
+    const text = [header, '-'.repeat(120), row, missingRow].join('\n');
+    expect(parseLandByPage(text)).toEqual({ p57: 0.0497, p50: 0.0497 });
+    // An old-format table (no land columns) must NOT misread skew/aniso.
+    const oldHeader = header.replace(/\s+area_km2\s+land_km2/, '');
+    const oldRow =
+      'p9              3   2    4    3     4.90     4.67      59.2     103.1       47.3     -2.11    +4.89   +0.25   1.019';
+    expect(
+      parseLandByPage([oldHeader, '-'.repeat(100), oldRow].join('\n')),
+    ).toBeNull();
   });
 });

--- a/app/server/compareTxt.ts
+++ b/app/server/compareTxt.ts
@@ -25,6 +25,10 @@ export interface ComparePageStats {
   skewDegrees?: number;
   /** Anisotropy (x/y scale ratio, 1 = isotropic), when reported (aniso column); else undefined. */
   anisotropy?: number;
+  /** Truth footprint area in km², when the table carries land columns; else undefined. */
+  areaKm2?: number;
+  /** Usable-land area in km² (street-proximity weighted) — the score's per-page weight. */
+  landKm2?: number;
 }
 
 /** Response of GET /iiif-api/compare — paired-page stats plus the table's summary footer. */
@@ -38,6 +42,13 @@ export interface CompareResponse {
   missing: string[];
   /** The summary block below the table ("N/M = …% pages georeferenced", RMSE stats, …); "" if none. */
   footer: string;
+  /**
+   * Usable-land km² per truth page key, covering BOTH placed and `(no fit)` rows,
+   * when the table carries land columns. With `pages[].rmseFt` this is enough to
+   * compute the land-weighted score client-side:
+   * (Σ land where rmse ≤ 25 − Σ land where rmse ≥ 200) / Σ land over every key here.
+   */
+  landKm2ByPage?: Record<string, number>;
 }
 
 // Whether a line is a header/rule row of the compare table (not a data row).
@@ -52,6 +63,38 @@ export function parseMissingRow(line: string): string | null {
   const tokens = line.slice(0, trailing.index).trim().split(/\s+/);
   const key = tokens[0];
   return key && !isSeparator(key) ? key : null;
+}
+
+/**
+ * Usable-land km² per page key over every table row (placed and `(no fit)`),
+ * or null when the table predates the land columns. The header is the
+ * authority: without `land_km2` there, a row's trailing numeric pair is
+ * skew/aniso and must not be misread as land.
+ */
+export function parseLandByPage(text: string): Record<string, number> | null {
+  const lines = text.split('\n');
+  if (!lines.some((line) => /area_km2\s+land_km2/.test(line))) return null;
+  const land: Record<string, number> = {};
+  for (const line of lines) {
+    const entry = parseRowLandKm2(line);
+    if (entry) land[entry[0]] = entry[1];
+  }
+  return Object.keys(land).length > 0 ? land : null;
+}
+
+// The land pair of one row; only meaningful when the header carries land columns.
+function parseRowLandKm2(line: string): [string, number] | null {
+  let body = line;
+  const trailing = body.match(/\s+\(([^)]*)\)\s*$/);
+  if (trailing) body = body.slice(0, trailing.index);
+  const tokens = body.trim().split(/\s+/);
+  const key = tokens[0];
+  if (!key || isSeparator(key) || tokens.length < 3) return null;
+  const land = Number(tokens[tokens.length - 1]);
+  const area = Number(tokens[tokens.length - 2]);
+  // Land columns always travel as a pair; a lone numeric tail is another column.
+  if (!Number.isFinite(land) || !Number.isFinite(area)) return null;
+  return [key.toLowerCase(), land];
 }
 
 // Parse one data row; returns null for `(no fit)` (truth-only) rows and unparseable lines.
@@ -84,9 +127,12 @@ function parseRow(line: string): ComparePageStats | null {
   ) {
     return null;
   }
-  // Skew/aniso are the last two columns; absent in older tables, so they don't gate the row.
+  // Skew/aniso and the land columns trail the table; absent in older tables,
+  // so they never gate the row.
   const skewDegrees = Number(numeric[11]);
   const anisotropy = Number(numeric[12]);
+  const areaKm2 = Number(numeric[13]);
+  const landKm2 = Number(numeric[14]);
   const genPageKey =
     (disagree ? (genKeyOverride ?? tokens[0]) : tokens[0]) ?? '';
   return {
@@ -98,6 +144,8 @@ function parseRow(line: string): ComparePageStats | null {
     scaleErrorPercent,
     ...(Number.isFinite(skewDegrees) ? { skewDegrees } : {}),
     ...(Number.isFinite(anisotropy) ? { anisotropy } : {}),
+    ...(Number.isFinite(areaKm2) ? { areaKm2 } : {}),
+    ...(Number.isFinite(landKm2) ? { landKm2 } : {}),
   };
 }
 

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -23,6 +23,7 @@ import { jpegDimensions } from './jpegDimensions.ts';
 import {
   parseCompareFooter,
   parseCompareTxt,
+  parseLandByPage,
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { volumePages } from './adjacencyTruth.ts';
@@ -178,6 +179,9 @@ export function registerIiifApi(
       return {
         pages: parseCompareTxt(text),
         missing: parseMissingTruthKeys(text),
+        ...((land) => (land ? { landKm2ByPage: land } : {}))(
+          parseLandByPage(text),
+        ),
         footer: parseCompareFooter(text),
       };
     } catch {

--- a/mapsnap/compare_iiif_georef.py
+++ b/mapsnap/compare_iiif_georef.py
@@ -31,7 +31,12 @@ from shapely.geometry import Point as ShapelyPoint
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import box
 
-from mapsnap.utils import FEET_PER_METER, haversine_m, source_id_to_page_key
+from mapsnap.utils import (
+    FEET_PER_METER,
+    default_centerlines,
+    haversine_m,
+    source_id_to_page_key,
+)
 
 GCP = tuple[tuple[float, float], tuple[float, float]]  # ((px, py), (lon, lat))
 EARTH_RADIUS_FT = 20_925_524.0
@@ -405,6 +410,7 @@ def analyze_pair(
     return {
         "page_key": page_key,
         "gen_page_key": gen_page_key,
+        "truth_ring": truth_ring_of(truth_item),
         "n_truth": len(truth_gcps),
         "n_gen": len(gen_gcps),
         "n_streets": extract_metadata_int(gen_item, "streets"),
@@ -419,6 +425,16 @@ def analyze_pair(
         "skew_deg": skew_deg,
         "aniso": aniso,
     }
+
+
+def truth_ring_of(truth_item: dict) -> list[list[float]] | None:
+    """World footprint ring for land weighting (lazy import: score imports us)."""
+    from mapsnap.score import truth_footprint_ring
+
+    try:
+        return truth_footprint_ring(truth_item)
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def analyze_truth_only(truth_item: dict) -> dict:
@@ -436,7 +452,46 @@ def analyze_truth_only(truth_item: dict) -> dict:
         "n_truth": len(truth_gcps),
         "skew_deg": skew_deg,
         "aniso": aniso,
+        "truth_ring": truth_ring_of(truth_item),
     }
+
+
+def attach_land(
+    rows: list[dict], missing: list[dict], centerlines: Path | None
+) -> None:
+    """Annotate every row with area_m2/land_m2 from its truth footprint, in place.
+
+    The land-weighted score (mapsnap score) needs each truth page's usable-land
+    area; carrying it on the comparison rows lets any consumer of this table --
+    the debugger frontend included -- compute the score from the columns alone.
+    Rows keep their ``truth_ring`` key only long enough to compute; pages with
+    no usable footprint (or no centerlines) get None and print as dashes.
+    """
+    from mapsnap.score import LocalFrame, land_fraction, street_tree
+
+    everything = rows + missing
+    rings = [row.get("truth_ring") for row in everything]
+    points = [p for ring in rings if ring for p in ring]
+    tree = None
+    frame = None
+    if centerlines is not None and centerlines.exists() and points:
+        frame = LocalFrame(
+            lon0=sum(p[0] for p in points) / len(points),
+            lat0=sum(p[1] for p in points) / len(points),
+        )
+        tree = street_tree(centerlines, frame)
+    for row, ring in zip(everything, rings):
+        row.pop("truth_ring", None)
+        row["area_m2"] = row["land_m2"] = None
+        if tree is None or frame is None or not ring:
+            continue
+        footprint = ShapelyPolygon([frame.to_xy(lon, lat) for lon, lat in ring]).buffer(
+            0
+        )
+        if footprint.is_empty:
+            continue
+        row["area_m2"] = footprint.area
+        row["land_m2"] = footprint.area * land_fraction(footprint, tree)
 
 
 def split_numbers_disagree(row: dict) -> bool:
@@ -450,6 +505,11 @@ def page_label(row: dict) -> str:
     return f"{row['page_key']} (t)" if split_numbers_disagree(row) else row["page_key"]
 
 
+def fmt_km2(area_m2: float | None) -> str:
+    """A land/area cell in km2, or a dash when land weighting was unavailable."""
+    return "—" if area_m2 is None else f"{area_m2 / 1e6:.4f}"
+
+
 def print_table(rows: list[dict], missing: list[dict]) -> None:
     """Print paired results (sorted by RMSE desc) then missing pages, with summary stats."""
     rows_sorted = sorted(rows, key=lambda r: r["rmse_ft"], reverse=True)
@@ -458,7 +518,8 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
         f"{'Page':<13} {'n_t':>3} {'n_g':>3} {'str':>4} {'int':>4}  "
         f"{'t.px/ft':>7}  {'g.px/ft':>7}  "
         f"{'rmse_ft':>8}  {'max_ft':>8}  {'trans_ft':>9}  "
-        f"{'rot_err':>8}  {'scale_%':>7}  {'skew°':>6}  {'aniso':>6}"
+        f"{'rot_err':>8}  {'scale_%':>7}  {'skew°':>6}  {'aniso':>6}  "
+        f"{'area_km2':>9}  {'land_km2':>9}"
     )
     sep = "-" * len(header)
     print(header)
@@ -474,7 +535,8 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
             f"{r['truth_px_per_ft']:>7.2f}  {r['gen_px_per_ft']:>7.2f}  "
             f"{r['rmse_ft']:>8.1f}  {r['max_ft']:>8.1f}  {r['trans_ft']:>9.1f}  "
             f"{r['rot_err']:>+8.2f}  {r['scale_pct']:>+7.2f}  "
-            f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}{trailing}"
+            f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}  "
+            f"{fmt_km2(r.get('area_m2')):>9}  {fmt_km2(r.get('land_m2')):>9}{trailing}"
         )
     if missing:
         missing_sorted = sorted(missing, key=lambda r: r["page_key"])
@@ -484,7 +546,8 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
                 f"{'—':>7}  {'—':>7}  "
                 f"{'—':>8}  {'—':>8}  {'—':>9}  "
                 f"{'—':>8}  {'—':>7}  "
-                f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}  (no fit)"
+                f"{r['skew_deg']:>+6.2f}  {r['aniso']:>6.3f}  "
+                f"{fmt_km2(r.get('area_m2')):>9}  {fmt_km2(r.get('land_m2')):>9}  (no fit)"
             )
     print(sep)
 
@@ -495,6 +558,26 @@ def print_table(rows: list[dict], missing: list[dict]) -> None:
     print(
         f"\n{n_paired}/{n_truth_total} = {pct:.02f}% pages georeferenced ({n_missing} total losses)"
     )
+
+    landed = [r for r in rows + missing if r.get("land_m2") is not None]
+    total_land = sum(r["land_m2"] for r in landed)
+    if landed and total_land > 0:
+        good = sum(
+            r["land_m2"]
+            for r in landed
+            if r.get("rmse_ft") is not None and r["rmse_ft"] <= 25.0
+        )
+        disaster = sum(
+            r["land_m2"]
+            for r in landed
+            if r.get("rmse_ft") is not None and r["rmse_ft"] >= 200.0
+        )
+        print(
+            f"Score: {100 * (good - disaster) / total_land:.1f}% "
+            f"(<=25ft {100 * good / total_land:.1f}% of land, "
+            f">=200ft {100 * disaster / total_land:.1f}%, "
+            f"total {total_land / 1e6:.2f} km2)"
+        )
 
     if rows:
         rmsers = np.array([r["rmse_ft"] for r in rows])
@@ -779,6 +862,15 @@ def main() -> None:
         "truth", metavar="TRUTH_IIIF", help="Human-generated IIIF AnnotationPage"
     )
     parser.add_argument(
+        "--centerlines",
+        metavar="FILE",
+        default=None,
+        help=(
+            "Street centerlines GeoJSON for the land-area columns and the "
+            "land-weighted score footer (default: discovered next to TRUTH)."
+        ),
+    )
+    parser.add_argument(
         "generated", metavar="GEN_IIIF", help="Computer-generated IIIF AnnotationPage"
     )
     parser.add_argument(
@@ -806,6 +898,12 @@ def main() -> None:
     )
 
     rows, missing = compare_pages(Path(args.truth), Path(args.generated))
+    centerlines = (
+        Path(args.centerlines)
+        if args.centerlines
+        else default_centerlines(Path(args.truth).parent)
+    )
+    attach_land(rows, missing, centerlines)
 
     if args.omit_missing:
         missing = []

--- a/mapsnap/compare_iiif_georef_test.py
+++ b/mapsnap/compare_iiif_georef_test.py
@@ -466,3 +466,41 @@ def test_compare_pages_warns_on_truth_splits_without_oim_panels(tmp_path, capsys
     assert len(missing) == 2
     err = capsys.readouterr().err
     assert "p52" in err and "oim-split-truth" in err
+
+
+def test_attach_land_annotates_rows_and_strips_rings(tmp_path):
+    import json
+
+    from mapsnap.compare_iiif_georef import attach_land
+
+    # A 200m x 200m square footprint at the origin, one street through it.
+    ring = [[0.0, 0.0], [0.002, 0.0], [0.002, 0.0018], [0.0, 0.0018], [0.0, 0.0]]
+    centerlines = tmp_path / "centerlines.geojson"
+    centerlines.write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "MAIN ST"},
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[0.0, 0.0009], [0.002, 0.0009]],
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    rows = [{"page_key": "p1", "rmse_ft": 10.0, "truth_ring": ring}]
+    missing = [{"page_key": "p2", "truth_ring": ring}]
+    attach_land(rows, missing, centerlines)
+    for row in rows + missing:
+        assert "truth_ring" not in row
+        assert row["area_m2"] is not None and row["area_m2"] > 30000
+        assert 0 < row["land_m2"] <= row["area_m2"]
+    # No centerlines: columns are None, rings still stripped.
+    rows2 = [{"page_key": "p1", "truth_ring": ring}]
+    attach_land(rows2, [], tmp_path / "absent.geojson")
+    assert rows2[0]["area_m2"] is None and "truth_ring" not in rows2[0]


### PR DESCRIPTION
Adds score-related columns to `mapsnap compare` so the land-weighted score is computable from the output alone — for the frontend, or anything else that reads the table.

Closes #185 

## The columns

Every row — placed **and** `(no fit)` — gains `area_km2` and `land_km2`: the truth footprint's area and its street-proximity-weighted usable land, computed with the *same* helpers `mapsnap score` uses (`LocalFrame`, `street_tree`, `land_fraction`), so the weights are identical by construction. The score formula from columns:

```
score = (Σ land where rmse ≤ 25 − Σ land where rmse ≥ 200) / Σ land over all rows
```

## The footer

The summary now prints the score directly:

```
54/62 = 87.10% pages georeferenced (8 total losses)
Score: 87.9% (<=25ft 87.9% of land, >=200ft 0.0%, total 5.75 km2)
```

**Verified to match `mapsnap score` exactly on Brooklyn (87.9%)** — two independent code paths to the same number. Also spot-checked per-page: p12's panels report 0.0 land in both implementations (genuine pier pages).

## Plumbing

- `--centerlines FILE` on the compare CLI, defaulting to discovery next to the truth file — so `mapsnap fit`-produced `.txt` files get the columns with no invocation change. Without centerlines the columns print as dashes and the footer is omitted (old invocations and truthless volumes degrade cleanly).
- Internally: the analyzers stash each row's truth footprint ring; one `attach_land` post-pass builds the frame + street tree once and annotates every row, then strips the rings.

## Frontend

`compareTxt.ts` gains optional `areaKm2`/`landKm2` on `ComparePageStats` and a `landKm2ByPage` map on `CompareResponse` covering the `(no fit)` rows too — everything the client needs for the denominator. **Parsing is header-gated**: my first cut misread old-format rows' trailing skew/aniso pair as land values; the test that caught it now pins the fix (`parseLandByPage` returns null unless the header declares `land_km2`). Old `.txt` files keep parsing exactly as before.

822 Python tests (1 new) + 174 app tests (2 new), ruff/pyright/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
