### PR TITLE
adjacency: one-sided claims as a lower-trust pose-graph tier

### DIFF
--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -1837,10 +1837,11 @@ def measurement_sigmas(
     enter with loose sigmas and rely on the solver's Huber loss to be outvoted
     when wrong. Synthetic-anchor measurements (both pages unfitted, anchor
     posed at its keymap guess) searched a worse frame, so they get 1.5x;
-    measurements from one-sided-claim pairs (a printed reference whose
-    reciprocal never read — ~90% genuine against the label truth, but junk
-    reads land in the same tier) get the same 1.5x so mutual-edge evidence
-    outvotes them where they disagree.
+    measurements from one-sided-claim pairs get the same 1.5x so mutual-edge
+    evidence outvotes them where they disagree. That tier is only 32-54%
+    genuine against the label truth (vs 96-100% for mutual edges), so the
+    widening is doing real work — the join's own verification is the primary
+    filter, and the solver's Huber loss the backstop.
     """
     if verification >= 1.3:
         pos, theta = 5.0, 0.6
@@ -2226,10 +2227,12 @@ def cmd_posegraph(
     suffix so the printed-graph baseline is preserved for comparison.
 
     With ``one_sided`` the pair set is augmented with unreciprocated-claim
-    edges (adjacency.json's lower-trust ``one_sided`` tier — ~90% genuine
-    against the label truth, the reciprocal side simply failed to read).
-    Their measurements are tagged and solved at widened sigmas so mutual-edge
-    evidence outvotes them; outputs get a ``_1sided`` suffix.
+    edges (adjacency.json's lower-trust ``one_sided`` tier: 32-54% genuine
+    against the label truth, so most are junk reads that resolved to a real
+    page). They are proposals only — the join's verification gate and the
+    solver's Huber loss do the filtering, and their measurements are tagged
+    and solved at widened sigmas so mutual-edge evidence outvotes them.
+    Outputs get a ``_1sided`` suffix.
     """
     from mapsnap.edge_join_graph import (
         AbsolutePrior,

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -283,18 +283,28 @@ def page_rect_metres(
     return ring
 
 
-def detected_pairs(volume: Path) -> set[frozenset[int]]:
-    """Mutual adjacency edges as unordered page-number pairs, or empty if absent."""
+def adjacency_number_pairs(volume: Path, doc_key: str) -> set[frozenset[int]]:
+    """An adjacency.json edge list as unordered page-number pairs, or empty if absent."""
     path = volume / "adjacency.json"
     if not path.exists():
         return set()
     doc = json.loads(path.read_text())
     pairs: set[frozenset[int]] = set()
-    for a, b in doc.get("adjacency", []):
+    for a, b in doc.get(doc_key, []):
         na, nb = page_number(a), page_number(b)
         if na is not None and nb is not None and na != nb:
             pairs.add(frozenset((na, nb)))
     return pairs
+
+
+def detected_pairs(volume: Path) -> set[frozenset[int]]:
+    """Mutual adjacency edges as unordered page-number pairs, or empty if absent."""
+    return adjacency_number_pairs(volume, "adjacency")
+
+
+def one_sided_pairs(volume: Path) -> set[frozenset[int]]:
+    """Unreciprocated-claim edges (the lower-trust tier), or empty if absent."""
+    return adjacency_number_pairs(volume, "one_sided")
 
 
 def keymap_region_adjacency(
@@ -1818,13 +1828,19 @@ STREET_FACTOR_MIN_CONFIDENCE = 0.7
 STREET_FACTOR_TRUST_M = 15.0
 
 
-def measurement_sigmas(verification: float, synthetic: bool) -> tuple[float, float]:
+def measurement_sigmas(
+    verification: float, synthetic: bool, one_sided: bool = False
+) -> tuple[float, float]:
     """(sigma_pos_m, sigma_theta_rad) for one join measurement.
 
     Calibrated on DC: verification>=1.3 joins are ~5m-class; sub-gate joins
     enter with loose sigmas and rely on the solver's Huber loss to be outvoted
     when wrong. Synthetic-anchor measurements (both pages unfitted, anchor
-    posed at its keymap guess) searched a worse frame, so they get 1.5x.
+    posed at its keymap guess) searched a worse frame, so they get 1.5x;
+    measurements from one-sided-claim pairs (a printed reference whose
+    reciprocal never read — ~90% genuine against the label truth, but junk
+    reads land in the same tier) get the same 1.5x so mutual-edge evidence
+    outvotes them where they disagree.
     """
     if verification >= 1.3:
         pos, theta = 5.0, 0.6
@@ -1835,6 +1851,8 @@ def measurement_sigmas(verification: float, synthetic: bool) -> tuple[float, flo
     else:
         pos, theta = 35.0, 5.0
     factor = 1.5 if synthetic else 1.0
+    if one_sided:
+        factor *= 1.5
     return pos * factor, math.radians(theta * factor)
 
 
@@ -1888,6 +1906,7 @@ def collect_graph_measurements(
     limit: int | None = None,
     extra_pairs: set[frozenset[int]] | None = None,
     keymap_centroids: dict[int, tuple[float, float]] | None = None,
+    loose_pairs: set[frozenset[int]] | None = None,
 ) -> list[dict]:
     """Run the matcher over every measurable mutual-adjacency edge.
 
@@ -1901,6 +1920,9 @@ def collect_graph_measurements(
     region adjacency) beyond the printed-number graph; for those, the printed
     reciprocal side is unavailable, so the anchor-side direction gate is fed
     from ``keymap_centroids`` (the region-centroid bearing) instead.
+    ``loose_pairs`` marks pairs from the lower-trust one-sided-claim tier:
+    their records are tagged ``one_sided_pair`` so the solver widens their
+    sigmas (see measurement_sigmas).
     """
     by_number = {u.number: u for u in units}
     pairs = detected_pairs(volume)
@@ -2008,6 +2030,8 @@ def collect_graph_measurements(
         if record is None:
             continue
         record["synthetic_anchor"] = synthetic
+        if loose_pairs and frozenset((anchor.number, target.number)) in loose_pairs:
+            record["one_sided_pair"] = True
         record["anchor_state"] = anchor.fit_state
         record["target_state"] = target.fit_state
         record["anchor_affine"] = [list(row) for row in anchor_affine]
@@ -2184,6 +2208,7 @@ def cmd_posegraph(
     street_factors: bool = False,
     keymap_adjacency: bool = False,
     keymap_gap_m: float = 40.0,
+    one_sided: bool = False,
 ) -> None:
     """Global pose-graph solve over all edge-join measurements.
 
@@ -2199,6 +2224,12 @@ def cmd_posegraph(
     region-adjacency pairs that involve a not-yet-fitted page (the printed graph
     misses these on 4-digit-page volumes like LA); outputs get a ``_kmadj``
     suffix so the printed-graph baseline is preserved for comparison.
+
+    With ``one_sided`` the pair set is augmented with unreciprocated-claim
+    edges (adjacency.json's lower-trust ``one_sided`` tier — ~90% genuine
+    against the label truth, the reciprocal side simply failed to read).
+    Their measurements are tagged and solved at widened sigmas so mutual-edge
+    evidence outvotes them; outputs get a ``_1sided`` suffix.
     """
     from mapsnap.edge_join_graph import (
         AbsolutePrior,
@@ -2211,34 +2242,49 @@ def cmd_posegraph(
     units = load_page_units(volume)
     by_stem = {u.stem: u for u in units}
     out_dir = volume / "artifacts" / "edge_join"
-    suffix = "_kmadj" if keymap_adjacency else ""
+    suffix = ("_kmadj" if keymap_adjacency else "") + ("_1sided" if one_sided else "")
     meas_path = out_dir / f"measurements{suffix}.jsonl"
 
-    extra_pairs: set[frozenset[int]] | None = None
-    keymap_centroids: dict[int, tuple[float, float]] | None = None
-    if keymap_adjacency:
-        km_pairs, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
-        real_numbers = {u.number for u in units}
-        fitted_numbers = {
-            u.number
-            for u in units
-            if u.fit_state == "fitted" and u.gen_affine is not None
-        }
-        detected = detected_pairs(volume)
+    real_numbers = {u.number for u in units}
+    fitted_numbers = {
+        u.number for u in units if u.fit_state == "fitted" and u.gen_affine is not None
+    }
+    detected = detected_pairs(volume)
+
+    def new_unfitted_pairs(candidates: set[frozenset[int]]) -> set[frozenset[int]]:
         # Keep only pairs between two real volume pages (the key map also reads
         # stray lot/scale numbers) that connect a not-yet-fitted page and aren't
         # already in the printed graph — fitted-fitted pairs would only re-refine
         # already-placed sheets.
-        extra_pairs = {
+        return {
             pair
-            for pair in km_pairs
+            for pair in candidates
             if pair <= real_numbers
             and pair not in detected
             and not pair <= fitted_numbers
         }
+
+    extra_pairs: set[frozenset[int]] | None = None
+    loose_pairs: set[frozenset[int]] | None = None
+    keymap_centroids: dict[int, tuple[float, float]] | None = None
+    if keymap_adjacency:
+        km_pairs, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
+        extra_pairs = new_unfitted_pairs(km_pairs)
         print(
             f"keymap region adjacency (gap<={keymap_gap_m:g}m): {len(km_pairs)} pairs,"
             f" {len(extra_pairs)} new real pairs involving an unfitted page"
+        )
+    if one_sided:
+        os_pairs = one_sided_pairs(volume)
+        loose_pairs = new_unfitted_pairs(os_pairs) - (extra_pairs or set())
+        extra_pairs = (extra_pairs or set()) | loose_pairs
+        # The centroid substitute keeps the anchor-side gate alive when the
+        # anchor is the side whose claim never read.
+        if keymap_centroids is None:
+            _, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
+        print(
+            f"one-sided claims: {len(os_pairs)} pairs,"
+            f" {len(loose_pairs)} new pairs involving an unfitted page"
         )
 
     if meas_path.exists() and not remeasure:
@@ -2248,7 +2294,7 @@ def cmd_posegraph(
         print(f"loaded {len(records)} cached measurements from {meas_path}")
     else:
         records = collect_graph_measurements(
-            volume, units, limit, extra_pairs, keymap_centroids
+            volume, units, limit, extra_pairs, keymap_centroids, loose_pairs
         )
         meas_path.write_text("\n".join(json.dumps(r) for r in records))
         print(f"wrote {len(records)} measurements to {meas_path}")
@@ -2291,7 +2337,9 @@ def cmd_posegraph(
             pose_t = vframe.affine_to_pose(np.array(alternate["world_affine"]))
             dx, dy, dtheta = vframe.relative(pose_a, pose_t)
             sigma_pos, sigma_theta = measurement_sigmas(
-                alternate["verification"], r.get("synthetic_anchor", False)
+                alternate["verification"],
+                r.get("synthetic_anchor", False),
+                r.get("one_sided_pair", False),
             )
             candidates.append(
                 RelativeMeasurement(
@@ -2625,6 +2673,11 @@ def main() -> None:
         help="posegraph: refine with street-label line factors",
     )
     parser.add_argument(
+        "--one-sided",
+        action="store_true",
+        help="posegraph: add unreciprocated-claim pairs at widened sigmas (writes *_1sided)",
+    )
+    parser.add_argument(
         "--keymap-adjacency",
         action="store_true",
         help="posegraph: add key-map region-adjacency candidate pairs (writes *_kmadj)",
@@ -2669,6 +2722,7 @@ def main() -> None:
             args.street_factors,
             args.keymap_adjacency,
             args.keymap_gap_m,
+            args.one_sided,
         )
     elif args.command == "materialize":
         cmd_materialize(args.volume, args.source)

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -420,15 +420,14 @@ def is_claim(
     return True
 
 
-def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
-    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
+def claim_resolver(claims_by_page: dict[str, set[str]]):
+    """resolve(claim key) -> stems carrying it, shared by both edge builders.
 
-    ``claims_by_page`` maps page stems to claimed page keys. A claimed key resolves to
-    the stem(s) carrying exactly that key; a bare-number claim in a volume whose sheet
-    has a lettered stem (Chicago prints "60" for p60w) falls back to the number, but
-    only when it names a single stem — a number shared by many lettered sheets (LA's
-    p1499a-r) is ambiguous and resolves to nothing. The edge exists only if each side's
-    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
+    A claimed key resolves to the stem(s) carrying exactly that key; a
+    bare-number claim in a volume whose sheet has a lettered stem (Chicago
+    prints "60" for p60w) falls back to the number, but only when it names a
+    single stem — a number shared by many lettered sheets (LA's p1499a-r) is
+    ambiguous and resolves to nothing.
     """
     stems_by_key: dict[str, list[str]] = defaultdict(list)
     stems_by_number: dict[int, list[str]] = defaultdict(list)
@@ -450,6 +449,17 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
                 return fallback
         return []
 
+    return resolve
+
+
+def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
+
+    ``claims_by_page`` maps page stems to claimed page keys (see claim_resolver
+    for how claims resolve to stems). The edge exists only if each side's
+    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
+    """
+    resolve = claim_resolver(claims_by_page)
     edges: set[tuple[str, str]] = set()
     for stem, claimed in claims_by_page.items():
         for claim in claimed:
@@ -461,6 +471,27 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
                 ):
                     first, second = sorted((stem, other))
                     edges.add((first, second))
+    return sorted(edges)
+
+
+def one_sided_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Directed claims that resolve to a real page but are not reciprocated.
+
+    The lower-trust adjacency tier: measured against the hand-labelled truth,
+    88% of Hudson's and 89% of LA's unreciprocated-but-resolvable claims are
+    genuine printed references whose reciprocal side failed to read (truth
+    itself reciprocates 91-93%). Consumers must treat these as candidates to
+    verify, not facts — a junk read that resolves to a real page lands here.
+    Returns sorted (claimer, target) pairs, excluding mutual edges.
+    """
+    resolve = claim_resolver(claims_by_page)
+    mutual = {frozenset(edge) for edge in mutual_edges(claims_by_page)}
+    edges: set[tuple[str, str]] = set()
+    for stem, claimed in claims_by_page.items():
+        for claim in claimed:
+            for other in resolve(claim):
+                if other != stem and frozenset((stem, other)) not in mutual:
+                    edges.add((stem, other))
     return sorted(edges)
 
 
@@ -623,6 +654,7 @@ def main() -> None:
             )
 
     edges = mutual_edges(claims_by_page)
+    one_sided = one_sided_edges(claims_by_page)
     doc = {
         "timestamp": datetime.now(UTC).isoformat(),
         "command": sys.argv[:],
@@ -634,13 +666,14 @@ def main() -> None:
         "single_digit_min_gap": round(min_gap, 1) if min_gap is not None else None,
         "pages": pages,
         "adjacency": [list(edge) for edge in edges],
+        "one_sided": [list(edge) for edge in one_sided],
     }
     output = args.output or (args.volume / "adjacency.json")
     output.write_text(json.dumps(doc, indent=2))
     total_claims = sum(len(c) for c in claims_by_page.values())
     print(
         f"Wrote {output}: {len(pages)} pages, {total_claims} directed claims, "
-        f"{len(edges)} mutual edges.",
+        f"{len(edges)} mutual edges, {len(one_sided)} one-sided.",
         file=sys.stderr,
     )
 

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -156,8 +156,11 @@ def resolve_page_key(
                  forms a valid key ("1499G" -> 1499G); checked first because
                  the digits pass renders the same ink as a bare "1499" -- a
                  different, wrong page.
-      exact      the digit read is a valid key as-is (the only method that
-                 applies to keys shorter than ``min_repair_digits``).
+      exact      the digit read is a valid key as-is.
+      number     the digit read matches exactly ONE key's digit part: Chicago
+                 prints a bare "60" for sheet p60w, and Miami "8" for p8s.
+                 A digit part shared by many lettered keys (LA's 18 p1499*
+                 sheets) is ambiguous and never resolved this way.
       suffix     the read lost its leading digit against the sheet trim:
                  exactly one valid key ends with it ("409" -> 1409). Requires
                  a read of >= 3 digits: 2-digit remnants are house-number
@@ -183,6 +186,11 @@ def resolve_page_key(
         return None
     if digits in valid_keys:
         return digits, "exact"
+    same_number = [
+        key for key in valid_keys if "".join(c for c in key if c.isdigit()) == digits
+    ]
+    if len(same_number) == 1:
+        return same_number[0], "number"
     repairable = [
         key for key in valid_keys if key.isdigit() and len(key) >= min_repair_digits
     ]

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -6,8 +6,13 @@ sheet continues. Reading these gives page adjacency that is independent of the k
 detected neighbor's edge (top/left/bottom/right of the image) pins the page's orientation.
 
 Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a
-detection only becomes a *claim* when it is a valid page number, near the page edge, printed
-large, and axis-aligned; and a claim only becomes an adjacency *edge* when it is reciprocated —
+detection only becomes a *claim* when it resolves to a valid page key, near the page edge,
+printed large, and axis-aligned. Resolution is letter-aware (a "1499G" read claims p1499g, not
+p1499) and repairs the two systematic read failures of long page numbers — leading digits lost
+against the sheet trim ("409" -> 1409) and neighboring ink absorbed into the box ("14027" ->
+1402) — but only on a unique match against keys of >= MIN_REPAIR_DIGITS digits, so volumes
+with 1- and 2-digit page numbers resolve exact reads only. A claim only becomes an adjacency
+*edge* when it is reciprocated —
 page A claims B AND page B claims A. Reciprocity alone is not proof: junk claims of small
 numbers are common enough to reciprocate by chance (and page numbering correlates with
 adjacency, so such accidents are often "correct"), so single-digit claims — where any tall
@@ -27,6 +32,7 @@ each page's number detections and the mutual-edge adjacency graph.
 import argparse
 import json
 import math
+import re
 import sys
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -36,7 +42,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
-from mapsnap.keymap.locate import page_number
+from mapsnap.keymap.locate import page_key, page_number
 from mapsnap.utils import image_stem
 
 # A detection only counts as an adjacency claim when it sits in the outer EDGE_BAND of the
@@ -117,6 +123,81 @@ def bbox_gap(a: list[list[float]], b: list[list[float]]) -> float:
     return math.hypot(dx, dy)
 
 
+MIN_REPAIR_DIGITS = 3
+"""Fewest digits a page key must have before read-repair may target it.
+
+Repair (suffix completion, embedded extraction) exists for volumes like LA 1949
+whose 4-digit '1'-leading references truncate against the sheet trim ("1409"
+reads "409" at conf 1.0) or absorb neighboring ink ("14027" for 1402) — the
+LA truth labels put 49% of all printed references in this boxed-but-unread
+class. For volumes with 1- and 2-digit page numbers, short reads are
+substrings of everything, so repair against short keys would be guesswork:
+below this floor only exact and lettered matches fire, leaving those volumes'
+behavior untouched (Hudson reads 96% of its references fine without repair).
+"""
+
+LETTERED_KEY_PATTERN = re.compile(r"([0-9IO]+)\s*([A-Z]{1,2})$")
+"""A letters-pass read that ends in a short letter suffix ("1499G", "I33S")."""
+
+
+def resolve_page_key(
+    digit_text: str,
+    letter_text: str,
+    valid_keys: set[str],
+    min_repair_digits: int = MIN_REPAIR_DIGITS,
+) -> tuple[str, str] | None:
+    """Resolve raw OCR reads of a margin reference to a valid page key.
+
+    ``digit_text`` is the digits-allowlist read, ``letter_text`` the
+    letters-allowed read of the same box ("" when none). Returns
+    ``(key, method)`` or None, trying in order:
+
+      lettered   the letter read shows a digit run plus a letter suffix that
+                 forms a valid key ("1499G" -> 1499G); checked first because
+                 the digits pass renders the same ink as a bare "1499" -- a
+                 different, wrong page.
+      exact      the digit read is a valid key as-is (the only method that
+                 applies to keys shorter than ``min_repair_digits``).
+      suffix     the read lost its leading digit against the sheet trim:
+                 exactly one valid key ends with it ("409" -> 1409). Requires
+                 a read of >= 3 digits: 2-digit remnants are house-number
+                 fragments that happen to end a page number, measured 8%
+                 precise on the LA truth labels (13/164) — including a
+                 symmetric pair ("85" on p1475, "75" on p1485) confident
+                 enough to reciprocate into a false edge. 3-digit remnants
+                 measure 71% precise and reciprocity removes the rest.
+      embedded   the read absorbed extra digits from neighboring ink: exactly
+                 one valid key appears inside it ("14027" -> 1402).
+
+    Repairs require a UNIQUE match among keys of >= ``min_repair_digits``
+    digits; any ambiguity resolves to None, never a guess.
+    """
+    digits = "".join(c for c in digit_text if c.isdigit())
+    match = LETTERED_KEY_PATTERN.search(letter_text.replace(" ", "").upper())
+    if match:
+        base = match.group(1).replace("I", "1").replace("O", "0")
+        lettered = base + match.group(2)
+        if lettered in valid_keys:
+            return lettered, "lettered"
+    if not digits:
+        return None
+    if digits in valid_keys:
+        return digits, "exact"
+    repairable = [
+        key for key in valid_keys if key.isdigit() and len(key) >= min_repair_digits
+    ]
+    if len(digits) >= 3:
+        suffixes = [
+            key for key in repairable if len(key) > len(digits) and key.endswith(digits)
+        ]
+        if len(suffixes) == 1:
+            return suffixes[0], "suffix"
+    embedded = [key for key in repairable if len(key) < len(digits) and key in digits]
+    if len(embedded) == 1:
+        return embedded[0], "embedded"
+    return None
+
+
 def is_text_veto(
     letter_text: str, letter_confidence: float, digit_confidence: float
 ) -> bool:
@@ -166,24 +247,28 @@ def cached_craft_boxes(image_path: Path) -> tuple[list, list] | None:
 def digit_detections(
     image_path: Path,
     reader,
-    valid_numbers: set[int],
+    valid_keys: set[str],
     craft_boxes: tuple[list, list] | None = None,
 ) -> list[dict]:
-    """All digit reads on one page that parse to a valid volume page number.
+    """All digit reads on one page that resolve to a valid volume page key.
 
     Two recognition passes over the same image: the digits-only pass supplies the
     transcription (immune to look-alike substitutions like 0 -> O), and a letters-allowed
     pass over the same boxes vetoes the ones that are actually street names or other text
-    (see is_text_veto). ``craft_boxes`` (from cached_craft_boxes) skips the CRAFT
-    detection pass — by far the most expensive step — reusing the boxes ``mapsnap ocr``
-    already computed for the same image.
+    (see is_text_veto) and supplies letter suffixes for lettered keys ("1499G").
+    Reads that are not a valid key verbatim go through ``resolve_page_key`` repair.
+    ``craft_boxes`` (from cached_craft_boxes) skips the CRAFT detection pass — by far
+    the most expensive step — reusing the boxes ``mapsnap ocr`` already computed for
+    the same image.
 
-    Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
-    confidence, the glyph ``height`` in pixels, position as width/height fractions, the
-    ``edge`` classification, and ``nearest_box`` — the gap to the nearest other OCR box, since
-    a genuine sheet reference is printed in open whitespace while a junk single digit is
-    usually a fragment of a larger number with sibling text right beside it. Filtering into
-    claims is left to the caller so the JSON keeps the full picture.
+    Each detection records the resolved ``key`` and how it resolved (``via``), the
+    digit part as ``number`` (for size rules and older readers), the raw OCR ``text``,
+    EasyOCR's polygon and confidence, the glyph ``height`` in pixels, position as
+    width/height fractions, the ``edge`` classification, and ``nearest_box`` — the gap
+    to the nearest other OCR box, since a genuine sheet reference is printed in open
+    whitespace while a junk single digit is usually a fragment of a larger number with
+    sibling text right beside it. Filtering into claims is left to the caller so the
+    JSON keeps the full picture.
     """
     from easyocr.utils import reformat_input
 
@@ -210,7 +295,7 @@ def digit_detections(
     detections = []
     for index, (bbox, text, confidence) in enumerate(results):
         digits = "".join(c for c in text if c.isdigit())
-        if not digits or int(digits) not in valid_numbers:
+        if not digits:
             continue
         # Veto boxes whose letters-pass read reveals text. Pair by box center; the two
         # passes share the same detector so boxes normally coincide.
@@ -223,10 +308,16 @@ def digit_detections(
             ),
             default=(math.inf, -1),
         )
+        letter_text = ""
         if nearest_letter[0] < box_height:
             letter_read = letter_results[nearest_letter[1]]
             if is_text_veto(letter_read[1], float(letter_read[2]), float(confidence)):
                 continue
+            letter_text = str(letter_read[1])
+        resolved = resolve_page_key(text, letter_text, valid_keys)
+        if resolved is None:
+            continue
+        key, via = resolved
         x_frac = sum(p[0] for p in bbox) / 4 / width
         y_frac = sum(p[1] for p in bbox) / 4 / height
         glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))
@@ -240,7 +331,9 @@ def digit_detections(
         )
         detections.append(
             {
-                "number": int(digits),
+                "key": key,
+                "via": via,
+                "number": int("".join(c for c in key if c.isdigit())),
                 "text": text,
                 "confidence": round(float(confidence), 4),
                 "polygon": [[int(p[0]), int(p[1])] for p in bbox],
@@ -287,7 +380,7 @@ def single_digit_height_band(
 
 def is_claim(
     detection: dict,
-    own_number: int | None,
+    own_key: str | None,
     *,
     min_height: float = MIN_HEIGHT,
     min_confidence: float = MIN_CONF,
@@ -297,7 +390,7 @@ def is_claim(
 ) -> bool:
     """Whether a detection qualifies as an adjacency claim.
 
-    Every claim must be a valid page number other than the page's own, near a page edge, tall
+    Every claim must be a valid page key other than the page's own, near a page edge, tall
     enough, confident enough, and axis-aligned (rotated quads are always misread street names
     or pipe annotations). Single-digit numbers face three stricter tests — the high
     ``single_digit_min_confidence`` floor, the ``height_band`` around the volume's
@@ -307,7 +400,7 @@ def is_claim(
     coincidence, so reciprocity alone cannot vouch for them.
     """
     if (
-        detection["number"] == own_number
+        detection["key"] == own_key
         or detection["edge"] == "center"
         or detection["height"] < min_height
         or detection["confidence"] < min_confidence
@@ -327,26 +420,45 @@ def is_claim(
     return True
 
 
-def mutual_edges(claims_by_page: dict[str, set[int]]) -> list[tuple[str, str]]:
-    """Reciprocated adjacency edges: A claims B's number and B claims A's number.
+def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
 
-    ``claims_by_page`` maps page stems to claimed page numbers. A number claimed by A resolves
-    to the page stem(s) carrying that number; the edge exists only if some such stem claims A's
-    number back. Returns sorted (stem, stem) pairs, each once.
+    ``claims_by_page`` maps page stems to claimed page keys. A claimed key resolves to
+    the stem(s) carrying exactly that key; a bare-number claim in a volume whose sheet
+    has a lettered stem (Chicago prints "60" for p60w) falls back to the number, but
+    only when it names a single stem — a number shared by many lettered sheets (LA's
+    p1499a-r) is ambiguous and resolves to nothing. The edge exists only if each side's
+    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
     """
+    stems_by_key: dict[str, list[str]] = defaultdict(list)
     stems_by_number: dict[int, list[str]] = defaultdict(list)
     for stem in claims_by_page:
+        key = page_key(stem)
+        if key is not None:
+            stems_by_key[key].append(stem)
         number = page_number(stem)
         if number is not None:
             stems_by_number[number].append(stem)
+
+    def resolve(claim: str) -> list[str]:
+        stems = stems_by_key.get(claim.upper(), [])
+        if stems:
+            return stems
+        if claim.isdigit():
+            fallback = stems_by_number.get(int(claim), [])
+            if len(fallback) == 1:
+                return fallback
+        return []
+
     edges: set[tuple[str, str]] = set()
     for stem, claimed in claims_by_page.items():
-        own = page_number(stem)
-        if own is None:
-            continue
-        for number in claimed:
-            for other in stems_by_number.get(number, []):
-                if other != stem and own in claims_by_page.get(other, set()):
+        for claim in claimed:
+            for other in resolve(claim):
+                if other == stem:
+                    continue
+                if any(
+                    stem in resolve(back) for back in claims_by_page.get(other, set())
+                ):
                     first, second = sorted((stem, other))
                     edges.add((first, second))
     return sorted(edges)
@@ -407,13 +519,11 @@ def main() -> None:
     images = volume_page_images(args.volume)
     if not images:
         sys.exit(f"No page images found in {args.volume}.")
-    valid_numbers = {
-        number
-        for image in images
-        if (number := page_number(image_stem(str(image)))) is not None
+    valid_keys = {
+        key for image in images if (key := page_key(image_stem(str(image)))) is not None
     }
     print(
-        f"Scanning {len(images)} pages ({len(valid_numbers)} page numbers)...",
+        f"Scanning {len(images)} pages ({len(valid_keys)} page keys)...",
         file=sys.stderr,
     )
     reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
@@ -428,10 +538,11 @@ def main() -> None:
         craft_boxes = cached_craft_boxes(image) if args.reuse_boxes else None
         reused += craft_boxes is not None
         pages[stem] = {
+            "key": page_key(stem),
             "number": page_number(stem),
             "width": width,
             "height": height,
-            "detections": digit_detections(image, reader, valid_numbers, craft_boxes),
+            "detections": digit_detections(image, reader, valid_keys, craft_boxes),
         }
     if args.reuse_boxes:
         print(f"Reused CRAFT boxes for {reused}/{len(images)} pages.", file=sys.stderr)
@@ -439,14 +550,14 @@ def main() -> None:
     def compute_claims(
         height_band: tuple[float, float] | None,
         min_gap: float | None,
-    ) -> dict[str, set[int]]:
+    ) -> dict[str, set[str]]:
         return {
             stem: {
-                d["number"]
+                d["key"]
                 for d in page["detections"]
                 if is_claim(
                     d,
-                    page["number"],
+                    page["key"],
                     min_height=args.min_height,
                     min_confidence=args.min_confidence,
                     single_digit_min_confidence=args.single_digit_min_confidence,
@@ -461,19 +572,19 @@ def main() -> None:
     # printed-reference height from their multi-digit claims; single-digit claims are then
     # re-filtered against the derived band and isolation floor and the graph rebuilt.
     provisional_edges = mutual_edges(compute_claims(None, None))
-    mutual_numbers: dict[str, set[int]] = defaultdict(set)
+    mutual_keys: dict[str, set[str]] = defaultdict(set)
     for first, second in provisional_edges:
-        mutual_numbers[first].add(pages[second]["number"])
-        mutual_numbers[second].add(pages[first]["number"])
+        mutual_keys[first].add(pages[second]["key"])
+        mutual_keys[second].add(pages[first]["key"])
     confirmed_heights = [
         d["height"]
         for stem, page in pages.items()
         for d in page["detections"]
         if d["number"] >= 10
-        and d["number"] in mutual_numbers[stem]
+        and d["key"] in mutual_keys[stem]
         and is_claim(
             d,
-            page["number"],
+            page["key"],
             min_height=args.min_height,
             min_confidence=args.min_confidence,
             single_digit_min_confidence=args.single_digit_min_confidence,
@@ -503,7 +614,7 @@ def main() -> None:
         for detection in page["detections"]:
             detection["claim"] = is_claim(
                 detection,
-                page["number"],
+                page["key"],
                 min_height=args.min_height,
                 min_confidence=args.min_confidence,
                 single_digit_min_confidence=args.single_digit_min_confidence,

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -485,12 +485,16 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
 def one_sided_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
     """Directed claims that resolve to a real page but are not reciprocated.
 
-    The lower-trust adjacency tier: measured against the hand-labelled truth,
-    88% of Hudson's and 89% of LA's unreciprocated-but-resolvable claims are
-    genuine printed references whose reciprocal side failed to read (truth
-    itself reciprocates 91-93%). Consumers must treat these as candidates to
-    verify, not facts — a junk read that resolves to a real page lands here.
-    Returns sorted (claimer, target) pairs, excluding mutual edges.
+    The lower-trust adjacency tier. Truth itself reciprocates 89-93% of its
+    printed edges, so a one-sided claim CAN be a genuine reference whose
+    reciprocal failed to read — but this tier is where every junk read that
+    resolves to a real page also lands, and reciprocity is precisely the
+    filter that was removing them. Measured against the hand-labelled truth:
+    LA 105/193 = 54%, Hudson 48/98 = 49%, Nashville 52/165 = 32% genuine,
+    tracking each volume's claim precision (79/87/63%). Mutual edges on the
+    same volumes are 96-100%. Consumers must therefore treat these as
+    candidates to verify, never as facts, and weight them well below mutual
+    edges. Returns sorted (claimer, target) pairs, excluding mutual edges.
     """
     resolve = claim_resolver(claims_by_page)
     mutual = {frozenset(edge) for edge in mutual_edges(claims_by_page)}

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -206,6 +206,15 @@ def test_resolve_page_key_repairs_long_keys():
     assert resolve_page_key("14021403", "", LA_KEYS) is None
 
 
+def test_resolve_page_key_bare_number_reaches_a_unique_lettered_key():
+    # Chicago prints a bare "60" for sheet p60w; Miami "8" for p8s. The read
+    # must resolve at DETECTION time, not just at edge-resolution time.
+    assert resolve_page_key("60", "", {"59W", "60W", "61W"}) == ("60W", "number")
+    assert resolve_page_key("8", "", {"7", "8S", "9"}) == ("8S", "number")
+    # A digit part shared by many lettered sheets stays ambiguous.
+    assert resolve_page_key("1499", "", {"1499A", "1499G", "1499L"}) is None
+
+
 def test_resolve_page_key_is_inert_for_short_key_volumes():
     # Volumes with 1-2 digit page numbers: short reads are substrings of
     # everything, so repair would be guesswork. Exact matches only.

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -6,6 +6,7 @@ from mapsnap.page_adjacency import (
     classify_edge,
     is_claim,
     mutual_edges,
+    one_sided_edges,
     polygon_rotation_deg,
     resolve_page_key,
     single_digit_height_band,
@@ -147,6 +148,19 @@ def test_mutual_edges_lettered_stems():
 
 def test_mutual_edges_empty_when_one_sided():
     assert mutual_edges({"p1": {"2"}, "p2": set()}) == []
+
+
+def test_one_sided_edges_are_the_unreciprocated_remainder():
+    claims = {"p49": {"50", "51"}, "p50": {"49"}, "p51": set()}
+    # 49<->50 is mutual and excluded; 49->51 resolves but lacks the reciprocal.
+    assert one_sided_edges(claims) == [("p49", "p51")]
+
+
+def test_one_sided_edges_skip_unresolvable_claims():
+    # A claim of a page outside the volume, and an ambiguous bare number among
+    # lettered sheets, resolve to nothing and produce no one-sided edge.
+    claims = {"p1499a": {"1488", "7777"}, "p1488": set(), "p1499b": {"1499"}}
+    assert one_sided_edges(claims) == [("p1499a", "p1488")]
 
 
 def test_mutual_edges_lettered_keys_do_not_collide():

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -7,6 +7,7 @@ from mapsnap.page_adjacency import (
     is_claim,
     mutual_edges,
     polygon_rotation_deg,
+    resolve_page_key,
     single_digit_height_band,
     volume_page_images,
 )
@@ -29,8 +30,10 @@ def make_detection(
     confidence: float = 0.95,
     polygon: list[list[float]] | None = None,
     nearest_box: float | None = 100.0,
+    key: str | None = None,
 ) -> dict:
     return {
+        "key": key if key is not None else str(number),
         "number": number,
         "edge": edge,
         "height": height,
@@ -61,41 +64,39 @@ def test_polygon_rotation_deg():
 
 
 def test_is_claim_accepts_large_edge_number():
-    assert is_claim(make_detection(50), own_number=49)
+    assert is_claim(make_detection(50), own_key="49")
 
 
 def test_is_claim_rejects_own_number_center_small_and_lowconf():
-    assert not is_claim(make_detection(49), own_number=49)  # the sheet's own number
-    assert not is_claim(make_detection(50, edge="center"), own_number=49)
-    assert not is_claim(make_detection(50, height=12.0), own_number=49)
-    assert not is_claim(make_detection(50, confidence=0.01), own_number=49)
+    assert not is_claim(make_detection(49), own_key="49")  # the sheet's own number
+    assert not is_claim(make_detection(50, edge="center"), own_key="49")
+    assert not is_claim(make_detection(50, height=12.0), own_key="49")
+    assert not is_claim(make_detection(50, confidence=0.01), own_key="49")
 
 
 def test_is_claim_rejects_rotated_quads():
     # Every rotated candidate inspected was a misread street name or pipe annotation.
     rotated = make_detection(50, polygon=rotated_polygon(17.0))
-    assert not is_claim(rotated, own_number=49)
+    assert not is_claim(rotated, own_key="49")
 
 
 def test_is_claim_single_digit_confidence_floor():
     # Junk single-digit reads reciprocate by coincidence; require high confidence.
-    assert not is_claim(make_detection(6, confidence=0.5), own_number=49)
-    assert is_claim(make_detection(6, confidence=0.95), own_number=49)
+    assert not is_claim(make_detection(6, confidence=0.5), own_key="49")
+    assert is_claim(make_detection(6, confidence=0.95), own_key="49")
     # Multi-digit numbers keep the permissive floor.
-    assert is_claim(make_detection(50, confidence=0.5), own_number=49)
+    assert is_claim(make_detection(50, confidence=0.5), own_key="49")
 
 
 def test_is_claim_single_digit_height_band():
     band = (30.0, 65.0)
     # A 130px "1" is a frame rule, not a reference; a 45px one matches the printed size.
-    assert not is_claim(
-        make_detection(1, height=130.0), own_number=49, height_band=band
-    )
-    assert is_claim(make_detection(1, height=45.0), own_number=49, height_band=band)
+    assert not is_claim(make_detection(1, height=130.0), own_key="49", height_band=band)
+    assert is_claim(make_detection(1, height=45.0), own_key="49", height_band=band)
     # The band applies only to single digits; multi-digit heights are already trustworthy.
-    assert is_claim(make_detection(50, height=130.0), own_number=49, height_band=band)
+    assert is_claim(make_detection(50, height=130.0), own_key="49", height_band=band)
     # Without a band (no confirmed references), single digits pass on confidence alone.
-    assert is_claim(make_detection(1, height=130.0), own_number=49, height_band=None)
+    assert is_claim(make_detection(1, height=130.0), own_key="49", height_band=None)
 
 
 def test_bbox_gap():
@@ -112,12 +113,12 @@ def test_is_claim_single_digit_isolation():
     # A perfect-glyph, right-sized single digit that touches another box is a fragment
     # of a larger number (p10's "8" torn off a block number), not a sheet reference.
     fragment = make_detection(8, confidence=1.0, nearest_box=0.0)
-    assert not is_claim(fragment, own_number=10, min_gap=14.0)
+    assert not is_claim(fragment, own_key="10", min_gap=14.0)
     isolated = make_detection(8, confidence=1.0, nearest_box=21.6)
-    assert is_claim(isolated, own_number=10, min_gap=14.0)
+    assert is_claim(isolated, own_key="10", min_gap=14.0)
     # Multi-digit claims are exempt; missing gap data (only box on the page) passes.
-    assert is_claim(make_detection(50, nearest_box=0.0), own_number=10, min_gap=14.0)
-    assert is_claim(make_detection(8, nearest_box=None), own_number=10, min_gap=14.0)
+    assert is_claim(make_detection(50, nearest_box=0.0), own_key="10", min_gap=14.0)
+    assert is_claim(make_detection(8, nearest_box=None), own_key="10", min_gap=14.0)
 
 
 def test_single_digit_height_band_from_median():
@@ -132,19 +133,72 @@ def test_single_digit_height_band_empty():
 
 
 def test_mutual_edges_requires_reciprocity():
-    claims = {"p49": {50, 51}, "p50": {49}, "p51": set()}
+    claims = {"p49": {"50", "51"}, "p50": {"49"}, "p51": set()}
     # 49<->50 reciprocate; 49->51 is unreciprocated and produces no edge.
     assert mutual_edges(claims) == [("p49", "p50")]
 
 
 def test_mutual_edges_lettered_stems():
-    # Chicago-style stems: numbers resolve to the lettered page stem.
-    claims = {"p59w": {60}, "p60w": {59}}
+    # Chicago-style stems: a bare-number claim resolves to the lettered page stem
+    # when that number names exactly one sheet.
+    claims = {"p59w": {"60"}, "p60w": {"59"}}
     assert mutual_edges(claims) == [("p59w", "p60w")]
 
 
 def test_mutual_edges_empty_when_one_sided():
-    assert mutual_edges({"p1": {2}, "p2": set()}) == []
+    assert mutual_edges({"p1": {"2"}, "p2": set()}) == []
+
+
+def test_mutual_edges_lettered_keys_do_not_collide():
+    # LA-style: 18 sheets share the number 1499. A lettered claim reaches exactly
+    # its sheet; a bare "1499" claim is ambiguous among them and resolves to nothing.
+    claims = {
+        "p1499a": {"1499B"},
+        "p1499b": {"1499A"},
+        "p1488": {"1499"},
+        "p1499c": {"1488"},
+    }
+    assert mutual_edges(claims) == [("p1499a", "p1499b")]
+
+
+# 1401..1498 plus lettered 1499 sheets (no plain 1499, so a bare read of it
+# must resolve to nothing rather than guess among the lettered variants).
+LA_KEYS = {f"14{i:02d}" for i in range(1, 99)} | {"1499A", "1499G", "1499L"}
+SHORT_KEYS = {str(i) for i in range(1, 93)}  # a Hudson-style 1-2 digit volume
+
+
+def test_resolve_page_key_exact_and_lettered():
+    assert resolve_page_key("1409", "", LA_KEYS) == ("1409", "exact")
+    # The digits pass renders "1499G" as a bare "1499" -- a different, wrong page;
+    # the letters pass reveals the suffix (with I/O look-alike digits normalized).
+    assert resolve_page_key("1499", "1499G", LA_KEYS) == ("1499G", "lettered")
+    assert resolve_page_key("14994", "I499G", LA_KEYS) == ("1499G", "lettered")
+    # A bare "1499" with no letter suffix is not a valid LA key: no guess.
+    assert resolve_page_key("1499", "1499", LA_KEYS) is None
+
+
+def test_resolve_page_key_repairs_long_keys():
+    # Leading digit lost against the sheet trim: unique suffix completion.
+    assert resolve_page_key("409", "", LA_KEYS) == ("1409", "suffix")
+    # 2-digit remnants are house-number fragments (8% precise on the LA truth,
+    # confident enough to reciprocate into false edges): never repaired.
+    assert resolve_page_key("85", "", LA_KEYS) is None
+    # Neighboring ink absorbed into the box: unique embedded key.
+    assert resolve_page_key("14027", "", LA_KEYS) == ("1402", "embedded")
+    assert resolve_page_key("21408", "", LA_KEYS) == ("1408", "embedded")
+    # Ambiguity never resolves: "9" is a suffix of many keys, and a read
+    # containing two valid keys names neither.
+    assert resolve_page_key("9", "", LA_KEYS) is None
+    assert resolve_page_key("14021403", "", LA_KEYS) is None
+
+
+def test_resolve_page_key_is_inert_for_short_key_volumes():
+    # Volumes with 1-2 digit page numbers: short reads are substrings of
+    # everything, so repair would be guesswork. Exact matches only.
+    assert resolve_page_key("21", "", SHORT_KEYS) == ("21", "exact")
+    assert resolve_page_key("214", "", SHORT_KEYS) is None  # no embedded repair
+    assert resolve_page_key("408", "", SHORT_KEYS) is None  # no suffix repair
+    assert resolve_page_key("3", "", SHORT_KEYS) == ("3", "exact")
 
 
 def test_volume_page_images_skips_splits_and_keymaps(tmp_path: Path):


### PR DESCRIPTION
Stacked on #206. Records unreciprocated-but-resolvable claims as a `one_sided` list in `adjacency.json`, and lets the **experimental** pose graph consume them via `posegraph --one-sided` (tagged measurements, 1.5× widened sigmas, `_1sided` output suffix).

> **Recommendation after Nashville's truth data: merge the data emission, do NOT promote the consumption.** The tier is far less precise than this PR originally claimed, and on one volume its pose-graph consumption is actively destructive. Details below. The `one_sided` field is inert in production (no production consumer reads it; `mapsnap fit` never calls `posegraph`), so the emission is safe and useful for future gated work.

## Corrected precision (this PR's original numbers were wrong)

The original description claimed "~90% genuine". That figure came from the **pre-#206** adjacency, where the union added 133 LA edges of which 118 were correct. It does not survive #206's repair layer, which raises claim recall (46→68% on LA) but lowers claim precision (93→79%) — and the extra claims land in exactly this tier. The Hudson "88%" was mis-derived from the union total rather than the added edges. Measured against the hand-labelled truth on the current generation:

| volume | key digits | claim precision | mutual edges | **one-sided edges** |
|---|---|---|---|---|
| Los Angeles | 4 | 79% | 125 @ **100%** | 193 @ **54%** |
| Hudson | 1–2 | 87% | 165 @ **100%** | 98 @ **49%** |
| Nashville | 1–2 | 63% | 79 @ **96%** | 165 @ **32%** |

One-sided precision tracks each volume's claim precision. Reciprocity is not a formality — it is the filter that removes junk reads which happen to resolve to a real page.

## Nashville (new truth: 70 keys, 311 references, all 1–2 digit)

- **vs label truth**: claims 63% precision / 69% recall; mutual **96%** precision (76/79), 49% recall; union 52% precision, 83% recall.
- **vs footprint-derived truth**: mutual **96%** precision, 38% recall; union 55% / 67%.
- **The two truth notions agree**, as on LA: 147/149 printed edges are footprint-adjacent (99%), while 53/200 footprint pairs (26%) are never printed — so `score_adjacency`'s recall denominator remains inflated by about a quarter.
- **#206's repair is provably inert here**: all 360 claim resolutions are `exact`, zero repairs — the direct confirmation that short-page-number volumes are untouched.
- **Every one of the 3 mutual edges contradicting the labels involves p8** (p2~p8, p49~p8, p50~p8 are junk reciprocation; p8~p29 is genuine), independently confirming the false-demotion diagnosis in #208.
- Misses: 14% gate loss (dominated by `height<28`), 11% CRAFT miss, 8% read/parse loss — unlike LA, where recognition was 49%.

## Pose-graph A/B on Nashville: the consequence

Same measurement file for both arms, so the comparison is exact.

| | placed | median | ≤100 ft | **≥200 ft** |
|---|---|---|---|---|
| mutual only | 5 | 72 ft | 3 | 1 |
| + one-sided | 10 | 637 ft | 2 | **7** |

**Five new disasters** (p6 2004 ft, p7 1304 ft, p8 1178 ft, p9 744 ft, p28 637 ft) plus p27 degraded 72→274 ft. At 32% precision the junk edges propose wrong pairs faster than verification and the Huber loss can reject them.

Full ledger across the four A/B'd volumes: LA +2 placements/0 disasters, Hudson neutral-positive (median 73→68 ft, disasters 5→4), DC +3 placements but p212 broken 55→266 ft, Nashville +5 disasters. That is not a feature to switch on by default.

## Caveats

The LA/Hudson/DC A/B numbers were measured before this branch's bare-number-fallback commit, which grew LA's tier from 111 to 193 edges; those arms were not re-run, so treat their deltas as indicative rather than current. Nashville's A/B is on the current generation.

843 tests, ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
