### PR TITLE
adjacency-gate: demote fits that contradict their mutual claims, re-search from the seam

### DIFF
--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -40,6 +40,7 @@ is a no-op.
 import argparse
 import json
 import math
+import statistics
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -290,13 +291,8 @@ class StampGate:
     partner_stamps: list[tuple[float, float]]
     own_claims: list[list[tuple[float, float]]]
 
-    def separation_m(self, affine: np.ndarray) -> float | None:
-        """Best-partner stamp separation under a candidate pose, or None.
-
-        The minimum over partners: satisfying ONE genuine seam stamp already
-        pins the pose to within the threshold at that point, and taking the
-        minimum keeps a single junk partner from vetoing the true pose.
-        """
+    def partner_separations_m(self, affine: np.ndarray) -> list[float]:
+        """Per-partner stamp separation under a candidate pose."""
         corners = [
             (0.0, 0.0),
             (float(self.width), 0.0),
@@ -310,7 +306,7 @@ class StampGate:
                 affine[1, 0] * px + affine[1, 1] * py + affine[1, 2],
             )
 
-        best: float | None = None
+        separations: list[float] = []
         for (lon, lat), claims in zip(self.partner_stamps, self.own_claims):
             if claims:
                 distance = min(
@@ -329,8 +325,34 @@ class StampGate:
                     )
                     - self.footprint_diag_m(affine) / 2.0,
                 )
-            best = distance if best is None else min(best, distance)
-        return best
+            separations.append(distance)
+        return separations
+
+    def separation_m(self, affine: np.ndarray) -> float | None:
+        """Best-partner stamp separation under a candidate pose, or None.
+
+        The minimum over partners: the permissive HARD-gate statistic. A pose
+        inconsistent with every partner is certainly not where the neighbors
+        say the page belongs, and a single junk partner cannot veto the true
+        pose.
+        """
+        separations = self.partner_separations_m(affine)
+        return min(separations) if separations else None
+
+    def median_separation_m(self, affine: np.ndarray) -> float | None:
+        """Median-partner stamp separation: the strict CORROBORATION statistic.
+
+        Genuine hints agree — a true pose satisfies essentially all of them —
+        while junk hints (single-digit reciprocation) scatter across the
+        volume, so no wrong pose can satisfy most. Nashville p8's 325 ft
+        candidate matched ONE of its four junk stamps at 66 m (min) but its
+        median was far out; requiring the median keeps relaxed adoption from
+        publishing it.
+        """
+        separations = self.partner_separations_m(affine)
+        if not separations:
+            return None
+        return float(statistics.median(separations))
 
     def footprint_diag_m(self, affine: np.ndarray) -> float:
         tl = (affine[0, 2], affine[1, 2])

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -1,0 +1,326 @@
+"""Demote fitted pages that contradict their own printed mutual-adjacency claims.
+
+Mutual adjacent-sheet references are ~100% precise (measured against hand-labelled
+truth on LA and Hudson), and both sides of an edge print their reference at the
+same physical spot on the shared boundary road. Mapping each claim's pixel through
+its own page's fit, correct pairs land a median 35 m apart (p95 63 m) — so a pair
+whose stamps land > GATE_STAMP_M apart is a contradiction: one page, the other, or
+the edge itself is wrong. Arbitration, in order of trust:
+
+  1. multi-contradiction   a page contradicting >= 2 different neighbors is the
+                           liar; its partners each contradict only it
+  2. corroboration         a page with other COMPATIBLE mutual edges is vouched
+                           for; a page with none is the suspect
+  3. edge verdict          both sides corroborated -> the EDGE is junk (false
+                           reciprocation, or a long boundary printed at two
+                           spots); demote nobody
+  4. tie-breaks            fewer effective GCPs, then rotation/scale deviation
+
+A named suspect is only demoted when a hard signal corroborates the verdict —
+effective GCPs <= GATE_MAX_GCPS, or rotation/scale deviation from the volume
+median beyond GATE_ROT_DEV_DEG / GATE_SCALE_DEV_LOG. On the 14 truth volumes
+this combination names the wrong page on 18 of 19 decidable contradictions and
+demotes 10 true disasters against one false demotion (Nashville p8, a genuine
+odd-scale sheet whose five mutual edges are all junk single-digit reciprocation).
+
+Demotion renames every channel sidecar (pN.georef*.json ->
+pN.<channel>-contradicted.json, invisible to the IIIF globs) and writes
+pN.contradiction.json carrying the partner-side stamp positions — the trusted
+neighbors' printed claims of this page, each a world point on the shared seam.
+Snap's rescue reads those as extra search centers (see build_page_context), so a
+demoted page gets re-searched where its neighbors say it belongs; the usual
+rescue verification gates decide whether anything better is published.
+
+Runs in ``mapsnap fit`` between georef and snap. A volume without adjacency.json
+is a no-op.
+
+    uv run mapsnap adjacency-gate data/kansas_city_mo_1951_vol_4 [--dry-run]
+"""
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+
+from mapsnap.keymap.locate import page_key
+from mapsnap.road_model import effective_gcp_count, page_world_affine
+from mapsnap.utils import haversine_m
+
+GATE_STAMP_M = 100.0
+"""Stamp-pair distance beyond which a mutual edge is a contradiction.
+
+Healthy pairs across the 14 truth volumes: p50 35 m, p95 63 m, p99 126 m.
+100 m keeps the flag above the healthy p95 while catching 200 ft-class errors
+(a 200 ft misplacement moves its stamp ~61 m relative to the neighbor's)."""
+
+GATE_MAX_GCPS = 2
+"""A suspect supported by <= this many effective GCPs may be demoted: two
+points exactly determine a similarity, so nothing over-determines the pose."""
+
+GATE_ROT_DEV_DEG = 15.0
+GATE_SCALE_DEV_LOG = 0.2
+"""Suspects whose rotation/scale deviate this far from the volume median may
+be demoted even with many GCPs (NO-1896 p125: 12 GCPs, 46 deg and 0.76 off —
+a confidently wrong fit). Both thresholds clear every healthy suspect measured
+across the corpus."""
+
+CHANNELS = ("georef-streets", "georef-osm", "georef")
+
+
+@dataclass
+class FittedPage:
+    """One parent page's published fit, with the signals arbitration needs."""
+
+    stem: str
+    affine: np.ndarray  # 2x3 page px -> (lon, lat)
+    width: int
+    height: int
+    channel_paths: list[Path]
+    gcps: int
+    theta_deg: float
+    log_scale: float
+
+
+@dataclass
+class Contradiction:
+    """One flagged mutual edge."""
+
+    a: str
+    b: str
+    distance_m: float
+
+
+@dataclass
+class Verdict:
+    """Arbitration outcome for one gated suspect."""
+
+    stem: str
+    reason: str  # arbitration rule that named it
+    signal: str  # hard signal that licensed demotion
+    partners: list[dict] = field(default_factory=list)  # re-search hints
+
+
+def load_fitted_pages(volume: Path, adjacency: dict) -> dict[str, FittedPage]:
+    """Parent pages with a published fit, keyed by stem.
+
+    Effective GCPs are taken as the max over channel sidecars: a snap-rescued
+    page keeps its RANSAC doc's intersections when one exists, and a
+    rescue-only page (no intersections anywhere) counts 0 — appropriately
+    fragile for the hard-signal gate.
+    """
+    pages: dict[str, FittedPage] = {}
+    for stem in adjacency.get("pages", {}):
+        paths = [
+            volume / f"{stem}.{channel}.json"
+            for channel in CHANNELS
+            if (volume / f"{stem}.{channel}.json").exists()
+        ]
+        if not paths:
+            continue
+        try:
+            doc = json.loads(paths[0].read_text())
+            affine = page_world_affine(doc)
+        except (ValueError, KeyError, TypeError):
+            continue
+        gcps = 0
+        for path in paths:
+            try:
+                gcps = max(gcps, effective_gcp_count(json.loads(path.read_text())))
+            except (ValueError, KeyError, TypeError):
+                pass
+        pages[stem] = FittedPage(
+            stem=stem,
+            affine=affine,
+            width=int(doc["width"]),
+            height=int(doc["height"]),
+            channel_paths=paths,
+            gcps=gcps,
+            theta_deg=math.degrees(math.atan2(-affine[1, 0], affine[0, 0])),
+            log_scale=math.log(math.hypot(affine[1, 0], affine[1, 1])),
+        )
+    return pages
+
+
+def stamp_worlds(
+    adjacency: dict, page: FittedPage, other_stem: str
+) -> list[tuple[float, float]]:
+    """World (lon, lat) of ``page``'s printed claims of ``other_stem``'s key."""
+    want = (page_key(other_stem) or "").upper()
+    out: list[tuple[float, float]] = []
+    for det in adjacency["pages"].get(page.stem, {}).get("detections", []):
+        key = str(det.get("key") or det.get("number") or "").upper()
+        if not det.get("claim") or key != want:
+            continue
+        px = det["x_frac"] * page.width
+        py = det["y_frac"] * page.height
+        a = page.affine
+        out.append(
+            (
+                a[0, 0] * px + a[0, 1] * py + a[0, 2],
+                a[1, 0] * px + a[1, 1] * py + a[1, 2],
+            )
+        )
+    return out
+
+
+def edge_contradictions(
+    adjacency: dict, pages: dict[str, FittedPage], stamp_m: float = GATE_STAMP_M
+) -> tuple[list[Contradiction], dict[str, list[bool]]]:
+    """Flagged edges plus, per page, the compatible/contradicted flags of its edges."""
+    contradictions: list[Contradiction] = []
+    edge_flags: dict[str, list[bool]] = defaultdict(list)
+    for a, b in adjacency.get("adjacency", []):
+        if a not in pages or b not in pages:
+            continue
+        wa = stamp_worlds(adjacency, pages[a], b)
+        wb = stamp_worlds(adjacency, pages[b], a)
+        if not wa or not wb:
+            continue
+        distance = min(haversine_m(p[1], p[0], q[1], q[0]) for p in wa for q in wb)
+        bad = distance > stamp_m
+        edge_flags[a].append(bad)
+        edge_flags[b].append(bad)
+        if bad:
+            contradictions.append(Contradiction(a, b, distance))
+    return contradictions, edge_flags
+
+
+def hard_signal(
+    page: FittedPage, median_theta_deg: float, median_log_scale: float
+) -> str | None:
+    """The demotion-licensing signal, or None when the fit looks structurally sound."""
+    if page.gcps <= GATE_MAX_GCPS:
+        return f"gcps={page.gcps}"
+    rot = abs((page.theta_deg - median_theta_deg + 180.0) % 360.0 - 180.0)
+    if rot > GATE_ROT_DEV_DEG:
+        return f"rot_dev={rot:.0f}deg"
+    scale = abs(page.log_scale - median_log_scale)
+    if scale > GATE_SCALE_DEV_LOG:
+        return f"scale_dev={scale:.2f}"
+    return None
+
+
+def arbitrate_suspects(adjacency: dict, pages: dict[str, FittedPage]) -> list[Verdict]:
+    """Gated suspects across the volume's contradicted mutual edges."""
+    contradictions, edge_flags = edge_contradictions(adjacency, pages)
+    if not contradictions:
+        return []
+    thetas = sorted(p.theta_deg for p in pages.values())
+    scales = sorted(p.log_scale for p in pages.values())
+    median_theta = thetas[len(thetas) // 2]
+    median_scale = scales[len(scales) // 2]
+
+    def n_bad(stem: str) -> int:
+        return sum(1 for bad in edge_flags[stem] if bad)
+
+    def n_good(stem: str) -> int:
+        return sum(1 for bad in edge_flags[stem] if not bad)
+
+    suspects: dict[str, Verdict] = {}
+    for edge in contradictions:
+        a, b = edge.a, edge.b
+        if n_bad(a) >= 2 and n_bad(b) < 2:
+            suspect, reason = a, "multi-contradiction"
+        elif n_bad(b) >= 2 and n_bad(a) < 2:
+            suspect, reason = b, "multi-contradiction"
+        elif n_good(a) > 0 and n_good(b) == 0:
+            suspect, reason = b, "uncorroborated"
+        elif n_good(b) > 0 and n_good(a) == 0:
+            suspect, reason = a, "uncorroborated"
+        elif n_good(a) > 0 and n_good(b) > 0:
+            continue  # both vouched for: the edge is the liar, demote nobody
+        elif pages[a].gcps != pages[b].gcps:
+            suspect = a if pages[a].gcps < pages[b].gcps else b
+            reason = "fewer-gcps"
+        else:
+            continue  # undecidable pair: leave both alone
+        signal = hard_signal(pages[suspect], median_theta, median_scale)
+        if signal is None:
+            continue  # structurally sound fit: never demote on the stamp alone
+        partner = b if suspect == a else a
+        verdict = suspects.setdefault(suspect, Verdict(suspect, reason, signal))
+        for lon, lat in stamp_worlds(adjacency, pages[partner], suspect):
+            verdict.partners.append(
+                {
+                    "stem": partner,
+                    "stamp": [round(lon, 7), round(lat, 7)],
+                    "distance_m": round(edge.distance_m, 1),
+                }
+            )
+    return sorted(suspects.values(), key=lambda v: v.stem)
+
+
+def demote(volume: Path, page: FittedPage, verdict: Verdict) -> None:
+    """Rename the page's channel sidecars and write the re-search hint file."""
+    for path in page.channel_paths:
+        path.rename(path.with_name(path.name[: -len(".json")] + "-contradicted.json"))
+    hint = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "reason": verdict.reason,
+        "signal": verdict.signal,
+        "partners": verdict.partners,
+    }
+    (volume / f"{page.stem}.contradiction.json").write_text(json.dumps(hint, indent=2))
+
+
+def contradiction_centers(volume: Path, stem: str) -> list[tuple[float, float]]:
+    """Partner-stamp search centers for a demoted page, or [] (snap rescue hook).
+
+    Each stamp is the trusted neighbor's printed claim of this page, mapped
+    through the NEIGHBOR's fit — a world point on the shared seam the page
+    must sit against.
+    """
+    path = volume / f"{stem}.contradiction.json"
+    if not path.exists():
+        return []
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    return [
+        (float(p["stamp"][0]), float(p["stamp"][1]))
+        for p in doc.get("partners", [])
+        if isinstance(p.get("stamp"), list) and len(p["stamp"]) == 2
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Demote fits that contradict their printed mutual-adjacency claims."
+    )
+    parser.add_argument("volume", type=Path, help="Volume directory")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report verdicts without renaming files."
+    )
+    args = parser.parse_args()
+
+    adjacency_path = args.volume / "adjacency.json"
+    if not adjacency_path.exists():
+        print(f"No {adjacency_path}; nothing to gate.", file=sys.stderr)
+        return
+    adjacency = json.loads(adjacency_path.read_text())
+    pages = load_fitted_pages(args.volume, adjacency)
+    verdicts = arbitrate_suspects(adjacency, pages)
+    if not verdicts:
+        print("No gated contradictions.", file=sys.stderr)
+        return
+    for verdict in verdicts:
+        partners = sorted({p["stem"] for p in verdict.partners})
+        print(
+            f"{'Would demote' if args.dry_run else 'Demoted'} {verdict.stem}: "
+            f"contradicts {', '.join(partners)} "
+            f"[{verdict.reason}; {verdict.signal}]",
+            file=sys.stderr,
+        )
+        if not args.dry_run:
+            demote(args.volume, pages[verdict.stem], verdict)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -269,6 +269,118 @@ def demote(volume: Path, page: FittedPage, verdict: Verdict) -> None:
     (volume / f"{page.stem}.contradiction.json").write_text(json.dumps(hint, indent=2))
 
 
