### PR TITLE
Repair key-map page-number assignments from the printed adjacency graph

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,7 +24,7 @@ import {
   type IndexedDetection,
 } from './detections';
 import { filterBoxes } from './boxes';
-import { pageStem, parseDroppedJson } from './fileLoading';
+import { isKeymapJson, pageStem, parseDroppedJson } from './fileLoading';
 import { ImageColumn, type Mode } from './components/ImageColumn';
 import { MapView } from './components/MapView';
 import { GcpControls, type GcpFitStats } from './components/GcpControls';
@@ -140,6 +140,9 @@ export function App() {
   const [streets, setStreets] = useState<Street[]>([]);
   const [intersections, setIntersections] = useState<IntersectionPoint[]>([]);
   const [keymap, setKeymap] = useState<KeymapLocation | null>(null);
+  // Whether the loaded JSON is a key map's own sidecar (rather than a page's),
+  // which only its filename reveals. Drives the wide-image layout (#215).
+  const [keymapSheet, setKeymapSheet] = useState(false);
   const [truth, setTruth] = useState<[number, number][][] | null>(null);
   const [gcpPairs, setGcpPairs] = useState<GcpPairResult[] | null>(null);
   const [selectedPair, setSelectedPair] = useState<[number, number] | null>(
@@ -378,16 +381,20 @@ export function App() {
   }
 
   // Classify dropped JSON text and switch modes / load data accordingly.
+  // `sourceName` is the file it came from, when known: a key map's detections
+  // parse as ordinary streets, and only the name tells them apart (#215).
   function processJson(
     text: string,
     fallbackWidth: number,
     fallbackHeight: number,
+    sourceName?: string,
   ): void {
     const result = parseDroppedJson(text, {
       width: fallbackWidth,
       height: fallbackHeight,
     });
     if (result.kind === 'invalid') return;
+    setKeymapSheet(!!sourceName && isKeymapJson(sourceName));
     if (result.kind === 'streets') {
       setMode('streets');
       setSelectedIndices(new Set());
@@ -479,7 +486,7 @@ export function App() {
 
     if (jsonFile) {
       const text = await jsonFile.text();
-      processJson(text, fallbackWidth, fallbackHeight);
+      processJson(text, fallbackWidth, fallbackHeight, jsonFile.name);
     }
   }
 
@@ -519,7 +526,12 @@ export function App() {
         if (!response.ok) {
           throw new Error(`${jsonFile}: HTTP ${response.status}`);
         }
-        processJson(await response.text(), fallbackWidth, fallbackHeight);
+        processJson(
+          await response.text(),
+          fallbackWidth,
+          fallbackHeight,
+          jsonFile,
+        );
       }
     } catch (err) {
       console.error('Failed to load files from URL:', err);
@@ -574,10 +586,19 @@ export function App() {
     );
   }
 
+  // A key-map sheet is thousands of pixels wide and its marks are a few dozen
+  // across, so it gets the full column width with a fixed table beside it --
+  // whether it arrived as page regions or as page-number detections (#215).
+  const containerClass = [
+    'container',
+    mode === 'panels' || keymapSheet ? 'container-wide' : '',
+    mode === 'streets' && keymapSheet ? 'container-keymap' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div
-      className={mode === 'panels' ? 'container container-panels' : 'container'}
-    >
+    <div className={containerClass}>
       <nav className="view-nav">
         <a href="?view=iiif">volume viewer</a>
         {noteContext && <NoteButton ctx={noteContext} />}

--- a/app/src/components/DetectionsTable.tsx
+++ b/app/src/components/DetectionsTable.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react';
 import type { IndexedDetection } from '../detections';
 import { isOnBuildingFill } from '../detections';
+import type { Detection } from '../types';
 import { DetectionCanvas } from './DetectionCanvas';
 
 interface DetectionsTableProps {
@@ -13,10 +15,20 @@ interface DetectionsTableProps {
 
 const NUM_PREVIEW_IMAGES = 100;
 
+/** Columns in the table, for the metadata row that spans them all. */
+const COLUMN_COUNT = 7;
+
+/**
+ * How few rows a selection must be down to before each one expands to show where
+ * it came from. Narrowing to a handful is the gesture that means "explain these".
+ */
+const MAX_ROWS_WITH_METADATA = 5;
+
 /**
  * Table of detections sorted by confidence. Shows all filtered detections, or
  * only the selected ones when a selection is active. The first ten rows render
- * a deskewed image patch. Clicking a row selects that detection.
+ * a deskewed image patch. Clicking a row selects that detection. Narrow the
+ * selection to a few rows and each grows a metadata block explaining itself.
  */
 export function DetectionsTable(props: DetectionsTableProps) {
   const {
@@ -31,6 +43,10 @@ export function DetectionsTable(props: DetectionsTableProps) {
   const visible = detections
     .filter(({ i }) => selectedIndices.size === 0 || selectedIndices.has(i))
     .sort((a, b) => b.det.confidence - a.det.confidence);
+  // Only once a selection has narrowed things down: every row of a full sheet
+  // carrying a metadata block would bury the table it belongs to.
+  const showMetadata =
+    selectedIndices.size > 0 && visible.length <= MAX_ROWS_WITH_METADATA;
 
   return (
     <div id="detections-panel">
@@ -59,7 +75,7 @@ export function DetectionsTable(props: DetectionsTableProps) {
               .filter(Boolean)
               .join(' ');
             const type = det.ignore ? 'ignore' : det.hint ? 'hint' : 'street';
-            return (
+            return [
               <tr
                 key={i}
                 className={classes || undefined}
@@ -113,11 +129,70 @@ export function DetectionsTable(props: DetectionsTableProps) {
                     />
                   )}
                 </td>
-              </tr>
-            );
+              </tr>,
+              showMetadata && (
+                <tr key={`${i}-meta`} className="detection-meta">
+                  <td colSpan={COLUMN_COUNT}>
+                    <DetectionMetadata det={det} />
+                  </td>
+                </tr>
+              ),
+            ];
           })}
         </tbody>
       </table>
     </div>
+  );
+}
+
+/**
+ * Where a detection came from, for the handful of rows a small selection shows.
+ *
+ * Everything the row's own columns do not already say: how a key-map number was
+ * repaired and on whose word (#213), the colour under a label, the flags that
+ * decide whether georeferencing keeps it, and where on the sheet it sits.
+ */
+function DetectionMetadata({ det }: { det: Detection }) {
+  const xs = det.polygon.map(([x]) => x);
+  const ys = det.polygon.map(([, y]) => y);
+  const center: [number, number] = [
+    Math.round(xs.reduce((a, b) => a + b, 0) / xs.length),
+    Math.round(ys.reduce((a, b) => a + b, 0) / ys.length),
+  ];
+
+  const rows: [string, ReactNode][] = [];
+  if (det.via) rows.push(['via', det.via]);
+  if (det.support !== undefined) rows.push(['support', det.support.toFixed(2)]);
+  if (det.cited_by?.length) rows.push(['cited by', det.cited_by.join(', ')]);
+  if (det.background) {
+    rows.push([
+      'background',
+      <>
+        <span
+          className="fill-swatch"
+          style={{ background: det.background.color }}
+        />
+        {det.background.color} — hue {det.background.hue}°, chroma{' '}
+        {det.background.chroma}
+      </>,
+    ]);
+  }
+  const flags = [
+    det.ignore && 'ignored',
+    det.hint && 'hint',
+    det.fallback && 'fallback vocabulary',
+  ].filter(Boolean);
+  if (flags.length) rows.push(['flags', flags.join(', ')]);
+  rows.push(['center', `${center[0]}, ${center[1]} px`]);
+
+  return (
+    <dl className="detection-metadata">
+      {rows.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/app/src/fileLoading.test.ts
+++ b/app/src/fileLoading.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pageStem, parseDroppedJson } from './fileLoading';
+import { isKeymapJson, pageStem, parseDroppedJson } from './fileLoading';
 
 const fallback = { width: 800, height: 600 };
 
@@ -192,5 +192,22 @@ describe('pageStem', () => {
 
   it('matches split-panel stems', () => {
     expect(pageStem('p86__2.jpg')).toBe('p86__2');
+  });
+});
+
+describe('isKeymapJson', () => {
+  it('recognizes a key map’s own sidecars', () => {
+    expect(isKeymapJson('data/vol/raw/p0__1.keymap.json')).toBe(true);
+    expect(isKeymapJson('p0.keymap-raw.json')).toBe(true);
+    expect(isKeymapJson('/abs/raw/p1b.regions.panels.json')).toBe(true);
+  });
+
+  it('does not mistake a page’s own sidecars for a key map', () => {
+    // A page's streets.json parses identically to a key map's detections, so
+    // this predicate is the only thing separating them.
+    expect(isKeymapJson('data/vol/p49.streets.json')).toBe(false);
+    expect(isKeymapJson('p49.georef.json')).toBe(false);
+    expect(isKeymapJson('p49.panels.json')).toBe(false);
+    expect(isKeymapJson('adjacency.json')).toBe(false);
   });
 });

--- a/app/src/fileLoading.ts
+++ b/app/src/fileLoading.ts
@@ -48,6 +48,23 @@ export function pageStem(fileName: string): string {
   return base.split('.')[0];
 }
 
+/**
+ * Whether a JSON path holds a key map's own contents.
+ *
+ * A key map's page-number detections and its page regions are shaped exactly
+ * like any page's streets and panels, so nothing in the parsed data says the
+ * sheet is a key map -- only the filename does. The view uses this to widen the
+ * image, since a key map's marks are illegible at the default 800px cap (#215).
+ */
+export function isKeymapJson(fileName: string): boolean {
+  const base = (fileName.split(/[\\/]/).pop() ?? fileName).toLowerCase();
+  return (
+    base.endsWith('.keymap.json') ||
+    base.endsWith('.keymap-raw.json') ||
+    base.endsWith('.regions.panels.json')
+  );
+}
+
 /** Fallback image dimensions used when an old-format streets.json omits them. */
 export interface FallbackDimensions {
   width: number;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -93,35 +93,45 @@
 }
 
 /*
- * Panels mode: page-region boxes are tiny, so give the image the bulk of the width and let it
- * scroll vertically with the page; the Index/Page/Area table needs only a narrow strip.
+ * Wide-image views: a full key-map sheet, whether shown as page-region panels or as its
+ * page-number detections. Both draw marks a few dozen pixels across on a sheet thousands
+ * wide, so the 800px cap above renders them illegibly (#215). Give the image the bulk of
+ * the width and let it scroll vertically with the page; the table beside it needs only a
+ * narrow strip and stays in view.
  */
-.container-panels {
+.container-wide {
   align-items: flex-start;
+  --wide-table-width: 220px;
 }
 
-.container-panels .image-column {
+/* The key-map detections table carries seven columns (angle, both sides, confidence, type,
+   text, crop) where the panels table carries three, so it needs more of the strip. */
+.container-keymap {
+  --wide-table-width: 360px;
+}
+
+.container-wide .image-column {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-.container-panels .image-wrapper {
+.container-wide .image-wrapper {
   display: block;
   width: 100%;
 }
 
-.container-panels .image-wrapper img {
+.container-wide .image-wrapper img {
   width: 100%;
   max-width: none;
   max-height: none;
 }
 
-.container-panels .map-column {
-  flex: 0 0 220px;
+.container-wide .map-column {
+  flex: 0 0 var(--wide-table-width);
   min-width: 0;
 }
 
-.container-panels #detections-panel {
+.container-wide #detections-panel {
   height: auto;
   position: sticky;
   top: 16px;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -126,15 +126,24 @@
   max-height: none;
 }
 
+/* The whole column is pinned beside the scrolling sheet -- links and controls
+   included, so nothing slides out from over the table -- and bounded by the
+   viewport so the list below scrolls inside itself rather than off-screen.
+   It starts below .view-nav, which is fixed over this same top-right corner and
+   would otherwise sit on the table's header row. */
 .container-wide .map-column {
   flex: 0 0 var(--wide-table-width);
   min-width: 0;
+  position: sticky;
+  top: 32px;
+  align-self: flex-start;
+  max-height: calc(100vh - 48px);
 }
 
 .container-wide #detections-panel {
   height: auto;
-  position: sticky;
-  top: 16px;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 #map {
@@ -324,6 +333,46 @@
 
 #detections-table tr.selected:hover {
   background: #ffe0b2;
+}
+
+/*
+ * Where a detection came from, shown under its row once a selection is down to a
+ * handful. Reads as an annotation on the row above rather than a row of its own,
+ * so it shares the selection tint and drops the cursor and hover affordances.
+ */
+#detections-table tr.detection-meta {
+  cursor: default;
+  background: #fff8ec;
+}
+
+#detections-table tr.detection-meta:hover {
+  background: #fff8ec;
+}
+
+#detections-table tr.detection-meta td {
+  padding: 2px 8px 8px 20px;
+  white-space: normal;
+}
+
+.detection-metadata {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 1px 10px;
+  color: #555;
+}
+
+.detection-metadata > div {
+  display: contents;
+}
+
+.detection-metadata dt {
+  color: #999;
+}
+
+.detection-metadata dd {
+  margin: 0;
+  overflow-wrap: anywhere;
 }
 
 #detections-table tr.ignored td {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -59,6 +59,17 @@ export interface Detection {
    * neighbor), false amber (an unreciprocated claim); absent for non-claims.
    */
   mutual?: boolean;
+  /**
+   * How a key-map page number came to be, when it was not simply read (#213):
+   * 'adjacency-gap' for one synthesized where nothing was detected, or
+   * 'adjacency-relabel' for a read the adjacency graph overruled. Absent for an
+   * ordinary read.
+   */
+  via?: string;
+  /** Adjacency support behind a `via` repair: mutual citations, plus 0.25 per one-sided claim. */
+  support?: number;
+  /** Page numbers whose printed margins vouch for a `via` repair. */
+  cited_by?: string[];
 }
 
 /** The key map's expected center and OCR/fit radius for a page (georef.json `keymap`). */

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -326,6 +326,7 @@ def plan_gap_repairs(
     mutual: dict[str, set[str]],
     one_sided: dict[str, set[str]],
     volume_keys: set[str],
+    missing_keys: set[str] | None = None,
 ) -> list[Repair]:
     """Propose a location for each missing key from the pages that cite it.
 
@@ -335,16 +336,24 @@ def plan_gap_repairs(
     estimate. Requires GAP_MIN_MUTUAL mutual citations and GAP_MIN_SUPPORT in
     total, so a page vouched for only by one-sided claims is never placed.
 
+    ``missing_keys`` narrows the candidates to the volume-wide shortfall. A
+    volume's key maps split the city between them, so a page already drawn on
+    another sheet is not missing at all: filling it here anyway put Brooklyn's
+    9 and 22 on the wrong half, 6970 ft and 1079 ft from truth, while correct
+    copies sat on the other sheet. Absent the argument every key the sheet
+    lacks is fair game, which is right for a single-sheet volume.
+
     The vouching panel indices ride along in ``evidence_indices`` so the caller
     can compute the position and apply its own spatial sanity check.
     """
     assigned = set(sheet.labels)
+    wanted = volume_keys if missing_keys is None else volume_keys & missing_keys
     panels_by_label: dict[str, list[int]] = {}
     for index, label in enumerate(sheet.labels):
         panels_by_label.setdefault(label, []).append(index)
 
     repairs: list[Repair] = []
-    for key in sorted(key for key in volume_keys if key not in assigned):
+    for key in sorted(key for key in wanted if key not in assigned):
         strong = sorted(mutual.get(key, set()) & assigned)
         weak = sorted((one_sided.get(key, set()) - mutual.get(key, set())) & assigned)
         score = len(strong) + ONE_SIDED_WEIGHT * len(weak)
@@ -370,6 +379,23 @@ def plan_gap_repairs(
             )
         )
     return repairs
+
+
+def volume_shortfall(
+    sheets: list[SheetNumbers], volume_keys: set[str], splits: dict[str, int]
+) -> set[str]:
+    """Keys the volume's key maps draw fewer times than the page deserves.
+
+    Counted across every sheet, because a volume's key maps divide the city
+    between them and a page drawn on one is not missing from the volume. A
+    split page is drawn once per panel, so its expected count is its panel
+    count rather than one.
+    """
+    placed: dict[str, int] = {}
+    for sheet in sheets:
+        for label in sheet.labels:
+            placed[label] = placed.get(label, 0) + 1
+    return {key for key in volume_keys if placed.get(key, 0) < splits.get(key, 1)}
 
 
 # --- volume-level inputs ----------------------------------------------------
@@ -611,23 +637,34 @@ def plan_volume_repairs(
 
     repairs: list[Repair] = []
     placements: dict[str, dict[str, tuple[float, float]]] = {}
+    # Gap recovery must see the relabels: a key just recovered from a misread
+    # panel is no longer missing, and proposing it again would place the same
+    # page twice (Detroit's 65 was found both ways). So relabel every sheet
+    # first, then take stock of what the volume is still short of.
+    repaired_sheets: list[SheetNumbers] = []
     for sheet in sheet_panels:
         relabels = plan_sheet_repairs(sheet, mutual, one_sided, volume_keys)
         repairs.extend(relabels)
-        # Gap recovery must see the relabels: a key just recovered from a
-        # misread panel is no longer missing, and proposing it again would
-        # place the same page twice (Detroit's 65 was found both ways).
         repaired = SheetNumbers(sheet.sheet, list(sheet.labels), sheet.contacts)
         for relabel in relabels:
             if relabel.index is not None and relabel.new is not None:
                 repaired.labels[relabel.index] = relabel.new
-        centers, pitch = geometry[sheet.sheet]
-        for repair in plan_gap_repairs(repaired, mutual, one_sided, volume_keys):
+        repaired_sheets.append(repaired)
+
+    missing = volume_shortfall(repaired_sheets, volume_keys, splits)
+    for repaired in repaired_sheets:
+        centers, pitch = geometry[repaired.sheet]
+        for repair in plan_gap_repairs(
+            repaired, mutual, one_sided, volume_keys, missing
+        ):
             point = gap_placement(repair, centers, pitch)
             if point is None or repair.new is None:
                 continue
             repairs.append(repair)
-            placements.setdefault(sheet.sheet, {})[repair.new] = point
+            placements.setdefault(repaired.sheet, {})[repair.new] = point
+            # One fill per shortfall: two sheets that both border the page
+            # must not each grow a copy of it.
+            missing.discard(repair.new)
     repairs.extend(plan_cross_sheet_repairs(sheet_panels, mutual, one_sided, splits))
     return repairs, placements
 

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -1,0 +1,628 @@
+"""Repair key-map page-number assignments using the printed adjacency graph (#213).
+
+The key map's page numbers are the coarse-location source for OCR restriction,
+georeferencing and snap: placing each page at its region centroid alone puts
+Detroit's pages a median 158 ft from truth, which is why a missing or misread
+number is expensive. Two failure classes survive the CRNN's own repair pass
+(#172), because that pass arbitrates by CTC margin and these cells have no
+margin to arbitrate:
+
+  * a number read as a shorter one, where BOTH reads are confident and valid
+    (Detroit prints 22 and 65; the sheet carries two "2"s and three "6"s at
+    confidence 1.0, so the duplicate keeper logic cannot tell which is which);
+  * a number with no detection at all (Detroit p59 — nothing to repair).
+
+The printed adjacency graph settles both, and is now precise enough to do it:
+mutual edges measure 96-100% against hand-labelled truth (#209), letter-aware
+with roughly twice the recall on 4-digit volumes (#206). The evidence is
+strikingly asymmetric on exactly the cells that matter — Detroit's *missing*
+p22 carries three mutual edges (p21, p28, p29) while the *false* duplicate p2
+carries none.
+
+The rule in one line: a page's key-map region should sit among the regions of
+the pages that print its number in their margins.
+
+Three cell types, in decreasing order of evidence:
+
+  duplicates    Instances of one label are scored by how many of that page's
+                MUTUAL neighbours are nearby. Every mutually-vouched instance
+                keeps its label -- split pages legitimately appear several
+                times on the key map (Champaign draws p4 four times), and
+                undersplit pages may too, so multiplicity is never itself a
+                trigger. Only an unvouched instance is a suspect, and it is
+                relabelled solely to a MISSING key its own neighbours name.
+  cross-sheet   The same key drawn on two key-map SHEETS beyond its expected
+                multiplicity: keep the vouched sheet's copies, drop the
+                other's (Brooklyn's p8/p1/p5 each sit correctly on one sheet
+                and 1-1.8 km wrong on the other). Duplicates within one sheet
+                are the case above, and are relabelled rather than stripped.
+  gaps          A missing key is placed at the centroid of the regions whose
+                pages print its number, when enough of them do.
+
+Constraints inherited from #183's failed global-optimization experiments:
+adjacency never overrides a read that has its own support (its negative signal
+is weak); spatial coherence is a gate, never an energy; repairs only ever
+target keys the sheet is missing; ambiguity means no action.
+
+One-sided claims are corroboration only, never decisive: they measure 32-54%
+precise against label truth (#207) versus 96-100% for mutual edges.
+"""
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROXIMITY_FACTOR = 2.0
+"""How many region-widths apart two key-map regions may be and still count as
+neighbours (see proximity_graph)."""
+
+ONE_SIDED_WEIGHT = 0.25
+"""Weight of an unreciprocated claim relative to a mutual edge.
+
+One-sided claims are 32-54% precise (LA/Hudson/Nashville label truth) against
+96-100% for mutual edges, so four of them are worth less than one mutual edge
+and cannot on their own reach any adoption threshold below."""
+
+RELABEL_MIN_MUTUAL = 2
+"""Mutual neighbours that must vouch for a key before it takes over a panel.
+
+A relabel OVERWRITES an existing assignment, so it can regress a page that was
+right: two independent mutual edges is the bar. Detroit's 22 clears it with
+three (p21, p28, p29) and its 65 with two (p34, p40)."""
+
+GAP_MIN_MUTUAL = 1
+GAP_MIN_SUPPORT = 1.5
+"""Bar for placing a missing key: at least one mutual citation, plus
+corroboration reaching GAP_MIN_SUPPORT in total.
+
+Deliberately weaker than the relabel bar, because the two decisions have
+different downsides. A relabel can take a correct assignment away; a gap
+placement fills a void -- the page has no key-map location at all today, so
+it cannot be snapped or vocabulary-restricted, and the worst case is that it
+stays unusable. Detroit p59 is exactly this shape: one mutual edge (p27) plus
+one-sided claims from p57 and p61, which is 1.5. A mutual edge is still
+required, since one-sided claims are only 32-54% precise and no pile of them
+should place a page on its own."""
+
+
+@dataclass(frozen=True)
+class Repair:
+    """One proposed change to a key map's page-number assignment."""
+
+    sheet: str
+    index: int | None  # panel/detection index; None for a synthesized gap panel
+    old: str | None  # previous label; None when nothing was there
+    new: str | None  # new label; None strips the assignment
+    reason: str
+    support: float = 0.0
+    evidence: tuple[str, ...] = ()
+    evidence_indices: tuple[int, ...] = ()
+    mutual_indices: tuple[int, ...] = ()
+
+    def describe(self) -> str:
+        vouchers = ", ".join(self.evidence) if self.evidence else "-"
+        old = self.old if self.old is not None else "(none)"
+        new = self.new if self.new is not None else "(strip)"
+        return (
+            f"{self.sheet}[{self.index if self.index is not None else 'new'}] "
+            f"{old} -> {new} [{self.reason}; support {self.support:.2f}; {vouchers}]"
+        )
+
+
+@dataclass
+class SheetPanels:
+    """One key-map sheet's labelled regions and their contact graph."""
+
+    sheet: str
+    labels: list[str]
+    contacts: set[frozenset[int]] = field(default_factory=set)
+
+    def touching(self, index: int) -> set[int]:
+        return {
+            other
+            for pair in self.contacts
+            if index in pair
+            for other in pair
+            if other != index
+        }
+
+
+def digit_family(text: str, keys: set[str]) -> set[str]:
+    """Keys a read could be, had the recogniser dropped digits.
+
+    The key-map failure is digit LOSS: a printed "22" reads "2", "65" reads
+    "6". So a candidate is any key whose digits contain the read's digits in
+    order (a subsequence), which covers both a lost leading digit and a lost
+    trailing one. Mirrors the spirit of page_adjacency.resolve_page_key (#206)
+    without its uniqueness requirement, since adjacency -- not the string --
+    does the disambiguating here.
+    """
+    read = "".join(ch for ch in text if ch.isdigit())
+    if not read:
+        return set()
+    family = set()
+    for key in keys:
+        digits = "".join(ch for ch in key if ch.isdigit())
+        if len(digits) <= len(read):
+            continue
+        position = 0
+        for char in digits:
+            if position < len(read) and char == read[position]:
+                position += 1
+        if position == len(read):
+            family.add(key)
+    return family
+
+
+def support_for(
+    index: int,
+    key: str,
+    sheet: SheetPanels,
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+) -> tuple[float, tuple[str, ...]]:
+    """How strongly the printed graph vouches for ``key`` sitting at ``index``.
+
+    Counts the page's mutual neighbours that own a region touching this one,
+    plus a fractional credit for one-sided claims. Returns the score and the
+    vouching page keys, which are carried into the repair record so a human
+    can check the reasoning.
+    """
+    neighbours = {sheet.labels[other] for other in sheet.touching(index)}
+    return score_neighbours(neighbours, key, mutual, one_sided)
+
+
+def score_neighbours(
+    neighbours: set[str],
+    key: str,
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+) -> tuple[float, tuple[str, ...]]:
+    """(support, vouching keys) for ``key`` given the page keys around it."""
+    vouchers = sorted(neighbours & mutual.get(key, set()))
+    weak = sorted(neighbours & (one_sided.get(key, set()) - mutual.get(key, set())))
+    return len(vouchers) + ONE_SIDED_WEIGHT * len(weak), tuple(vouchers + weak)
+
+
+def mutual_count(neighbours: set[str], key: str, mutual: dict[str, set[str]]) -> int:
+    """How many of ``neighbours`` are mutual-adjacency neighbours of ``key``."""
+    return len(neighbours & mutual.get(key, set()))
+
+
+def plan_sheet_repairs(
+    sheet: SheetPanels,
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+    volume_keys: set[str],
+) -> list[Repair]:
+    """Duplicate-label arbitration for one sheet (the pure decision core).
+
+    A label with several instances is only interesting when some instance has
+    NO adjacency support: split pages appear several times legitimately, and
+    every supported instance keeps its label. A zero-support instance adopts a
+    missing key only when exactly one candidate in its digit family is vouched
+    for by RELABEL_MIN_MUTUAL neighbours, so a tie or a shortage of evidence
+    changes nothing.
+    """
+    assigned = {label for label in sheet.labels}
+    missing = {key for key in volume_keys if key not in assigned}
+    by_label: dict[str, list[int]] = {}
+    for index, label in enumerate(sheet.labels):
+        by_label.setdefault(label, []).append(index)
+
+    repairs: list[Repair] = []
+    claimed: set[str] = set()
+    for label, indices in sorted(by_label.items()):
+        if len(indices) < 2:
+            continue
+        for index in indices:
+            neighbours = {sheet.labels[other] for other in sheet.touching(index)}
+            if mutual_count(neighbours, label, mutual) > 0:
+                continue  # a mutually-vouched instance always keeps its label
+            # Only MUTUAL edges protect a label. Detroit's misread "2" panel
+            # sits next to one page that one-sidedly claims p2 -- 0.25 of
+            # support, and at 32-54% precision nowhere near enough to shield
+            # it from three mutual edges naming 22.
+            # The sibling instances are deliberately NOT consulted: Detroit's
+            # p2 has no mutual edges at all, so neither of its "2" panels can
+            # be vouched for. What identifies the impostor is the positive
+            # evidence for 22 at one of them, not a comparison between them.
+            candidates = []
+            for key in sorted(digit_family(label, missing - claimed)):
+                if mutual_count(neighbours, key, mutual) < RELABEL_MIN_MUTUAL:
+                    continue
+                key_score, vouchers = score_neighbours(
+                    neighbours, key, mutual, one_sided
+                )
+                candidates.append((key_score, key, vouchers))
+            if len(candidates) != 1:
+                continue  # no evidence, or ambiguous: leave it alone
+            key_score, key, vouchers = candidates[0]
+            claimed.add(key)
+            repairs.append(
+                Repair(
+                    sheet=sheet.sheet,
+                    index=index,
+                    old=label,
+                    new=key,
+                    reason="duplicate-no-support",
+                    support=key_score,
+                    evidence=vouchers,
+                )
+            )
+    return repairs
+
+
+def plan_cross_sheet_repairs(
+    sheets: list[SheetPanels],
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+    split_counts: dict[str, int] | None = None,
+) -> list[Repair]:
+    """Strip a key from the SHEET whose regions nothing vouches for.
+
+    Only applies to keys drawn on more than one key-map sheet: a volume with
+    two index sheets can place the same number on both, and one of them is
+    wrong (Brooklyn's p8 sits 72 m from truth on p0b and 1827 m away on p0).
+    Duplicates WITHIN one sheet are not this case -- they are usually split
+    panels, and plan_sheet_repairs relabels rather than strips them.
+
+    Fires only on a clean asymmetry: some sheet's copies are mutually vouched
+    for and another sheet's are not, beyond the key's split multiplicity.
+    """
+    split_counts = split_counts or {}
+    placements: dict[str, dict[str, list[int]]] = {}
+    by_name = {sheet.sheet: sheet for sheet in sheets}
+    for sheet in sheets:
+        for index, label in enumerate(sheet.labels):
+            placements.setdefault(label, {}).setdefault(sheet.sheet, []).append(index)
+
+    repairs: list[Repair] = []
+    for label, per_sheet in sorted(placements.items()):
+        if len(per_sheet) < 2:
+            continue  # one sheet only: not a cross-sheet conflict
+        total = sum(len(indices) for indices in per_sheet.values())
+        if total <= max(1, split_counts.get(label, 1)):
+            continue
+        vouched: dict[str, int] = {}
+        for name, indices in per_sheet.items():
+            sheet = by_name[name]
+            vouched[name] = max(
+                mutual_count(
+                    {sheet.labels[other] for other in sheet.touching(index)},
+                    label,
+                    mutual,
+                )
+                for index in indices
+            )
+        supported = [name for name, count in vouched.items() if count > 0]
+        unsupported = [name for name, count in vouched.items() if count == 0]
+        if not supported or not unsupported:
+            continue  # all or nothing vouched for: no asymmetry to exploit
+        for name in unsupported:
+            sheet = by_name[name]
+            for index in per_sheet[name]:
+                score, _vouchers = support_for(index, label, sheet, mutual, one_sided)
+                repairs.append(
+                    Repair(
+                        sheet=name,
+                        index=index,
+                        old=label,
+                        new=None,
+                        reason="cross-sheet-no-support",
+                        support=score,
+                        evidence=tuple(sorted(supported)),
+                    )
+                )
+    return repairs
+
+
+def plan_gap_repairs(
+    sheet: SheetPanels,
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+    volume_keys: set[str],
+) -> list[Repair]:
+    """Propose a location for each missing key from the pages that cite it.
+
+    A page absent from the key map has no region to score, so the evidence is
+    the other direction: the panels of the pages whose margins print its
+    number. Those panels surround where it belongs, and their centroid is the
+    estimate. Requires GAP_MIN_MUTUAL mutual citations and GAP_MIN_SUPPORT in
+    total, so a page vouched for only by one-sided claims is never placed.
+
+    The vouching panel indices ride along in ``evidence_indices`` so the caller
+    can compute the position and apply its own spatial sanity check.
+    """
+    assigned = set(sheet.labels)
+    panels_by_label: dict[str, list[int]] = {}
+    for index, label in enumerate(sheet.labels):
+        panels_by_label.setdefault(label, []).append(index)
+
+    repairs: list[Repair] = []
+    for key in sorted(key for key in volume_keys if key not in assigned):
+        strong = sorted(mutual.get(key, set()) & assigned)
+        weak = sorted((one_sided.get(key, set()) - mutual.get(key, set())) & assigned)
+        score = len(strong) + ONE_SIDED_WEIGHT * len(weak)
+        if len(strong) < GAP_MIN_MUTUAL or score < GAP_MIN_SUPPORT:
+            continue
+        strong_indices = tuple(
+            index for label in strong for index in panels_by_label.get(label, [])
+        )
+        weak_indices = tuple(
+            index for label in weak for index in panels_by_label.get(label, [])
+        )
+        repairs.append(
+            Repair(
+                sheet=sheet.sheet,
+                index=None,
+                old=None,
+                new=key,
+                reason="gap",
+                support=score,
+                evidence=tuple(strong + weak),
+                evidence_indices=strong_indices + weak_indices,
+                mutual_indices=strong_indices,
+            )
+        )
+    return repairs
+
+
+# --- volume-level inputs ----------------------------------------------------
+
+
+def page_key_of(stem: str) -> str | None:
+    """The page key a stem or printed text denotes ('p22' -> '22', '1499A')."""
+    match = re.search(r"\d+[A-Za-z]{0,2}", str(stem))
+    return match.group().upper() if match else None
+
+
+def adjacency_graphs(volume: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """(mutual, one_sided) neighbour maps keyed by page key, from adjacency.json."""
+    path = volume / "adjacency.json"
+    mutual: dict[str, set[str]] = {}
+    one_sided: dict[str, set[str]] = {}
+    if not path.exists():
+        return mutual, one_sided
+    doc = json.loads(path.read_text())
+    for field_name, target in (("adjacency", mutual), ("one_sided", one_sided)):
+        for pair in doc.get(field_name, []):
+            if len(pair) != 2:
+                continue
+            first, second = (page_key_of(pair[0]), page_key_of(pair[1]))
+            if not first or not second or first == second:
+                continue
+            target.setdefault(first, set()).add(second)
+            target.setdefault(second, set()).add(first)
+    return mutual, one_sided
+
+
+def volume_page_keys(volume: Path) -> set[str]:
+    """Page keys of the volume's real page images (split parents included)."""
+    keys = set()
+    for image in volume.glob("p*.jpg"):
+        if "__" in image.stem:
+            continue
+        key = page_key_of(image.stem)
+        if key:
+            keys.add(key)
+    return keys
+
+
+def split_multiplicity(volume: Path) -> dict[str, int]:
+    """Page key -> number of split panels, for pages the splitter divided.
+
+    A split page is legitimately drawn once per panel on the key map, so its
+    duplicate regions are expected rather than suspicious.
+    """
+    counts: dict[str, int] = {}
+    for path in volume.glob("p*.panels.json"):
+        stem = path.name[: -len(".panels.json")]
+        key = page_key_of(stem)
+        if not key:
+            continue
+        try:
+            panels = json.loads(path.read_text()).get("panels", [])
+        except (OSError, ValueError):
+            continue
+        if panels:
+            counts[key] = len(panels)
+    return counts
+
+
+def panel_centroids(
+    panels: list[list[list[float]]],
+) -> list[tuple[float, float] | None]:
+    """Each region ring's centroid, or None for a degenerate ring."""
+    from shapely.geometry import Polygon
+
+    out: list[tuple[float, float] | None] = []
+    for ring in panels:
+        if len(ring) < 3:
+            out.append(None)
+            continue
+        polygon = Polygon([(float(x), float(y)) for x, y in ring])
+        if not polygon.is_valid:
+            polygon = polygon.buffer(0)
+        if polygon.is_empty:
+            out.append(None)
+            continue
+        out.append((polygon.centroid.x, polygon.centroid.y))
+    return out
+
+
+def panel_scale(panels: list[list[list[float]]]) -> float:
+    """Typical region width in key-map pixels (root of the median area)."""
+    from shapely.geometry import Polygon
+
+    areas = []
+    for ring in panels:
+        if len(ring) < 3:
+            continue
+        polygon = Polygon([(float(x), float(y)) for x, y in ring])
+        if not polygon.is_valid:
+            polygon = polygon.buffer(0)
+        if not polygon.is_empty:
+            areas.append(polygon.area)
+    if not areas:
+        return 0.0
+    areas.sort()
+    return math.sqrt(areas[len(areas) // 2])
+
+
+def proximity_graph(
+    panels: list[list[list[float]]], factor: float = PROXIMITY_FACTOR
+) -> set[frozenset[int]]:
+    """Region pairs close enough to be plausible neighbours on the sheet.
+
+    Deliberately NOT polygon contact. Segmented key-map regions are islands,
+    not a mosaic -- Detroit's cover 18% of the sheet, so p65's block sits
+    ~180 px of blank paper from p34's and p40's and no contact tolerance that
+    also respects real separations will join them. Centroid distance within
+    ``factor`` region-widths is permissive by design: the *printed* graph does
+    the discriminating (a candidate still needs two mutual edges among these
+    neighbours), so proximity only has to avoid missing the true ones.
+    """
+    centroids = panel_centroids(panels)
+    scale = panel_scale(panels)
+    if scale <= 0:
+        return set()
+    radius = factor * scale
+    pairs: set[frozenset[int]] = set()
+    for i, first in enumerate(centroids):
+        if first is None:
+            continue
+        for j in range(i + 1, len(centroids)):
+            second = centroids[j]
+            if second is None:
+                continue
+            if math.dist(first, second) <= radius:
+                pairs.add(frozenset((i, j)))
+    return pairs
+
+
+def load_sheets(volume: Path) -> list[tuple[str, dict, dict]]:
+    """(stem, keymap doc, regions doc) for every key map with both sidecars."""
+    sheets = []
+    for regions_path in sorted((volume / "raw").glob("*.regions.panels.json")):
+        if ".truth." in regions_path.name:
+            continue
+        stem = regions_path.name[: -len(".regions.panels.json")]
+        keymap_path = volume / "raw" / f"{stem}.keymap.json"
+        if not keymap_path.exists():
+            continue
+        try:
+            regions = json.loads(regions_path.read_text())
+            keymap = json.loads(keymap_path.read_text())
+        except (OSError, ValueError):
+            continue
+        sheets.append((stem, keymap, regions))
+    return sheets
+
+
+GAP_SPREAD_FACTOR = 3.0
+"""How far apart the panels citing a missing page may be, in region-widths.
+
+The gap placement is the centroid of the citing regions, which is only
+meaningful if they actually surround one spot. Scattered citations mean at
+least one of them is itself misassigned, so the placement is refused rather
+than dropped in the middle of the sheet."""
+
+
+def gap_placement(
+    repair: Repair, centroids: list[tuple[float, float] | None], scale: float
+) -> tuple[float, float] | None:
+    """Where a gap repair's page belongs: the centroid of its citing regions.
+
+    Anchored on the MUTUAL citations, which are 96-100% precise, then refined
+    with whichever one-sided citations agree with them. Detroit's p59 is cited
+    by p27 mutually and by p57, p61 and p1 one-sidedly, and the p1 claim is
+    junk (issue #213 names it) -- averaging it in would drag the placement
+    across the sheet, so a one-sided citation more than GAP_SPREAD_FACTOR
+    region-widths from the mutual anchor is discarded.
+
+    Returns None when no mutual citation has a usable region, or when the
+    mutual citations themselves disagree on a location (which means one of
+    them is misassigned).
+    """
+
+    def point_of(index: int) -> tuple[float, float] | None:
+        if 0 <= index < len(centroids):
+            return centroids[index]
+        return None
+
+    anchors = [
+        point for point in map(point_of, repair.mutual_indices) if point is not None
+    ]
+    if not anchors:
+        return None
+    anchor = (
+        sum(point[0] for point in anchors) / len(anchors),
+        sum(point[1] for point in anchors) / len(anchors),
+    )
+    limit = GAP_SPREAD_FACTOR * scale if scale > 0 else math.inf
+    if len(anchors) > 1 and max(math.dist(anchor, p) for p in anchors) > limit:
+        return None
+    weak = [
+        point
+        for index in repair.evidence_indices
+        if index not in repair.mutual_indices
+        and (point := point_of(index)) is not None
+        and math.dist(anchor, point) <= limit
+    ]
+    points = anchors + weak
+    return (
+        sum(point[0] for point in points) / len(points),
+        sum(point[1] for point in points) / len(points),
+    )
+
+
+def plan_volume_repairs(
+    volume: Path,
+) -> tuple[list[Repair], dict[str, dict[str, tuple[float, float]]]]:
+    """All proposed repairs for a volume, plus the placement of each gap fill.
+
+    Returns (repairs, placements) where ``placements[sheet][key]`` is the
+    key-map pixel position for a gap recovery, so the caller can synthesize a
+    detection there without redoing the geometry. Gap repairs whose citing
+    regions disagree on a location are dropped here rather than proposed.
+    """
+    mutual, one_sided = adjacency_graphs(volume)
+    if not mutual:
+        return [], {}
+    volume_keys = volume_page_keys(volume)
+    splits = split_multiplicity(volume)
+
+    sheet_panels: list[SheetPanels] = []
+    geometry: dict[str, tuple[list[tuple[float, float] | None], float]] = {}
+    for stem, _keymap, regions in load_sheets(volume):
+        panels = regions.get("panels", [])
+        labels = [
+            page_key_of(label) or str(label) for label in regions.get("labels", [])
+        ]
+        sheet_panels.append(SheetPanels(stem, labels, proximity_graph(panels)))
+        geometry[stem] = (panel_centroids(panels), panel_scale(panels))
+
+    repairs: list[Repair] = []
+    placements: dict[str, dict[str, tuple[float, float]]] = {}
+    for sheet in sheet_panels:
+        relabels = plan_sheet_repairs(sheet, mutual, one_sided, volume_keys)
+        repairs.extend(relabels)
+        # Gap recovery must see the relabels: a key just recovered from a
+        # misread panel is no longer missing, and proposing it again would
+        # place the same page twice (Detroit's 65 was found both ways).
+        repaired = SheetPanels(sheet.sheet, list(sheet.labels), sheet.contacts)
+        for relabel in relabels:
+            if relabel.index is not None and relabel.new is not None:
+                repaired.labels[relabel.index] = relabel.new
+        centroids, scale = geometry[sheet.sheet]
+        for repair in plan_gap_repairs(repaired, mutual, one_sided, volume_keys):
+            point = gap_placement(repair, centroids, scale)
+            if point is None or repair.new is None:
+                continue
+            repairs.append(repair)
+            placements.setdefault(sheet.sheet, {})[repair.new] = point
+    repairs.extend(plan_cross_sheet_repairs(sheet_panels, mutual, one_sided, splits))
+    return repairs, placements

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -690,6 +690,13 @@ on a different scale (``support``, roughly 1.5-5), so it is not a stand-in.
 What is left is a deliberately low placeholder: low enough to sort below every
 real read, non-zero so the debugger draws it (a 0 renders as invisible)."""
 
+MIN_GAP_SIDE = 20.0
+"""Smallest square a synthesized gap detection may be drawn as, in key-map pixels.
+
+Matches the debugger's default minimum-short-side filter, so a gap detection is
+never hidden by it. Only affects display and the colour-block sample page_regions
+takes underneath -- both indifferent to a few pixels on a sheet thousands wide."""
+
 
 def synthetic_detection(
     key: str, point: tuple[float, float], pitch: float, repair: Repair
@@ -701,8 +708,12 @@ def synthetic_detection(
     provenance. The box is a nominal glyph-sized square at the estimated spot:
     page_regions only uses a seed's box to pick the colour block under it, and
     the world position downstream comes from the box centre.
+
+    The floor keeps the box at least MIN_GAP_SIDE across, since the debugger
+    hides anything whose short side falls under its default slider -- a
+    tightly-pitched sheet would otherwise synthesize invisible boxes.
     """
-    half = max(8.0, pitch * 0.06)
+    half = max(MIN_GAP_SIDE / 2, pitch * 0.06)
     x, y = point
     return {
         "polygon": [

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -53,6 +53,7 @@ precise against label truth (#207) versus 96-100% for mutual edges.
 import json
 import math
 import re
+import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -691,42 +692,72 @@ What is left is a deliberately low placeholder: low enough to sort below every
 real read, non-zero so the debugger draws it (a 0 renders as invisible)."""
 
 MIN_GAP_SIDE = 20.0
-"""Smallest square a synthesized gap detection may be drawn as, in key-map pixels.
+"""Smallest a synthesized gap detection's box may be, in key-map pixels.
 
-Matches the debugger's default minimum-short-side filter, so a gap detection is
-never hidden by it. Only affects display and the colour-block sample page_regions
-takes underneath -- both indifferent to a few pixels on a sheet thousands wide."""
+A floor under the sheet's median detection box, matching the debugger's default
+minimum-short-side filter so a gap detection is never hidden by it. Only affects
+display and the colour-block sample page_regions takes underneath -- both
+indifferent to a few pixels on a sheet thousands wide."""
+
+
+def median_detection_box(streets: list[dict]) -> tuple[float, float]:
+    """(width, height) of the sheet's typical page-number box, in key-map pixels.
+
+    Measured from the polygons rather than the long_side/short_side fields, so
+    it holds whatever their orientation convention is. Previously-synthesized
+    boxes are excluded -- otherwise re-running the repair would let them drag
+    the median toward themselves. Falls back to a MIN_GAP_SIDE square when the
+    sheet has no real detections to measure.
+    """
+    widths: list[float] = []
+    heights: list[float] = []
+    for street in streets:
+        polygon = street.get("polygon") or []
+        if street.get("via") == "adjacency-gap" or len(polygon) < 3:
+            continue
+        xs = [point[0] for point in polygon]
+        ys = [point[1] for point in polygon]
+        widths.append(max(xs) - min(xs))
+        heights.append(max(ys) - min(ys))
+    if not widths:
+        return (MIN_GAP_SIDE, MIN_GAP_SIDE)
+    return (
+        max(MIN_GAP_SIDE, statistics.median(widths)),
+        max(MIN_GAP_SIDE, statistics.median(heights)),
+    )
 
 
 def synthetic_detection(
-    key: str, point: tuple[float, float], pitch: float, repair: Repair
+    key: str, point: tuple[float, float], box: tuple[float, float], repair: Repair
 ) -> dict:
     """A detection record for a page the sheet never printed a readable number for.
 
     Shaped like a CRNN detection so every existing reader (load_seeds,
     load_detections, the debugger) treats it as one, with ``via`` marking its
-    provenance. The box is a nominal glyph-sized square at the estimated spot:
-    page_regions only uses a seed's box to pick the colour block under it, and
-    the world position downstream comes from the box centre.
-
-    The floor keeps the box at least MIN_GAP_SIDE across, since the debugger
-    hides anything whose short side falls under its default slider -- a
-    tightly-pitched sheet would otherwise synthesize invisible boxes.
+    provenance. ``box`` is the (width, height) to draw it at -- the sheet's
+    median real detection, so a gap reads at a glance as the same kind of thing
+    as its neighbours rather than as a speck. page_regions only uses a seed's
+    box to pick the colour block under it, and the world position downstream
+    comes from the box centre, so the size is a display choice either way.
     """
-    half = max(MIN_GAP_SIDE / 2, pitch * 0.06)
-    x, y = point
+    # Integer half-extents about an integer centre, so the polygon's centre is
+    # exactly the estimate rather than half a pixel off it: downstream this box
+    # IS the page's position, and the sides are reported from what was drawn.
+    half_width = max(1, round(box[0] / 2))
+    half_height = max(1, round(box[1] / 2))
+    x, y = round(point[0]), round(point[1])
     return {
         "polygon": [
-            [int(x - half), int(y - half)],
-            [int(x + half), int(y - half)],
-            [int(x + half), int(y + half)],
-            [int(x - half), int(y + half)],
+            [x - half_width, y - half_height],
+            [x + half_width, y - half_height],
+            [x + half_width, y + half_height],
+            [x - half_width, y + half_height],
         ],
         "text": key,
         "confidence": GAP_CONFIDENCE,
         "angle": 0,
-        "long_side": round(2 * half, 1),
-        "short_side": round(2 * half, 1),
+        "long_side": float(max(2 * half_width, 2 * half_height)),
+        "short_side": float(min(2 * half_width, 2 * half_height)),
         "dir_pix": 0.0,
         "via": "adjacency-gap",
         "support": round(repair.support, 2),
@@ -761,14 +792,14 @@ def apply_repairs(
         if not raw_path.exists():
             raw_path.write_text(json.dumps(doc, indent=2))
 
-        pitch = page_pitch(detection_centers(streets))
+        box = median_detection_box(streets)
         stripped: list[int] = []
         for repair in sheet_repairs:
             if repair.index is None:
                 point = placements.get(stem, {}).get(repair.new or "")
                 if point is None or repair.new is None:
                     continue
-                streets.append(synthetic_detection(repair.new, point, pitch, repair))
+                streets.append(synthetic_detection(repair.new, point, box, repair))
             elif repair.new is None:
                 stripped.append(repair.index)
             elif 0 <= repair.index < len(streets):

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -679,6 +679,18 @@ re-running the repair never overwrites the true original with a repaired one.
 """
 
 
+GAP_CONFIDENCE = 0.2
+"""``confidence`` on a synthesized gap detection.
+
+``confidence`` means the recogniser's posterior over the text it read, and a
+gap detection read nothing -- there is no posterior to report. Claiming a high
+one would let it pass for a confident read anywhere confidence is thresholded
+or ranked, and the adjacency support that DID place it is a different quantity
+on a different scale (``support``, roughly 1.5-5), so it is not a stand-in.
+What is left is a deliberately low placeholder: low enough to sort below every
+real read, non-zero so the debugger draws it (a 0 renders as invisible)."""
+
+
 def synthetic_detection(
     key: str, point: tuple[float, float], pitch: float, repair: Repair
 ) -> dict:
@@ -700,7 +712,7 @@ def synthetic_detection(
             [int(x - half), int(y + half)],
         ],
         "text": key,
-        "confidence": 0.0,
+        "confidence": GAP_CONFIDENCE,
         "angle": 0,
         "long_side": round(2 * half, 1),
         "short_side": round(2 * half, 1),

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -19,8 +19,10 @@ strikingly asymmetric on exactly the cells that matter — Detroit's *missing*
 p22 carries three mutual edges (p21, p28, p29) while the *false* duplicate p2
 carries none.
 
-The rule in one line: a page's key-map region should sit among the regions of
-the pages that print its number in their margins.
+The rule in one line: a page's number should be printed among the numbers of
+the pages that cite it in their margins. Only the DETECTIONS are consulted --
+never the segmented regions -- so a poor segmentation cannot corrupt a page
+number, and the repair can run before page_regions and seed it.
 
 Three cell types, in decreasing order of evidence:
 
@@ -36,8 +38,8 @@ Three cell types, in decreasing order of evidence:
                 other's (Brooklyn's p8/p1/p5 each sit correctly on one sheet
                 and 1-1.8 km wrong on the other). Duplicates within one sheet
                 are the case above, and are relabelled rather than stripped.
-  gaps          A missing key is placed at the centroid of the regions whose
-                pages print its number, when enough of them do.
+  gaps          A missing key is placed at the centroid of the numbers whose
+                pages cite it, when enough of them do.
 
 Constraints inherited from #183's failed global-optimization experiments:
 adjacency never overrides a read that has its own support (its negative signal
@@ -54,8 +56,8 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-PROXIMITY_FACTOR = 2.0
-"""How many region-widths apart two key-map regions may be and still count as
+PROXIMITY_FACTOR = 1.5
+"""How many page-pitches apart two printed numbers may be and still count as
 neighbours (see proximity_graph)."""
 
 ONE_SIDED_WEIGHT = 0.25
@@ -112,8 +114,8 @@ class Repair:
 
 
 @dataclass
-class SheetPanels:
-    """One key-map sheet's labelled regions and their contact graph."""
+class SheetNumbers:
+    """One key-map sheet's page-number detections and which are near each other."""
 
     sheet: str
     labels: list[str]
@@ -159,13 +161,13 @@ def digit_family(text: str, keys: set[str]) -> set[str]:
 def support_for(
     index: int,
     key: str,
-    sheet: SheetPanels,
+    sheet: SheetNumbers,
     mutual: dict[str, set[str]],
     one_sided: dict[str, set[str]],
 ) -> tuple[float, tuple[str, ...]]:
     """How strongly the printed graph vouches for ``key`` sitting at ``index``.
 
-    Counts the page's mutual neighbours that own a region touching this one,
+    Counts the page's mutual neighbours printed near this number,
     plus a fractional credit for one-sided claims. Returns the score and the
     vouching page keys, which are carried into the repair record so a human
     can check the reasoning.
@@ -192,7 +194,7 @@ def mutual_count(neighbours: set[str], key: str, mutual: dict[str, set[str]]) ->
 
 
 def plan_sheet_repairs(
-    sheet: SheetPanels,
+    sheet: SheetNumbers,
     mutual: dict[str, set[str]],
     one_sided: dict[str, set[str]],
     volume_keys: set[str],
@@ -256,7 +258,7 @@ def plan_sheet_repairs(
 
 
 def plan_cross_sheet_repairs(
-    sheets: list[SheetPanels],
+    sheets: list[SheetNumbers],
     mutual: dict[str, set[str]],
     one_sided: dict[str, set[str]],
     split_counts: dict[str, int] | None = None,
@@ -320,7 +322,7 @@ def plan_cross_sheet_repairs(
 
 
 def plan_gap_repairs(
-    sheet: SheetPanels,
+    sheet: SheetNumbers,
     mutual: dict[str, set[str]],
     one_sided: dict[str, set[str]],
     volume_keys: set[str],
@@ -432,70 +434,65 @@ def split_multiplicity(volume: Path) -> dict[str, int]:
     return counts
 
 
-def panel_centroids(
-    panels: list[list[list[float]]],
-) -> list[tuple[float, float] | None]:
-    """Each region ring's centroid, or None for a degenerate ring."""
-    from shapely.geometry import Polygon
-
-    out: list[tuple[float, float] | None] = []
-    for ring in panels:
-        if len(ring) < 3:
-            out.append(None)
+def detection_centers(streets: list[dict]) -> list[tuple[float, float] | None]:
+    """Each page-number detection's centre, from its CRNN polygon."""
+    centers: list[tuple[float, float] | None] = []
+    for street in streets:
+        polygon = street.get("polygon") or []
+        if len(polygon) < 3:
+            centers.append(None)
             continue
-        polygon = Polygon([(float(x), float(y)) for x, y in ring])
-        if not polygon.is_valid:
-            polygon = polygon.buffer(0)
-        if polygon.is_empty:
-            out.append(None)
-            continue
-        out.append((polygon.centroid.x, polygon.centroid.y))
-    return out
+        centers.append(
+            (
+                sum(float(point[0]) for point in polygon) / len(polygon),
+                sum(float(point[1]) for point in polygon) / len(polygon),
+            )
+        )
+    return centers
 
 
-def panel_scale(panels: list[list[list[float]]]) -> float:
-    """Typical region width in key-map pixels (root of the median area)."""
-    from shapely.geometry import Polygon
+def page_pitch(centers: list[tuple[float, float] | None]) -> float:
+    """Typical spacing between neighbouring page numbers, in key-map pixels.
 
-    areas = []
-    for ring in panels:
-        if len(ring) < 3:
-            continue
-        polygon = Polygon([(float(x), float(y)) for x, y in ring])
-        if not polygon.is_valid:
-            polygon = polygon.buffer(0)
-        if not polygon.is_empty:
-            areas.append(polygon.area)
-    if not areas:
+    The median nearest-neighbour distance over the printed numbers: one page
+    step on this sheet, measured from the drawing rather than assumed (Detroit
+    320 px, Champaign 351, Brooklyn 580).
+    """
+    points = [point for point in centers if point is not None]
+    if len(points) < 3:
         return 0.0
-    areas.sort()
-    return math.sqrt(areas[len(areas) // 2])
+    nearest = sorted(
+        min(math.dist(point, other) for j, other in enumerate(points) if j != i)
+        for i, point in enumerate(points)
+    )
+    return nearest[len(nearest) // 2]
 
 
 def proximity_graph(
-    panels: list[list[list[float]]], factor: float = PROXIMITY_FACTOR
+    centers: list[tuple[float, float] | None], factor: float = PROXIMITY_FACTOR
 ) -> set[frozenset[int]]:
-    """Region pairs close enough to be plausible neighbours on the sheet.
+    """Detection pairs close enough to be plausible neighbours on the sheet.
 
-    Deliberately NOT polygon contact. Segmented key-map regions are islands,
-    not a mosaic -- Detroit's cover 18% of the sheet, so p65's block sits
-    ~180 px of blank paper from p34's and p40's and no contact tolerance that
-    also respects real separations will join them. Centroid distance within
-    ``factor`` region-widths is permissive by design: the *printed* graph does
-    the discriminating (a candidate still needs two mutual edges among these
-    neighbours), so proximity only has to avoid missing the true ones.
+    Distance between printed numbers, scaled by the sheet's own page pitch.
+    Deliberately permissive: the *printed* graph does the discriminating (a
+    candidate still needs two mutual edges among these neighbours), so this
+    only has to avoid missing true neighbours.
+
+    Region contact was tried first and is unusable -- segmented regions are
+    islands, not a mosaic (Detroit's cover 18% of the sheet), so p65's block
+    sits ~180 px of blank paper from p34's and p40's and no contact tolerance
+    that also respects real separations joins them.
     """
-    centroids = panel_centroids(panels)
-    scale = panel_scale(panels)
-    if scale <= 0:
+    pitch = page_pitch(centers)
+    if pitch <= 0:
         return set()
-    radius = factor * scale
+    radius = factor * pitch
     pairs: set[frozenset[int]] = set()
-    for i, first in enumerate(centroids):
+    for i, first in enumerate(centers):
         if first is None:
             continue
-        for j in range(i + 1, len(centroids)):
-            second = centroids[j]
+        for j in range(i + 1, len(centers)):
+            second = centers[j]
             if second is None:
                 continue
             if math.dist(first, second) <= radius:
@@ -503,29 +500,33 @@ def proximity_graph(
     return pairs
 
 
-def load_sheets(volume: Path) -> list[tuple[str, dict, dict]]:
-    """(stem, keymap doc, regions doc) for every key map with both sidecars."""
+def load_sheets(volume: Path) -> list[tuple[str, dict]]:
+    """(stem, keymap doc) for every key map carrying page-number detections.
+
+    Only ``<stem>.keymap.json`` is read. The segmented regions are NOT an
+    input: their quality varies and their failures are cheap to fix, while a
+    wrong page number poisons every downstream coarse location. This also
+    lets the repair run before page_regions, so corrected numbers seed the
+    segmentation rather than depending on it.
+    """
     sheets = []
-    for regions_path in sorted((volume / "raw").glob("*.regions.panels.json")):
-        if ".truth." in regions_path.name:
+    for keymap_path in sorted((volume / "raw").glob("*.keymap.json")):
+        if ".truth." in keymap_path.name:
             continue
-        stem = regions_path.name[: -len(".regions.panels.json")]
-        keymap_path = volume / "raw" / f"{stem}.keymap.json"
-        if not keymap_path.exists():
-            continue
+        stem = keymap_path.name[: -len(".keymap.json")]
         try:
-            regions = json.loads(regions_path.read_text())
-            keymap = json.loads(keymap_path.read_text())
+            doc = json.loads(keymap_path.read_text())
         except (OSError, ValueError):
             continue
-        sheets.append((stem, keymap, regions))
+        if doc.get("streets"):
+            sheets.append((stem, doc))
     return sheets
 
 
 GAP_SPREAD_FACTOR = 3.0
-"""How far apart the panels citing a missing page may be, in region-widths.
+"""How far apart the numbers citing a missing page may be, in page pitches.
 
-The gap placement is the centroid of the citing regions, which is only
+The gap placement is the centroid of the citing numbers, which is only
 meaningful if they actually surround one spot. Scattered citations mean at
 least one of them is itself misassigned, so the placement is refused rather
 than dropped in the middle of the sheet."""
@@ -534,16 +535,16 @@ than dropped in the middle of the sheet."""
 def gap_placement(
     repair: Repair, centroids: list[tuple[float, float] | None], scale: float
 ) -> tuple[float, float] | None:
-    """Where a gap repair's page belongs: the centroid of its citing regions.
+    """Where a gap repair's page belongs: the centroid of its citing numbers.
 
     Anchored on the MUTUAL citations, which are 96-100% precise, then refined
     with whichever one-sided citations agree with them. Detroit's p59 is cited
     by p27 mutually and by p57, p61 and p1 one-sidedly, and the p1 claim is
     junk (issue #213 names it) -- averaging it in would drag the placement
     across the sheet, so a one-sided citation more than GAP_SPREAD_FACTOR
-    region-widths from the mutual anchor is discarded.
+    page pitches from the mutual anchor is discarded.
 
-    Returns None when no mutual citation has a usable region, or when the
+    Returns None when no mutual citation has a usable position, or when the
     mutual citations themselves disagree on a location (which means one of
     them is misassigned).
     """
@@ -584,9 +585,10 @@ def plan_volume_repairs(
 ) -> tuple[list[Repair], dict[str, dict[str, tuple[float, float]]]]:
     """All proposed repairs for a volume, plus the placement of each gap fill.
 
-    Returns (repairs, placements) where ``placements[sheet][key]`` is the
-    key-map pixel position for a gap recovery, so the caller can synthesize a
-    detection there without redoing the geometry. Gap repairs whose citing
+    Reads only ``raw/*.keymap.json`` and ``adjacency.json`` -- never the
+    segmented regions. Returns (repairs, placements) where
+    ``placements[sheet][key]`` is the key-map pixel position for a gap
+    recovery, so the caller can synthesize a detection there. Gap repairs whose citing
     regions disagree on a location are dropped here rather than proposed.
     """
     mutual, one_sided = adjacency_graphs(volume)
@@ -595,15 +597,17 @@ def plan_volume_repairs(
     volume_keys = volume_page_keys(volume)
     splits = split_multiplicity(volume)
 
-    sheet_panels: list[SheetPanels] = []
+    sheet_panels: list[SheetNumbers] = []
     geometry: dict[str, tuple[list[tuple[float, float] | None], float]] = {}
-    for stem, _keymap, regions in load_sheets(volume):
-        panels = regions.get("panels", [])
+    for stem, doc in load_sheets(volume):
+        streets = doc.get("streets", [])
         labels = [
-            page_key_of(label) or str(label) for label in regions.get("labels", [])
+            page_key_of(street.get("text", "")) or str(street.get("text", ""))
+            for street in streets
         ]
-        sheet_panels.append(SheetPanels(stem, labels, proximity_graph(panels)))
-        geometry[stem] = (panel_centroids(panels), panel_scale(panels))
+        centers = detection_centers(streets)
+        sheet_panels.append(SheetNumbers(stem, labels, proximity_graph(centers)))
+        geometry[stem] = (centers, page_pitch(centers))
 
     repairs: list[Repair] = []
     placements: dict[str, dict[str, tuple[float, float]]] = {}
@@ -613,13 +617,13 @@ def plan_volume_repairs(
         # Gap recovery must see the relabels: a key just recovered from a
         # misread panel is no longer missing, and proposing it again would
         # place the same page twice (Detroit's 65 was found both ways).
-        repaired = SheetPanels(sheet.sheet, list(sheet.labels), sheet.contacts)
+        repaired = SheetNumbers(sheet.sheet, list(sheet.labels), sheet.contacts)
         for relabel in relabels:
             if relabel.index is not None and relabel.new is not None:
                 repaired.labels[relabel.index] = relabel.new
-        centroids, scale = geometry[sheet.sheet]
+        centers, pitch = geometry[sheet.sheet]
         for repair in plan_gap_repairs(repaired, mutual, one_sided, volume_keys):
-            point = gap_placement(repair, centroids, scale)
+            point = gap_placement(repair, centers, pitch)
             if point is None or repair.new is None:
                 continue
             repairs.append(repair)

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -630,3 +630,115 @@ def plan_volume_repairs(
             placements.setdefault(sheet.sheet, {})[repair.new] = point
     repairs.extend(plan_cross_sheet_repairs(sheet_panels, mutual, one_sided, splits))
     return repairs, placements
+
+
+RAW_SUFFIX = ".keymap-raw.json"
+"""Where the pre-repair detections are preserved, once per sheet.
+
+The repaired file BECOMES the key map (that is the point -- better numbers
+must drive region segmentation and OCR restriction downstream), so the
+original is kept beside it for inspection. Written only if absent, so
+re-running the repair never overwrites the true original with a repaired one.
+"""
+
+
+def synthetic_detection(
+    key: str, point: tuple[float, float], pitch: float, repair: Repair
+) -> dict:
+    """A detection record for a page the sheet never printed a readable number for.
+
+    Shaped like a CRNN detection so every existing reader (load_seeds,
+    load_detections, the debugger) treats it as one, with ``via`` marking its
+    provenance. The box is a nominal glyph-sized square at the estimated spot:
+    page_regions only uses a seed's box to pick the colour block under it, and
+    the world position downstream comes from the box centre.
+    """
+    half = max(8.0, pitch * 0.06)
+    x, y = point
+    return {
+        "polygon": [
+            [int(x - half), int(y - half)],
+            [int(x + half), int(y - half)],
+            [int(x + half), int(y + half)],
+            [int(x - half), int(y + half)],
+        ],
+        "text": key,
+        "confidence": 0.0,
+        "angle": 0,
+        "long_side": round(2 * half, 1),
+        "short_side": round(2 * half, 1),
+        "dir_pix": 0.0,
+        "via": "adjacency-gap",
+        "support": round(repair.support, 2),
+        "cited_by": list(repair.evidence),
+    }
+
+
+def apply_repairs(
+    volume: Path,
+    repairs: list[Repair],
+    placements: dict[str, dict[str, tuple[float, float]]],
+) -> dict[str, int]:
+    """Rewrite each sheet's keymap.json with its repairs; return per-sheet counts.
+
+    The repaired detections become the key map. The pre-repair file is copied
+    to ``<stem>.keymap-raw.json`` once, and a ``assignment_repairs`` array
+    records every change with its evidence so the reasoning survives in the
+    artifact.
+    """
+    by_sheet: dict[str, list[Repair]] = {}
+    for repair in repairs:
+        by_sheet.setdefault(repair.sheet, []).append(repair)
+
+    counts: dict[str, int] = {}
+    for stem, sheet_repairs in sorted(by_sheet.items()):
+        path = volume / "raw" / f"{stem}.keymap.json"
+        if not path.exists():
+            continue
+        doc = json.loads(path.read_text())
+        streets = doc.get("streets", [])
+        raw_path = volume / "raw" / f"{stem}{RAW_SUFFIX}"
+        if not raw_path.exists():
+            raw_path.write_text(json.dumps(doc, indent=2))
+
+        pitch = page_pitch(detection_centers(streets))
+        stripped: list[int] = []
+        for repair in sheet_repairs:
+            if repair.index is None:
+                point = placements.get(stem, {}).get(repair.new or "")
+                if point is None or repair.new is None:
+                    continue
+                streets.append(synthetic_detection(repair.new, point, pitch, repair))
+            elif repair.new is None:
+                stripped.append(repair.index)
+            elif 0 <= repair.index < len(streets):
+                streets[repair.index]["text"] = repair.new
+                streets[repair.index]["via"] = "adjacency-relabel"
+                streets[repair.index]["cited_by"] = list(repair.evidence)
+        for index in sorted(stripped, reverse=True):
+            if 0 <= index < len(streets):
+                del streets[index]
+
+        doc["streets"] = streets
+        doc.setdefault("assignment_repairs", []).extend(
+            {
+                "index": repair.index,
+                "old": repair.old,
+                "new": repair.new,
+                "reason": repair.reason,
+                "support": round(repair.support, 2),
+                "evidence": list(repair.evidence),
+            }
+            for repair in sheet_repairs
+        )
+        path.write_text(json.dumps(doc, indent=2))
+        counts[stem] = len(sheet_repairs)
+    return counts
+
+
+def repair_volume(volume: Path, dry_run: bool = False) -> list[Repair]:
+    """Plan (and unless ``dry_run``, apply) a volume's assignment repairs."""
+    repairs, placements = plan_volume_repairs(volume)
+    if repairs and not dry_run:
+        apply_repairs(volume, repairs, placements)
+    return repairs

--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -382,6 +382,57 @@ def plan_gap_repairs(
     return repairs
 
 
+GAP_OCCUPANCY_FACTOR = 0.5
+"""How close a gap placement must land to an existing number to be the same block.
+
+Half a page-pitch: nearer than that and the two boxes are on one panel, so the
+page's number was printed after all and simply misread."""
+
+
+def occupant_index(
+    point: tuple[float, float],
+    centers: list[tuple[float, float] | None],
+    pitch: float,
+) -> int | None:
+    """The detection already sitting where a gap wants to go, if any."""
+    limit = GAP_OCCUPANCY_FACTOR * pitch
+    best: tuple[float, int] | None = None
+    for index, center in enumerate(centers):
+        if center is None:
+            continue
+        distance = math.dist(point, center)
+        if distance <= limit and (best is None or distance < best[0]):
+            best = (distance, index)
+    return None if best is None else best[1]
+
+
+def displaceable(
+    index: int,
+    key: str,
+    sheet: SheetNumbers,
+    mutual: dict[str, set[str]],
+    one_sided: dict[str, set[str]],
+) -> bool:
+    """Whether ``key`` may take over the detection at ``index``.
+
+    Taking a panel over is a RELABEL, not a fill, so it answers to the relabel
+    bar rather than the gap one -- and to the bar measured HERE, among the
+    numbers printed beside this panel. A gap's own support is sheet-wide, which
+    is too weak a warrant to overwrite a read: Grand Rapids' 840 scored 2.25 on
+    citations scattered across the sheet, none of them beside the panel it
+    landed on, and would have overwritten a correct 841.
+
+    Both directions must agree, the same asymmetry that governs duplicates: no
+    mutual neighbour vouches for what the panel currently says, and at least
+    RELABEL_MIN_MUTUAL vouch for what it would become.
+    """
+    neighbours = {sheet.labels[other] for other in sheet.touching(index)}
+    if mutual_count(neighbours, key, mutual) < RELABEL_MIN_MUTUAL:
+        return False
+    score, _ = support_for(index, sheet.labels[index], sheet, mutual, one_sided)
+    return score == 0.0
+
+
 def volume_shortfall(
     sheets: list[SheetNumbers], volume_keys: set[str], splits: dict[str, int]
 ) -> set[str]:
@@ -661,8 +712,30 @@ def plan_volume_repairs(
             point = gap_placement(repair, centers, pitch)
             if point is None or repair.new is None:
                 continue
-            repairs.append(repair)
-            placements.setdefault(repaired.sheet, {})[repair.new] = point
+            # A gap that lands on an existing panel is not a gap: the number IS
+            # printed there, it was misread. Take the panel over rather than
+            # drawing a second box on the same block.
+            sitting = occupant_index(point, centers, pitch)
+            if sitting is not None and displaceable(
+                sitting, repair.new, repaired, mutual, one_sided
+            ):
+                repairs.append(
+                    Repair(
+                        sheet=repaired.sheet,
+                        index=sitting,
+                        old=repaired.labels[sitting],
+                        new=repair.new,
+                        reason="gap-displaces-unsupported",
+                        support=repair.support,
+                        evidence=repair.evidence,
+                        evidence_indices=repair.evidence_indices,
+                        mutual_indices=repair.mutual_indices,
+                    )
+                )
+                repaired.labels[sitting] = repair.new
+            else:
+                repairs.append(repair)
+                placements.setdefault(repaired.sheet, {})[repair.new] = point
             # One fill per shortfall: two sheets that both border the page
             # must not each grow a copy of it.
             missing.discard(repair.new)

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -1,12 +1,14 @@
 import json
 
 from mapsnap.keymap.adjacency_assign import (
+    MIN_GAP_SIDE,
     Repair,
     SheetNumbers,
     adjacency_graphs,
     detection_centers,
     digit_family,
     gap_placement,
+    median_detection_box,
     page_pitch,
     plan_cross_sheet_repairs,
     plan_gap_repairs,
@@ -230,23 +232,41 @@ def test_synthetic_detection_reads_as_a_detection_and_declares_its_provenance():
         support=1.75,
         evidence=("27", "57"),
     )
-    detection = synthetic_detection("59", (500.0, 400.0), pitch=200.0, repair=repair)
+    detection = synthetic_detection("59", (500.0, 400.0), (72.0, 115.0), repair)
     assert detection["text"] == "59"
     assert detection["via"] == "adjacency-gap"
     assert detection["support"] == 1.75 and detection["cited_by"] == ["27", "57"]
     # Non-zero so the debugger draws it, but below any real read's confidence.
     assert 0 < detection["confidence"] < 0.5
-    # A glyph-sized box centred on the estimate, so page_regions samples the
-    # colour block underneath it.
+    # The given box, centred exactly on the estimate (that centre is the page's
+    # position downstream), with the sides reporting what was actually drawn --
+    # an odd height rounds out to an even one.
     xs = [point[0] for point in detection["polygon"]]
     ys = [point[1] for point in detection["polygon"]]
     assert (sum(xs) / 4, sum(ys) / 4) == (500.0, 400.0)
-    assert max(xs) - min(xs) == max(ys) - min(ys) == 24
-    # A tightly-pitched sheet still gets a box the debugger's short-side filter
-    # will show, rather than one scaled down into invisibility.
-    tight = synthetic_detection("59", (500.0, 400.0), pitch=60.0, repair=repair)
-    sides = [point[0] for point in tight["polygon"]]
-    assert max(sides) - min(sides) == 20
+    assert (max(xs) - min(xs), max(ys) - min(ys)) == (72, 116)
+    assert (detection["long_side"], detection["short_side"]) == (116.0, 72.0)
+
+
+def test_median_detection_box_measures_the_sheet_and_ignores_earlier_gaps():
+    def street(width, height, via=None):
+        record = {"polygon": [[0, 0], [width, 0], [width, height], [0, height]]}
+        if via:
+            record["via"] = via
+        return record
+
+    streets = [street(23, 115), street(72, 115), street(96, 115)]
+    assert median_detection_box(streets) == (72, 115)
+    # A gap synthesized by an earlier run must not pull the median toward
+    # itself, or repeated repairs would drift the box size.
+    assert median_detection_box([*streets, street(500, 500, via="adjacency-gap")]) == (
+        72,
+        115,
+    )
+    # Tiny boxes are floored so the debugger's short-side filter still shows
+    # them, and a sheet with nothing to measure falls back to that floor.
+    assert median_detection_box([street(4, 4)]) == (MIN_GAP_SIDE, MIN_GAP_SIDE)
+    assert median_detection_box([]) == (MIN_GAP_SIDE, MIN_GAP_SIDE)
 
 
 def test_gap_placement_discards_a_far_flung_one_sided_citation():

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -373,3 +373,26 @@ def test_dry_run_writes_nothing(tmp_path):
     assert repair_volume(volume, dry_run=True)
     assert (volume / "raw" / "p0.keymap.json").read_text() == before
     assert not (volume / "raw" / "p0.keymap-raw.json").exists()
+
+
+def test_keymap_sidecar_mtime_tracks_the_newest_sidecar(tmp_path):
+    import os
+
+    from mapsnap.osm_snap_experiment import keymap_sidecar_mtime
+
+    assert keymap_sidecar_mtime(tmp_path) is None  # no raw/ at all
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    assert keymap_sidecar_mtime(tmp_path) is None  # no sidecars
+    keymap = raw / "p0.keymap.json"
+    keymap.write_text("{}")
+    os.utime(keymap, (1_000_000, 1_000_000))
+    regions = raw / "p0.regions.panels.json"
+    regions.write_text("{}")
+    os.utime(regions, (2_000_000, 2_000_000))
+    assert keymap_sidecar_mtime(tmp_path) == 2_000_000
+    # Hand-labelled truth files are not inputs and must not move the key.
+    truth = raw / "p0.truth.regions.panels.json"
+    truth.write_text("{}")
+    os.utime(truth, (9_000_000, 9_000_000))
+    assert keymap_sidecar_mtime(tmp_path) == 2_000_000

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -2,11 +2,12 @@ import json
 
 from mapsnap.keymap.adjacency_assign import (
     Repair,
-    SheetPanels,
+    SheetNumbers,
     adjacency_graphs,
+    detection_centers,
     digit_family,
     gap_placement,
-    panel_scale,
+    page_pitch,
     plan_cross_sheet_repairs,
     plan_gap_repairs,
     plan_sheet_repairs,
@@ -24,8 +25,8 @@ def graph(pairs: list[tuple[str, str]]) -> dict[str, set[str]]:
     return out
 
 
-def sheet(labels: list[str], contacts: list[tuple[int, int]]) -> SheetPanels:
-    return SheetPanels("p0", labels, {frozenset(pair) for pair in contacts})
+def sheet(labels: list[str], contacts: list[tuple[int, int]]) -> SheetNumbers:
+    return SheetNumbers("p0", labels, {frozenset(pair) for pair in contacts})
 
 
 def test_digit_family_covers_lost_digits():
@@ -118,8 +119,10 @@ def test_support_for_counts_mutual_and_weights_one_sided():
 def test_cross_sheet_strips_only_the_unsupported_copy():
     # Brooklyn: key 8 drawn on both sheets; only p0b's copy touches 8's
     # neighbours, so p0's copy is stripped.
-    first = SheetPanels("p0", ["8", "40"], {frozenset((0, 1))})
-    second = SheetPanels("p0b", ["8", "7", "9"], {frozenset((0, 1)), frozenset((0, 2))})
+    first = SheetNumbers("p0", ["8", "40"], {frozenset((0, 1))})
+    second = SheetNumbers(
+        "p0b", ["8", "7", "9"], {frozenset((0, 1)), frozenset((0, 2))}
+    )
     mutual = graph([("8", "7"), ("8", "9")])
     repairs = plan_cross_sheet_repairs([first, second], mutual, {})
     assert [(r.sheet, r.index, r.old, r.new) for r in repairs] == [("p0", 0, "8", None)]
@@ -127,8 +130,8 @@ def test_cross_sheet_strips_only_the_unsupported_copy():
 
 def test_cross_sheet_respects_split_multiplicity():
     # A page split into two panels is drawn twice on purpose.
-    first = SheetPanels("p0", ["8", "7"], {frozenset((0, 1))})
-    second = SheetPanels("p0b", ["8", "40"], set())
+    first = SheetNumbers("p0", ["8", "7"], {frozenset((0, 1))})
+    second = SheetNumbers("p0b", ["8", "40"], set())
     mutual = graph([("8", "7")])
     assert plan_cross_sheet_repairs([first, second], mutual, {}, {"8": 2}) == []
     # Beyond the expected multiplicity the asymmetry applies again.
@@ -215,19 +218,30 @@ def test_gap_placement_discards_a_far_flung_one_sided_citation():
     assert gap_placement(repair, centroids, scale=200.0) == (1000.0, 1000.0)
 
 
-def test_proximity_graph_joins_islands_within_a_few_region_widths():
-    # 100px squares: neighbours 150px apart are joined (Detroit's regions are
-    # islands separated by blank paper), one 900px away is not.
-    squares: list[list[list[float]]] = [
-        [[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0], [0.0, 0.0]],
-        [[150.0, 0.0], [250.0, 0.0], [250.0, 100.0], [150.0, 100.0], [150.0, 0.0]],
-        [[900.0, 0.0], [1000.0, 0.0], [1000.0, 100.0], [900.0, 100.0], [900.0, 0.0]],
+def test_page_pitch_and_proximity_use_the_printed_numbers():
+    # Four numbers 100px apart in a row, plus one far away: the pitch is the
+    # median nearest-neighbour step, and proximity spans 1.5 of them.
+    centers: list[tuple[float, float] | None] = [
+        (0.0, 0.0),
+        (100.0, 0.0),
+        (200.0, 0.0),
+        (900.0, 0.0),
     ]
-    assert panel_scale(squares) == 100.0
-    assert proximity_graph(squares) == {frozenset((0, 1))}
-    # Degenerate rings are skipped rather than crashing.
-    assert proximity_graph([[[0.0, 0.0], [1.0, 1.0]]]) == set()
-    assert panel_scale([]) == 0.0
+    assert page_pitch(centers) == 100.0
+    # Radius is 1.5 pitches (150 px): adjacent numbers pair up, the 200 px
+    # skip-one pair does not, and the far number joins nothing.
+    assert proximity_graph(centers) == {frozenset((0, 1)), frozenset((1, 2))}
+    # Detections with no usable polygon are skipped, not crashed on.
+    assert proximity_graph([None, None, (0.0, 0.0)]) == set()
+    assert page_pitch([(0.0, 0.0)]) == 0.0
+
+
+def test_detection_centers_from_polygons():
+    streets = [
+        {"polygon": [[0, 0], [10, 0], [10, 10], [0, 10]], "text": "7"},
+        {"polygon": [[0, 0]], "text": "8"},  # degenerate
+    ]
+    assert detection_centers(streets) == [(5.0, 5.0), None]
 
 
 def test_adjacency_graphs_and_split_multiplicity(tmp_path):

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -7,8 +7,10 @@ from mapsnap.keymap.adjacency_assign import (
     adjacency_graphs,
     detection_centers,
     digit_family,
+    displaceable,
     gap_placement,
     median_detection_box,
+    occupant_index,
     page_pitch,
     plan_cross_sheet_repairs,
     plan_gap_repairs,
@@ -177,6 +179,38 @@ def test_gap_recovery_skips_a_key_another_sheet_already_carries():
     volume_keys = {"27", "57", "61", "40", "9"}
     assert plan_gap_repairs(panels, mutual, {}, volume_keys, {"9"})[0].new == "9"
     assert plan_gap_repairs(panels, mutual, {}, volume_keys, set()) == []
+
+
+def test_occupant_index_finds_the_panel_a_gap_landed_on():
+    centers: list[tuple[float, float] | None] = [
+        (100.0, 100.0),
+        (500.0, 100.0),
+        None,
+    ]
+    # Within half a pitch of the second panel: the number IS printed there.
+    assert occupant_index((520.0, 110.0), centers, 320.0) == 1
+    # Squarely in the empty space between them: a real gap.
+    assert occupant_index((300.0, 100.0), centers, 320.0) is None
+
+
+def test_displacement_needs_local_mutual_support_both_ways():
+    # Detroit: the panel reads '80', which nothing beside it vouches for, while
+    # 86's mutual neighbours 87 and 93 are printed right there. Truth says 86.
+    panels = sheet(labels=["80", "87", "93", "54"], contacts=[(0, 1), (0, 2), (0, 3)])
+    mutual = graph([("86", "87"), ("86", "93")])
+    assert displaceable(0, "86", panels, mutual, {})
+
+    # Grand Rapids: 840's citations are scattered across the sheet, none beside
+    # the panel it landed on -- too weak a warrant to overwrite a correct 841.
+    far = sheet(labels=["841", "12"], contacts=[(0, 1)])
+    scattered = graph([("840", "834"), ("840", "842")])
+    assert not displaceable(0, "840", far, scattered, {})
+
+    # And a read with support of its own is never displaced, however well the
+    # newcomer is vouched for: an observation outranks an inferred position.
+    vouched = sheet(labels=["80", "87", "93"], contacts=[(0, 1), (0, 2)])
+    both = graph([("86", "87"), ("86", "93"), ("80", "87")])
+    assert not displaceable(0, "86", vouched, both, {})
 
 
 def test_volume_shortfall_counts_across_every_sheet():

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -261,3 +261,115 @@ def test_adjacency_graphs_and_split_multiplicity(tmp_path):
     (tmp_path / "p4.panels.json").write_text(json.dumps({"panels": [[], [], [], []]}))
     (tmp_path / "p9.panels.json").write_text(json.dumps({"panels": []}))
     assert split_multiplicity(tmp_path) == {"4": 4}
+
+
+def keymap_doc(entries: list[tuple[str, float, float]]) -> dict:
+    return {
+        "width": 4000,
+        "height": 4000,
+        "streets": [
+            {
+                "polygon": [
+                    [x - 20, y - 20],
+                    [x + 20, y - 20],
+                    [x + 20, y + 20],
+                    [x - 20, y + 20],
+                ],
+                "text": text,
+                "confidence": 0.99,
+                "angle": 0,
+            }
+            for text, x, y in entries
+        ],
+    }
+
+
+def write_volume(tmp_path, entries, adjacency, one_sided=None, pages=None):
+    raw = tmp_path / "raw"
+    raw.mkdir(exist_ok=True)
+    (raw / "p0.keymap.json").write_text(json.dumps(keymap_doc(entries)))
+    (tmp_path / "adjacency.json").write_text(
+        json.dumps({"adjacency": adjacency, "one_sided": one_sided or []})
+    )
+    for key in pages or []:
+        (tmp_path / f"p{key}.jpg").write_bytes(b"")
+    return tmp_path
+
+
+def test_apply_repairs_rewrites_the_keymap_and_keeps_the_original(tmp_path):
+    from mapsnap.keymap.adjacency_assign import repair_volume
+
+    # Two "2"s: the one among 21/28/29 is really 22. 59 is cited by 27 (mutual)
+    # and 57 (one-sided) but never printed.
+    volume = write_volume(
+        tmp_path,
+        entries=[
+            ("2", 100.0, 100.0),  # the real p2, off on its own
+            ("2", 1000.0, 1000.0),  # the impostor, among 22's neighbours
+            ("21", 1100.0, 1000.0),
+            ("28", 900.0, 1000.0),
+            ("29", 1000.0, 1100.0),
+            ("27", 2000.0, 2000.0),
+            ("57", 2100.0, 2000.0),
+            ("61", 2000.0, 2100.0),
+        ],
+        adjacency=[["p22", "p21"], ["p22", "p28"], ["p22", "p29"], ["p59", "p27"]],
+        one_sided=[["p59", "p57"], ["p59", "p61"]],
+        pages=["2", "21", "22", "27", "28", "29", "57", "59", "61"],
+    )
+    repairs = repair_volume(volume)
+    kinds = {r.reason for r in repairs}
+    assert kinds == {"duplicate-no-support", "gap"}
+
+    doc = json.loads((volume / "raw" / "p0.keymap.json").read_text())
+    texts = [street["text"] for street in doc["streets"]]
+    assert texts.count("22") == 1 and texts.count("2") == 1
+    assert "59" in texts
+    # The synthesized detection is marked and sits between its citations.
+    gap = next(s for s in doc["streets"] if s["text"] == "59")
+    assert gap["via"] == "adjacency-gap" and gap["cited_by"] == ["27", "57", "61"]
+    centre = sum(p[0] for p in gap["polygon"]) / 4
+    assert 2000.0 <= centre <= 2100.0
+    # The relabelled detection is marked with its evidence.
+    fixed = next(s for s in doc["streets"] if s["text"] == "22")
+    assert fixed["via"] == "adjacency-relabel" and "21" in fixed["cited_by"]
+    # Provenance and the untouched original both survive.
+    assert len(doc["assignment_repairs"]) == len(repairs)
+    original = json.loads((volume / "raw" / "p0.keymap-raw.json").read_text())
+    assert [s["text"] for s in original["streets"]].count("2") == 2
+
+    # Re-running must not overwrite the true original with a repaired copy.
+    repair_volume(volume)
+    original_again = json.loads((volume / "raw" / "p0.keymap-raw.json").read_text())
+    assert original_again == original
+
+
+def test_repair_volume_is_a_no_op_without_adjacency(tmp_path):
+    from mapsnap.keymap.adjacency_assign import repair_volume
+
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "p0.keymap.json").write_text(json.dumps(keymap_doc([("2", 1.0, 1.0)])))
+    assert repair_volume(tmp_path) == []
+    assert not (raw / "p0.keymap-raw.json").exists()
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    from mapsnap.keymap.adjacency_assign import repair_volume
+
+    volume = write_volume(
+        tmp_path,
+        entries=[
+            ("2", 100.0, 100.0),
+            ("2", 1000.0, 1000.0),
+            ("21", 1100.0, 1000.0),
+            ("28", 900.0, 1000.0),
+            ("29", 1000.0, 1100.0),
+        ],
+        adjacency=[["p22", "p21"], ["p22", "p28"], ["p22", "p29"]],
+        pages=["2", "21", "22", "28", "29"],
+    )
+    before = (volume / "raw" / "p0.keymap.json").read_text()
+    assert repair_volume(volume, dry_run=True)
+    assert (volume / "raw" / "p0.keymap.json").read_text() == before
+    assert not (volume / "raw" / "p0.keymap-raw.json").exists()

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -14,6 +14,7 @@ from mapsnap.keymap.adjacency_assign import (
     proximity_graph,
     split_multiplicity,
     support_for,
+    volume_shortfall,
 )
 
 
@@ -162,6 +163,30 @@ def test_gap_recovery_never_places_on_one_sided_claims_alone():
     panels = sheet(labels=labels, contacts=[])
     one_sided = graph([("59", label) for label in labels])
     assert plan_gap_repairs(panels, {}, one_sided, {*labels, "59"}) == []
+
+
+def test_gap_recovery_skips_a_key_another_sheet_already_carries():
+    # Brooklyn's two key maps split the city. Page 9 is drawn on the other
+    # sheet, so the pages bordering it here vouch for a page that is not
+    # missing: filling it anyway put 9 on the wrong half, 6970 ft from truth.
+    panels = sheet(labels=["27", "57", "61", "40"], contacts=[])
+    mutual = graph([("9", "27"), ("9", "40")])
+    volume_keys = {"27", "57", "61", "40", "9"}
+    assert plan_gap_repairs(panels, mutual, {}, volume_keys, {"9"})[0].new == "9"
+    assert plan_gap_repairs(panels, mutual, {}, volume_keys, set()) == []
+
+
+def test_volume_shortfall_counts_across_every_sheet():
+    sheets = [
+        SheetNumbers("p0", ["1", "2"], set()),
+        SheetNumbers("p0b", ["3", "4"], set()),
+    ]
+    keys = {"1", "2", "3", "4", "5"}
+    # 3 and 4 live on the other sheet, so only 5 is genuinely missing.
+    assert volume_shortfall(sheets, keys, {}) == {"5"}
+    # A page split into three panels is expected three times, so it is short
+    # while only one is drawn.
+    assert volume_shortfall(sheets, keys, {"1": 3}) == {"1", "5"}
 
 
 def test_gap_placement_averages_the_mutual_citations():

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -1,0 +1,249 @@
+import json
+
+from mapsnap.keymap.adjacency_assign import (
+    Repair,
+    SheetPanels,
+    adjacency_graphs,
+    digit_family,
+    gap_placement,
+    panel_scale,
+    plan_cross_sheet_repairs,
+    plan_gap_repairs,
+    plan_sheet_repairs,
+    proximity_graph,
+    split_multiplicity,
+    support_for,
+)
+
+
+def graph(pairs: list[tuple[str, str]]) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for first, second in pairs:
+        out.setdefault(first, set()).add(second)
+        out.setdefault(second, set()).add(first)
+    return out
+
+
+def sheet(labels: list[str], contacts: list[tuple[int, int]]) -> SheetPanels:
+    return SheetPanels("p0", labels, {frozenset(pair) for pair in contacts})
+
+
+def test_digit_family_covers_lost_digits():
+    keys = {"2", "20", "22", "29", "65", "6"}
+    # A "2" read could be any longer key containing 2 (a lost digit either side).
+    assert digit_family("2", keys) == {"20", "22", "29"}
+    assert digit_family("6", keys) == {"65"}
+    # Same-length or shorter keys are never candidates, and a letters-only read
+    # has no digits to extend.
+    assert digit_family("22", {"2", "22"}) == set()
+    assert digit_family("", keys) == set()
+
+
+def test_detroit_duplicate_relabels_the_unsupported_instance():
+    # Detroit: two panels read "2". The real p2 has no mutual edges at all;
+    # the other panel sits among 22's neighbours p21, p28, p29.
+    panels = sheet(
+        labels=["2", "2", "21", "28", "29", "3"],
+        contacts=[(0, 5), (1, 2), (1, 3), (1, 4)],
+    )
+    mutual = graph([("22", "21"), ("22", "28"), ("22", "29")])
+    repairs = plan_sheet_repairs(panels, mutual, {}, {"2", "3", "21", "22", "28", "29"})
+    assert [(r.index, r.old, r.new) for r in repairs] == [(1, "2", "22")]
+    assert repairs[0].evidence == ("21", "28", "29")
+    assert repairs[0].support == 3.0
+
+
+def test_split_twins_with_support_both_keep_their_labels():
+    # Champaign draws p4 on four panels; each touches a different neighbour of
+    # p4, so every instance is vouched for and none is a suspect.
+    panels = sheet(
+        labels=["4", "4", "4", "4", "3", "5", "6", "7"],
+        contacts=[(0, 4), (1, 5), (2, 6), (3, 7)],
+    )
+    mutual = graph([("4", "3"), ("4", "5"), ("4", "6"), ("4", "7")])
+    assert plan_sheet_repairs(panels, mutual, {}, {"3", "4", "5", "6", "7", "44"}) == []
+
+
+def test_duplicate_with_no_support_anywhere_is_left_alone():
+    # Neither instance is vouched for AND no candidate key is either: the pass
+    # must not guess. (When a candidate IS vouched for, the sibling's score is
+    # irrelevant -- see the Detroit case above, where p2 has no edges at all.)
+    panels = sheet(labels=["9", "9", "3"], contacts=[(0, 2), (1, 2)])
+    assert plan_sheet_repairs(panels, graph([]), {}, {"9", "3", "19"}) == []
+
+
+def test_relabel_requires_two_mutual_neighbours():
+    # One vouching neighbour is below RELABEL_MIN_MUTUAL: no action.
+    panels = sheet(labels=["2", "2", "21", "9"], contacts=[(0, 3), (1, 2)])
+    mutual = graph([("22", "21"), ("2", "9")])
+    assert plan_sheet_repairs(panels, mutual, {}, {"2", "9", "21", "22"}) == []
+
+
+def test_one_sided_claims_alone_never_relabel():
+    # Four one-sided claims score 1.0, still under the bar that two mutual
+    # edges clear -- they are 32-54% precise and may not decide anything.
+    panels = sheet(
+        labels=["2", "2", "21", "28", "29", "31"],
+        contacts=[(0, 5), (1, 2), (1, 3), (1, 4), (1, 5)],
+    )
+    one_sided = graph([("22", "21"), ("22", "28"), ("22", "29"), ("22", "31")])
+    mutual = graph([("2", "31")])
+    assert (
+        plan_sheet_repairs(
+            panels, mutual, one_sided, {"2", "22", "21", "28", "29", "31"}
+        )
+        == []
+    )
+
+
+def test_ambiguous_candidates_change_nothing():
+    # The zero-support "2" could be 22 or 29 on the evidence: refuse both.
+    panels = sheet(
+        labels=["2", "2", "21", "28", "3", "9"],
+        contacts=[(0, 4), (1, 2), (1, 3)],
+    )
+    mutual = graph([("22", "21"), ("22", "28"), ("29", "21"), ("29", "28"), ("2", "3")])
+    keys = {"2", "3", "9", "21", "22", "28", "29"}
+    assert plan_sheet_repairs(panels, mutual, {}, keys) == []
+
+
+def test_support_for_counts_mutual_and_weights_one_sided():
+    panels = sheet(labels=["7", "8", "9"], contacts=[(0, 1), (0, 2)])
+    mutual = graph([("7", "8")])
+    one_sided = graph([("7", "9")])
+    score, vouchers = support_for(0, "7", panels, mutual, one_sided)
+    assert score == 1.25 and vouchers == ("8", "9")
+
+
+def test_cross_sheet_strips_only_the_unsupported_copy():
+    # Brooklyn: key 8 drawn on both sheets; only p0b's copy touches 8's
+    # neighbours, so p0's copy is stripped.
+    first = SheetPanels("p0", ["8", "40"], {frozenset((0, 1))})
+    second = SheetPanels("p0b", ["8", "7", "9"], {frozenset((0, 1)), frozenset((0, 2))})
+    mutual = graph([("8", "7"), ("8", "9")])
+    repairs = plan_cross_sheet_repairs([first, second], mutual, {})
+    assert [(r.sheet, r.index, r.old, r.new) for r in repairs] == [("p0", 0, "8", None)]
+
+
+def test_cross_sheet_respects_split_multiplicity():
+    # A page split into two panels is drawn twice on purpose.
+    first = SheetPanels("p0", ["8", "7"], {frozenset((0, 1))})
+    second = SheetPanels("p0b", ["8", "40"], set())
+    mutual = graph([("8", "7")])
+    assert plan_cross_sheet_repairs([first, second], mutual, {}, {"8": 2}) == []
+    # Beyond the expected multiplicity the asymmetry applies again.
+    assert plan_cross_sheet_repairs([first, second], mutual, {}, {"8": 1}) != []
+
+
+def test_gap_recovery_places_a_missing_key_from_its_citations():
+    # Detroit p59: no detection anywhere, but p27 cites it mutually and
+    # p57/p61 one-sidedly, so those three regions bracket where it belongs.
+    panels = sheet(labels=["27", "57", "61", "40"], contacts=[])
+    mutual = graph([("59", "27"), ("59", "58")])
+    one_sided = graph([("59", "57"), ("59", "61")])
+    placed = plan_gap_repairs(panels, mutual, one_sided, {"27", "57", "61", "40", "59"})
+    assert [(r.new, r.old) for r in placed] == [("59", None)]
+    assert placed[0].support == 1.5  # 1 mutual + 2 one-sided at 0.25
+    assert placed[0].evidence_indices == (0, 1, 2)
+
+
+def test_gap_recovery_needs_more_than_a_lone_mutual_citation():
+    panels = sheet(labels=["27", "40"], contacts=[])
+    assert plan_gap_repairs(panels, graph([("59", "27")]), {}, {"27", "40", "59"}) == []
+
+
+def test_gap_recovery_never_places_on_one_sided_claims_alone():
+    # Eight one-sided claims reach 2.0 but include no mutual edge: refused,
+    # because one-sided claims are only 32-54% precise.
+    labels = [str(n) for n in range(70, 78)]
+    panels = sheet(labels=labels, contacts=[])
+    one_sided = graph([("59", label) for label in labels])
+    assert plan_gap_repairs(panels, {}, one_sided, {*labels, "59"}) == []
+
+
+def test_gap_placement_averages_the_mutual_citations():
+    repair = Repair(
+        sheet="p0",
+        index=None,
+        old=None,
+        new="59",
+        reason="gap",
+        support=2.0,
+        evidence=("27", "28"),
+        evidence_indices=(0, 1),
+        mutual_indices=(0, 1),
+    )
+    centroids: list[tuple[float, float] | None] = [(100.0, 100.0), (300.0, 100.0)]
+    assert gap_placement(repair, centroids, scale=200.0) == (200.0, 100.0)
+    # Mutual citations that disagree on a location mean one is misassigned.
+    assert gap_placement(repair, [(0.0, 0.0), (5000.0, 0.0)], scale=200.0) is None
+    # No usable centroid, and no mutual citation at all.
+    assert gap_placement(repair, [None, None], scale=200.0) is None
+    weak_only = Repair(
+        sheet="p0",
+        index=None,
+        old=None,
+        new="59",
+        reason="gap",
+        evidence_indices=(0, 1),
+        mutual_indices=(),
+    )
+    assert gap_placement(weak_only, centroids, scale=200.0) is None
+
+
+def test_gap_placement_discards_a_far_flung_one_sided_citation():
+    # Detroit p59: p27 cites it mutually; p57 and p61 agree nearby; the p1
+    # claim is junk (#213 names it) and sits across the sheet. Averaging p1 in
+    # would throw the placement, so it is dropped and the rest still count.
+    repair = Repair(
+        sheet="p0",
+        index=None,
+        old=None,
+        new="59",
+        reason="gap",
+        support=1.75,
+        evidence=("27", "57", "61", "1"),
+        evidence_indices=(0, 1, 2, 3),
+        mutual_indices=(0,),
+    )
+    centroids: list[tuple[float, float] | None] = [
+        (1000.0, 1000.0),  # 27, the mutual anchor
+        (1100.0, 1000.0),  # 57
+        (900.0, 1000.0),  # 61
+        (9000.0, 9000.0),  # 1, junk
+    ]
+    assert gap_placement(repair, centroids, scale=200.0) == (1000.0, 1000.0)
+
+
+def test_proximity_graph_joins_islands_within_a_few_region_widths():
+    # 100px squares: neighbours 150px apart are joined (Detroit's regions are
+    # islands separated by blank paper), one 900px away is not.
+    squares: list[list[list[float]]] = [
+        [[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0], [0.0, 0.0]],
+        [[150.0, 0.0], [250.0, 0.0], [250.0, 100.0], [150.0, 100.0], [150.0, 0.0]],
+        [[900.0, 0.0], [1000.0, 0.0], [1000.0, 100.0], [900.0, 100.0], [900.0, 0.0]],
+    ]
+    assert panel_scale(squares) == 100.0
+    assert proximity_graph(squares) == {frozenset((0, 1))}
+    # Degenerate rings are skipped rather than crashing.
+    assert proximity_graph([[[0.0, 0.0], [1.0, 1.0]]]) == set()
+    assert panel_scale([]) == 0.0
+
+
+def test_adjacency_graphs_and_split_multiplicity(tmp_path):
+    (tmp_path / "adjacency.json").write_text(
+        json.dumps(
+            {
+                "adjacency": [["p21", "p22"], ["p22", "p28"]],
+                "one_sided": [["p24", "p22"]],
+            }
+        )
+    )
+    mutual, one_sided = adjacency_graphs(tmp_path)
+    assert mutual["22"] == {"21", "28"} and one_sided["22"] == {"24"}
+    # Missing file is an empty graph, not an error.
+    assert adjacency_graphs(tmp_path / "nowhere") == ({}, {})
+
+    (tmp_path / "p4.panels.json").write_text(json.dumps({"panels": [[], [], [], []]}))
+    (tmp_path / "p9.panels.json").write_text(json.dumps({"panels": []}))
+    assert split_multiplicity(tmp_path) == {"4": 4}

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -242,6 +242,11 @@ def test_synthetic_detection_reads_as_a_detection_and_declares_its_provenance():
     ys = [point[1] for point in detection["polygon"]]
     assert (sum(xs) / 4, sum(ys) / 4) == (500.0, 400.0)
     assert max(xs) - min(xs) == max(ys) - min(ys) == 24
+    # A tightly-pitched sheet still gets a box the debugger's short-side filter
+    # will show, rather than one scaled down into invisibility.
+    tight = synthetic_detection("59", (500.0, 400.0), pitch=60.0, repair=repair)
+    sides = [point[0] for point in tight["polygon"]]
+    assert max(sides) - min(sides) == 20
 
 
 def test_gap_placement_discards_a_far_flung_one_sided_citation():

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -14,6 +14,7 @@ from mapsnap.keymap.adjacency_assign import (
     proximity_graph,
     split_multiplicity,
     support_for,
+    synthetic_detection,
     volume_shortfall,
 )
 
@@ -217,6 +218,30 @@ def test_gap_placement_averages_the_mutual_citations():
         mutual_indices=(),
     )
     assert gap_placement(weak_only, centroids, scale=200.0) is None
+
+
+def test_synthetic_detection_reads_as_a_detection_and_declares_its_provenance():
+    repair = Repair(
+        sheet="p0",
+        index=None,
+        old=None,
+        new="59",
+        reason="gap",
+        support=1.75,
+        evidence=("27", "57"),
+    )
+    detection = synthetic_detection("59", (500.0, 400.0), pitch=200.0, repair=repair)
+    assert detection["text"] == "59"
+    assert detection["via"] == "adjacency-gap"
+    assert detection["support"] == 1.75 and detection["cited_by"] == ["27", "57"]
+    # Non-zero so the debugger draws it, but below any real read's confidence.
+    assert 0 < detection["confidence"] < 0.5
+    # A glyph-sized box centred on the estimate, so page_regions samples the
+    # colour block underneath it.
+    xs = [point[0] for point in detection["polygon"]]
+    ys = [point[1] for point in detection["polygon"]]
+    assert (sum(xs) / 4, sum(ys) / 4) == (500.0, 400.0)
+    assert max(xs) - min(xs) == max(ys) - min(ys) == 24
 
 
 def test_gap_placement_discards_a_far_flung_one_sided_citation():

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -19,6 +19,13 @@ its key-map neighborhood; that needs three sidecars next to the (raw) key-map im
   * ``<stem>.regions.panels.json`` — the colored block polygon around each page number
     (``mapsnap.keymap.page_regions``), so a page's key-map neighborhood is its own block.
 
+Between the first and the rest, the page-number assignments are repaired against the volume's
+printed adjacency graph (``mapsnap.keymap.adjacency_assign``, issue #213): a number misread as a
+shorter one and a page whose number never read at all are both settled by which pages cite it in
+their margins. The repaired detections BECOME ``<stem>.keymap.json`` (the original is kept as
+``<stem>.keymap-raw.json``), so the corrections flow into the region segmentation below and into
+every downstream consumer of the key map.
+
 They are built in that order for a reason: ``<stem>.keymap.json`` is what identifies a page as a
 key map, and the georef step reads it to decide whether to refit the corners with a full 6-DOF
 affine. Detecting the page numbers after georeferencing would leave a first run with the plain
@@ -32,6 +39,7 @@ import sys
 from collections.abc import Iterable
 from pathlib import Path
 
+from mapsnap.keymap.adjacency_assign import repair_volume
 from mapsnap.keymap.fit_keymap import volume_page_keys
 from mapsnap.keymap.records import keymap_path, page_key_sort
 from mapsnap.utils import default_centerlines, run_cmd
@@ -132,6 +140,14 @@ def main() -> None:
         action="store_true",
         help="Skip the key-map OCR pass for images that already have a .streets.json output.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Report the adjacency-driven page-number repairs and stop, writing "
+            "nothing (the detection pass still runs)."
+        ),
+    )
     args = parser.parse_args()
 
     images = [Path(image) for image in args.images]
@@ -173,7 +189,26 @@ def main() -> None:
         ]
     )
 
-    # 2. Georeference each key map from its own street labels, exactly like a regular page, so the
+    # 2. Repair the page-number assignments against the printed adjacency graph
+    #    (#213): a number misread as a shorter one (Detroit's 22 read as "2"),
+    #    and a page whose number never read at all, are both settled by which
+    #    pages cite it in their margins. Runs here, before the regions are
+    #    segmented, so the corrected numbers SEED the segmentation -- and it
+    #    reads only <stem>.keymap.json, so a poor segmentation can never
+    #    corrupt a page number. A volume with no adjacency.json is a no-op.
+    volume = keymap_volume_dir(images[0])
+    repairs = repair_volume(volume, dry_run=args.dry_run)
+    for repair in repairs:
+        print(f"  assignment repair: {repair.describe()}", file=sys.stderr)
+    print(
+        f"{len(repairs)} assignment repair(s)"
+        + (" (dry run, nothing written)" if args.dry_run else ""),
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        return
+
+    # 3. Georeference each key map from its own street labels, exactly like a regular page, so the
     #    downstream --keymap flag has a <stem>.georef.json to read. OCR runs at a key-map-
     #    appropriate detector floor and (by default) tiles the oversized sheet at native
     #    resolution; georef must be told to geocode key maps, which it skips by default for a page
@@ -203,7 +238,7 @@ def main() -> None:
         ]
     )
 
-    # 3. Segment the colored block around each page number (one key map at a time).
+    # 4. Segment the colored block around each page number (one key map at a time).
     for image in images:
         run_cmd(
             [

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -405,7 +405,11 @@ def georef_variant_mtime(volume: Path, stem: str) -> int | None:
 
 
 def candidates_record_fresh(
-    record: dict, unit: PageUnit, mtime: int | None, hint_mtime: int | None = None
+    record: dict,
+    unit: PageUnit,
+    mtime: int | None,
+    hint_mtime: int | None = None,
+    keymap_mtime: int | None = None,
 ) -> bool:
     """Whether a cached candidates record still matches the page's fit state.
 
@@ -420,6 +424,13 @@ def candidates_record_fresh(
     this key the second snap pass reuses the first pass's candidates —
     generated before the hint (or the stamp-consistency gate) existed — and
     re-adopts the very alias the gate demoted (KC p551).
+
+    ``keymap_mtime`` covers the key map's own sidecars, which supply every
+    page's search centers, radius and region rings. The adjacency assignment
+    repair (#213) rewrites them without touching any page's georef, so a
+    page that just gained a key-map location — or had a wrong one corrected —
+    would otherwise keep candidates searched around the old place, or none at
+    all.
     """
     if record.get("status") != "ok":
         return False
@@ -427,7 +438,27 @@ def candidates_record_fresh(
         record.get("fit_state") == unit.fit_state
         and record.get("georef_mtime") == mtime
         and record.get("contradiction_mtime") == hint_mtime
+        and record.get("keymap_mtime") == keymap_mtime
     )
+
+
+def keymap_sidecar_mtime(volume: Path) -> int | None:
+    """Newest mtime across the volume's key-map sidecars, or None when absent.
+
+    One number for the whole volume, since every page's coarse location comes
+    from the same key maps: any change to the numbers or the regions can move
+    any page's search centers.
+    """
+    raw = volume / "raw"
+    if not raw.is_dir():
+        return None
+    mtimes = [
+        int(path.stat().st_mtime)
+        for pattern in ("*.keymap.json", "*.regions.panels.json")
+        for path in raw.glob(pattern)
+        if ".truth." not in path.name
+    ]
+    return max(mtimes) if mtimes else None
 
 
 def contradiction_hint_mtime(volume: Path, stem: str) -> int | None:
@@ -778,6 +809,7 @@ def page_record(vctx: VolumeContext, unit: PageUnit) -> dict:
         "status": status,
         "fit_state": unit.fit_state,
         "georef_mtime": georef_variant_mtime(vctx.volume, unit.stem),
+        "keymap_mtime": keymap_sidecar_mtime(vctx.volume),
         "contradiction_mtime": contradiction_hint_mtime(vctx.volume, unit.stem),
         "width": unit.width,
         "height": unit.height,
@@ -1047,6 +1079,7 @@ def cmd_candidates(
     vis_dir = out_dir / "vis"
     if vis:
         vis_dir.mkdir(exist_ok=True)
+    keymap_mtime = keymap_sidecar_mtime(volume)
     stale = [
         unit
         for unit in targets
@@ -1058,6 +1091,7 @@ def cmd_candidates(
             unit,
             georef_variant_mtime(volume, unit.stem),
             contradiction_hint_mtime(volume, unit.stem),
+            keymap_mtime,
         )
     ]
     by_stem = {unit.stem: unit for unit in targets}

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -266,6 +266,15 @@ def test_candidates_record_fresh_tracks_fit_changes():
     hinted = {**base, "status": "ok", "contradiction_mtime": 555}
     assert candidates_record_fresh(hinted, make_unit("fitted"), 111, hint_mtime=555)
     assert not candidates_record_fresh(hinted, make_unit("fitted"), 111, hint_mtime=777)
+    # The key map's sidecars moved (the #213 assignment repair rewrites them
+    # without touching any page's georef): the cached search centers are stale.
+    keyed = {**hinted, "keymap_mtime": 999}
+    assert candidates_record_fresh(
+        keyed, make_unit("fitted"), 111, hint_mtime=555, keymap_mtime=999
+    )
+    assert not candidates_record_fresh(
+        keyed, make_unit("fitted"), 111, hint_mtime=555, keymap_mtime=1000
+    )
 
 
 def test_init_worker_indexes_pages_and_panels(monkeypatch, tmp_path):


### PR DESCRIPTION
Repairs key-map page-number assignments from the printed adjacency graph, inside `mapsnap keymap`. The repaired detections **become** `<stem>.keymap.json`, so better numbers drive region segmentation, OCR vocabulary restriction, georef and snap alike; the pre-repair file is preserved as `<stem>.keymap-raw.json`.

Closes #213. Builds on #216 (`mapsnap craft` + the pipeline reorder that puts `adjacency` before `keymap`), which is what makes the adjacency graph available this early.

## Why this works now

The key map is the coarse-location source for everything downstream — the #211 null test measured it directly: placing a page at its region centroid alone lands a median 158 ft from truth. So a missing or misread page number is expensive, and Detroit had 14 real pages with no panel at all.

Two failure classes survive the CRNN's own repair pass (#172), because that pass arbitrates by CTC margin and these cells have no margin to arbitrate:

- **a number read as a shorter one**, where both reads are confident and valid — Detroit prints 22 and 65, so the sheet carries two `"2"`s and three `"6"`s at confidence 1.0 and the duplicate-keeper logic cannot tell which is which;
- **a number with no detection at all** — Detroit p59, nothing to repair.

The printed adjacency graph settles both, and is only now precise enough to: mutual edges measure 96–100% against hand-labelled truth (#209), letter-aware with roughly twice the recall on 4-digit volumes (#206). The evidence is strikingly asymmetric on exactly the cells that matter — Detroit's *missing* p22 carries three mutual edges (p21, p28, p29) while the *false* duplicate p2 carries none.

## The rule

A page's number should be printed among the numbers of the pages that cite it in their margins. Three cell types, in decreasing order of evidence:

| cell | rule | bar |
| --- | --- | --- |
| duplicates | instances of one label scored by how many of that page's mutual neighbours are printed nearby; every vouched instance keeps its label, and only an unvouched one is relabelled — to a **missing** key its own neighbours name | 2 mutual |
| cross-sheet | the same key on two sheets beyond its expected multiplicity: keep the vouched sheet's copies, drop the other's | support asymmetry |
| gaps | a missing key placed at the centroid of the numbers whose pages cite it | 1 mutual + 1.5 total |

Only the **detections** are consulted, never the segmented regions — so a poor segmentation can never corrupt a page number, and the repair runs before `page_regions` and seeds it. Split pages legitimately appear several times (Champaign draws p4 on four panels), so multiplicity is a prior, never a trigger; and the shortfall a gap fills is counted volume-wide, since a volume's key maps divide the city between them.

Constraints inherited from #183's failed global-optimization experiments: adjacency never overrides a read that has its own support; spatial coherence is a gate, never an energy; repairs only ever target keys the volume is missing; ambiguity means no action. One-sided claims are corroboration only (weight 0.25) — 32–54% precise (#207) against 96–100% for mutual edges — and can never reach any adoption bar on their own.

## Validation

**Every proposed repair judged against hand-labelled key-map truth** (22 labelled sheets):

```
relabel CORRECT                 7     gap, correct page within 1 page-pitch    28
relabel WRONG (was right)       0     gap, correct page 1-2 page-pitches        9
relabel wrong (both wrong)      2     gap, correct page over 2 page-pitches     1
relabel, no truth point nearby  1     gap, page absent from truth labels        1
```

**Zero repairs took a correct label and made it wrong.** The 7 confirmed relabels are exactly the digit-loss class — Hudson `8`→78, `9`→49, `9`→59; KC `5`→547; DC `1`→144, `1`→231, `1`→176. The 2 "both wrong" are LA cross-sheet strips where truth says the detection was a *different* page already (1499D, 1457), so the old label was not right either. Gap placements are measured against each sheet's own page pitch (median nearest-neighbour spacing of its printed numbers): 37 of 39 land within two pitches of the page's true spot, which is the accuracy the region segmentation needs to grab the right colour block. The lone outlier is LA 1499N at 3.8 pitches.

**Key-map prior quality** — every detection mapped through the key map's own georef and measured against the page's truth centre:

| Detroit | pages located | median | p90 | max |
| --- | --- | --- | --- | --- |
| before | 85/99 | 91 ft | 222 ft | 1125 ft |
| after | **93/99** | 101 ft | 247 ft | **439 ft** |

Eight pages gain a location (18, 22, 53, 59, 65, 69, 89, 99) at 125–439 ft, and a ninth, 86, moves from a stray 272 ft estimate onto the number actually printed for it, at 57 ft. No page that already had a location moved. The median rises only because the newcomers sit above the old median — a mix shift, not a regression.

The max is the headline: **1125 ft → 439 ft**. That worst-case stray *was* a misread — a confident `"80"` printed on what truth says is page 86 — and it is gone because the repair now takes such a panel over rather than drawing a second box beside it. `80` drops off the key map, correctly but not completely: the truth labels put a real 80 one row up at (3757, 4964), which the recogniser never detected at all. So the old `"80"` was a misread of 86's panel, and the genuine 80 is simply missing — a second repair pass proposes it as a gap with support 3.75, the strongest on the sheet. The pass is run once, so that one is left on the table for now. Two more strays disappear the same way (p1's 1948 ft, p2's 4505 ft).

**Champaign** (the split-rich regression volume: p4 in four panels, five more in two): **zero** repairs proposed, so no legitimate split twin is disturbed.

**Brooklyn** caught a real bug during validation and is why `volume_shortfall` exists: gap recovery originally asked whether a key was missing from *this* sheet, and grew second copies of pages 9 and 22 on the wrong half of the city, 6970 ft and 1079 ft from truth, beside correct copies on the other sheet. Counted volume-wide, Brooklyn now proposes nothing and its stray count is unchanged.

**Corpus reach** — 13 volumes gain 79 repairs (miami 13 · los_angeles 11 · detroit 9 · kansas_city 8 · nashville 7 · grand_rapids 6 · hudson 6 · atlanta 4 · columbus 4 · new_orleans_1951 4 · washington_dc 4 · new_orleans_1896 2 · asheville 1). Applying them in memory and re-running the same measurement over every volume with truth:

**+58 pages gain a key-map location they did not have** (939 → 997 located), and pages carrying a detection more than 1000 ft off go **55 → 53** — a net *reduction* in bad priors, because taking over misread panels removes strays as well as adding coverage. Hudson goes 5 → 2, Kansas City 5 → 3, and Miami sheds an 11,699 ft stray. Nashville, Columbus and New Orleans 1951 reach full coverage (63/63, 88/88, 104/104); Miami gains the most, 53 → 65. Each volume's median offset rises a few feet for the same mix-shift reason as Detroit — the newly located pages are harder than the ones already covered, and no page that had a good location lost or moved one.

**End-to-end**: `mapsnap fit` on Detroit scores **68.2% — unchanged** (86/103 placed, 72.2% ≤25 ft, 3.9% ≥200 ft). Three separate runs give the same number: the repair as first written, the same after re-OCR'ing the twelve pages whose vocabulary restriction actually changed (83/109 georeferenced either way, so this is not the stale-OCR caveat below), and again after the panel-takeover rule cut the worst stray prior from 1125 ft to 439 ft. The repaired key map genuinely moves no page on Detroit.

That deserves stating rather than burying, because it is a real constraint on where this helps. Eight of Detroit's nine newly-located pages were *already* fitted from their own street labels (p18 at 16 ft, p53 at 10 ft, p89 at 15 ft …), so a location they did not need changed nothing. Of the volume's 19 unplaced pages only two — p22 and p69 — gain a location, and neither converts: a page centre is not by itself enough for snap or street-solve to place a sheet that has no usable street reads. **Key-map coverage and end-to-end score are decoupled here** — the pages missing a key-map number largely are not the pages failing to fit. The score win, if it comes, should be looked for on volumes where those two sets overlap; Miami (53 → 66 located) and Grand Rapids are the candidates worth measuring next.

What this PR does buy on its own terms is a better, wider, and more trustworthy prior: +58 pages covered, fewer bad priors than before rather than more, and zero truth regressions.

## Also here

- **`keymap_mtime` staleness key** (`osm_snap_experiment`): a key-map repair now invalidates cached snap candidates, mirroring #208's `contradiction_mtime`. Without it a repaired key map would be ignored by any page whose candidates were already cached `ok`.
- **`mapsnap keymap --dry-run`**: report the proposed repairs and write nothing.
- `assignment_repairs` provenance array in the rewritten sidecar, recording each change with its support and vouching pages.
- **Debugger fixes so the repairs are inspectable** (closes #215): a key-map sheet now gets the full column width with a fixed-width table beside it, instead of the shared 800px cap that made its page numbers illegible — `container-panels` becomes `container-wide` and applies to a key map's detections as well as its regions. A synthesized gap detection carries a non-zero `confidence` (the debugger drops `confidence <= 0`) and a box no smaller than the default short-side filter, so gap-recovered pages are visible; at 0.2 they draw orange among the green reads.

## Known limitation

A volume repaired by re-running `mapsnap keymap` keeps whatever OCR vocabulary restriction it had until it is re-OCR'd; pages whose assignment changed are restricted to their old neighbourhood. Fresh runs under the #216 pipeline order (craft → adjacency → keymap → ocr) are consistent by construction.




