### PR TITLE
printed-scale: cold-start calibration + a note-derived rung in snap's ladder

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -441,7 +441,8 @@ def printed_scale_verdicts(
     if not notes:
         return {}
     calibration, calibration_source = resolve_px_per_paper_inch(
-        [(px, notes[img]) for img, px in scale_records if img in notes]
+        [(px, notes[img]) for img, px in scale_records if img in notes],
+        median_px_per_ft=statistics.median(px for _, px in scale_records),
     )
     if calibration_source != "self-calibrated":
         print(

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -429,7 +429,7 @@ def printed_scale_verdicts(
     from mapsnap.printed_scale import (
         expected_px_per_ft,
         printed_scale_ft,
-        volume_px_per_paper_inch,
+        resolve_px_per_paper_inch,
     )
 
     notes: dict[str, int] = {}
@@ -438,11 +438,17 @@ def printed_scale_verdicts(
         note = printed_scale_ft(Path(stem + ".streets.json"))
         if note is not None:
             notes[img_path] = note[0]
-    calibration = volume_px_per_paper_inch(
+    if not notes:
+        return {}
+    calibration, calibration_source = resolve_px_per_paper_inch(
         [(px, notes[img]) for img, px in scale_records if img in notes]
     )
-    if calibration is None:
-        return {}
+    if calibration_source != "self-calibrated":
+        print(
+            f"Printed-scale calibration: {calibration:.1f} px/paper-inch "
+            f"({calibration_source})",
+            file=sys.stderr,
+        )
     verdicts: dict[str, tuple[str, float]] = {}
     for img_path, px_per_ft in scale_records:
         if img_path not in notes:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -568,6 +568,36 @@ def rotation_priors_for(
     return priors
 
 
+_note_calibration_cache: dict[str, tuple[float, str]] = {}
+
+
+def volume_note_calibration(vctx: VolumeContext) -> tuple[float, str]:
+    """Per-volume px-per-paper-inch for printed-scale notes (memoized).
+
+    Self-calibrates from fitted pages whose notes read; volumes that print
+    notes only on their unfittable odd sheets (Columbus) fall back to the
+    corpus default. Working-scale px per paper inch, matching the 25% images.
+    """
+    from mapsnap.printed_scale import printed_scale_ft, resolve_px_per_paper_inch
+
+    key = str(vctx.volume)
+    if key not in _note_calibration_cache:
+        pairs = []
+        for unit in vctx.units:
+            if unit.fit_state != "fitted" or unit.gen_affine is None:
+                continue
+            note = printed_scale_ft(vctx.volume / f"{unit.stem}.streets.json")
+            if note is None:
+                continue
+            m_per_px = (
+                math.hypot(unit.gen_affine[1, 0], unit.gen_affine[1, 1]) * 110_540.0
+            )
+            # px per paper inch = px_per_ft * printed_ft = ft*0.3048/m_per_px...
+            pairs.append((0.3048 / m_per_px, note[0]))
+        _note_calibration_cache[key] = resolve_px_per_paper_inch(pairs)
+    return _note_calibration_cache[key]
+
+
 def build_page_context(
     vctx: VolumeContext, unit: PageUnit
 ) -> tuple[PageContext | None, str]:
@@ -620,6 +650,18 @@ def build_page_context(
         scales = page_scale_priors(
             vctx.volume_m_per_px, regions, unit.width, unit.height
         )
+    # The page's own printed scale note, where read, is the most authoritative
+    # scale rung of all -- Columbus p297 is a 200 ft district sheet in a 50 ft
+    # volume, ~5x the median, a rung no other prior source proposes.
+    from mapsnap.osm_snap import ScalePrior as _ScalePrior
+    from mapsnap.printed_scale import note_m_per_px, printed_scale_ft
+
+    note = printed_scale_ft(vctx.volume / f"{unit.stem}.streets.json")
+    if note is not None:
+        calibration, _source = volume_note_calibration(vctx)
+        implied = note_m_per_px(note[0], calibration)
+        if all(abs(math.log(implied / prior.m_per_px)) > 0.15 for prior in scales):
+            scales = [_ScalePrior(implied, 0.05, "printed-note"), *scales]
     # Overlapping discs are one search; see cluster_search_centers.
     centers = cluster_search_centers(centers, 0.75 * radius)
     ctx = PageContext(

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -575,8 +575,10 @@ def volume_note_calibration(vctx: VolumeContext) -> tuple[float, str]:
     """Per-volume px-per-paper-inch for printed-scale notes (memoized).
 
     Self-calibrates from fitted pages whose notes read; volumes that print
-    notes only on their unfittable odd sheets (Columbus) fall back to the
-    corpus default. Working-scale px per paper inch, matching the 25% images.
+    notes only on their unfittable odd sheets (Columbus) get the median-rung
+    estimate from their own fitted scales instead -- Columbus's scan runs 22%
+    denser than the corpus default assumed, and the median rung absorbs that.
+    Working-scale px per paper inch, matching the 25% images.
     """
     from mapsnap.printed_scale import printed_scale_ft, resolve_px_per_paper_inch
 
@@ -594,7 +596,9 @@ def volume_note_calibration(vctx: VolumeContext) -> tuple[float, str]:
             )
             # px per paper inch = px_per_ft * printed_ft = ft*0.3048/m_per_px...
             pairs.append((0.3048 / m_per_px, note[0]))
-        _note_calibration_cache[key] = resolve_px_per_paper_inch(pairs)
+        _note_calibration_cache[key] = resolve_px_per_paper_inch(
+            pairs, median_px_per_ft=0.3048 / vctx.volume_m_per_px
+        )
     return _note_calibration_cache[key]
 
 

--- a/mapsnap/printed_scale.py
+++ b/mapsnap/printed_scale.py
@@ -26,6 +26,33 @@ sub-0.1 reads are junk-box conversions."""
 MIN_CALIBRATION_PAGES = 3
 """Fewest (fit, note) pages that anchor a volume's px-per-paper-inch."""
 
+DEFAULT_PX_PER_PAPER_INCH = 62.5
+"""Cold-start calibration for volumes that cannot self-calibrate.
+
+Some volumes print scale notes ONLY on their odd sheets -- exactly the pages
+that fail to fit -- so the self-calibration (which needs note+fit pairs) is
+undefined precisely where the note matters most (Columbus: 0 pairs, while
+p297's 200 ft note read at 0.92). Measured self-calibrations across the truth
+corpus at the standard 25% working scale: Brooklyn 62.3, DC 63, KC ~62 --
+LOC's scan pipeline is uniform (~250 DPI full-res), so a 62.5 default is
+within ~1% of every measured volume. Only valid for the 25% working scale."""
+
+
+def resolve_px_per_paper_inch(
+    pairs: list[tuple[float, int]],
+) -> tuple[float, str]:
+    """(px-per-paper-inch, source): self-calibrated when possible, else the default."""
+    measured = volume_px_per_paper_inch(pairs)
+    if measured is not None:
+        return measured, "self-calibrated"
+    return DEFAULT_PX_PER_PAPER_INCH, "corpus-default"
+
+
+def note_m_per_px(printed_ft: int, px_per_paper_inch: float) -> float:
+    """The working-scale metres-per-pixel a printed note implies."""
+    return printed_ft * 0.3048 / px_per_paper_inch
+
+
 VALID_PRINTED_FT = (25, 50, 100, 200, 300, 400, 600)
 """Scales Sanborn actually printed; a parse outside this list is a misread."""
 

--- a/mapsnap/printed_scale.py
+++ b/mapsnap/printed_scale.py
@@ -27,24 +27,54 @@ MIN_CALIBRATION_PAGES = 3
 """Fewest (fit, note) pages that anchor a volume's px-per-paper-inch."""
 
 DEFAULT_PX_PER_PAPER_INCH = 62.5
-"""Cold-start calibration for volumes that cannot self-calibrate.
+"""Last-resort calibration for volumes with no fitted pages at all.
 
-Some volumes print scale notes ONLY on their odd sheets -- exactly the pages
-that fail to fit -- so the self-calibration (which needs note+fit pairs) is
-undefined precisely where the note matters most (Columbus: 0 pairs, while
-p297's 200 ft note read at 0.92). Measured self-calibrations across the truth
-corpus at the standard 25% working scale: Brooklyn 62.3, DC 63, KC ~62 --
-LOC's scan pipeline is uniform (~250 DPI full-res), so a 62.5 default is
-within ~1% of every measured volume. Only valid for the 25% working scale."""
+Measured self-calibrations at the standard 25% working scale: Brooklyn 62.3,
+DC 63, KC ~62 -- but Columbus measures 76.2 (~305 DPI raw vs ~250), so scan
+resolution is NOT uniform across LOC volumes and this constant can run 20%
+hot or cold. Any volume with fitted pages gets the median-rung estimate
+instead. Only valid for the 25% working scale."""
+
+MEDIAN_RUNG_FT = 50
+"""Sanborn's standard detail scale. A volume's median fitted scale is assumed
+to sit on this rung, which calibrates px-per-paper-inch without any note+fit
+pair: Columbus's median-rung estimate lands 0.8% from p297's truth scale
+where the corpus default was 21% off."""
+
+PLAUSIBLE_PX_PER_PAPER_INCH = (45.0, 100.0)
+"""Working-scale calibrations implying ~180-400 DPI raw scans. A median-rung
+estimate outside this band means the volume's median rung is not 50 ft (or
+its fits are junk), so the estimate is discarded rather than trusted."""
+
+
+def median_rung_px_per_paper_inch(median_px_per_ft: float | None) -> float | None:
+    """Calibration assuming the volume's median fitted scale is the 50 ft rung."""
+    if median_px_per_ft is None or median_px_per_ft <= 0:
+        return None
+    estimate = median_px_per_ft * MEDIAN_RUNG_FT
+    low, high = PLAUSIBLE_PX_PER_PAPER_INCH
+    if low <= estimate <= high:
+        return estimate
+    return None
 
 
 def resolve_px_per_paper_inch(
     pairs: list[tuple[float, int]],
+    median_px_per_ft: float | None = None,
 ) -> tuple[float, str]:
-    """(px-per-paper-inch, source): self-calibrated when possible, else the default."""
+    """(px-per-paper-inch, source), by decreasing trust.
+
+    Self-calibration (>=3 note+fit pairs) measures the scan directly;
+    the median-rung estimate assumes the volume's median fitted scale is
+    the 50 ft rung; the corpus default is a last resort for volumes with
+    no fitted pages.
+    """
     measured = volume_px_per_paper_inch(pairs)
     if measured is not None:
         return measured, "self-calibrated"
+    rung = median_rung_px_per_paper_inch(median_px_per_ft)
+    if rung is not None:
+        return rung, "median-rung"
     return DEFAULT_PX_PER_PAPER_INCH, "corpus-default"
 
 

--- a/mapsnap/printed_scale_test.py
+++ b/mapsnap/printed_scale_test.py
@@ -3,6 +3,7 @@ import json
 from mapsnap.printed_scale import (
     DEFAULT_PX_PER_PAPER_INCH,
     expected_px_per_ft,
+    median_rung_px_per_paper_inch,
     note_m_per_px,
     printed_scale_ft,
     resolve_px_per_paper_inch,
@@ -68,6 +69,29 @@ def test_cold_start_calibration_falls_back_to_the_corpus_default():
     assert source == "self-calibrated" and 300 <= measured <= 312
     fallback, source = resolve_px_per_paper_inch([(6.1, 50)])  # too few pairs
     assert source == "corpus-default" and fallback == DEFAULT_PX_PER_PAPER_INCH
+
+
+def test_median_rung_estimate_beats_the_corpus_default():
+    # Columbus: median fitted scale 0.2001 m/px -> 1.523 px/ft -> 76.2 px/inch,
+    # 22% denser than the corpus default and 0.8% from p297's truth scale.
+    estimate, source = resolve_px_per_paper_inch([], median_px_per_ft=1.523)
+    assert source == "median-rung" and 76.0 <= estimate <= 76.3
+    assert abs(note_m_per_px(200, estimate) - 0.8005) < 0.002
+    # Self-calibration still outranks it.
+    _, source = resolve_px_per_paper_inch(
+        [(6.1, 50), (6.05, 50), (6.2, 50)], median_px_per_ft=1.523
+    )
+    assert source == "self-calibrated"
+
+
+def test_median_rung_estimate_rejects_implausible_scan_resolutions():
+    # A volume whose median rung is 100 ft would imply a ~150 DPI scan: the
+    # 50 ft assumption is wrong there, so the estimate is discarded.
+    assert median_rung_px_per_paper_inch(0.762) is None
+    assert median_rung_px_per_paper_inch(None) is None
+    assert median_rung_px_per_paper_inch(-1.0) is None
+    _, source = resolve_px_per_paper_inch([], median_px_per_ft=0.762)
+    assert source == "corpus-default"
 
 
 def test_note_m_per_px_conversion():

--- a/mapsnap/printed_scale_test.py
+++ b/mapsnap/printed_scale_test.py
@@ -2,10 +2,10 @@ import json
 
 from mapsnap.printed_scale import (
     DEFAULT_PX_PER_PAPER_INCH,
-    note_m_per_px,
-    resolve_px_per_paper_inch,
     expected_px_per_ft,
+    note_m_per_px,
     printed_scale_ft,
+    resolve_px_per_paper_inch,
     volume_px_per_paper_inch,
 )
 

--- a/mapsnap/printed_scale_test.py
+++ b/mapsnap/printed_scale_test.py
@@ -1,6 +1,9 @@
 import json
 
 from mapsnap.printed_scale import (
+    DEFAULT_PX_PER_PAPER_INCH,
+    note_m_per_px,
+    resolve_px_per_paper_inch,
     expected_px_per_ft,
     printed_scale_ft,
     volume_px_per_paper_inch,
@@ -58,3 +61,16 @@ def test_calibration_and_expected_scale():
     # A 100ft note then implies half the px/ft of a 50ft page.
     assert abs(expected_px_per_ft(px_per_inch, 100) - px_per_inch / 100) < 1e-9
     assert volume_px_per_paper_inch([(6.1, 50)]) is None  # too few to calibrate
+
+
+def test_cold_start_calibration_falls_back_to_the_corpus_default():
+    measured, source = resolve_px_per_paper_inch([(6.1, 50), (6.05, 50), (6.2, 50)])
+    assert source == "self-calibrated" and 300 <= measured <= 312
+    fallback, source = resolve_px_per_paper_inch([(6.1, 50)])  # too few pairs
+    assert source == "corpus-default" and fallback == DEFAULT_PX_PER_PAPER_INCH
+
+
+def test_note_m_per_px_conversion():
+    # A 200 ft note at the corpus default: ~0.98 m/px, ~5x a 50 ft page.
+    assert abs(note_m_per_px(200, 62.5) - 0.9754) < 0.001
+    assert abs(note_m_per_px(50, 62.5) / note_m_per_px(200, 62.5) - 0.25) < 1e-9


### PR DESCRIPTION
Breaks the printed-scale cold-start deadlock (#197's calibration needs note+fit pairs; some volumes print notes only on their unfittable odd sheets) and puts the note's rung into snap's search ladder. Motivated by Columbus p297 — a 200 ft district sheet carrying **13.9 of the volume's 22.5 missing points**, with its scale printed on the sheet at 0.92 confidence.

## Changes

1. **Median-rung calibration** (new middle tier): when self-calibration is impossible, assume the volume's median fitted scale is the 50 ft rung — `px_per_paper_inch = median_px_per_ft × 50` — guarded by a plausible-scan-resolution band (45–100 px/paper-inch ≈ 180–400 DPI raw) so a hypothetical 100 ft-median volume falls back rather than trusting a 2×-wrong rung.
2. **Corpus-default calibration** (last resort, volumes with no fitted pages): 62.5 px/paper-inch at the 25% working scale, logged as `corpus-default`.
3. **`printed-note` scale prior in snap's ladder**: the page's own printed scale, converted through the calibration, prepended when no existing prior is within 15% of it. p297's rescue previously searched *only* the volume-median 50 ft rung — the correct rung was never in the ladder.

## Why the median-rung tier: the corpus default was 21% off

Scoring p297 at its truth pose measured truth at **0.8066 m/px — almost exactly 4.03× the volume-median rung** (0.2001, the 50 ft sheets), while the 62.5 px/paper-inch default implied 0.9754, i.e. 3.8σ of the prior's sigma_log. Columbus scans at ~305 DPI, not ~250: the "LOC scanning is uniform" assumption behind the constant is false. Hudson is off the same way (median-rung 75.1 vs default 62.5). The median-rung estimate puts Columbus's note prior 0.8% from p297's truth scale.

## Columbus outcome — honest ledger

- The note check activated: p297's fresh refit came out at **1.42× its own printed note** and was correctly demoted (previously the check was silent on this volume). No other page moved. Score unchanged at 77.5%.
- **p297: the note rung was searched, and lost — and a controlled experiment shows why it cannot lock yet.** With the corrected rung in the ladder, the truth pose inside the search radius, and even a scale-appropriate P(road) (UNet re-run on the full-resolution scan), no candidate at the correct rung survives into the top 8. The full-res P(road) fixes the hallucination (16% → 0.8% of the page marked road) but on 200 ft-style line-drawn streets its **recall at the truth pose is 1.3%** — the model is style-blind, not just width-blind (bicubic-upscaled working images produce zero detections at all). Meanwhile wrong-rung small-footprint aliases verify at +0.44…0.61 in the dense grid.

So the note now delivers the right rung (at the right absolute scale) to every consumer, and the remaining wall for p297 is evidence, not search: a P(road) model that can see 200 ft-scale strokes, plus **per-area-normalized verification** (the same open item that blocks note-less down-flips). Either would let this prior place the single highest-value page in the corpus.

829 tests (4 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