+STAMP_REHOME_M = GATE_STAMP_M
+"""A rescue candidate for a contradiction-demoted page must satisfy the same
+invariant that demoted it: its own printed claim of a hinting neighbor, mapped
+through the CANDIDATE pose, must land within this distance of the neighbor's
+stamp. KC p551's re-adopted alias sits ~150 m from p545's stamp and dies here;
+a true pose passes by construction. Where the page never read that neighbor's
+number, the neighbor's stamp (printed on the shared seam) must at least touch
+the candidate footprint."""
+
+
+@dataclass
+class StampGate:
+    """Re-adoption consistency check for one contradiction-demoted page."""
+
+    width: int
+    height: int
+    # Parallel lists: each hinting partner's stamp (lon, lat) and this page's
+    # own claim pixels of that partner ([] when its read never resolved).
+    partner_stamps: list[tuple[float, float]]
+    own_claims: list[list[tuple[float, float]]]
+
+    def separation_m(self, affine: np.ndarray) -> float | None:
+        """Best-partner stamp separation under a candidate pose, or None.
+
+        The minimum over partners: satisfying ONE genuine seam stamp already
+        pins the pose to within the threshold at that point, and taking the
+        minimum keeps a single junk partner from vetoing the true pose.
+        """
+        corners = [
+            (0.0, 0.0),
+            (float(self.width), 0.0),
+            (float(self.width), float(self.height)),
+            (0.0, float(self.height)),
+        ]
+
+        def world(px: float, py: float) -> tuple[float, float]:
+            return (
+                affine[0, 0] * px + affine[0, 1] * py + affine[0, 2],
+                affine[1, 0] * px + affine[1, 1] * py + affine[1, 2],
+            )
+
+        best: float | None = None
+        for (lon, lat), claims in zip(self.partner_stamps, self.own_claims):
+            if claims:
+                distance = min(
+                    haversine_m(lat, lon, w[1], w[0])
+                    for w in (world(px, py) for px, py in claims)
+                )
+            else:
+                # No read of this neighbor's number: the neighbor's stamp sits
+                # on the shared seam, so it must at least touch the candidate
+                # footprint (corner distance is a conservative proxy).
+                distance = max(
+                    0.0,
+                    min(
+                        haversine_m(lat, lon, w[1], w[0])
+                        for w in (world(px, py) for px, py in corners)
+                    )
+                    - self.footprint_diag_m(affine) / 2.0,
+                )
+            best = distance if best is None else min(best, distance)
+        return best
+
+    def footprint_diag_m(self, affine: np.ndarray) -> float:
+        tl = (affine[0, 2], affine[1, 2])
+        br = (
+            affine[0, 0] * self.width + affine[0, 1] * self.height + affine[0, 2],
+            affine[1, 0] * self.width + affine[1, 1] * self.height + affine[1, 2],
+        )
+        return haversine_m(tl[1], tl[0], br[1], br[0])
+
+
+def load_stamp_gate(
+    volume: Path, stem: str, width: int, height: int
+) -> StampGate | None:
+    """The stamp-consistency gate for a demoted page, or None without hints."""
+    hint_path = volume / f"{stem}.contradiction.json"
+    adjacency_path = volume / "adjacency.json"
+    if not hint_path.exists() or not adjacency_path.exists():
+        return None
+    try:
+        hint = json.loads(hint_path.read_text())
+        adjacency = json.loads(adjacency_path.read_text())
+    except (OSError, ValueError):
+        return None
+    detections = adjacency.get("pages", {}).get(stem, {}).get("detections", [])
+    partner_stamps: list[tuple[float, float]] = []
+    own_claims: list[list[tuple[float, float]]] = []
+    seen: set[str] = set()
+    for partner in hint.get("partners", []):
+        partner_stem = partner.get("stem")
+        stamp = partner.get("stamp")
+        if not isinstance(stamp, list) or len(stamp) != 2:
+            continue
+        want = (page_key(partner_stem or "") or "").upper()
+        claims = [
+            (det["x_frac"] * width, det["y_frac"] * height)
+            for det in detections
+            if det.get("claim")
+            and str(det.get("key") or det.get("number") or "").upper() == want
+        ]
+        marker = f"{partner_stem}:{stamp[0]}:{stamp[1]}"
+        if marker in seen:
+            continue
+        seen.add(marker)
+        partner_stamps.append((float(stamp[0]), float(stamp[1])))
+        own_claims.append(claims)
+    if not partner_stamps:
+        return None
+    return StampGate(width, height, partner_stamps, own_claims)
+
+
 def contradiction_centers(volume: Path, stem: str) -> list[tuple[float, float]]:
     """Partner-stamp search centers for a demoted page, or [] (snap rescue hook).
 

--- a/mapsnap/adjacency_gate_test.py
+++ b/mapsnap/adjacency_gate_test.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+from mapsnap.adjacency_gate import (
+    arbitrate_suspects,
+    contradiction_centers,
+    demote,
+    load_fitted_pages,
+)
+
+# A row of 1000x800 pages, 1 px = 1e-5 deg (~1.1 m/px): p1 | p2 | p3 west-to-east.
+PAGE_LON_SPAN = 0.01
+LAT0 = 40.0
+
+
+def georef_doc(lon0: float, lat0: float = LAT0, n_gcps: int = 5) -> dict:
+    corners = [
+        [lon0, lat0],
+        [lon0 + PAGE_LON_SPAN, lat0],
+        [lon0 + PAGE_LON_SPAN, lat0 - 0.008],
+        [lon0, lat0 - 0.008],
+    ]
+    intersections = [
+        {"x": 100.0 + 150.0 * i, "y": 100.0 + 100.0 * i, "inlier": True}
+        for i in range(n_gcps)
+    ]
+    return {
+        "width": 1000,
+        "height": 800,
+        "corners": corners,
+        "intersections": intersections,
+    }
+
+
+def claim(key: str, x_frac: float, y_frac: float = 0.5) -> dict:
+    return {
+        "key": key,
+        "number": int("".join(c for c in key if c.isdigit())),
+        "claim": True,
+        "x_frac": x_frac,
+        "y_frac": y_frac,
+    }
+
+
+def write_volume(tmp_path: Path, p3_lat_shift: float, p3_gcps: int) -> Path:
+    """Three mutually-claiming pages; p3's fit optionally displaced north."""
+    adjacency = {
+        "pages": {
+            "p1": {"detections": [claim("2", 0.98)]},
+            "p2": {"detections": [claim("1", 0.02), claim("3", 0.98)]},
+            "p3": {"detections": [claim("2", 0.02)]},
+        },
+        "adjacency": [["p1", "p2"], ["p2", "p3"]],
+    }
+    (tmp_path / "adjacency.json").write_text(json.dumps(adjacency))
+    for i, (stem, shift, gcps) in enumerate(
+        [("p1", 0.0, 5), ("p2", 0.0, 5), ("p3", p3_lat_shift, p3_gcps)]
+    ):
+        doc = georef_doc(i * PAGE_LON_SPAN, LAT0 + shift, gcps)
+        (tmp_path / f"{stem}.georef.json").write_text(json.dumps(doc))
+    return tmp_path
+
+
+def gate(volume: Path):
+    adjacency = json.loads((volume / "adjacency.json").read_text())
+    pages = load_fitted_pages(volume, adjacency)
+    return pages, arbitrate_suspects(adjacency, pages)
+
+
+def test_compatible_row_produces_no_verdicts(tmp_path):
+    _, verdicts = gate(write_volume(tmp_path, p3_lat_shift=0.0, p3_gcps=1))
+    assert verdicts == []
+
+
+def test_displaced_weak_page_is_demoted_with_hints(tmp_path):
+    # p3's fit sits ~330 m north of where p2's printed claim says it belongs,
+    # and only 1 GCP supports it: uncorroborated suspect, hard signal agrees.
+    volume = write_volume(tmp_path, p3_lat_shift=0.003, p3_gcps=1)
+    pages, verdicts = gate(volume)
+    assert [v.stem for v in verdicts] == ["p3"]
+    verdict = verdicts[0]
+    assert verdict.reason == "uncorroborated"
+    assert verdict.signal == "gcps=1"
+    # The hint is p2's stamp mapped through p2's (trusted) fit: near the p2/p3 seam.
+    (partner,) = {p["stem"] for p in verdict.partners}
+    assert partner == "p2"
+    lon, lat = verdict.partners[0]["stamp"]
+    assert abs(lon - (PAGE_LON_SPAN + 0.98 * PAGE_LON_SPAN)) < 1e-6
+    assert abs(lat - (LAT0 - 0.004)) < 1e-6
+
+    demote(volume, pages["p3"], verdict)
+    assert not (volume / "p3.georef.json").exists()
+    assert (volume / "p3.georef-contradicted.json").exists()
+    centers = contradiction_centers(volume, "p3")
+    assert len(centers) == 1 and abs(centers[0][0] - lon) < 1e-9
+    assert contradiction_centers(volume, "p2") == []
+
+
+def test_structurally_sound_suspect_is_never_demoted(tmp_path):
+    # Same displacement, but p3 is a 5-GCP fit with median rotation and scale:
+    # the stamp alone must not demote it.
+    _, verdicts = gate(write_volume(tmp_path, p3_lat_shift=0.003, p3_gcps=5))
+    assert verdicts == []
+
+
+def test_corroborated_pair_blames_the_edge(tmp_path):
+    # p3 gains a compatible neighbor p4: both sides of the contradicted p2~p3
+    # edge are vouched for, so the edge is junk and nobody is demoted.
+    volume = write_volume(tmp_path, p3_lat_shift=0.003, p3_gcps=1)
+    adjacency = json.loads((volume / "adjacency.json").read_text())
+    adjacency["pages"]["p3"]["detections"].append(claim("4", 0.98))
+    adjacency["pages"]["p4"] = {"detections": [claim("3", 0.02)]}
+    adjacency["adjacency"].append(["p3", "p4"])
+    (volume / "adjacency.json").write_text(json.dumps(adjacency))
+    # p4 fitted consistently with p3's (displaced) pose: their edge agrees.
+    (volume / "p4.georef.json").write_text(
+        json.dumps(georef_doc(3 * PAGE_LON_SPAN, LAT0 + 0.003, 5))
+    )
+    _, verdicts = gate(volume)
+    assert verdicts == []

