### PR TITLE
mapsnap craft: CRAFT as its own step, and reorder adjacency before the key-map build

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -26,6 +26,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "Compare archived fit runs (experiments diff <id-a> <id-b>)",
     ),
     # Individual commands
+    "craft": (
+        "mapsnap.craft",
+        "Run CRAFT text detection and cache <stem>.boxes.json (prerequisite for ocr/adjacency)",
+    ),
     "ocr": ("mapsnap.detect_text", "Detect text regions in map images"),
     "georef": (
         "mapsnap.georef_from_labels",

--- a/mapsnap/craft.py
+++ b/mapsnap/craft.py
@@ -43,6 +43,31 @@ def expand_images(patterns: list[str]) -> list[str]:
     return list(seen)
 
 
+def volume_craft_images(
+    volume: Path, keymap_keys: list[str] | None = None
+) -> list[str]:
+    """Every image in a volume that some later step recognizes inside.
+
+    The union matters: ``mapsnap ocr`` reads the *effective* pages (split
+    panels supersede their parent), while ``mapsnap adjacency`` reads the
+    *parent* sheets, because the printed margin references live on the parent
+    even when panels supersede it downstream. Crafting only one of the two
+    lists leaves a split volume's parents (Champaign: p2, p4, p13, p20, p21,
+    p23) without boxes, and adjacency then refuses to run.
+    """
+    from mapsnap.page_adjacency import volume_page_images
+    from mapsnap.utils import list_pages
+
+    seen: dict[str, None] = {}
+    for path in [*list_pages(volume), *volume_page_images(volume)]:
+        seen.setdefault(str(path), None)
+    for key in keymap_keys or []:
+        raw = volume / "raw" / f"{key}.jpg"
+        if raw.exists():
+            seen.setdefault(str(raw), None)
+    return list(seen)
+
+
 def pending_images(images: list[str], resume: bool) -> list[str]:
     """Images still needing CRAFT: all of them, or those without fresh boxes."""
     if not resume:

--- a/mapsnap/craft.py
+++ b/mapsnap/craft.py
@@ -1,0 +1,137 @@
+"""Run CRAFT text detection and cache the boxes, without recognizing anything.
+
+CRAFT detection is the slowest stage of the pipeline, it depends on none of the
+recognition parameters (vocabulary, min-short-side, centerlines), and it now has
+several consumers: ``mapsnap ocr`` recognizes text inside these boxes,
+``mapsnap adjacency`` reads adjacent-sheet numbers from them, and the key-map
+passes read page numbers. Splitting it out (issue #132) lets adjacency run
+*before* OCR, which is what allows the key-map assignment repair to inform the
+OCR vocabulary rather than the other way round.
+
+Every consumer requires ``<stem>.boxes.json`` to exist and fails with the
+command to run; this is the only command that runs CRAFT.
+
+    mapsnap craft 'data/detroit_mich_1929_vol_11/p*.jpg'
+    mapsnap craft data/<volume>/raw/p0.jpg          # key-map sheets too
+"""
+
+import argparse
+import glob
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+from mapsnap.detect_text import boxes_path, write_craft_boxes
+
+
+def expand_images(patterns: list[str]) -> list[str]:
+    """Shell-style globs expanded and de-duplicated, in input order.
+
+    The pipelines quote their globs so a volume with hundreds of pages does not
+    overflow the command line, so expansion happens here as well as in the shell.
+    """
+    seen: dict[str, None] = {}
+    for pattern in patterns:
+        matches = (
+            sorted(glob.glob(pattern))
+            if any(ch in pattern for ch in "*?[")
+            else [pattern]
+        )
+        for match in matches:
+            seen.setdefault(match, None)
+    return list(seen)
+
+
+def pending_images(images: list[str], resume: bool) -> list[str]:
+    """Images still needing CRAFT: all of them, or those without fresh boxes."""
+    if not resume:
+        return images
+    return [
+        image
+        for image in images
+        if not Path(boxes_path(image)).exists()
+        or Path(boxes_path(image)).stat().st_mtime < Path(image).stat().st_mtime
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run CRAFT text detection and write <stem>.boxes.json."
+    )
+    parser.add_argument(
+        "images", nargs="+", metavar="IMAGE", help="Image paths or globs."
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip images whose .boxes.json is newer than the image.",
+    )
+    parser.add_argument("--no-gpu", action="store_true", help="Disable GPU.")
+    parser.add_argument(
+        "--min-size",
+        type=int,
+        default=15,
+        metavar="PX",
+        help="CRAFT minimum text-box size (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--link-threshold",
+        type=float,
+        default=0.4,
+        metavar="T",
+        help="CRAFT link threshold (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--craft-scale",
+        type=float,
+        default=1.0,
+        metavar="S",
+        help="Detect at this fraction of full resolution (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--tile-size",
+        type=int,
+        default=2560,
+        metavar="PX",
+        help=(
+            "Tile images whose long side exceeds this, so small labels survive "
+            "EasyOCR's canvas downscaling (default: %(default)s; 0 disables)."
+        ),
+    )
+    args = parser.parse_args()
+
+    images = expand_images(args.images)
+    if not images:
+        sys.exit(f"No images matched: {' '.join(args.images)}")
+    missing = [image for image in images if not Path(image).exists()]
+    if missing:
+        sys.exit(f"Image not found: {missing[0]}")
+
+    todo = pending_images(images, args.resume)
+    if args.resume and len(todo) < len(images):
+        print(
+            f"Resuming: {len(todo)}/{len(images)} image(s) need CRAFT.",
+            file=sys.stderr,
+        )
+    if not todo:
+        print("All images already have current boxes.", file=sys.stderr)
+        return
+
+    import easyocr
+
+    reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
+    for image in tqdm(todo, smoothing=0):
+        write_craft_boxes(
+            image,
+            reader,
+            min_size=args.min_size,
+            link_threshold=args.link_threshold,
+            craft_scale=args.craft_scale,
+            tile_size=args.tile_size,
+        )
+    print(f"Wrote boxes for {len(todo)} image(s).", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/craft_test.py
+++ b/mapsnap/craft_test.py
@@ -1,0 +1,64 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mapsnap.craft import expand_images, pending_images
+from mapsnap.detect_text import boxes_path, craft_hint, missing_boxes, require_boxes
+
+
+def touch(path: Path, mtime: float | None = None) -> Path:
+    path.write_text("{}")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_expand_images_globs_and_dedupes(tmp_path):
+    for name in ("p2.jpg", "p10.jpg", "p1.jpg"):
+        (tmp_path / name).write_bytes(b"")
+    got = expand_images([str(tmp_path / "p*.jpg"), str(tmp_path / "p1.jpg")])
+    assert [Path(p).name for p in got] == ["p1.jpg", "p10.jpg", "p2.jpg"]
+    # A literal path is passed through even before it exists (checked later).
+    assert expand_images([str(tmp_path / "absent.jpg")]) == [
+        str(tmp_path / "absent.jpg")
+    ]
+
+
+def test_pending_images_resume_skips_only_current_boxes(tmp_path):
+    image = tmp_path / "p1.jpg"
+    image.write_bytes(b"")
+    stale = tmp_path / "p2.jpg"
+    stale.write_bytes(b"")
+    images = [str(image), str(stale)]
+    assert pending_images(images, resume=False) == images
+    # No boxes at all -> pending.
+    assert pending_images(images, resume=True) == images
+    # Fresh boxes -> skipped; boxes older than the image -> still pending.
+    touch(Path(boxes_path(str(image))), mtime=os.path.getmtime(image) + 10)
+    touch(Path(boxes_path(str(stale))), mtime=os.path.getmtime(stale) - 10)
+    assert pending_images(images, resume=True) == [str(stale)]
+
+
+def test_missing_boxes_and_hint(tmp_path):
+    have = tmp_path / "p1.jpg"
+    lack = tmp_path / "p2.jpg"
+    for image in (have, lack):
+        image.write_bytes(b"")
+    Path(boxes_path(str(have))).write_text(json.dumps({"boxes": []}))
+    assert missing_boxes([str(have), str(lack)]) == [str(lack)]
+    hint = craft_hint([str(lack)])
+    assert hint == f"mapsnap craft '{tmp_path}/p*.jpg'"
+
+
+def test_require_boxes_exits_with_the_craft_command(tmp_path):
+    image = tmp_path / "p1.jpg"
+    image.write_bytes(b"")
+    with pytest.raises(SystemExit) as excinfo:
+        require_boxes([str(image)])
+    message = str(excinfo.value)
+    assert "p1.jpg" in message and "mapsnap craft" in message
+    # With boxes present it is a no-op.
+    Path(boxes_path(str(image))).write_text(json.dumps({"boxes": []}))
+    require_boxes([str(image)])

--- a/mapsnap/craft_test.py
+++ b/mapsnap/craft_test.py
@@ -62,3 +62,17 @@ def test_require_boxes_exits_with_the_craft_command(tmp_path):
     # With boxes present it is a no-op.
     Path(boxes_path(str(image))).write_text(json.dumps({"boxes": []}))
     require_boxes([str(image)])
+
+
+def test_volume_craft_images_covers_panels_and_split_parents(tmp_path):
+    # ocr reads panels; adjacency reads the parent sheet. Both need boxes.
+    for name in ("p1.jpg", "p2.jpg", "p2__1.jpg", "p2__2.jpg"):
+        (tmp_path / name).write_bytes(b"")
+    (tmp_path / "p2.panels.json").write_text(json.dumps({"panels": [[], []]}))
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "p0.jpg").write_bytes(b"")
+    from mapsnap.craft import volume_craft_images
+
+    stems = {Path(p).stem for p in volume_craft_images(tmp_path, ["p0"])}
+    assert {"p1", "p2", "p2__1", "p2__2", "p0"} <= stems

--- a/mapsnap/detect_text.py
+++ b/mapsnap/detect_text.py
@@ -217,10 +217,71 @@ def _erase_underlines(
     return img_out
 
 
-def _boxes_path(image_path: str) -> str:
+def boxes_path(image_path: str) -> str:
     """Return the path for the CRAFT boxes cache file (<stem>.boxes.json)."""
     stem = image_stem(image_path)
     return str(Path(image_path).parent / (stem + ".boxes.json"))
+
+
+# Backwards-compatible alias for the pre-`mapsnap craft` private name.
+_boxes_path = boxes_path
+
+
+def craft_hint(image_paths: list[str] | list[Path]) -> str:
+    """The `mapsnap craft` command that would produce the missing boxes.
+
+    CRAFT detection is its own step (`mapsnap craft`), so every consumer of
+    <stem>.boxes.json fails with an actionable message rather than silently
+    re-running the slowest stage of the pipeline under a different command.
+    """
+    parents = {str(Path(p).parent) for p in image_paths}
+    target = f"{next(iter(parents))}/p*.jpg" if len(parents) == 1 else "<images...>"
+    return f"mapsnap craft '{target}'"
+
+
+def missing_boxes(image_paths: list[str]) -> list[str]:
+    """Images with no CRAFT boxes cache, in input order."""
+    return [path for path in image_paths if not Path(boxes_path(path)).exists()]
+
+
+def require_boxes(image_paths: list[str]) -> None:
+    """Exit with the craft command to run when any image lacks its boxes."""
+    absent = missing_boxes(image_paths)
+    if not absent:
+        return
+    names = ", ".join(Path(p).name for p in absent[:5])
+    more = f" (+{len(absent) - 5} more)" if len(absent) > 5 else ""
+    sys.exit(
+        f"No CRAFT boxes for {len(absent)} image(s): {names}{more}\n"
+        f"Run: {craft_hint(absent)}"
+    )
+
+
+def write_craft_boxes(
+    image_path: str,
+    reader: easyocr.Reader,
+    *,
+    min_size: int = 15,
+    link_threshold: float = 0.4,
+    craft_scale: float = 1.0,
+    tile_size: int = 2560,
+) -> dict:
+    """Run CRAFT at 0/90/270 on one image and write <stem>.boxes.json."""
+    img = Image.open(image_path).convert("RGB")
+    width, height = img.size
+    angle_boxes = _craft_detect_all_angles(
+        img, reader, min_size, link_threshold, craft_scale, tile_size
+    )
+    doc = {
+        "width": width,
+        "height": height,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "command": filter_args(sys.argv[:], image_path),
+        "boxes": angle_boxes,
+    }
+    with open(boxes_path(image_path), "w") as f:
+        json.dump(doc, f, indent=2)
+    return doc
 
 
 def _streets_path(image_path: str) -> str:
@@ -545,7 +606,6 @@ def detect_text(
     beam_width: int = 20,
     craft_scale: float = 1.0,
     tile_size: int = 2560,
-    reuse_boxes: bool = False,
     fallback_vocab: list[str] | None = None,
 ) -> list[dict]:
     """Run CRAFT-based text detection at 0°, 90°, and 270° and return all results.
@@ -579,24 +639,20 @@ def detect_text(
     gives ~4× faster detection. Detected bounding boxes are scaled back up to
     original coordinates before recognition, which always runs at full resolution.
     min_size is also scaled proportionally so the same physical text size threshold
-    applies. Ignored when reuse_boxes=True.
+    applies. Applied by `mapsnap craft`, not here.
 
     tile_size splits images whose long side exceeds it into overlapping tiles that CRAFT
     detects at native resolution, avoiding EasyOCR's canvas_size (2560px) downscaling
     that shrinks small labels on oversized sheets (e.g. key maps). Only detection is
     tiled; recognition is unchanged. Set to 0 to disable (single-pass detection, the
-    prior behavior). Default 2560 matches EasyOCR's canvas_size. Ignored when
-    reuse_boxes=True.
+    prior behavior). Default 2560 matches EasyOCR's canvas_size. Applied by
+    `mapsnap craft`, not here.
 
-    reuse_boxes loads CRAFT bounding boxes from the existing <stem>.boxes.json
-    file instead of re-running CRAFT. Useful for iterating on recognition
-    parameters without redoing the (slower) detection step. An image with no
-    .boxes.json falls back to running CRAFT (and writes the file); the CLI
-    gates that fallback behind --allow-missing-boxes.
-
-    Writes <stem>.boxes.json alongside the image whenever CRAFT is run (i.e.
-    when reuse_boxes=False). The file records the image dimensions, a timestamp,
-    the command line, and the per-angle box data.
+    CRAFT detection is NOT run here: <stem>.boxes.json must already exist,
+    written by `mapsnap craft` (see write_craft_boxes). Detection is the
+    slowest stage and is shared by several consumers (`mapsnap adjacency`,
+    the keymap passes), so it is its own pipeline step; a missing boxes file
+    raises rather than silently re-running it under another command.
 
     fallback_vocab, if given, recognizes each box a second time with a broader vocabulary and
     keeps, per box, the higher-confidence read. When the fallback vocabulary wins with a
@@ -626,22 +682,12 @@ def detect_text(
     img = Image.open(image_path).convert("RGB")
     orig_width, orig_height = img.size
 
-    if reuse_boxes and Path(_boxes_path(image_path)).exists():
-        with open(_boxes_path(image_path)) as f:
-            angle_boxes: list[dict] = json.load(f)["boxes"]
-    else:
-        angle_boxes = _craft_detect_all_angles(
-            img, reader, min_size, link_threshold, craft_scale, tile_size
+    cached = Path(boxes_path(image_path))
+    if not cached.exists():
+        raise FileNotFoundError(
+            f"No CRAFT boxes for {image_path}. Run: {craft_hint([image_path])}"
         )
-        boxes_doc = {
-            "width": orig_width,
-            "height": orig_height,
-            "timestamp": datetime.now(UTC).isoformat(),
-            "command": filter_args(sys.argv[:], image_path),
-            "boxes": angle_boxes,
-        }
-        with open(_boxes_path(image_path), "w") as f:
-            json.dump(boxes_doc, f, indent=2)
+    angle_boxes: list[dict] = json.loads(cached.read_text())["boxes"]
 
     def recognize(vocab: list[str]) -> list[dict]:
         return _recognize_pass(
@@ -702,7 +748,6 @@ def _worker_init(
     beam_width: int,
     craft_scale: float,
     tile_size: int,
-    reuse_boxes: bool,
     gpu: bool,
 ) -> None:
     """Initialize per-worker state once per process: create the EasyOCR reader."""
@@ -715,7 +760,6 @@ def _worker_init(
     _worker_state["beam_width"] = beam_width
     _worker_state["craft_scale"] = craft_scale
     _worker_state["tile_size"] = tile_size
-    _worker_state["reuse_boxes"] = reuse_boxes
 
 
 def _process_image(image_path: str) -> str:
@@ -731,7 +775,6 @@ def _process_image(image_path: str) -> str:
         beam_width=_worker_state["beam_width"],
         craft_scale=_worker_state["craft_scale"],
         tile_size=_worker_state["tile_size"],
-        reuse_boxes=_worker_state["reuse_boxes"],
     )
     return image_path
 
@@ -917,25 +960,6 @@ def main() -> None:
             "tiled; recognition is unchanged. Set to 0 to disable (single-pass detection)."
         ),
     )
-    parser.add_argument(
-        "--reuse-boxes",
-        action="store_true",
-        help=(
-            "Reuse CRAFT bounding boxes from existing <stem>.boxes.json files instead "
-            "of re-running CRAFT detection. Useful for iterating on recognition "
-            "parameters without redoing detection. All images must already have a "
-            ".boxes.json file; this flag aborts with an error if any are missing "
-            "(see --allow-missing-boxes)."
-        ),
-    )
-    parser.add_argument(
-        "--allow-missing-boxes",
-        action="store_true",
-        help=(
-            "With --reuse-boxes: images that have no .boxes.json (e.g. freshly split "
-            "panels) run full CRAFT detection instead of aborting the run."
-        ),
-    )
     args = parser.parse_args()
 
     if args.backfill_background:
@@ -1024,21 +1048,7 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    if args.reuse_boxes:
-        missing = [p for p in images if not Path(_boxes_path(p)).exists()]
-        if missing and not args.allow_missing_boxes:
-            for p in missing:
-                print(f"Missing boxes file: {_boxes_path(p)}", file=sys.stderr)
-            sys.exit(
-                f"--reuse-boxes: {len(missing)} image(s) have no .boxes.json file "
-                "(pass --allow-missing-boxes to run CRAFT for them)."
-            )
-        if missing:
-            print(
-                f"--reuse-boxes: {len(missing)}/{len(images)} image(s) have no "
-                ".boxes.json; running full CRAFT detection for those.",
-                file=sys.stderr,
-            )
+    require_boxes(images)
 
     gpu = not args.no_gpu
 
@@ -1059,7 +1069,6 @@ def main() -> None:
             args.beam_width,
             args.craft_scale,
             args.tile_size,
-            args.reuse_boxes,
             gpu,
         )
         with multiprocessing.Pool(
@@ -1090,7 +1099,6 @@ def main() -> None:
                 beam_width=args.beam_width,
                 craft_scale=args.craft_scale,
                 tile_size=args.tile_size,
-                reuse_boxes=args.reuse_boxes,
                 fallback_vocab=fallback_vocab,
             )
 

--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -47,7 +47,7 @@ from mapsnap.keymap.detect_numbers_cnn import (
 from mapsnap.keymap.detect_numbers_crnn import read_candidates, snap_to_pages
 from mapsnap.keymap.fit_keymap import page_number, volume_page_keys
 from mapsnap.keymap.number_model import build_model, select_device
-from mapsnap.keymap.records import page_key_sort
+from mapsnap.keymap.records import page_key_sort, write_keymaps_record
 from mapsnap.utils import image_stem
 
 DEFAULT_CNN_WEIGHTS = Path("models/number_detector.pt")
@@ -311,6 +311,7 @@ def main() -> None:
         cnn_weights=args.cnn_weights,
         crnn_weights=args.crnn_weights,
     )
+    write_keymaps_record(args.volume, keys)
     if not keys:
         print(f"No key map identified in {args.volume}.", file=sys.stderr)
         sys.exit(1)

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -132,14 +132,6 @@ def main() -> None:
         action="store_true",
         help="Skip the key-map OCR pass for images that already have a .streets.json output.",
     )
-    parser.add_argument(
-        "--reuse-boxes",
-        action="store_true",
-        help=(
-            "Pass --reuse-boxes --allow-missing-boxes to the key-map OCR pass: reuse existing "
-            "<stem>.boxes.json CRAFT boxes and run detection only for key maps without one."
-        ),
-    )
     args = parser.parse_args()
 
     images = [Path(image) for image in args.images]
@@ -198,8 +190,6 @@ def main() -> None:
     ]
     if args.resume:
         ocr_cmd.append("--resume")
-    if args.reuse_boxes:
-        ocr_cmd.extend(["--reuse-boxes", "--allow-missing-boxes"])
     run_cmd([*ocr_cmd, *image_args])
     run_cmd(
         [

--- a/mapsnap/keymap/records.py
+++ b/mapsnap/keymap/records.py
@@ -5,6 +5,7 @@ mapsnap.detect_text (so the debugger app loads them); these helpers build that s
 parse the volume's valid page-number set.
 """
 
+import json
 import re
 from pathlib import Path
 
@@ -76,3 +77,32 @@ def detection_record(bbox: list[list[float]], text: str, confidence: float) -> d
         "short_side": round(min(sides), 1),
         "dir_pix": round(float(np.arctan2(long_vec[1], long_vec[0])) % np.pi, 4),
     }
+
+
+KEYMAPS_FILENAME = "keymaps.json"
+
+
+def write_keymaps_record(volume: Path, keys: list[str]) -> Path:
+    """Record the volume's identified key-map page keys in ``keymaps.json``.
+
+    Consumers that must skip key-map sheets used to test for
+    ``<stem>.keymap.json``, which only exists once ``mapsnap keymap`` has run.
+    Since ``mapsnap adjacency`` now runs BEFORE that (#132/#213), the
+    identification is persisted here, right where ``keymap-detect`` computes it.
+    Lives in this module rather than ``identify`` so light consumers do not
+    import torch to read one JSON file.
+    """
+    path = volume / KEYMAPS_FILENAME
+    path.write_text(json.dumps({"keys": sorted(keys)}, indent=2))
+    return path
+
+
+def recorded_keymap_keys(volume: Path) -> set[str]:
+    """Key-map page keys from ``keymaps.json``, or empty when absent/unreadable."""
+    path = volume / KEYMAPS_FILENAME
+    if not path.exists():
+        return set()
+    try:
+        return {str(key) for key in json.loads(path.read_text()).get("keys", [])}
+    except (OSError, ValueError):
+        return set()

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -43,6 +43,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
+from mapsnap.detect_text import craft_hint
 from mapsnap.keymap.locate import page_key, page_number
 from mapsnap.utils import image_stem
 
@@ -248,7 +249,7 @@ def box_center(bbox: list[list[float]]) -> tuple[float, float]:
 
 
 def cached_craft_boxes(image_path: Path) -> tuple[list, list] | None:
-    """The angle-0 CRAFT boxes from ``<stem>.boxes.json`` (written by ``mapsnap ocr``), or None.
+    """The angle-0 CRAFT boxes from ``<stem>.boxes.json`` (written by ``mapsnap craft``), or None.
 
     Returns (horizontal_list, free_list) in the same shape ``reader.detect`` yields, so
     recognition can skip the CRAFT pass entirely. Returns None when the file is absent, records
@@ -578,15 +579,6 @@ def main() -> None:
     parser.add_argument(
         "--no-gpu", action="store_true", help="Disable GPU acceleration for EasyOCR."
     )
-    parser.add_argument(
-        "--reuse-boxes",
-        action="store_true",
-        help=(
-            "Reuse CRAFT boxes from each page's <stem>.boxes.json (written by mapsnap ocr) "
-            "instead of re-running detection; pages without one (or whose boxes were computed "
-            "at different image dimensions) still run CRAFT."
-        ),
-    )
     args = parser.parse_args()
 
     import easyocr
@@ -604,14 +596,17 @@ def main() -> None:
     reader = easyocr.Reader(["en"], gpu=not args.no_gpu, verbose=False)
 
     pages: dict[str, dict] = {}
-    reused = 0
     for image in tqdm(images, smoothing=0):
         stem = image_stem(str(image))
         # Record the scanned image's dimensions so a viewer can rescale detection
         # polygons when it loads the page at a different resolution.
         width, height = Image.open(image).size
-        craft_boxes = cached_craft_boxes(image) if args.reuse_boxes else None
-        reused += craft_boxes is not None
+        craft_boxes = cached_craft_boxes(image)
+        if craft_boxes is None:
+            sys.exit(
+                f"No usable CRAFT boxes for {image.name} (missing, or computed at "
+                f"different image dimensions).\nRun: {craft_hint([str(image)])}"
+            )
         pages[stem] = {
             "key": page_key(stem),
             "number": page_number(stem),
@@ -619,8 +614,6 @@ def main() -> None:
             "height": height,
             "detections": digit_detections(image, reader, valid_keys, craft_boxes),
         }
-    if args.reuse_boxes:
-        print(f"Reused CRAFT boxes for {reused}/{len(images)} pages.", file=sys.stderr)
 
     def compute_claims(
         height_band: tuple[float, float] | None,

--- a/mapsnap/page_adjacency.py
+++ b/mapsnap/page_adjacency.py
@@ -45,6 +45,7 @@ from tqdm import tqdm
 
 from mapsnap.detect_text import craft_hint
 from mapsnap.keymap.locate import page_key, page_number
+from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import image_stem
 
 # A detection only counts as an adjacency claim when it sits in the outer EDGE_BAND of the
@@ -96,11 +97,20 @@ def volume_page_images(volume: Path) -> list[Path]:
     live on the parent; the parent is scanned even when panels supersede it for OCR. Key-map
     sheets are excluded: their faces are covered in page numbers, which would all read as
     spurious claims.
+
+    Key maps are recognised either from ``keymaps.json`` (written by
+    ``mapsnap keymap-detect``) or from an existing ``<stem>.keymap.json``
+    sidecar. Both are needed: adjacency now runs BEFORE ``mapsnap keymap``
+    (#132/#213), so the sidecar does not exist yet on a fresh volume, while
+    volumes processed under the old order have no ``keymaps.json``.
     """
+    recorded = recorded_keymap_keys(volume)
     images = []
     for image in sorted(volume.glob("p*.jpg")):
         stem = image_stem(str(image))
         if "__" in stem:
+            continue
+        if stem in recorded:
             continue
         if (volume / f"{stem}.keymap.json").exists() or (
             volume / "raw" / f"{stem}.keymap.json"

--- a/mapsnap/page_adjacency_test.py
+++ b/mapsnap/page_adjacency_test.py
@@ -249,6 +249,24 @@ def test_volume_page_images_skips_splits_and_keymaps(tmp_path: Path):
     assert names == ["p1.jpg", "p2.jpg"]
 
 
+def test_volume_page_images_skips_keymaps_from_keymaps_json(tmp_path: Path):
+    # Adjacency now runs BEFORE `mapsnap keymap`, so no <stem>.keymap.json
+    # sidecar exists yet; keymap-detect's keymaps.json is the marker.
+    import json as json_module
+
+    for name in ["p0.jpg", "p1.jpg", "p2.jpg"]:
+        (tmp_path / name).write_bytes(b"")
+    (tmp_path / "keymaps.json").write_text(json_module.dumps({"keys": ["p0"]}))
+    assert [p.name for p in volume_page_images(tmp_path)] == ["p1.jpg", "p2.jpg"]
+    # An absent or unreadable keymaps.json falls back to scanning everything.
+    (tmp_path / "keymaps.json").write_text("not json")
+    assert [p.name for p in volume_page_images(tmp_path)] == [
+        "p0.jpg",
+        "p1.jpg",
+        "p2.jpg",
+    ]
+
+
 def test_is_text_veto():
     from mapsnap.page_adjacency import is_text_veto
 

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -5,6 +5,7 @@ import glob
 import sys
 from pathlib import Path
 
+from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import Step, list_pages, run_cmd, write_run_record
 
 
@@ -75,13 +76,15 @@ def main() -> None:
             ]
         )
 
-    # Identify the key map(s) from the 25%-scale pages, download just those at full resolution,
-    # and build their sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json
-    # and restrict each page to its key-map neighborhood.
-    with step("keymap"):
+    # Identify the key map(s) and fetch them at full resolution. Recorded in
+    # keymaps.json so the adjacency scan below can skip them before their
+    # sidecars exist.
+    with step("keymap-detect"):
         from mapsnap.keymap.identify import identify_keymaps
+        from mapsnap.keymap.records import write_keymaps_record
 
         keymap_keys = identify_keymaps(dir_path)
+        write_keymaps_record(dir_path, keymap_keys)
         if keymap_keys:
             print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
             # A key confirmed as a split panel (p0__1) has no LOC image of its
@@ -100,10 +103,33 @@ def main() -> None:
             ]
             if split_parents:
                 run_cmd(["mapsnap", "split", *split_parents])
-            raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-            run_cmd(["mapsnap", "keymap", *raw_keymaps])
         else:
             print("No key map identified; continuing without one.", flush=True)
+
+    # Read the keys back from keymaps.json rather than the step's local: a
+    # resumed run skips the step body entirely, so the local would be unbound.
+    keymap_keys = sorted(recorded_keymap_keys(dir_path))
+
+    # CRAFT once for everything downstream (#132): adjacency, the key-map
+    # passes and ocr all recognize inside these boxes and none of them run
+    # detection themselves.
+    raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+    craft_images = [str(p) for p in list_pages(dir_path)] + raw_keymaps
+    with step("craft"):
+        run_cmd(["mapsnap", "craft", "--resume", *craft_images])
+
+    # Printed adjacent-sheet graph. Runs BEFORE the key-map step so its mutual
+    # edges can repair key-map page-number assignments (#213); key-map sheets
+    # are skipped via keymaps.json.
+    with step("adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(dir_path)])
+
+    # Build the key-map sidecars, including the adjacency-informed assignment
+    # repair. The subsequent ocr/fit steps auto-discover raw/*.keymap.json and
+    # restrict each page to its (now better-placed) key-map neighborhood.
+    with step("keymap"):
+        if raw_keymaps:
+            run_cmd(["mapsnap", "keymap", *raw_keymaps])
 
     # --resume so an OCR interrupted partway resumes per page on the re-run that follows.
     ocr_images = [str(p) for p in list_pages(dir_path)]
@@ -118,12 +144,6 @@ def main() -> None:
                 *ocr_images,
             ]
         )
-
-    # Printed adjacent-sheet graph, consumed by fit's snap/rescue channels. Runs after the
-    # keymap step (so identified key-map sheets are skipped) and after ocr (so the CRAFT
-    # boxes it needs are reused instead of re-detected).
-    with step("adjacency"):
-        run_cmd(["mapsnap", "adjacency", str(dir_path), "--reuse-boxes"])
 
     run_cmd(["mapsnap", "fit", str(dir_path), "--tag", "mapsnap"])
 

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -5,6 +5,7 @@ import glob
 import sys
 from pathlib import Path
 
+from mapsnap.craft import volume_craft_images
 from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import Step, list_pages, run_cmd, write_run_record
 
@@ -114,9 +115,15 @@ def main() -> None:
     # passes and ocr all recognize inside these boxes and none of them run
     # detection themselves.
     raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-    craft_images = [str(p) for p in list_pages(dir_path)] + raw_keymaps
     with step("craft"):
-        run_cmd(["mapsnap", "craft", "--resume", *craft_images])
+        run_cmd(
+            [
+                "mapsnap",
+                "craft",
+                "--resume",
+                *volume_craft_images(dir_path, keymap_keys),
+            ]
+        )
 
     # Printed adjacent-sheet graph. Runs BEFORE the key-map step so its mutual
     # edges can repair key-map page-number assignments (#213); key-map sheets

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -5,6 +5,7 @@ import glob
 import urllib.request
 from pathlib import Path
 
+from mapsnap.craft import volume_craft_images
 from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import (
     Step,
@@ -174,9 +175,15 @@ def main() -> None:
     # CRAFT once for everything downstream (#132): adjacency, the key-map
     # passes and ocr all recognize inside these boxes.
     raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-    craft_images = [str(p) for p in list_pages(dir_path)] + raw_keymaps
     with step("craft"):
-        run_cmd(["mapsnap", "craft", "--resume", *craft_images])
+        run_cmd(
+            [
+                "mapsnap",
+                "craft",
+                "--resume",
+                *volume_craft_images(dir_path, keymap_keys),
+            ]
+        )
 
     # Printed adjacent-sheet graph. Runs BEFORE the key-map step so its mutual
     # edges can repair key-map page-number assignments (#213); key-map sheets

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -5,6 +5,7 @@ import glob
 import urllib.request
 from pathlib import Path
 
+from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import (
     Step,
     image_stem,
@@ -149,22 +150,46 @@ def main() -> None:
             ]
         )
 
-    # Identify the key map(s) from the 25%-scale pages, keep only those at full resolution (the
-    # other raw pages duplicate the 25% pN.jpg — delete them unless --keep_raw), and build their
-    # sidecars. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json and restrict
-    # each page to its key-map neighborhood.
-    with step("keymap"):
+    # Identify the key map(s); recorded in keymaps.json so the adjacency scan
+    # below can skip them before their sidecars exist.
+    with step("keymap-detect"):
         from mapsnap.keymap.identify import identify_keymaps
+        from mapsnap.keymap.records import write_keymaps_record
 
         keymap_keys = identify_keymaps(dir_path)
+        write_keymaps_record(dir_path, keymap_keys)
         if keymap_keys:
             print(f"Key map page(s): {', '.join(keymap_keys)}", flush=True)
+            # The other raw pages duplicate the 25% pN.jpg — delete them unless
+            # --keep_raw. Only the key maps are needed at full resolution.
             if not args.keep_raw:
                 delete_other_raw(dir_path, keymap_keys)
-            raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
-            run_cmd(["mapsnap", "keymap", *raw_keymaps])
         else:
             print("No key map identified; continuing without one.", flush=True)
+
+    # Read the keys back from keymaps.json rather than the step's local: a
+    # resumed run skips the step body entirely, so the local would be unbound.
+    keymap_keys = sorted(recorded_keymap_keys(dir_path))
+
+    # CRAFT once for everything downstream (#132): adjacency, the key-map
+    # passes and ocr all recognize inside these boxes.
+    raw_keymaps = [str(dir_path / "raw" / f"{key}.jpg") for key in keymap_keys]
+    craft_images = [str(p) for p in list_pages(dir_path)] + raw_keymaps
+    with step("craft"):
+        run_cmd(["mapsnap", "craft", "--resume", *craft_images])
+
+    # Printed adjacent-sheet graph. Runs BEFORE the key-map step so its mutual
+    # edges can repair key-map page-number assignments (#213); key-map sheets
+    # are skipped via keymaps.json.
+    with step("adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(dir_path)])
+
+    # Build the key-map sidecars, including the adjacency-informed assignment
+    # repair. The subsequent ocr/fit steps then auto-discover raw/*.keymap.json
+    # and restrict each page to its key-map neighborhood.
+    with step("keymap"):
+        if raw_keymaps:
+            run_cmd(["mapsnap", "keymap", *raw_keymaps])
 
     # --resume so an OCR interrupted partway resumes per page on the re-run that follows.
     ocr_images = [str(p) for p in list_pages(dir_path)]
@@ -179,12 +204,6 @@ def main() -> None:
                 *ocr_images,
             ]
         )
-
-    # Printed adjacent-sheet graph, consumed by fit's snap/rescue channels. Runs after the
-    # keymap step (so identified key-map sheets are skipped) and after ocr (so the CRAFT
-    # boxes it needs are reused instead of re-detected).
-    with step("adjacency"):
-        run_cmd(["mapsnap", "adjacency", str(dir_path), "--reuse-boxes"])
 
     # Locate OIM's manual split regions on the canvas (ground truth for compare).
     with step("oim-split-truth"):

--- a/mapsnap/pipeline_rerun.py
+++ b/mapsnap/pipeline_rerun.py
@@ -36,6 +36,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from mapsnap.craft import volume_craft_images
 from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import Step, list_pages, run_cmd
 
@@ -79,8 +80,9 @@ def rerun_volume(volume: Path, tag: str, force: bool) -> None:
     # CRAFT once for adjacency, the key-map passes and ocr (#132). --resume
     # keeps existing boxes, which is the whole point of a re-run.
     with step(f"rerun-{tag}-craft"):
-        images = [str(p) for p in list_pages(volume)] + raw_keymaps
-        run_cmd(["mapsnap", "craft", "--resume", *images])
+        run_cmd(
+            ["mapsnap", "craft", "--resume", *volume_craft_images(volume, keymap_keys)]
+        )
 
     # Adjacency before the key-map build so its mutual edges can repair
     # key-map page-number assignments (#213).

--- a/mapsnap/pipeline_rerun.py
+++ b/mapsnap/pipeline_rerun.py
@@ -11,13 +11,16 @@ Per volume:
   1. verify the volume was set up by a pipeline run (``mapsnap.json`` exists) and has
      ``centerlines.geojson`` — this pipeline never downloads;
   2. ``mapsnap split`` regenerates the split panels (pN__i.jpg + pN.panels.json);
-  3. ``mapsnap keymap-detect`` identifies the key map(s); ``mapsnap keymap --reuse-boxes``
-     rebuilds their sidecars from the full-resolution ``raw/`` scans (a detected key map
-     with no raw scan is skipped with a warning — downloading is out of scope here);
-  4. ``mapsnap ocr --reuse-boxes --allow-missing-boxes`` re-recognizes every page (panels
-     supersede their parent), auto-discovering the georeferenced key maps;
-  5. ``mapsnap adjacency --reuse-boxes`` rebuilds the printed-neighbor adjacency graph;
-  6. ``mapsnap fit --tag <tag>`` georeferences, runs the geometry-first snap
+  3. ``mapsnap keymap-detect`` identifies the key map(s), recording them in ``keymaps.json``;
+  4. ``mapsnap craft --resume`` refreshes the CRAFT boxes every later step recognizes inside;
+  5. ``mapsnap adjacency`` rebuilds the printed-neighbor adjacency graph — before the key-map
+     build, so its mutual edges can repair key-map page-number assignments (#213);
+  6. ``mapsnap keymap`` rebuilds the key-map sidecars from the full-resolution ``raw/`` scans
+     (a detected key map with no raw scan is skipped with a warning — downloading is out of
+     scope here), including that assignment repair;
+  7. ``mapsnap ocr`` re-recognizes every page (panels supersede their parent),
+     auto-discovering the georeferenced key maps;
+  8. ``mapsnap fit --tag <tag>`` georeferences, runs the geometry-first snap
      channel (rescue/arbitrate/refine), builds the IIIF AnnotationPage, and
      compares against truth.
 
@@ -33,6 +36,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import Step, list_pages, run_cmd
 
 
@@ -53,23 +57,39 @@ def rerun_volume(volume: Path, tag: str, force: bool) -> None:
         pages = [str(p) for p in sorted(volume.glob("p*.jpg")) if "__" not in p.stem]
         run_cmd(["mapsnap", "split", *pages])
 
-    with step(f"rerun-{tag}-keymap"):
+    with step(f"rerun-{tag}-keymap-detect"):
         from mapsnap.keymap.identify import identify_keymaps
+        from mapsnap.keymap.records import write_keymaps_record
 
-        keymap_keys = identify_keymaps(volume)
-        raw_keymaps = []
-        for key in keymap_keys:
-            raw = volume / "raw" / f"{key}.jpg"
-            if raw.exists():
-                raw_keymaps.append(str(raw))
-            else:
-                print(
-                    f"WARNING: key map {key} has no full-resolution scan at {raw}; "
-                    "skipping its sidecars (fetch it and re-run with --force to use it).",
-                    file=sys.stderr,
-                )
+        write_keymaps_record(volume, identify_keymaps(volume))
+
+    keymap_keys = sorted(recorded_keymap_keys(volume))
+    raw_keymaps = []
+    for key in keymap_keys:
+        raw = volume / "raw" / f"{key}.jpg"
+        if raw.exists():
+            raw_keymaps.append(str(raw))
+        else:
+            print(
+                f"WARNING: key map {key} has no full-resolution scan at {raw}; "
+                "skipping its sidecars (fetch it and re-run with --force to use it).",
+                file=sys.stderr,
+            )
+
+    # CRAFT once for adjacency, the key-map passes and ocr (#132). --resume
+    # keeps existing boxes, which is the whole point of a re-run.
+    with step(f"rerun-{tag}-craft"):
+        images = [str(p) for p in list_pages(volume)] + raw_keymaps
+        run_cmd(["mapsnap", "craft", "--resume", *images])
+
+    # Adjacency before the key-map build so its mutual edges can repair
+    # key-map page-number assignments (#213).
+    with step(f"rerun-{tag}-adjacency"):
+        run_cmd(["mapsnap", "adjacency", str(volume)])
+
+    with step(f"rerun-{tag}-keymap"):
         if raw_keymaps:
-            run_cmd(["mapsnap", "keymap", "--reuse-boxes", *raw_keymaps])
+            run_cmd(["mapsnap", "keymap", *raw_keymaps])
         else:
             print(f"No usable key map for {volume.name}.", flush=True)
 
@@ -80,16 +100,11 @@ def rerun_volume(volume: Path, tag: str, force: bool) -> None:
                 "mapsnap",
                 "ocr",
                 "--resume",
-                "--reuse-boxes",
-                "--allow-missing-boxes",
                 "--centerlines",
                 str(centerlines),
                 *images,
             ]
         )
-
-    with step(f"rerun-{tag}-adjacency"):
-        run_cmd(["mapsnap", "adjacency", str(volume), "--reuse-boxes"])
 
     # fit resumes itself (an already-archived run id is skipped), so no stamp.
     run_cmd(["mapsnap", "fit", str(volume), "--tag", tag])


### PR DESCRIPTION
Splits CRAFT detection into its own `mapsnap craft` step and reorders the pipelines so `mapsnap adjacency` runs **before** the key-map build. Closes #132.

This is the enabling half of #213: the adjacency-driven key-map assignment repair needs adjacency's mutual edges *before* the key map is built, and the repaired key map needs to reach OCR's vocabulary restriction. That was impossible while adjacency depended on OCR for its CRAFT boxes. The assignment repair itself follows in a second PR on top of this one.

## `mapsnap craft`

CRAFT is the slowest stage, depends on none of the recognition parameters (vocabulary, min-short-side, centerlines), and now has three consumers: `ocr` recognizes text inside these boxes, `adjacency` reads adjacent-sheet numbers from them, and the key-map passes read page numbers. It is now one command:

```
mapsnap craft 'data/detroit_mich_1929_vol_11/p*.jpg'   # globs expanded internally
mapsnap craft --resume ...                             # skips boxes newer than the image
```

**Boxes are a hard prerequisite, not a lazily-regenerated cache** (removing `--reuse-boxes` / `--allow-missing-boxes` from `ocr` and `adjacency`, plus the CRAFT fallback inside `detect_text`). Consumers exit with the command to run:

```
No CRAFT boxes for 1 image(s): p7.jpg
Run: mapsnap craft '/path/to/volume/p*.jpg'
```

## New pipeline order

All three runners (`run-loc`, `run-oim`, `rerun`):

`keymap-detect` → **craft** → **adjacency** → **keymap** → `ocr` → `fit`

`keymap-detect` now persists its answer to `<volume>/keymaps.json`, because `adjacency` skips key-map sheets (their faces are covered in page numbers, which would read as hundreds of spurious claims) and the old marker — `<stem>.keymap.json` — no longer exists by the time adjacency runs. Both markers are honoured, so volumes processed under the old order keep working.

## Two bugs caught while testing, worth calling out

1. **Unbound variable on a resumed run.** `Step` skips its body *entirely* on resume (it installs a trace that raises before the first statement), so reading `keymap_keys` from the `keymap-detect` block's local would crash every resumed pipeline. Both pipelines read the keys back from `keymaps.json` instead — which is a second reason to persist them.
2. **Split parents had no boxes.** Smoke-testing the new order on Champaign, adjacency exited on p13: `ocr` reads the *effective* pages (panels supersede their parent) while `adjacency` reads the *parent* sheets, since the printed margin references live on the parent. Crafting only `list_pages()` left p2, p4, p13, p20, p21, p23 boxless. `volume_craft_images()` unions both lists plus the raw key-map sheets. The old `--allow-missing-boxes` fallback had been silently papering over this by re-running CRAFT mid-OCR.

## Verification

- `mapsnap craft` on a real page produces the expected 3-angle document (0/90/270, 250 angle-0 boxes) — byte-compatible with what `ocr` used to write, so existing `boxes.json` files are still valid.
- The missing-boxes error path was exercised on a scratch volume and on Champaign (which is how bug 2 surfaced).
- `volume_craft_images` verified on Champaign: 39 images covering all six split parents, the panels, and the raw key map.
- 852 tests (6 new: glob expansion, `--resume` freshness, missing-boxes detection/hint/exit, the parent+panel union, and `keymaps.json`-based key-map skipping). ruff and pyright clean.

**Note for existing volumes**: nothing needs regenerating — `boxes.json` files already on disk are reused as-is. A volume whose split parents were never crafted will get a clear error from `adjacency` naming the command to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
