### PR TITLE
Run the key-map repair to convergence, and never draw on an occupied panel

### DIFF
--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -733,6 +733,13 @@ def plan_volume_repairs(
                     )
                 )
                 repaired.labels[sitting] = repair.new
+            elif sitting is not None:
+                # Occupied, and the occupant has a claim to its own label that
+                # this gap cannot beat. Drawing the number here anyway would
+                # hand that page's colour block to two pages at segmentation
+                # time (#218) -- worse than leaving the page unplaced, which is
+                # only where it already was. So decline rather than guess.
+                continue
             else:
                 repairs.append(repair)
                 placements.setdefault(repaired.sheet, {})[repair.new] = point
@@ -900,9 +907,33 @@ def apply_repairs(
     return counts
 
 
+MAX_REPAIR_ROUNDS = 5
+"""How many times the pass may run on its own output before giving up.
+
+Convergence is normally one or two rounds; the cap is a backstop against a
+volume where a repair keeps re-opening the cell it just closed."""
+
+
 def repair_volume(volume: Path, dry_run: bool = False) -> list[Repair]:
-    """Plan (and unless ``dry_run``, apply) a volume's assignment repairs."""
-    repairs, placements = plan_volume_repairs(volume)
-    if repairs and not dry_run:
+    """Plan (and unless ``dry_run``, apply) a volume's assignment repairs.
+
+    Repairs uncover repairs, so the pass runs again on its own output until a
+    round proposes nothing. Detroit is the case that showed it: the panel read
+    as "80" is really 86, and only once 86 has taken it over does the REAL 80
+    -- never detected at all -- become a visible gap, with more support (3.75)
+    than anything the first round found. One pass left it on the table.
+
+    Bounded by MAX_REPAIR_ROUNDS. A dry run reports the first round only, since
+    later rounds are defined by what the earlier ones wrote.
+    """
+    if dry_run:
+        return plan_volume_repairs(volume)[0]
+
+    applied: list[Repair] = []
+    for _round in range(MAX_REPAIR_ROUNDS):
+        repairs, placements = plan_volume_repairs(volume)
+        if not repairs:
+            break
         apply_repairs(volume, repairs, placements)
-    return repairs
+        applied.extend(repairs)
+    return applied

--- a/mapsnap/keymap/adjacency_assign_test.py
+++ b/mapsnap/keymap/adjacency_assign_test.py
@@ -418,9 +418,11 @@ def test_apply_repairs_rewrites_the_keymap_and_keeps_the_original(tmp_path):
             ("21", 1100.0, 1000.0),
             ("28", 900.0, 1000.0),
             ("29", 1000.0, 1100.0),
+            # Spread a full pitch apart, so 59's estimate lands in the empty
+            # middle rather than inside a citation's own block.
             ("27", 2000.0, 2000.0),
-            ("57", 2100.0, 2000.0),
-            ("61", 2000.0, 2100.0),
+            ("57", 2100.0, 2200.0),
+            ("61", 2200.0, 2000.0),
         ],
         adjacency=[["p22", "p21"], ["p22", "p28"], ["p22", "p29"], ["p59", "p27"]],
         one_sided=[["p59", "p57"], ["p59", "p61"]],
@@ -451,6 +453,71 @@ def test_apply_repairs_rewrites_the_keymap_and_keeps_the_original(tmp_path):
     repair_volume(volume)
     original_again = json.loads((volume / "raw" / "p0.keymap-raw.json").read_text())
     assert original_again == original
+
+
+def test_repair_volume_runs_until_it_stops_finding_things(tmp_path):
+    from mapsnap.keymap.adjacency_assign import repair_volume
+
+    # Detroit's shape: the panel read "80" is really 86, and only once 86 has
+    # taken it over does the real 80 -- never detected -- become a visible gap.
+    volume = write_volume(
+        tmp_path,
+        entries=[
+            # 87 and 93 bracket the panel read "80", so 86's estimate lands on
+            # it and takes it over.
+            ("80", 1000.0, 1000.0),
+            ("87", 600.0, 1000.0),
+            ("93", 1400.0, 1000.0),
+            # 80's own neighbours, off in their own corner.
+            ("64", 3000.0, 3000.0),
+            ("79", 3400.0, 3000.0),
+            ("81", 3200.0, 3400.0),
+        ],
+        adjacency=[
+            ["p86", "p87"],
+            ["p86", "p93"],
+            ["p80", "p64"],
+            ["p80", "p79"],
+            ["p80", "p81"],
+        ],
+        pages=["64", "79", "80", "81", "86", "87", "93"],
+    )
+    repairs = repair_volume(volume)
+    reasons = [r.reason for r in repairs]
+    assert "gap-displaces-unsupported" in reasons  # round one: 86 takes the panel
+    assert "gap" in reasons  # round two: the real 80, now visibly missing
+    texts = [
+        s["text"]
+        for s in json.loads((volume / "raw" / "p0.keymap.json").read_text())["streets"]
+    ]
+    assert texts.count("86") == 1 and texts.count("80") == 1
+    # Running again changes nothing: the pass has converged.
+    assert repair_volume(volume) == []
+
+
+def test_a_gap_is_declined_rather_than_drawn_on_another_pages_panel(tmp_path):
+    from mapsnap.keymap.adjacency_assign import repair_volume
+
+    # 30's citations put it right on top of 29, whose own label 29 is vouched
+    # for by 28. Drawing it anyway would hand 29's colour block to two pages
+    # (#218), so the pass declines and 30 stays unplaced.
+    volume = write_volume(
+        tmp_path,
+        entries=[
+            ("29", 1000.0, 1000.0),
+            ("28", 1000.0, 900.0),  # vouches for 29 being 29
+            ("31", 900.0, 1000.0),  # 30's citations bracket 29, so 30's
+            ("51", 1100.0, 1000.0),  # estimate lands squarely on 29's panel
+        ],
+        adjacency=[["p29", "p28"], ["p30", "p31"], ["p30", "p51"]],
+        pages=["28", "29", "30", "31", "51"],
+    )
+    assert repair_volume(volume) == []
+    texts = [
+        s["text"]
+        for s in json.loads((volume / "raw" / "p0.keymap.json").read_text())["streets"]
+    ]
+    assert "30" not in texts and texts.count("29") == 1
 
 
 def test_repair_volume_is_a_no_op_without_adjacency(tmp_path):