--- a/mapsnap/adjacency_gate_test.py
+++ b/mapsnap/adjacency_gate_test.py
@@ -103,6 +103,59 @@ def test_structurally_sound_suspect_is_never_demoted(tmp_path):
     assert verdicts == []
 
 
+def test_stamp_gate_accepts_true_pose_and_rejects_the_alias(tmp_path):
+    import numpy as np
+
+    from mapsnap.adjacency_gate import load_stamp_gate
+
+    volume = write_volume(tmp_path, p3_lat_shift=0.003, p3_gcps=1)
+    pages, verdicts = gate(volume)
+    demote(volume, pages["p3"], verdicts[0])
+    stamp_gate = load_stamp_gate(volume, "p3", 1000, 800)
+    assert stamp_gate is not None
+    # p3's own claim of p2 exists, so the strict pairwise check applies.
+    assert stamp_gate.own_claims == [[(0.02 * 1000, 0.5 * 800)]]
+
+    def affine(lon0: float, lat0: float) -> np.ndarray:
+        scale = PAGE_LON_SPAN / 1000
+        return np.array([[scale, 0.0, lon0], [0.0, -0.008 / 800, lat0]])
+
+    true_pose = affine(2 * PAGE_LON_SPAN, LAT0)  # back where p2's stamp says
+    alias = affine(2 * PAGE_LON_SPAN, LAT0 + 0.003)  # the old wrong pose
+    good = stamp_gate.separation_m(true_pose)
+    bad = stamp_gate.separation_m(alias)
+    assert good is not None and good < 100.0
+    assert bad is not None and bad > 100.0
+
+
+def test_stamp_gate_footprint_fallback_when_own_read_missing(tmp_path):
+    import json as json_module
+
+    import numpy as np
+
+    from mapsnap.adjacency_gate import load_stamp_gate
+
+    volume = write_volume(tmp_path, p3_lat_shift=0.003, p3_gcps=1)
+    pages, verdicts = gate(volume)
+    demote(volume, pages["p3"], verdicts[0])
+    # Erase p3's own claim of p2: the neighbor's stamp must then at least
+    # touch the candidate footprint.
+    adjacency = json_module.loads((volume / "adjacency.json").read_text())
+    adjacency["pages"]["p3"]["detections"] = []
+    (volume / "adjacency.json").write_text(json_module.dumps(adjacency))
+    stamp_gate = load_stamp_gate(volume, "p3", 1000, 800)
+    assert stamp_gate is not None and stamp_gate.own_claims == [[]]
+
+    def affine(lon0: float, lat0: float) -> np.ndarray:
+        scale = PAGE_LON_SPAN / 1000
+        return np.array([[scale, 0.0, lon0], [0.0, -0.008 / 800, lat0]])
+
+    touching = stamp_gate.separation_m(affine(2 * PAGE_LON_SPAN, LAT0))
+    far = stamp_gate.separation_m(affine(2 * PAGE_LON_SPAN + 0.05, LAT0))
+    assert touching is not None and touching < 100.0
+    assert far is not None and far > 100.0
+
+
 def test_corroborated_pair_blames_the_edge(tmp_path):
     # p3 gains a compatible neighbor p4: both sides of the contradicted p2~p3
     # edge are vouched for, so the edge is junk and nobody is demoted.

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -43,6 +43,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.page_adjacency",
         "Detect printed adjacent-sheet numbers and build a volume adjacency graph",
     ),
