### PR TITLE
Generate adjacency data in the LOC and OIM pipelines

### DIFF
--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -119,6 +119,12 @@ def main() -> None:
             ]
         )
 
+    # Printed adjacent-sheet graph, consumed by fit's snap/rescue channels. Runs after the
+    # keymap step (so identified key-map sheets are skipped) and after ocr (so the CRAFT
+    # boxes it needs are reused instead of re-detected).
+    with step("adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(dir_path), "--reuse-boxes"])
+
     run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 
 

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -180,6 +180,12 @@ def main() -> None:
             ]
         )
 
+    # Printed adjacent-sheet graph, consumed by fit's snap/rescue channels. Runs after the
+    # keymap step (so identified key-map sheets are skipped) and after ocr (so the CRAFT
+    # boxes it needs are reused instead of re-detected).
+    with step("adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(dir_path), "--reuse-boxes"])
+
     # Locate OIM's manual split regions on the canvas (ground truth for compare).
     with step("oim-split-truth"):
         run_cmd(["mapsnap", "oim-split-truth", str(dir_path / "main.iiif.json")])


### PR DESCRIPTION
`fit`'s snap channel consumes `<volume>/adjacency.json` (rotation priors via `adjacency_keymap_rotations`, region adjacency, edge-join anchors), but only `mapsnap rerun` ever built it — fresh `run-loc` / `run-oim` volumes were being fit without one. Columbus and Miami both completed their first runs with no adjacency graph at all.

## Placement

Between `ocr` and `fit`, for two reasons:

- **after `keymap`** — the detector skips identified key-map sheets via `<stem>.keymap.json`, whose faces are covered in page numbers and would otherwise pollute the graph;
- **after `ocr`** — `--reuse-boxes` reuses each page's `<stem>.boxes.json` CRAFT boxes instead of re-detecting, and CRAFT is by far the expensive part of the scan.

Uses the standard `.pipeline/<step>.done` stamps, so re-running either pipeline on an existing volume executes only this step.

## Measured effect

Miami 1950 vol 1, against a **no-adjacency control run on identical code** (the control matters — the first refit looked like a regression until it isolated an unrelated calibration change):

| run | score |
|---|---|
| no adjacency | 64.9% |
| adjacency | **66.4%** |

Per page: fixes a rescue (p76 352 ft → 4 ft), removes a disaster (p4 3193 ft → unplaced), and breaks one page (p13 13 ft → 972 ft). Columbus was neutral (only p205 crossed the 25 ft line, at rounding level).

Both directions come from the same mechanism: adjacency contributes an `adjacency-keymap` rotation prior (σ 12) beside the existing `ransac-neighbor` prior (σ 8), and where they disagree (p13: 6.09° vs 1.08°; p76: 9.38° vs 1.97°) the priors are no longer unanimous, so `frame_thetas` stops collapsing the ladder and re-appends the mask-mod90 sweep. The wider search rescues p76 and admits p13's 180° flip (θ −177.8°, verification 1.45 at 83% inliers — a confident wrong lock). Miami already carried two baseline 180° flips (p25, p8), so a publish-time flip check would cover three pages there; that's follow-up work, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)