### PR DESCRIPTION
Runs the key-map assignment repair to convergence, and stops it drawing a synthesized number inside another page's block.

Follows #217. Related: #218.

## Repairs uncover repairs

Detroit's panel read `"80"` is really 86. Only once 86 has taken it over does the *real* 80 — never detected at all — become a visible gap, and it comes with support 3.75, more than anything the first round found. A single pass left it on the table. The pass now re-runs on its own output until a round proposes nothing, bounded by `MAX_REPAIR_ROUNDS = 5`.

Volumes converge in **one to three rounds**; none comes close to the cap.

## Iterating alone made #218 worse

A second round is placed partly from the first round's *estimates*, so the error compounds. Measured on the two volumes in #218:

| | synthesized on another page's panel |
| --- | --- |
| Miami, one round | 3 |
| Miami, iterated | **4** — including `56` drawn on top of the `30` round one had just synthesized |
| Detroit, one round | 1 |
| Detroit, iterated | **2** — the recovered `80` landed on 64's block |

This is the "more than cosmetic" part of #218: a label inside another page's block hands that block to two pages when `page_regions` seeds from the detections, so the occupied page loses its region. That is worse than leaving a page unplaced, which is only where it already was.

So a gap whose estimate lands on an occupied panel it cannot justify taking over is now **declined outright** instead of drawn anyway. The takeover path is unchanged — when the occupant has no claim to its own label and the newcomer clears the relabel bar locally, it still takes the panel.

## Results

Corpus, pre-repair to converged:

- **931 → 994 pages located** (+63); **905 → 954** within 500 ft of truth
- **synthesized-on-another-panel: several → 0**
- Truth ledger over the 22 hand-labelled sheets: **21 relabels correct** (was 20), **zero that broke a correct label**, 22 gaps within one page-pitch / 10 within two / 1 beyond

Per volume: Columbus 84→88, Detroit 85→92, Grand Rapids 23→26, Hudson 80→86, Kansas City 102→111, LA 83→90, Miami 53→64, Nashville 56→62, New Orleans 1896 83→85 and 1951 100→103, Washington 109→114. Brooklyn and Champaign propose nothing and are untouched.

Medians rise a few feet on most volumes for the usual mix-shift reason — the pages newly gaining a location are harder than the ones already covered. A handful of volumes gain a worst case over 1000 ft (KC 1471 ft, DC 1031 ft, LA 1015 ft, Nashville 1006 ft) from later-round gaps placed at the edge of usefulness; that is the tail cost of the extra coverage, and it is what a better estimator would fix.

## What this deliberately does not fix

Declining is the conservative half of #218. Detroit's 80 is *still* not recovered, because the centroid estimator puts it on 64's panel and the guard then refuses it. A better estimate would place it correctly rather than having to be refused — measured separately, projecting each citation one pitch along its claim's recorded margin takes gap placement from a median 0.81 to 0.64 page-pitches and from 10/30 to 14/30 landing within half a pitch. That belongs in #218, not here.


---

## Follow-up: re-audited against the #218 exploration

After this PR was opened, the #218 work (anisotropic cell model, snap-to-free-cell, claim-margin compass — all measured, none merged) produced a better yardstick for the collision claim above. Re-running the audit with it:

| yardstick | synthesized labels sitting on another page's panel |
| --- | --- |
| half a page-pitch, a circle — **what this PR reports** | **0** |
| the grid's own cell: oriented rectangle, axes measured from the sheet | **26** |

The pitch is the median *nearest-neighbour* distance and runs 20–30% under the true grid step on every sheet measured (Detroit 319 px against 383), so the circle this PR uses is smaller than a real cell and under-counts. **The "0" above should be read as "none within half a page-pitch", not "none at all".**

That does not change the merge decision, for a measured reason: **none of the 26 produce the harm the rule exists to prevent.** Checking whether any segmented block ends up claimed by two pages, corpus-wide only 5 pairs of regions overlap by >50% — and every label involved carries `via: null`, i.e. they are ordinary CRNN detections that predate this work. Not one contested block traces to a synthesized label. The cell rectangle is a coarse proxy: a label can fall inside a neighbour's estimated cell while still sitting on its own distinct colour block.

Two further results from that exploration argue for keeping this PR's threshold exactly as it is rather than "fixing" it:

- **Adopting the accurate cell costs more than it buys.** It is uniformly *larger* than the half-pitch circle, so it refuses strictly more: corpus coverage falls 994 → 976 located, and Nashville drops from six gap fills to one.
- **Snapping a refused estimate into the neighbouring free cell does not work.** Splitting gaps by how their position was chosen: direct placements land a median 0.50 page-pitches from truth (13/17 within one pitch), snapped ones 1.73 pitches (2/12). The residual from an occupant's centre is not a usable compass.

So the half-pitch circle is not the principled choice, but it is the empirically better operating point of the ones tested, and this PR's numbers stand.

One thing worth its own issue, unrelated to this change: those **5 contested colour blocks from ordinary detections** (Nashville 4, LA `pb` 1) are a pre-existing `page_regions` seeding problem.