+    "adjacency-gate": (
+        "mapsnap.adjacency_gate",
+        "Demote fits that contradict their printed mutual-adjacency claims",
+    ),
     "snap": (
         "mapsnap.snap",
         "Geometry-first OSM snap: rescue unplaced pages, arbitrate and refine fits",

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -1837,10 +1837,11 @@ def measurement_sigmas(
     enter with loose sigmas and rely on the solver's Huber loss to be outvoted
     when wrong. Synthetic-anchor measurements (both pages unfitted, anchor
     posed at its keymap guess) searched a worse frame, so they get 1.5x;
-    measurements from one-sided-claim pairs (a printed reference whose
-    reciprocal never read — ~90% genuine against the label truth, but junk
-    reads land in the same tier) get the same 1.5x so mutual-edge evidence
-    outvotes them where they disagree.
+    measurements from one-sided-claim pairs get the same 1.5x so mutual-edge
+    evidence outvotes them where they disagree. That tier is only 32-54%
+    genuine against the label truth (vs 96-100% for mutual edges), so the
+    widening is doing real work — the join's own verification is the primary
+    filter, and the solver's Huber loss the backstop.
     """
     if verification >= 1.3:
         pos, theta = 5.0, 0.6
@@ -2226,10 +2227,12 @@ def cmd_posegraph(
     suffix so the printed-graph baseline is preserved for comparison.
 
     With ``one_sided`` the pair set is augmented with unreciprocated-claim
-    edges (adjacency.json's lower-trust ``one_sided`` tier — ~90% genuine
-    against the label truth, the reciprocal side simply failed to read).
-    Their measurements are tagged and solved at widened sigmas so mutual-edge
-    evidence outvotes them; outputs get a ``_1sided`` suffix.
+    edges (adjacency.json's lower-trust ``one_sided`` tier: 32-54% genuine
+    against the label truth, so most are junk reads that resolved to a real
+    page). They are proposals only — the join's verification gate and the
+    solver's Huber loss do the filtering, and their measurements are tagged
+    and solved at widened sigmas so mutual-edge evidence outvotes them.
+    Outputs get a ``_1sided`` suffix.
     """
     from mapsnap.edge_join_graph import (
         AbsolutePrior,

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -283,18 +283,28 @@ def page_rect_metres(
     return ring
 
 
-def detected_pairs(volume: Path) -> set[frozenset[int]]:
-    """Mutual adjacency edges as unordered page-number pairs, or empty if absent."""
+def adjacency_number_pairs(volume: Path, doc_key: str) -> set[frozenset[int]]:
+    """An adjacency.json edge list as unordered page-number pairs, or empty if absent."""
     path = volume / "adjacency.json"
     if not path.exists():
         return set()
     doc = json.loads(path.read_text())
     pairs: set[frozenset[int]] = set()
-    for a, b in doc.get("adjacency", []):
+    for a, b in doc.get(doc_key, []):
         na, nb = page_number(a), page_number(b)
         if na is not None and nb is not None and na != nb:
             pairs.add(frozenset((na, nb)))
     return pairs
+
+
+def detected_pairs(volume: Path) -> set[frozenset[int]]:
+    """Mutual adjacency edges as unordered page-number pairs, or empty if absent."""
+    return adjacency_number_pairs(volume, "adjacency")
+
+
+def one_sided_pairs(volume: Path) -> set[frozenset[int]]:
+    """Unreciprocated-claim edges (the lower-trust tier), or empty if absent."""
+    return adjacency_number_pairs(volume, "one_sided")
 
 
 def keymap_region_adjacency(
@@ -1818,13 +1828,19 @@ STREET_FACTOR_MIN_CONFIDENCE = 0.7
 STREET_FACTOR_TRUST_M = 15.0
 
 
-def measurement_sigmas(verification: float, synthetic: bool) -> tuple[float, float]:
+def measurement_sigmas(
+    verification: float, synthetic: bool, one_sided: bool = False
+) -> tuple[float, float]:
     """(sigma_pos_m, sigma_theta_rad) for one join measurement.
 
     Calibrated on DC: verification>=1.3 joins are ~5m-class; sub-gate joins
     enter with loose sigmas and rely on the solver's Huber loss to be outvoted
     when wrong. Synthetic-anchor measurements (both pages unfitted, anchor
-    posed at its keymap guess) searched a worse frame, so they get 1.5x.
+    posed at its keymap guess) searched a worse frame, so they get 1.5x;
+    measurements from one-sided-claim pairs (a printed reference whose
+    reciprocal never read — ~90% genuine against the label truth, but junk
+    reads land in the same tier) get the same 1.5x so mutual-edge evidence
+    outvotes them where they disagree.
     """
     if verification >= 1.3:
         pos, theta = 5.0, 0.6
@@ -1835,6 +1851,8 @@ def measurement_sigmas(verification: float, synthetic: bool) -> tuple[float, flo
     else:
         pos, theta = 35.0, 5.0
     factor = 1.5 if synthetic else 1.0
+    if one_sided:
+        factor *= 1.5
     return pos * factor, math.radians(theta * factor)
 
 
@@ -1888,6 +1906,7 @@ def collect_graph_measurements(
     limit: int | None = None,
     extra_pairs: set[frozenset[int]] | None = None,
     keymap_centroids: dict[int, tuple[float, float]] | None = None,
+    loose_pairs: set[frozenset[int]] | None = None,
 ) -> list[dict]:
     """Run the matcher over every measurable mutual-adjacency edge.
 
@@ -1901,6 +1920,9 @@ def collect_graph_measurements(
     region adjacency) beyond the printed-number graph; for those, the printed
     reciprocal side is unavailable, so the anchor-side direction gate is fed
     from ``keymap_centroids`` (the region-centroid bearing) instead.
+    ``loose_pairs`` marks pairs from the lower-trust one-sided-claim tier:
+    their records are tagged ``one_sided_pair`` so the solver widens their
+    sigmas (see measurement_sigmas).
     """
     by_number = {u.number: u for u in units}
     pairs = detected_pairs(volume)
@@ -2008,6 +2030,8 @@ def collect_graph_measurements(
         if record is None:
             continue
         record["synthetic_anchor"] = synthetic
+        if loose_pairs and frozenset((anchor.number, target.number)) in loose_pairs:
+            record["one_sided_pair"] = True
         record["anchor_state"] = anchor.fit_state
         record["target_state"] = target.fit_state
         record["anchor_affine"] = [list(row) for row in anchor_affine]
@@ -2184,6 +2208,7 @@ def cmd_posegraph(
     street_factors: bool = False,
     keymap_adjacency: bool = False,
     keymap_gap_m: float = 40.0,
+    one_sided: bool = False,
 ) -> None:
     """Global pose-graph solve over all edge-join measurements.
 
@@ -2199,6 +2224,12 @@ def cmd_posegraph(
     region-adjacency pairs that involve a not-yet-fitted page (the printed graph
     misses these on 4-digit-page volumes like LA); outputs get a ``_kmadj``
     suffix so the printed-graph baseline is preserved for comparison.
+
+    With ``one_sided`` the pair set is augmented with unreciprocated-claim
+    edges (adjacency.json's lower-trust ``one_sided`` tier — ~90% genuine
+    against the label truth, the reciprocal side simply failed to read).
+    Their measurements are tagged and solved at widened sigmas so mutual-edge
+    evidence outvotes them; outputs get a ``_1sided`` suffix.
     """
     from mapsnap.edge_join_graph import (
         AbsolutePrior,
@@ -2211,34 +2242,49 @@ def cmd_posegraph(
     units = load_page_units(volume)
     by_stem = {u.stem: u for u in units}
     out_dir = volume / "artifacts" / "edge_join"
-    suffix = "_kmadj" if keymap_adjacency else ""
+    suffix = ("_kmadj" if keymap_adjacency else "") + ("_1sided" if one_sided else "")
     meas_path = out_dir / f"measurements{suffix}.jsonl"
 
-    extra_pairs: set[frozenset[int]] | None = None
-    keymap_centroids: dict[int, tuple[float, float]] | None = None
-    if keymap_adjacency:
-        km_pairs, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
-        real_numbers = {u.number for u in units}
-        fitted_numbers = {
-            u.number
-            for u in units
-            if u.fit_state == "fitted" and u.gen_affine is not None
-        }
-        detected = detected_pairs(volume)
+    real_numbers = {u.number for u in units}
+    fitted_numbers = {
+        u.number for u in units if u.fit_state == "fitted" and u.gen_affine is not None
+    }
+    detected = detected_pairs(volume)
+
+    def new_unfitted_pairs(candidates: set[frozenset[int]]) -> set[frozenset[int]]:
         # Keep only pairs between two real volume pages (the key map also reads
         # stray lot/scale numbers) that connect a not-yet-fitted page and aren't
         # already in the printed graph — fitted-fitted pairs would only re-refine
         # already-placed sheets.
-        extra_pairs = {
+        return {
             pair
-            for pair in km_pairs
+            for pair in candidates
             if pair <= real_numbers
             and pair not in detected
             and not pair <= fitted_numbers
         }
+
+    extra_pairs: set[frozenset[int]] | None = None
+    loose_pairs: set[frozenset[int]] | None = None
+    keymap_centroids: dict[int, tuple[float, float]] | None = None
+    if keymap_adjacency:
+        km_pairs, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
+        extra_pairs = new_unfitted_pairs(km_pairs)
         print(
             f"keymap region adjacency (gap<={keymap_gap_m:g}m): {len(km_pairs)} pairs,"
             f" {len(extra_pairs)} new real pairs involving an unfitted page"
+        )
+    if one_sided:
+        os_pairs = one_sided_pairs(volume)
+        loose_pairs = new_unfitted_pairs(os_pairs) - (extra_pairs or set())
+        extra_pairs = (extra_pairs or set()) | loose_pairs
+        # The centroid substitute keeps the anchor-side gate alive when the
+        # anchor is the side whose claim never read.
+        if keymap_centroids is None:
+            _, keymap_centroids = keymap_region_adjacency(volume, keymap_gap_m)
+        print(
+            f"one-sided claims: {len(os_pairs)} pairs,"
+            f" {len(loose_pairs)} new pairs involving an unfitted page"
         )
 
     if meas_path.exists() and not remeasure:
@@ -2248,7 +2294,7 @@ def cmd_posegraph(
         print(f"loaded {len(records)} cached measurements from {meas_path}")
     else:
         records = collect_graph_measurements(
-            volume, units, limit, extra_pairs, keymap_centroids
+            volume, units, limit, extra_pairs, keymap_centroids, loose_pairs
         )
         meas_path.write_text("\n".join(json.dumps(r) for r in records))
         print(f"wrote {len(records)} measurements to {meas_path}")
@@ -2291,7 +2337,9 @@ def cmd_posegraph(
             pose_t = vframe.affine_to_pose(np.array(alternate["world_affine"]))
             dx, dy, dtheta = vframe.relative(pose_a, pose_t)
             sigma_pos, sigma_theta = measurement_sigmas(
-                alternate["verification"], r.get("synthetic_anchor", False)
+                alternate["verification"],
+                r.get("synthetic_anchor", False),
+                r.get("one_sided_pair", False),
             )
             candidates.append(
                 RelativeMeasurement(
@@ -2625,6 +2673,11 @@ def main() -> None:
         help="posegraph: refine with street-label line factors",
     )
     parser.add_argument(
+        "--one-sided",
+        action="store_true",
+        help="posegraph: add unreciprocated-claim pairs at widened sigmas (writes *_1sided)",
+    )
+    parser.add_argument(
         "--keymap-adjacency",
         action="store_true",
         help="posegraph: add key-map region-adjacency candidate pairs (writes *_kmadj)",
@@ -2669,6 +2722,7 @@ def main() -> None:
             args.street_factors,
             args.keymap_adjacency,
             args.keymap_gap_m,
+            args.one_sided,
         )
     elif args.command == "materialize":
         cmd_materialize(args.volume, args.source)

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -144,6 +144,12 @@ def main() -> None:
         ["mapsnap", "georef", *images, "--centerlines", str(centerlines), *georef_extra]
     )
 
+    # Demote fits that contradict their own printed mutual-adjacency claims
+    # (adjacency edges are ~100% precise, so a contradicted, weakly-supported
+    # fit is wrong). The demotion leaves partner-stamp re-search hints that
+    # snap's rescue picks up, so it runs before snap. No adjacency.json: no-op.
+    run_cmd(["mapsnap", "adjacency-gate", str(dir_path)])
+
     # The geometry-first snap channel: rescue unplaced pages, arbitrate fits
     # OSM contradicts, refine mid-tier fits. Its pN.georef-osm.json sidecars
     # take priority over plain georefs in the hybrid glob below.

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -141,9 +141,13 @@ class SnapCandidate:
     name: NameAlignment | None = None
     plausible: bool = True
     gate_reasons: list[str] = field(default_factory=list)
-    # Best-partner stamp separation for contradiction-demoted rescue targets
+    # Stamp separations for contradiction-demoted rescue targets
     # (adjacency_gate.StampGate); None when the page carries no hints.
+    # min over partners = the permissive hard-gate statistic; median = the
+    # strict corroboration statistic (junk hints scatter, so no wrong pose
+    # satisfies most of them).
     stamp_separation_m: float | None = None
+    stamp_median_m: float | None = None
 
     def select_score(self) -> float:
         """The ranking score: matcher verification plus soft evidence bonuses."""

--- a/mapsnap/osm_snap.py
+++ b/mapsnap/osm_snap.py
@@ -141,6 +141,9 @@ class SnapCandidate:
     name: NameAlignment | None = None
     plausible: bool = True
     gate_reasons: list[str] = field(default_factory=list)
+    # Best-partner stamp separation for contradiction-demoted rescue targets
+    # (adjacency_gate.StampGate); None when the page carries no hints.
+    stamp_separation_m: float | None = None
 
     def select_score(self) -> float:
         """The ranking score: matcher verification plus soft evidence bonuses."""

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -17,6 +17,7 @@ import io
 import json
 import math
 import multiprocessing
+import statistics
 import sys
 import time
 from dataclasses import dataclass
@@ -741,6 +742,8 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
     }
     if candidate.stamp_separation_m is not None:
         record["stamp_separation_m"] = round(candidate.stamp_separation_m, 1)
+    if candidate.stamp_median_m is not None:
+        record["stamp_median_m"] = round(candidate.stamp_median_m, 1)
     if candidate.region_containment is not None:
         record["region_containment"] = round(candidate.region_containment, 3)
     if candidate.prior_theta_residual_sigma is not None:
@@ -857,8 +860,11 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
         stamp_gate = load_stamp_gate(vctx.volume, unit.stem, unit.width, unit.height)
         if stamp_gate is not None:
             for candidate in candidates:
-                separation = stamp_gate.separation_m(candidate.world_affine)
+                separations = stamp_gate.partner_separations_m(candidate.world_affine)
+                separation = min(separations) if separations else None
                 candidate.stamp_separation_m = separation
+                if separations:
+                    candidate.stamp_median_m = float(statistics.median(separations))
                 if separation is not None and separation > STAMP_REHOME_M:
                     candidate.plausible = False
                     candidate.gate_reasons.append(
@@ -2281,11 +2287,18 @@ def cmd_select(
 
 
 def stamp_corroborated(candidate: dict) -> bool:
-    """Whether a candidate record landed within the stamp-consistency bound."""
+    """Whether the hinting neighbors genuinely vouch for a candidate pose.
+
+    Uses the MEDIAN partner separation: genuine hints agree, so a true pose
+    satisfies essentially all of them, while junk hints (single-digit
+    reciprocation) scatter across the volume and no wrong pose can satisfy
+    most. Nashville p8's 325 ft candidate matched one of its four junk stamps
+    at 66 m (the min) and was wrongly adopted; its median was far out.
+    """
     from mapsnap.adjacency_gate import STAMP_REHOME_M
 
-    separation = candidate.get("stamp_separation_m")
-    return separation is not None and separation <= STAMP_REHOME_M
+    median = candidate.get("stamp_median_m")
+    return median is not None and median <= STAMP_REHOME_M
 
 
 def uncorroborated_margin(record: dict) -> float:

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -610,6 +610,17 @@ def build_page_context(
     if prob is None:
         return None, "no_prob"
     centers, regions = page_keymap_data(vctx, unit)
+    # A page the adjacency gate demoted carries its neighbors' printed-claim
+    # positions — world points on the shared seam the page must sit against.
+    # They join the search centers, and stand alone for pages the keymap
+    # never placed.
+    from mapsnap.adjacency_gate import contradiction_centers
+
+    for lon, lat in contradiction_centers(
+        vctx.volume, panel_base(unit.stem) or unit.stem
+    ):
+        if all(haversine_m(lat, lon, b, a) > 50.0 for a, b in centers):
+            centers = centers + [(lon, lat)]
     if unit.fit_state == "fitted" and unit.gen_affine is not None:
         # For arbitration the incumbent pose itself is the natural search
         # init — it also reaches fitted pages the keymap never placed.

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -403,7 +403,9 @@ def georef_variant_mtime(volume: Path, stem: str) -> int | None:
     return None
 
 
-def candidates_record_fresh(record: dict, unit: PageUnit, mtime: int | None) -> bool:
+def candidates_record_fresh(
+    record: dict, unit: PageUnit, mtime: int | None, hint_mtime: int | None = None
+) -> bool:
     """Whether a cached candidates record still matches the page's fit state.
 
     Only a successful record is ever fresh. A failure ('no_prob', 'no_keymap')
@@ -411,13 +413,26 @@ def candidates_record_fresh(record: dict, unit: PageUnit, mtime: int | None) -> 
     map's own sidecars — so caching one would pin the page behind a stale
     failure even after the input is fixed. Recomputing a failure is cheap: it
     fails at the same gate before any matching work.
+
+    ``hint_mtime`` is the contradiction-hint sidecar's mtime: a page the
+    adjacency gate demoted twice has georef_mtime None both times, and without
+    this key the second snap pass reuses the first pass's candidates —
+    generated before the hint (or the stamp-consistency gate) existed — and
+    re-adopts the very alias the gate demoted (KC p551).
     """
     if record.get("status") != "ok":
         return False
     return (
         record.get("fit_state") == unit.fit_state
         and record.get("georef_mtime") == mtime
+        and record.get("contradiction_mtime") == hint_mtime
     )
+
+
+def contradiction_hint_mtime(volume: Path, stem: str) -> int | None:
+    """mtime of the page's contradiction-hint sidecar, or None for none."""
+    path = volume / f"{stem}.contradiction.json"
+    return int(path.stat().st_mtime) if path.exists() else None
 
 
 def load_volume_context(
@@ -724,6 +739,8 @@ def candidate_record(candidate: SnapCandidate, unit: PageUnit) -> dict:
         "plausible": candidate.plausible,
         "gate_reasons": candidate.gate_reasons,
     }
+    if candidate.stamp_separation_m is not None:
+        record["stamp_separation_m"] = round(candidate.stamp_separation_m, 1)
     if candidate.region_containment is not None:
         record["region_containment"] = round(candidate.region_containment, 3)
     if candidate.prior_theta_residual_sigma is not None:
@@ -758,6 +775,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
         "status": status,
         "fit_state": unit.fit_state,
         "georef_mtime": georef_variant_mtime(vctx.volume, unit.stem),
+        "contradiction_mtime": contradiction_hint_mtime(vctx.volume, unit.stem),
         "width": unit.width,
         "height": unit.height,
         "has_truth": unit.truth is not None,
@@ -828,6 +846,26 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
                     "radius_source": "local-challenge",
                 }
     candidates = snap_page(ctx, vctx.feature_index)
+    if unit.fit_state in RESCUE_STATES:
+        # A contradiction-demoted page may only be re-adopted at a pose that
+        # satisfies the invariant that demoted it: its printed claim of a
+        # hinting neighbor must land back on that neighbor's stamp. Without
+        # this, a verification-confident alias simply re-verifies from the
+        # very hints meant to displace it (KC p551, re-adopted 686 -> 692 ft).
+        from mapsnap.adjacency_gate import STAMP_REHOME_M, load_stamp_gate
+
+        stamp_gate = load_stamp_gate(vctx.volume, unit.stem, unit.width, unit.height)
+        if stamp_gate is not None:
+            for candidate in candidates:
+                separation = stamp_gate.separation_m(candidate.world_affine)
+                candidate.stamp_separation_m = separation
+                if separation is not None and separation > STAMP_REHOME_M:
+                    candidate.plausible = False
+                    candidate.gate_reasons.append(
+                        f"stamp-inconsistent({separation:.0f}m)"
+                    )
+                    candidate.verification = -math.inf
+            candidates.sort(key=lambda c: -c.select_score())
     if not candidates:
         record["status"] = "no_candidates"
         return record
@@ -1010,7 +1048,10 @@ def cmd_candidates(
         or pages
         or (cached := existing.get(unit.stem)) is None
         or not candidates_record_fresh(
-            cached, unit, georef_variant_mtime(volume, unit.stem)
+            cached,
+            unit,
+            georef_variant_mtime(volume, unit.stem),
+            contradiction_hint_mtime(volume, unit.stem),
         )
     ]
     by_stem = {unit.stem: unit for unit in targets}
@@ -1678,6 +1719,18 @@ def cmd_sweep_refine(volumes: list[Path], recompute: bool = False) -> None:
 PRODUCTION_GATE_SCORE = 1.25
 PRODUCTION_GATE_MARGIN = 0.25
 PRODUCTION_ARBITRATE_GATE = 1.5
+
+STAMP_RESCUE_SCORE = 0.7
+"""Relaxed rescue bar for stamp-corroborated candidates.
+
+A contradiction-demoted page's rescue candidate that lands its printed claim
+back on the hinting neighbor's stamp carries external evidence the select
+score cannot see — the neighbor's printed testimony pins the pose at the seam.
+Measured true poses refused by the 1.25 bar: KC p551 at 0.77 (24 ft), GR p828
+at 0.93 (23 ft). Stamp-INconsistent candidates are already implausible, so the
+relaxed bar only ever admits poses the neighbors vouch for; the margin is
+computed against the best non-corroborated rival (NO-1896 p125's true pose at
+1.82 was margin-blocked by its own 16-degree twin)."""
 VOLUME_MODE_GATE = 1.5  # the dev-chosen conservative elbow for the energy mode
 
 # Arbitration: a snap candidate may replace a placed RANSAC fit only when it
@@ -2227,6 +2280,26 @@ def cmd_select(
     print(f"{accepted}/{len(selections)} pages accepted -> {out_path}")
 
 
+def stamp_corroborated(candidate: dict) -> bool:
+    """Whether a candidate record landed within the stamp-consistency bound."""
+    from mapsnap.adjacency_gate import STAMP_REHOME_M
+
+    separation = candidate.get("stamp_separation_m")
+    return separation is not None and separation <= STAMP_REHOME_M
+
+
+def uncorroborated_margin(record: dict) -> float:
+    """Rank-1's select_score lead over the best rival the neighbors don't vouch for."""
+    candidates = record.get("candidates") or []
+    top_score = candidates[0]["select_score"]
+    rivals = [
+        c["select_score"]
+        for c in candidates[1:]
+        if c.get("select_score") is not None and not stamp_corroborated(c)
+    ]
+    return top_score - max(rivals) if rivals else math.inf
+
+
 def select_argmax(
     records: list[dict],
     gate_score: float,
@@ -2262,17 +2335,29 @@ def select_argmax(
             top = record["candidates"][0]
             score = top.get("select_score")
             margin = distinct_margin(record)
+            corroborated = (
+                record.get("fit_state") in RESCUE_STATES
+                and score is not None
+                and stamp_corroborated(top)
+            )
+            if corroborated:
+                # The hinting neighbor's printed testimony pins this pose at
+                # the seam: relax the absolute bar, and measure ambiguity only
+                # against rivals the neighbors do NOT vouch for (a corroborated
+                # twin is the same corridor, not a competing hypothesis).
+                margin = uncorroborated_margin(record)
+            effective_gate = STAMP_RESCUE_SCORE if corroborated else gate_score
             if score is None:
                 choice["reason"] = "implausible"
-            elif score < gate_score:
-                choice["reason"] = f"score {score:.2f} < {gate_score}"
+            elif score < effective_gate:
+                choice["reason"] = f"score {score:.2f} < {effective_gate}"
             elif margin is None or margin < gate_margin:
                 choice["reason"] = f"margin {margin} < {gate_margin}"
             else:
                 choice = {
                     "target": stem,
                     "chosen": 0,
-                    "reason": "accepted",
+                    "reason": "stamp-corroborated" if corroborated else "accepted",
                     "select_score": score,
                     "margin": None if math.isinf(margin) else round(margin, 4),
                 }

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -411,7 +411,7 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
         select_argmax,
     )
 
-    def cand(score, sep=None, center=(-90.0, 30.0), theta=0.0):
+    def cand(score, sep=None, center=(-90.0, 30.0), theta=0.0, median=None):
         c = {
             "select_score": score,
             "center": list(center),
@@ -419,6 +419,7 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
         }
         if sep is not None:
             c["stamp_separation_m"] = sep
+            c["stamp_median_m"] = median if median is not None else sep
         return c
 
     def rec(candidates, fit_state="nofit"):
@@ -463,3 +464,12 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
         PRODUCTION_GATE_MARGIN,
     )
     assert choice["chosen"] is None
+
+    # Nashville p8 shape: the wrong pose matches ONE of four scattered junk
+    # stamps (min 66m) but the median partner is far out -- not corroborated.
+    (choice,) = select_argmax(
+        [rec([cand(0.99, sep=66.0, median=420.0)])],
+        PRODUCTION_GATE_SCORE,
+        PRODUCTION_GATE_MARGIN,
+    )
+    assert choice["chosen"] is None and "score" in choice["reason"]

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -258,6 +258,14 @@ def test_candidates_record_fresh_tracks_fit_changes():
             {**base, "status": status}, make_unit("fitted"), 111
         )
     assert candidates_record_fresh({**base, "status": "ok"}, make_unit("fitted"), 111)
+    # A contradiction hint appeared (or was rewritten by a re-demotion): the
+    # cached candidates predate the stamp-consistency gate and must recompute.
+    assert not candidates_record_fresh(
+        {**base, "status": "ok"}, make_unit("fitted"), 111, hint_mtime=555
+    )
+    hinted = {**base, "status": "ok", "contradiction_mtime": 555}
+    assert candidates_record_fresh(hinted, make_unit("fitted"), 111, hint_mtime=555)
+    assert not candidates_record_fresh(hinted, make_unit("fitted"), 111, hint_mtime=777)
 
 
 def test_init_worker_indexes_pages_and_panels(monkeypatch, tmp_path):
@@ -394,3 +402,64 @@ def test_cluster_search_centers_merges_overlapping_discs():
     # Singletons and empties pass through untouched.
     assert cluster_search_centers(far, 120.0) == far
     assert cluster_search_centers([], 120.0) == []
+
+
+def test_stamp_corroborated_rescue_relaxes_the_gates():
+    from mapsnap.osm_snap_experiment import (
+        PRODUCTION_GATE_MARGIN,
+        PRODUCTION_GATE_SCORE,
+        select_argmax,
+    )
+
+    def cand(score, sep=None, center=(-90.0, 30.0), theta=0.0):
+        c = {
+            "select_score": score,
+            "center": list(center),
+            "theta_deg": theta,
+        }
+        if sep is not None:
+            c["stamp_separation_m"] = sep
+        return c
+
+    def rec(candidates, fit_state="nofit"):
+        return {
+            "target": "p9",
+            "status": "ok",
+            "fit_state": fit_state,
+            "candidates": candidates,
+        }
+
+    # KC p551 shape: true pose at 0.77 within the stamp bound, rivals gated
+    # implausible (select_score None) -> adopted under the relaxed bar.
+    (choice,) = select_argmax(
+        [rec([cand(0.77, sep=24.0), {"select_score": None}])],
+        PRODUCTION_GATE_SCORE,
+        PRODUCTION_GATE_MARGIN,
+    )
+    assert choice["chosen"] == 0 and choice["reason"] == "stamp-corroborated"
+
+    # NO p125 shape: a corroborated twin close behind must NOT margin-block,
+    # but an uncorroborated rival within the margin still does.
+    twin = [cand(1.82, sep=30.0), cand(1.61, sep=40.0), cand(1.55, theta=20.0)]
+    (choice,) = select_argmax(
+        [rec(twin)], PRODUCTION_GATE_SCORE, PRODUCTION_GATE_MARGIN
+    )
+    assert choice["chosen"] == 0 and choice["reason"] == "stamp-corroborated"
+    rival = [cand(0.9, sep=30.0), cand(0.8, theta=20.0)]
+    (choice,) = select_argmax(
+        [rec(rival)], PRODUCTION_GATE_SCORE, PRODUCTION_GATE_MARGIN
+    )
+    assert choice["chosen"] is None and "margin" in choice["reason"]
+
+    # Without stamp corroboration the normal bar stands (0.77 < 1.25)...
+    (choice,) = select_argmax(
+        [rec([cand(0.77)])], PRODUCTION_GATE_SCORE, PRODUCTION_GATE_MARGIN
+    )
+    assert choice["chosen"] is None
+    # ...and a fitted page's record never takes the relaxed path.
+    (choice,) = select_argmax(
+        [rec([cand(0.77, sep=24.0)], fit_state="fitted")],
+        PRODUCTION_GATE_SCORE,
+        PRODUCTION_GATE_MARGIN,
+    )
+    assert choice["chosen"] is None

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -420,15 +420,14 @@ def is_claim(
     return True
 
 
-def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
-    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
+def claim_resolver(claims_by_page: dict[str, set[str]]):
+    """resolve(claim key) -> stems carrying it, shared by both edge builders.
 
-    ``claims_by_page`` maps page stems to claimed page keys. A claimed key resolves to
-    the stem(s) carrying exactly that key; a bare-number claim in a volume whose sheet
-    has a lettered stem (Chicago prints "60" for p60w) falls back to the number, but
-    only when it names a single stem — a number shared by many lettered sheets (LA's
-    p1499a-r) is ambiguous and resolves to nothing. The edge exists only if each side's
-    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
+    A claimed key resolves to the stem(s) carrying exactly that key; a
+    bare-number claim in a volume whose sheet has a lettered stem (Chicago
+    prints "60" for p60w) falls back to the number, but only when it names a
+    single stem — a number shared by many lettered sheets (LA's p1499a-r) is
+    ambiguous and resolves to nothing.
     """
     stems_by_key: dict[str, list[str]] = defaultdict(list)
     stems_by_number: dict[int, list[str]] = defaultdict(list)
@@ -450,6 +449,17 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
                 return fallback
         return []
 
+    return resolve
+
+
+def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
+
+    ``claims_by_page`` maps page stems to claimed page keys (see claim_resolver
+    for how claims resolve to stems). The edge exists only if each side's
+    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
+    """
+    resolve = claim_resolver(claims_by_page)
     edges: set[tuple[str, str]] = set()
     for stem, claimed in claims_by_page.items():
         for claim in claimed:
@@ -461,6 +471,27 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
                 ):
                     first, second = sorted((stem, other))
                     edges.add((first, second))
+    return sorted(edges)
+
+
+def one_sided_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Directed claims that resolve to a real page but are not reciprocated.
+
+    The lower-trust adjacency tier: measured against the hand-labelled truth,
+    88% of Hudson's and 89% of LA's unreciprocated-but-resolvable claims are
+    genuine printed references whose reciprocal side failed to read (truth
+    itself reciprocates 91-93%). Consumers must treat these as candidates to
+    verify, not facts — a junk read that resolves to a real page lands here.
+    Returns sorted (claimer, target) pairs, excluding mutual edges.
+    """
+    resolve = claim_resolver(claims_by_page)
+    mutual = {frozenset(edge) for edge in mutual_edges(claims_by_page)}
+    edges: set[tuple[str, str]] = set()
+    for stem, claimed in claims_by_page.items():
+        for claim in claimed:
+            for other in resolve(claim):
+                if other != stem and frozenset((stem, other)) not in mutual:
+                    edges.add((stem, other))
     return sorted(edges)
 
 
@@ -623,6 +654,7 @@ def main() -> None:
             )
 
     edges = mutual_edges(claims_by_page)
+    one_sided = one_sided_edges(claims_by_page)
     doc = {
         "timestamp": datetime.now(UTC).isoformat(),
         "command": sys.argv[:],
@@ -634,13 +666,14 @@ def main() -> None:
         "single_digit_min_gap": round(min_gap, 1) if min_gap is not None else None,
         "pages": pages,
         "adjacency": [list(edge) for edge in edges],
+        "one_sided": [list(edge) for edge in one_sided],
     }
     output = args.output or (args.volume / "adjacency.json")
     output.write_text(json.dumps(doc, indent=2))
     total_claims = sum(len(c) for c in claims_by_page.values())
     print(
         f"Wrote {output}: {len(pages)} pages, {total_claims} directed claims, "
-        f"{len(edges)} mutual edges.",
+        f"{len(edges)} mutual edges, {len(one_sided)} one-sided.",
         file=sys.stderr,
     )
 

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -156,8 +156,11 @@ def resolve_page_key(
                  forms a valid key ("1499G" -> 1499G); checked first because
                  the digits pass renders the same ink as a bare "1499" -- a
                  different, wrong page.
-      exact      the digit read is a valid key as-is (the only method that
-                 applies to keys shorter than ``min_repair_digits``).
+      exact      the digit read is a valid key as-is.
+      number     the digit read matches exactly ONE key's digit part: Chicago
+                 prints a bare "60" for sheet p60w, and Miami "8" for p8s.
+                 A digit part shared by many lettered keys (LA's 18 p1499*
+                 sheets) is ambiguous and never resolved this way.
       suffix     the read lost its leading digit against the sheet trim:
                  exactly one valid key ends with it ("409" -> 1409). Requires
                  a read of >= 3 digits: 2-digit remnants are house-number
@@ -183,6 +186,11 @@ def resolve_page_key(
         return None
     if digits in valid_keys:
         return digits, "exact"
+    same_number = [
+        key for key in valid_keys if "".join(c for c in key if c.isdigit()) == digits
+    ]
+    if len(same_number) == 1:
+        return same_number[0], "number"
     repairable = [
         key for key in valid_keys if key.isdigit() and len(key) >= min_repair_digits
     ]

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -6,8 +6,13 @@ sheet continues. Reading these gives page adjacency that is independent of the k
 detected neighbor's edge (top/left/bottom/right of the image) pins the page's orientation.
 
 Raw digit reads are noisy (house/block/dimension numbers collide with valid page numbers), so a
-detection only becomes a *claim* when it is a valid page number, near the page edge, printed
-large, and axis-aligned; and a claim only becomes an adjacency *edge* when it is reciprocated —
+detection only becomes a *claim* when it resolves to a valid page key, near the page edge,
+printed large, and axis-aligned. Resolution is letter-aware (a "1499G" read claims p1499g, not
+p1499) and repairs the two systematic read failures of long page numbers — leading digits lost
+against the sheet trim ("409" -> 1409) and neighboring ink absorbed into the box ("14027" ->
+1402) — but only on a unique match against keys of >= MIN_REPAIR_DIGITS digits, so volumes
+with 1- and 2-digit page numbers resolve exact reads only. A claim only becomes an adjacency
+*edge* when it is reciprocated —
 page A claims B AND page B claims A. Reciprocity alone is not proof: junk claims of small
 numbers are common enough to reciprocate by chance (and page numbering correlates with
 adjacency, so such accidents are often "correct"), so single-digit claims — where any tall
@@ -27,6 +32,7 @@ each page's number detections and the mutual-edge adjacency graph.
 import argparse
 import json
 import math
+import re
 import sys
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -36,7 +42,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
-from mapsnap.keymap.locate import page_number
+from mapsnap.keymap.locate import page_key, page_number
 from mapsnap.utils import image_stem
 
 # A detection only counts as an adjacency claim when it sits in the outer EDGE_BAND of the
@@ -117,6 +123,81 @@ def bbox_gap(a: list[list[float]], b: list[list[float]]) -> float:
     return math.hypot(dx, dy)
 
 
+MIN_REPAIR_DIGITS = 3
+"""Fewest digits a page key must have before read-repair may target it.
+
+Repair (suffix completion, embedded extraction) exists for volumes like LA 1949
+whose 4-digit '1'-leading references truncate against the sheet trim ("1409"
+reads "409" at conf 1.0) or absorb neighboring ink ("14027" for 1402) — the
+LA truth labels put 49% of all printed references in this boxed-but-unread
+class. For volumes with 1- and 2-digit page numbers, short reads are
+substrings of everything, so repair against short keys would be guesswork:
+below this floor only exact and lettered matches fire, leaving those volumes'
+behavior untouched (Hudson reads 96% of its references fine without repair).
+"""
+
+LETTERED_KEY_PATTERN = re.compile(r"([0-9IO]+)\s*([A-Z]{1,2})$")
+"""A letters-pass read that ends in a short letter suffix ("1499G", "I33S")."""
+
+
+def resolve_page_key(
+    digit_text: str,
+    letter_text: str,
+    valid_keys: set[str],
+    min_repair_digits: int = MIN_REPAIR_DIGITS,
+) -> tuple[str, str] | None:
+    """Resolve raw OCR reads of a margin reference to a valid page key.
+
+    ``digit_text`` is the digits-allowlist read, ``letter_text`` the
+    letters-allowed read of the same box ("" when none). Returns
+    ``(key, method)`` or None, trying in order:
+
+      lettered   the letter read shows a digit run plus a letter suffix that
+                 forms a valid key ("1499G" -> 1499G); checked first because
+                 the digits pass renders the same ink as a bare "1499" -- a
+                 different, wrong page.
+      exact      the digit read is a valid key as-is (the only method that
+                 applies to keys shorter than ``min_repair_digits``).
+      suffix     the read lost its leading digit against the sheet trim:
+                 exactly one valid key ends with it ("409" -> 1409). Requires
+                 a read of >= 3 digits: 2-digit remnants are house-number
+                 fragments that happen to end a page number, measured 8%
+                 precise on the LA truth labels (13/164) — including a
+                 symmetric pair ("85" on p1475, "75" on p1485) confident
+                 enough to reciprocate into a false edge. 3-digit remnants
+                 measure 71% precise and reciprocity removes the rest.
+      embedded   the read absorbed extra digits from neighboring ink: exactly
+                 one valid key appears inside it ("14027" -> 1402).
+
+    Repairs require a UNIQUE match among keys of >= ``min_repair_digits``
+    digits; any ambiguity resolves to None, never a guess.
+    """
+    digits = "".join(c for c in digit_text if c.isdigit())
+    match = LETTERED_KEY_PATTERN.search(letter_text.replace(" ", "").upper())
+    if match:
+        base = match.group(1).replace("I", "1").replace("O", "0")
+        lettered = base + match.group(2)
+        if lettered in valid_keys:
+            return lettered, "lettered"
+    if not digits:
+        return None
+    if digits in valid_keys:
+        return digits, "exact"
+    repairable = [
+        key for key in valid_keys if key.isdigit() and len(key) >= min_repair_digits
+    ]
+    if len(digits) >= 3:
+        suffixes = [
+            key for key in repairable if len(key) > len(digits) and key.endswith(digits)
+        ]
+        if len(suffixes) == 1:
+            return suffixes[0], "suffix"
+    embedded = [key for key in repairable if len(key) < len(digits) and key in digits]
+    if len(embedded) == 1:
+        return embedded[0], "embedded"
+    return None
+
+
 def is_text_veto(
     letter_text: str, letter_confidence: float, digit_confidence: float
 ) -> bool:
@@ -166,24 +247,28 @@ def cached_craft_boxes(image_path: Path) -> tuple[list, list] | None:
 def digit_detections(
     image_path: Path,
     reader,
-    valid_numbers: set[int],
+    valid_keys: set[str],
     craft_boxes: tuple[list, list] | None = None,
 ) -> list[dict]:
-    """All digit reads on one page that parse to a valid volume page number.
+    """All digit reads on one page that resolve to a valid volume page key.
 
     Two recognition passes over the same image: the digits-only pass supplies the
     transcription (immune to look-alike substitutions like 0 -> O), and a letters-allowed
     pass over the same boxes vetoes the ones that are actually street names or other text
-    (see is_text_veto). ``craft_boxes`` (from cached_craft_boxes) skips the CRAFT
-    detection pass — by far the most expensive step — reusing the boxes ``mapsnap ocr``
-    already computed for the same image.
+    (see is_text_veto) and supplies letter suffixes for lettered keys ("1499G").
+    Reads that are not a valid key verbatim go through ``resolve_page_key`` repair.
+    ``craft_boxes`` (from cached_craft_boxes) skips the CRAFT detection pass — by far
+    the most expensive step — reusing the boxes ``mapsnap ocr`` already computed for
+    the same image.
 
-    Each detection records the parsed ``number``, the raw OCR ``text``, EasyOCR's polygon and
-    confidence, the glyph ``height`` in pixels, position as width/height fractions, the
-    ``edge`` classification, and ``nearest_box`` — the gap to the nearest other OCR box, since
-    a genuine sheet reference is printed in open whitespace while a junk single digit is
-    usually a fragment of a larger number with sibling text right beside it. Filtering into
-    claims is left to the caller so the JSON keeps the full picture.
+    Each detection records the resolved ``key`` and how it resolved (``via``), the
+    digit part as ``number`` (for size rules and older readers), the raw OCR ``text``,
+    EasyOCR's polygon and confidence, the glyph ``height`` in pixels, position as
+    width/height fractions, the ``edge`` classification, and ``nearest_box`` — the gap
+    to the nearest other OCR box, since a genuine sheet reference is printed in open
+    whitespace while a junk single digit is usually a fragment of a larger number with
+    sibling text right beside it. Filtering into claims is left to the caller so the
+    JSON keeps the full picture.
     """
     from easyocr.utils import reformat_input
 
@@ -210,7 +295,7 @@ def digit_detections(
     detections = []
     for index, (bbox, text, confidence) in enumerate(results):
         digits = "".join(c for c in text if c.isdigit())
-        if not digits or int(digits) not in valid_numbers:
+        if not digits:
             continue
         # Veto boxes whose letters-pass read reveals text. Pair by box center; the two
         # passes share the same detector so boxes normally coincide.
@@ -223,10 +308,16 @@ def digit_detections(
             ),
             default=(math.inf, -1),
         )
+        letter_text = ""
         if nearest_letter[0] < box_height:
             letter_read = letter_results[nearest_letter[1]]
             if is_text_veto(letter_read[1], float(letter_read[2]), float(confidence)):
                 continue
+            letter_text = str(letter_read[1])
+        resolved = resolve_page_key(text, letter_text, valid_keys)
+        if resolved is None:
+            continue
+        key, via = resolved
         x_frac = sum(p[0] for p in bbox) / 4 / width
         y_frac = sum(p[1] for p in bbox) / 4 / height
         glyph_height = float(max(p[1] for p in bbox) - min(p[1] for p in bbox))
@@ -240,7 +331,9 @@ def digit_detections(
         )
         detections.append(
             {
-                "number": int(digits),
+                "key": key,
+                "via": via,
+                "number": int("".join(c for c in key if c.isdigit())),
                 "text": text,
                 "confidence": round(float(confidence), 4),
                 "polygon": [[int(p[0]), int(p[1])] for p in bbox],
@@ -287,7 +380,7 @@ def single_digit_height_band(
 
 def is_claim(
     detection: dict,
-    own_number: int | None,
+    own_key: str | None,
     *,
     min_height: float = MIN_HEIGHT,
     min_confidence: float = MIN_CONF,
@@ -297,7 +390,7 @@ def is_claim(
 ) -> bool:
     """Whether a detection qualifies as an adjacency claim.
 
-    Every claim must be a valid page number other than the page's own, near a page edge, tall
+    Every claim must be a valid page key other than the page's own, near a page edge, tall
     enough, confident enough, and axis-aligned (rotated quads are always misread street names
     or pipe annotations). Single-digit numbers face three stricter tests — the high
     ``single_digit_min_confidence`` floor, the ``height_band`` around the volume's
@@ -307,7 +400,7 @@ def is_claim(
     coincidence, so reciprocity alone cannot vouch for them.
     """
     if (
-        detection["number"] == own_number
+        detection["key"] == own_key
         or detection["edge"] == "center"
         or detection["height"] < min_height
         or detection["confidence"] < min_confidence
@@ -327,26 +420,45 @@ def is_claim(
     return True
 
 
-def mutual_edges(claims_by_page: dict[str, set[int]]) -> list[tuple[str, str]]:
-    """Reciprocated adjacency edges: A claims B's number and B claims A's number.
+def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
+    """Reciprocated adjacency edges: A claims B's key and B claims A's key.
 
-    ``claims_by_page`` maps page stems to claimed page numbers. A number claimed by A resolves
-    to the page stem(s) carrying that number; the edge exists only if some such stem claims A's
-    number back. Returns sorted (stem, stem) pairs, each once.
+    ``claims_by_page`` maps page stems to claimed page keys. A claimed key resolves to
+    the stem(s) carrying exactly that key; a bare-number claim in a volume whose sheet
+    has a lettered stem (Chicago prints "60" for p60w) falls back to the number, but
+    only when it names a single stem — a number shared by many lettered sheets (LA's
+    p1499a-r) is ambiguous and resolves to nothing. The edge exists only if each side's
+    claims resolve to the other. Returns sorted (stem, stem) pairs, each once.
     """
+    stems_by_key: dict[str, list[str]] = defaultdict(list)
     stems_by_number: dict[int, list[str]] = defaultdict(list)
     for stem in claims_by_page:
+        key = page_key(stem)
+        if key is not None:
+            stems_by_key[key].append(stem)
         number = page_number(stem)
         if number is not None:
             stems_by_number[number].append(stem)
+
+    def resolve(claim: str) -> list[str]:
+        stems = stems_by_key.get(claim.upper(), [])
+        if stems:
+            return stems
+        if claim.isdigit():
+            fallback = stems_by_number.get(int(claim), [])
+            if len(fallback) == 1:
+                return fallback
+        return []
+
     edges: set[tuple[str, str]] = set()
     for stem, claimed in claims_by_page.items():
-        own = page_number(stem)
-        if own is None:
-            continue
-        for number in claimed:
-            for other in stems_by_number.get(number, []):
-                if other != stem and own in claims_by_page.get(other, set()):
+        for claim in claimed:
+            for other in resolve(claim):
+                if other == stem:
+                    continue
+                if any(
+                    stem in resolve(back) for back in claims_by_page.get(other, set())
+                ):
                     first, second = sorted((stem, other))
                     edges.add((first, second))
     return sorted(edges)
@@ -407,13 +519,11 @@ def main() -> None:
     images = volume_page_images(args.volume)
     if not images:
         sys.exit(f"No page images found in {args.volume}.")
-    valid_numbers = {
-        number
-        for image in images
-        if (number := page_number(image_stem(str(image)))) is not None
+    valid_keys = {
+        key for image in images if (key := page_key(image_stem(str(image)))) is not None
     }
     print(
-        f"Scanning {len(images)} pages ({len(valid_numbers)} page numbers)...",
+        f"Scanning {len(images)} pages ({len(valid_keys)} page keys)...",
         file=sys.stderr,
     )
     reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
@@ -428,10 +538,11 @@ def main() -> None:
         craft_boxes = cached_craft_boxes(image) if args.reuse_boxes else None
         reused += craft_boxes is not None
         pages[stem] = {
+            "key": page_key(stem),
             "number": page_number(stem),
             "width": width,
             "height": height,
-            "detections": digit_detections(image, reader, valid_numbers, craft_boxes),
+            "detections": digit_detections(image, reader, valid_keys, craft_boxes),
         }
     if args.reuse_boxes:
         print(f"Reused CRAFT boxes for {reused}/{len(images)} pages.", file=sys.stderr)
@@ -439,14 +550,14 @@ def main() -> None:
     def compute_claims(
         height_band: tuple[float, float] | None,
         min_gap: float | None,
-    ) -> dict[str, set[int]]:
+    ) -> dict[str, set[str]]:
         return {
             stem: {
-                d["number"]
+                d["key"]
                 for d in page["detections"]
                 if is_claim(
                     d,
-                    page["number"],
+                    page["key"],
                     min_height=args.min_height,
                     min_confidence=args.min_confidence,
                     single_digit_min_confidence=args.single_digit_min_confidence,
@@ -461,19 +572,19 @@ def main() -> None:
     # printed-reference height from their multi-digit claims; single-digit claims are then
     # re-filtered against the derived band and isolation floor and the graph rebuilt.
     provisional_edges = mutual_edges(compute_claims(None, None))
-    mutual_numbers: dict[str, set[int]] = defaultdict(set)
+    mutual_keys: dict[str, set[str]] = defaultdict(set)
     for first, second in provisional_edges:
-        mutual_numbers[first].add(pages[second]["number"])
-        mutual_numbers[second].add(pages[first]["number"])
+        mutual_keys[first].add(pages[second]["key"])
+        mutual_keys[second].add(pages[first]["key"])
     confirmed_heights = [
         d["height"]
         for stem, page in pages.items()
         for d in page["detections"]
         if d["number"] >= 10
-        and d["number"] in mutual_numbers[stem]
+        and d["key"] in mutual_keys[stem]
         and is_claim(
             d,
-            page["number"],
+            page["key"],
             min_height=args.min_height,
             min_confidence=args.min_confidence,
             single_digit_min_confidence=args.single_digit_min_confidence,
@@ -503,7 +614,7 @@ def main() -> None:
         for detection in page["detections"]:
             detection["claim"] = is_claim(
                 detection,
-                page["number"],
+                page["key"],
                 min_height=args.min_height,
                 min_confidence=args.min_confidence,
                 single_digit_min_confidence=args.single_digit_min_confidence,

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -485,12 +485,16 @@ def mutual_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
 def one_sided_edges(claims_by_page: dict[str, set[str]]) -> list[tuple[str, str]]:
     """Directed claims that resolve to a real page but are not reciprocated.
 
-    The lower-trust adjacency tier: measured against the hand-labelled truth,
-    88% of Hudson's and 89% of LA's unreciprocated-but-resolvable claims are
-    genuine printed references whose reciprocal side failed to read (truth
-    itself reciprocates 91-93%). Consumers must treat these as candidates to
-    verify, not facts — a junk read that resolves to a real page lands here.
-    Returns sorted (claimer, target) pairs, excluding mutual edges.
+    The lower-trust adjacency tier. Truth itself reciprocates 89-93% of its
+    printed edges, so a one-sided claim CAN be a genuine reference whose
+    reciprocal failed to read — but this tier is where every junk read that
+    resolves to a real page also lands, and reciprocity is precisely the
+    filter that was removing them. Measured against the hand-labelled truth:
+    LA 105/193 = 54%, Hudson 48/98 = 49%, Nashville 52/165 = 32% genuine,
+    tracking each volume's claim precision (79/87/63%). Mutual edges on the
+    same volumes are 96-100%. Consumers must therefore treat these as
+    candidates to verify, never as facts, and weight them well below mutual
+    edges. Returns sorted (claimer, target) pairs, excluding mutual edges.
     """
     resolve = claim_resolver(claims_by_page)
     mutual = {frozenset(edge) for edge in mutual_edges(claims_by_page)}

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -206,6 +206,15 @@ def test_resolve_page_key_repairs_long_keys():
     assert resolve_page_key("14021403", "", LA_KEYS) is None
 
 
+def test_resolve_page_key_bare_number_reaches_a_unique_lettered_key():
+    # Chicago prints a bare "60" for sheet p60w; Miami "8" for p8s. The read
+    # must resolve at DETECTION time, not just at edge-resolution time.
+    assert resolve_page_key("60", "", {"59W", "60W", "61W"}) == ("60W", "number")
+    assert resolve_page_key("8", "", {"7", "8S", "9"}) == ("8S", "number")
+    # A digit part shared by many lettered sheets stays ambiguous.
+    assert resolve_page_key("1499", "", {"1499A", "1499G", "1499L"}) is None
+
+
 def test_resolve_page_key_is_inert_for_short_key_volumes():
     # Volumes with 1-2 digit page numbers: short reads are substrings of
     # everything, so repair would be guesswork. Exact matches only.

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -6,6 +6,7 @@ from mapsnap.page_adjacency import (
     classify_edge,
     is_claim,
     mutual_edges,
+    one_sided_edges,
     polygon_rotation_deg,
     resolve_page_key,
     single_digit_height_band,
@@ -147,6 +148,19 @@ def test_mutual_edges_lettered_stems():
 
 def test_mutual_edges_empty_when_one_sided():
     assert mutual_edges({"p1": {"2"}, "p2": set()}) == []
+
+
+def test_one_sided_edges_are_the_unreciprocated_remainder():
+    claims = {"p49": {"50", "51"}, "p50": {"49"}, "p51": set()}
+    # 49<->50 is mutual and excluded; 49->51 resolves but lacks the reciprocal.
+    assert one_sided_edges(claims) == [("p49", "p51")]
+
+
+def test_one_sided_edges_skip_unresolvable_claims():
+    # A claim of a page outside the volume, and an ambiguous bare number among
+    # lettered sheets, resolve to nothing and produce no one-sided edge.
+    claims = {"p1499a": {"1488", "7777"}, "p1488": set(), "p1499b": {"1499"}}
+    assert one_sided_edges(claims) == [("p1499a", "p1488")]
 
 
 def test_mutual_edges_lettered_keys_do_not_collide():

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -7,6 +7,7 @@ from mapsnap.page_adjacency import (
     is_claim,
     mutual_edges,
     polygon_rotation_deg,
+    resolve_page_key,
     single_digit_height_band,
     volume_page_images,
 )
@@ -29,8 +30,10 @@ def make_detection(
     confidence: float = 0.95,
     polygon: list[list[float]] | None = None,
     nearest_box: float | None = 100.0,
+    key: str | None = None,
 ) -> dict:
     return {
+        "key": key if key is not None else str(number),
         "number": number,
         "edge": edge,
         "height": height,
@@ -61,41 +64,39 @@ def test_polygon_rotation_deg():
 
 
 def test_is_claim_accepts_large_edge_number():
-    assert is_claim(make_detection(50), own_number=49)
+    assert is_claim(make_detection(50), own_key="49")
 
 
 def test_is_claim_rejects_own_number_center_small_and_lowconf():
-    assert not is_claim(make_detection(49), own_number=49)  # the sheet's own number
-    assert not is_claim(make_detection(50, edge="center"), own_number=49)
-    assert not is_claim(make_detection(50, height=12.0), own_number=49)
-    assert not is_claim(make_detection(50, confidence=0.01), own_number=49)
+    assert not is_claim(make_detection(49), own_key="49")  # the sheet's own number
+    assert not is_claim(make_detection(50, edge="center"), own_key="49")
+    assert not is_claim(make_detection(50, height=12.0), own_key="49")
+    assert not is_claim(make_detection(50, confidence=0.01), own_key="49")
 
 
 def test_is_claim_rejects_rotated_quads():
     # Every rotated candidate inspected was a misread street name or pipe annotation.
     rotated = make_detection(50, polygon=rotated_polygon(17.0))
-    assert not is_claim(rotated, own_number=49)
+    assert not is_claim(rotated, own_key="49")
 
 
 def test_is_claim_single_digit_confidence_floor():
     # Junk single-digit reads reciprocate by coincidence; require high confidence.
-    assert not is_claim(make_detection(6, confidence=0.5), own_number=49)
-    assert is_claim(make_detection(6, confidence=0.95), own_number=49)
+    assert not is_claim(make_detection(6, confidence=0.5), own_key="49")
+    assert is_claim(make_detection(6, confidence=0.95), own_key="49")
     # Multi-digit numbers keep the permissive floor.
-    assert is_claim(make_detection(50, confidence=0.5), own_number=49)
+    assert is_claim(make_detection(50, confidence=0.5), own_key="49")
 
 
 def test_is_claim_single_digit_height_band():
     band = (30.0, 65.0)
     # A 130px "1" is a frame rule, not a reference; a 45px one matches the printed size.
-    assert not is_claim(
-        make_detection(1, height=130.0), own_number=49, height_band=band
-    )
-    assert is_claim(make_detection(1, height=45.0), own_number=49, height_band=band)
+    assert not is_claim(make_detection(1, height=130.0), own_key="49", height_band=band)
+    assert is_claim(make_detection(1, height=45.0), own_key="49", height_band=band)
     # The band applies only to single digits; multi-digit heights are already trustworthy.
-    assert is_claim(make_detection(50, height=130.0), own_number=49, height_band=band)
+    assert is_claim(make_detection(50, height=130.0), own_key="49", height_band=band)
     # Without a band (no confirmed references), single digits pass on confidence alone.
-    assert is_claim(make_detection(1, height=130.0), own_number=49, height_band=None)
+    assert is_claim(make_detection(1, height=130.0), own_key="49", height_band=None)
 
 
 def test_bbox_gap():
@@ -112,12 +113,12 @@ def test_is_claim_single_digit_isolation():
     # A perfect-glyph, right-sized single digit that touches another box is a fragment
     # of a larger number (p10's "8" torn off a block number), not a sheet reference.
     fragment = make_detection(8, confidence=1.0, nearest_box=0.0)
-    assert not is_claim(fragment, own_number=10, min_gap=14.0)
+    assert not is_claim(fragment, own_key="10", min_gap=14.0)
     isolated = make_detection(8, confidence=1.0, nearest_box=21.6)
-    assert is_claim(isolated, own_number=10, min_gap=14.0)
+    assert is_claim(isolated, own_key="10", min_gap=14.0)
     # Multi-digit claims are exempt; missing gap data (only box on the page) passes.
-    assert is_claim(make_detection(50, nearest_box=0.0), own_number=10, min_gap=14.0)
-    assert is_claim(make_detection(8, nearest_box=None), own_number=10, min_gap=14.0)
+    assert is_claim(make_detection(50, nearest_box=0.0), own_key="10", min_gap=14.0)
+    assert is_claim(make_detection(8, nearest_box=None), own_key="10", min_gap=14.0)
 
 
 def test_single_digit_height_band_from_median():
@@ -132,19 +133,72 @@ def test_single_digit_height_band_empty():
 
 
 def test_mutual_edges_requires_reciprocity():
-    claims = {"p49": {50, 51}, "p50": {49}, "p51": set()}
+    claims = {"p49": {"50", "51"}, "p50": {"49"}, "p51": set()}
     # 49<->50 reciprocate; 49->51 is unreciprocated and produces no edge.
     assert mutual_edges(claims) == [("p49", "p50")]
 
 
 def test_mutual_edges_lettered_stems():
-    # Chicago-style stems: numbers resolve to the lettered page stem.
-    claims = {"p59w": {60}, "p60w": {59}}
+    # Chicago-style stems: a bare-number claim resolves to the lettered page stem
+    # when that number names exactly one sheet.
+    claims = {"p59w": {"60"}, "p60w": {"59"}}
     assert mutual_edges(claims) == [("p59w", "p60w")]
 
 
 def test_mutual_edges_empty_when_one_sided():
-    assert mutual_edges({"p1": {2}, "p2": set()}) == []
+    assert mutual_edges({"p1": {"2"}, "p2": set()}) == []
+
+
+def test_mutual_edges_lettered_keys_do_not_collide():
+    # LA-style: 18 sheets share the number 1499. A lettered claim reaches exactly
+    # its sheet; a bare "1499" claim is ambiguous among them and resolves to nothing.
+    claims = {
+        "p1499a": {"1499B"},
+        "p1499b": {"1499A"},
+        "p1488": {"1499"},
+        "p1499c": {"1488"},
+    }
+    assert mutual_edges(claims) == [("p1499a", "p1499b")]
+
+
+# 1401..1498 plus lettered 1499 sheets (no plain 1499, so a bare read of it
+# must resolve to nothing rather than guess among the lettered variants).
+LA_KEYS = {f"14{i:02d}" for i in range(1, 99)} | {"1499A", "1499G", "1499L"}
+SHORT_KEYS = {str(i) for i in range(1, 93)}  # a Hudson-style 1-2 digit volume
+
+
+def test_resolve_page_key_exact_and_lettered():
+    assert resolve_page_key("1409", "", LA_KEYS) == ("1409", "exact")
+    # The digits pass renders "1499G" as a bare "1499" -- a different, wrong page;
+    # the letters pass reveals the suffix (with I/O look-alike digits normalized).
+    assert resolve_page_key("1499", "1499G", LA_KEYS) == ("1499G", "lettered")
+    assert resolve_page_key("14994", "I499G", LA_KEYS) == ("1499G", "lettered")
+    # A bare "1499" with no letter suffix is not a valid LA key: no guess.
+    assert resolve_page_key("1499", "1499", LA_KEYS) is None
+
+
+def test_resolve_page_key_repairs_long_keys():
+    # Leading digit lost against the sheet trim: unique suffix completion.
+    assert resolve_page_key("409", "", LA_KEYS) == ("1409", "suffix")
+    # 2-digit remnants are house-number fragments (8% precise on the LA truth,
+    # confident enough to reciprocate into false edges): never repaired.
+    assert resolve_page_key("85", "", LA_KEYS) is None
+    # Neighboring ink absorbed into the box: unique embedded key.
+    assert resolve_page_key("14027", "", LA_KEYS) == ("1402", "embedded")
+    assert resolve_page_key("21408", "", LA_KEYS) == ("1408", "embedded")
+    # Ambiguity never resolves: "9" is a suffix of many keys, and a read
+    # containing two valid keys names neither.
+    assert resolve_page_key("9", "", LA_KEYS) is None
+    assert resolve_page_key("14021403", "", LA_KEYS) is None
+
+
+def test_resolve_page_key_is_inert_for_short_key_volumes():
+    # Volumes with 1-2 digit page numbers: short reads are substrings of
+    # everything, so repair would be guesswork. Exact matches only.
+    assert resolve_page_key("21", "", SHORT_KEYS) == ("21", "exact")
+    assert resolve_page_key("214", "", SHORT_KEYS) is None  # no embedded repair
+    assert resolve_page_key("408", "", SHORT_KEYS) is None  # no suffix repair
+    assert resolve_page_key("3", "", SHORT_KEYS) == ("3", "exact")
 
 
 def test_volume_page_images_skips_splits_and_keymaps(tmp_path: Path):


### PR DESCRIPTION
Stacked on #207. Productionizes the mutual-claim contradiction check **and closes the loop with stamp-guided re-search that converts disasters into good placements.**

## The gate

Mutual printed-reference edges are ~100% precise, and both sides print their reference at the same physical spot on the shared boundary — correct pairs' stamps land a median 35 m apart (p95 63 m) mapped through each page's own fit. `mapsnap adjacency-gate` (in `fit`, between georef and snap) flags pairs > 100 m, arbitrates (multi-contradiction → corroboration → edge-junk → GCP/consensus tie-breaks), and demotes a named suspect only when a hard signal agrees (effective GCPs ≤ 2, or rotation/scale > 15°/0.2 off the volume median). Demotion renames channel sidecars to `*-contradicted.json` and writes `pN.contradiction.json` with the partner-side stamp positions.

## The re-search loop

1. **Search hints**: `build_page_context` adds the partner stamps as rescue search centers (they also stand alone for pages the keymap never placed).
2. **Stamp-consistency hard gate**: a rescue candidate inconsistent with *every* hint (min partner separation > 100 m) is implausible — a confident alias can no longer re-verify its way back in (KC p551's 692 ft re-adoption, excluded at 199 m).
3. **Cache key**: candidate records store `contradiction_mtime`, so a twice-demoted page (georef mtime None both times) never reuses pre-hint candidates.
4. **Stamp-corroborated rescue**: a top candidate whose **median** partner separation is within the bound faces a relaxed bar (`STAMP_RESCUE_SCORE` 0.7 vs 1.25), with ambiguity measured only against rivals the neighbors do *not* vouch for. Median, not min: genuine hints agree, junk hints (single-digit reciprocation) scatter — Nashville p8's 325 ft candidate matched one of four junk stamps at 66 m and was briefly adopted under min; under median it faces the normal bar and stays unplaced.

## Validated on 7 volumes (identical inputs, component deltas match the touched pages exactly)

| volume | pre | post | Δ | what happened |
|---|---|---|---|---|
| Grand Rapids | 68.9% | **73.1%** | +4.2 | p823 816 ft → unplaced; **p828 626 ft → 22.7 ft** |
| New Orleans 1896 | 80.0% | **82.3%** | +2.3 | **p125 842 ft → 12.8 ft** (was margin-blocked by its own 16° twin) |
| Kansas City | 77.1% | **79.1%** | +2.0 | p460 830 ft → unplaced; **p551 686 ft → 24.0 ft** |
| Nashville | 63.5% | **65.4%** | +1.9 | p26 684 ft → unplaced; p8 (false demotion) → unplaced, not mis-adopted |
| Los Angeles | 82.6% | **83.0%** | +0.4 | p1470 (unsplit fit of a mixed-scale split sheet, panel 2 at 12,105 ft) → unplaced; re-search correctly refused (0.43) |
| Brooklyn v1, Hudson | — | — | 0 | correctly no-op |

**+10.8 volume-points. Three disasters became good placements** — each adopted exactly where its neighbors' printed references said it belonged, at select scores (0.77–1.82) verification alone would have refused or margin-blocked. Five more disasters went to unplaced (their true poses still can't produce evidence — the null-verification wall), and the one false demotion (Nashville p8, junk single-digit edges) is priced at its minimum.

One measurement lesson folded in: the earlier prototype census over-counted disasters by reading RANSAC-channel sidecars; the production gate reads published channel priority (Brooklyn p57, KC p453, NO p157 are healthy there and correctly untouched).

843 tests (7 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
