### PR TITLE
A printed note may not publish an unsupported off-rung pose

### DIFF
--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -472,6 +472,31 @@ def printed_scale_verdicts(
     return verdicts
 
 
+NOTE_OVERRIDE_MIN_GCPS = 4
+"""Inlier GCPs required before a printed note may overrule a scattered-scale demotion.
+
+A note confirms a page's SCALE; it says nothing about its POSE. Columbus p297
+is the case that motivated this: a 200 ft district sheet whose fit sits at
+0.84x its truth scale -- genuinely consistent with the printed note, so the
+note check confirmed it -- but 621 ft wrong in position, published off two
+GCPs and worth 13.9 points of land. Where the volume's own rung structure
+calls a fit a scattered outlier, the note removes the only check that was
+catching it, so the pose has to stand on its own evidence instead. Two GCPs
+exactly determine a similarity; four leave it over-determined. Pages whose
+scale sits on a recognised rung never reach this gate, so across the twelve
+truth volumes it is exercised by exactly one page (p297, 2 GCPs).
+"""
+
+
+def inlier_gcp_count(georef_path: str) -> int:
+    """Inlier intersection GCPs in a written georef sidecar (0 if absent/unreadable)."""
+    try:
+        doc = json.loads(Path(georef_path).read_text())
+    except (OSError, ValueError):
+        return 0
+    return sum(1 for gcp in doc.get("intersections", []) if gcp.get("inlier"))
+
+
 def is_scale_outlier(ratio: float) -> bool:
     """Whether a fitted-scale / reference-scale ratio should be dropped as a scale outlier.
 
@@ -3923,7 +3948,38 @@ def main() -> None:
             if note is not None:
                 verdict, note_ratio = note
                 if verdict == "keep":
-                    continue  # the printed note confirms this scale outright
+                    if not is_scale_outlier(px_per_ft / ref_scale_px_per_ft):
+                        continue  # scale agrees with the volume's rungs too
+                    # The note confirms the scale of a page the volume's own
+                    # rungs call a scattered outlier, so it is overruling the
+                    # only check on this fit. Scale is not pose: require the
+                    # fit to be over-determined by its own GCPs before the
+                    # note may publish it (see NOTE_OVERRIDE_MIN_GCPS).
+                    _, out_path, _ = derive_paths(img_path)
+                    n_gcps = inlier_gcp_count(out_path)
+                    if n_gcps >= NOTE_OVERRIDE_MIN_GCPS:
+                        print(
+                            f"Keeping scale outlier {img_path}: {px_per_ft:.4f} px/ft "
+                            f"confirmed by its PRINTED note ({note_ratio:.2f}x) on "
+                            f"{n_gcps} inlier GCPs",
+                            file=sys.stderr,
+                        )
+                        continue
+                    misscale_path = out_path.replace(
+                        ".georef.json", ".georef-misscale.json"
+                    )
+                    if os.path.exists(out_path):
+                        os.rename(out_path, misscale_path)
+                        n_success -= 1
+                        n_dropped += 1
+                        print(
+                            f"Dropped scale outlier {img_path}: {px_per_ft:.4f} px/ft "
+                            f"matches its PRINTED note ({note_ratio:.2f}x) but only "
+                            f"{n_gcps} inlier GCP(s) support the pose "
+                            f"-> {misscale_path}",
+                            file=sys.stderr,
+                        )
+                    continue
                 _, out_path, _ = derive_paths(img_path)
                 misscale_path = out_path.replace(
                     ".georef.json", ".georef-misscale.json"

--- a/mapsnap/georef_from_labels_test.py
+++ b/mapsnap/georef_from_labels_test.py
@@ -1406,6 +1406,47 @@ def test_is_scale_outlier():
     assert is_scale_outlier(2.3)
 
 
+def test_inlier_gcp_count(tmp_path):
+    import json
+
+    from mapsnap.georef_from_labels import inlier_gcp_count
+
+    path = tmp_path / "p1.georef.json"
+    path.write_text(
+        json.dumps(
+            {
+                "intersections": [
+                    {"inlier": True},
+                    {"inlier": False},
+                    {"inlier": True},
+                    {},
+                ]
+            }
+        )
+    )
+    assert inlier_gcp_count(str(path)) == 2
+    # A missing or unreadable sidecar counts as no support, never a crash.
+    assert inlier_gcp_count(str(tmp_path / "absent.georef.json")) == 0
+    (tmp_path / "junk.georef.json").write_text("not json")
+    assert inlier_gcp_count(str(tmp_path / "junk.georef.json")) == 0
+
+
+def test_note_override_needs_an_over_determined_fit():
+    """A printed note may only overrule a scattered-scale demotion on real GCP support.
+
+    Columbus p297: a 200 ft sheet at 0.29x the volume reference (a scattered
+    outlier) whose fit matches its printed note but is 621 ft wrong on 2 GCPs.
+    """
+    from mapsnap.georef_from_labels import NOTE_OVERRIDE_MIN_GCPS, is_scale_outlier
+
+    # The p297 shape: note-confirmed, but the volume's rungs call it scattered.
+    assert is_scale_outlier(0.29)
+    assert 2 < NOTE_OVERRIDE_MIN_GCPS  # so p297's 2-GCP fit is demoted
+    # Pages sitting on a recognised rung never reach the gate at all.
+    assert not is_scale_outlier(0.50)  # every 100 ft sheet in the corpus
+    assert not is_scale_outlier(1.00)  # every 50 ft sheet in the corpus
+
+
 def test_family_scale_picks_middle_of_balanced_ladder():
     from mapsnap.georef_from_labels import family_scale
 


### PR DESCRIPTION
#201's median-rung calibration is *more accurate*, and that is precisely what broke Columbus. Measured on this branch's parent:

| volume | before #201 | after #201 | with this guard |
|---|---|---|---|
| Columbus | 77.5% | **64.5%** | **77.5%** |
| Miami | 67.3% | 64.9% | (guard does not fire) |

## What went wrong

Columbus p297's fit sits at **0.84× its truth scale** — genuinely consistent with the sheet's printed "200 FT TO ONE INCH". So the corrected calibration moved its note ratio from 1.43 (`DROP scattered`) to 1.18 (`KEEP note-confirmed`), and the page was published **621 ft wrong in position off two GCPs**: 13.9 points of land, disasters 0.3% → 14.2%. The old, wrong calibration had been an *accidental* guard, and fixing it removed the only check that fit was facing.

A note confirms **scale**. It says nothing about **pose**. Where the note agrees with the volume's own rung structure it changes no outcome, but a `keep` verdict also exempts the page from the relative-scale outlier check — so for a scattered outlier the note is overruling the sole remaining test.

## The guard

A note may overrule a scattered-scale demotion only when the pose is over-determined by its own GCPs (`NOTE_OVERRIDE_MIN_GCPS = 4`; two exactly determine a similarity). Pages whose scale sits on a recognised rung never reach the gate — every 50 ft sheet (ratio ≈ 1.0) and every 100 ft sheet (≈ 0.5) in the corpus passes `is_scale_outlier` already. Across the twelve truth volumes **exactly one page reaches this gate**: p297, at 2 GCPs.

The threshold is therefore documented as what it is — a principled floor (over-determined rather than exactly-determined), not a tuned one, since the corpus offers a single data point.

## Rejected alternative

A keymap-distance check was measured first and **rejected by the data**: p297's wrong fit sits 375 m from its keymap centre, comfortably *inside* the 528 m radius, while healthy pages fall outside (Champaign p19 at 1653 m, LA p1499l at 1975 m). It would miss the disaster and demote good fits.

Verification was also considered — p297's published pose scores −0.58 against a healthy Columbus median of 1.36 — but it is unavailable at this point in `georef` (snap runs afterwards), and the null-normalization work showed a low score cannot distinguish wrong from merely evidence-poor: p297's *truth* pose scores −0.48 too. Demoting to `misscale` hands the page to snap, which already carries the note's rung in its ladder and correctly declines to place it.

## Validation

- Columbus: 64.5% → **77.5%**, p297 demoted with `only 2 inlier GCP(s) support the pose`, every other page unchanged.
- Champaign (100 ft notes at ratio 0.51) and Hudson (100 ft notes, 8 unfittable note sheets): guard never fires; 97.8% and 51.3% with zero disasters.
- 831 tests (2 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)