### PR TITLE
clip_masks: don't let an invalid sliver abort the whole IIIF build

### DIFF
--- a/mapsnap/clip_masks.py
+++ b/mapsnap/clip_masks.py
@@ -27,10 +27,12 @@ from typing import cast
 
 import numpy as np
 from PIL import Image, ImageDraw
+from shapely import make_valid
+from shapely.errors import GEOSException
 from shapely.geometry import LineString, MultiPolygon, Polygon
 from shapely.geometry import mapping as geom_mapping
 from shapely.geometry import shape as geom_shape
-from shapely.geometry.base import BaseMultipartGeometry
+from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
 from shapely.ops import polygonize, unary_union
 
 # ~0.5 miles in degrees latitude (constant regardless of location).
@@ -255,6 +257,27 @@ def _assign_blocks_to_pages(
     return assignment
 
 
+def safe_overlay(a: BaseGeometry, b: BaseGeometry, op: str) -> BaseGeometry | None:
+    """Boolean overlay of two geometries, or None if GEOS can't do it.
+
+    Dent detection derives its operands from earlier overlays, which can leave
+    slivers that GEOS rejects with a side-location conflict. Those candidates
+    are heuristic refinements, so dropping one is harmless -- crashing the whole
+    IIIF build over it is not. A `make_valid` retry recovers most of them.
+
+    The result is passed through exactly as GEOS returns it, including
+    GeometryCollections, since callers do their own filtering.
+    """
+    try:
+        return cast(BaseGeometry, getattr(a, op)(b))
+    except GEOSException:
+        pass
+    try:
+        return cast(BaseGeometry, getattr(make_valid(a), op)(make_valid(b)))
+    except GEOSException:
+        return None
+
+
 def _collect_polygons(geom: object) -> list[Polygon]:
     """Extract all non-empty Polygon parts from any Shapely geometry."""
     if isinstance(geom, Polygon):
@@ -413,8 +436,13 @@ def _fill_concave_dents(
             for j, mask_j in enumerate(masks):
                 if j == i or mask_j is None:
                     continue
-                arm_geo = mask_j.intersection(page_polys[i]).difference(mask_i)
-                if arm_geo.is_empty:
+                overlap = safe_overlay(mask_j, page_polys[i], "intersection")
+                arm_geo = (
+                    safe_overlay(overlap, mask_i, "difference")
+                    if overlap is not None
+                    else None
+                )
+                if arm_geo is None or arm_geo.is_empty:
                     continue
                 for piece in _collect_polygons(arm_geo):
                     if piece.area < mask_i.area * 0.001:
@@ -440,7 +468,9 @@ def _fill_concave_dents(
                     # Verify removing piece from j improves j's convexity ratio
                     # (confirms it's a protrusion in j, not a legitimate block
                     # assignment that happens to lie within i's page extent).
-                    test_j = mask_j.difference(piece)
+                    test_j = safe_overlay(mask_j, piece, "difference")
+                    if test_j is None:
+                        continue
                     if not test_j.is_empty:
                         test_j_poly: Polygon | None = None
                         if isinstance(test_j, Polygon):
@@ -463,8 +493,8 @@ def _fill_concave_dents(
         for i, mask_i in enumerate(masks):
             if mask_i is None:
                 continue
-            dent_i = mask_i.convex_hull.difference(mask_i)
-            if dent_i.is_empty:
+            dent_i = safe_overlay(mask_i.convex_hull, mask_i, "difference")
+            if dent_i is None or dent_i.is_empty:
                 continue
             for piece in _collect_polygons(dent_i):
                 if piece.area < mask_i.area * 0.001:
@@ -505,12 +535,13 @@ def _fill_concave_dents(
         if cur_i is None or cur_j is None:
             continue
         # Verify j still owns the piece; an earlier transfer may have claimed it.
-        if cur_j.intersection(piece).area <= piece.area * 0.5:
+        still_owned = safe_overlay(cur_j, piece, "intersection")
+        if still_owned is None or still_owned.area <= piece.area * 0.5:
             continue
 
-        candidate_i = cur_i.union(piece)
-        candidate_j = cur_j.difference(piece)
-        if not isinstance(candidate_i, Polygon):
+        candidate_i = safe_overlay(cur_i, piece, "union")
+        candidate_j = safe_overlay(cur_j, piece, "difference")
+        if candidate_j is None or not isinstance(candidate_i, Polygon):
             continue
 
         # For the source, allow a MultiPolygon if one component dominates (≥90%).

--- a/mapsnap/clip_masks_test.py
+++ b/mapsnap/clip_masks_test.py
@@ -11,6 +11,7 @@ from mapsnap.clip_masks import (
     PageColorData,
     _assign_blocks_to_pages,
     _assign_blocks_to_pages_with_splits,
+    _collect_polygons,
     _convexity_ratio,
     _fill_concave_dents,
     _fill_coverage_gaps,
@@ -22,6 +23,7 @@ from mapsnap.clip_masks import (
     _score_block_on_page,
     compute_all_clip_masks,
     geo_polygon_to_svg,
+    safe_overlay,
 )
 
 
@@ -792,3 +794,37 @@ def test_fill_coverage_gaps_no_gaps():
 
     result = _fill_coverage_gaps([mask], [page_poly])
     assert result[0] is mask  # same object returned (no modification)
+
+
+def test_safe_overlay_normal_polygons():
+    """Valid operands behave exactly like the plain shapely call."""
+    a = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    b = Polygon([(2, 2), (6, 2), (6, 6), (2, 6)])
+    diff = safe_overlay(a, b, "difference")
+    inter = safe_overlay(a, b, "intersection")
+    assert diff is not None and inter is not None
+    assert diff.area == pytest.approx(a.difference(b).area)
+    assert inter.area == pytest.approx(4.0)
+
+
+def test_safe_overlay_recovers_from_invalid_operand():
+    """A self-intersecting bowtie is repaired rather than raising."""
+    bowtie = Polygon([(0, 0), (4, 4), (4, 0), (0, 4)])
+    assert not bowtie.is_valid
+    other = Polygon([(0, 0), (4, 0), (4, 4), (0, 4)])
+    result = safe_overlay(bowtie, other, "difference")
+    assert result is not None
+    assert result.is_valid
+
+
+def test_safe_overlay_passes_through_non_polygon_result():
+    """Non-polygonal results reach the caller, which does its own filtering.
+
+    Returning None here would silently drop GeometryCollections that the dent
+    heuristics rely on, quietly changing clip masks.
+    """
+    a = Polygon([(0, 0), (2, 0), (2, 2), (0, 2)])
+    b = Polygon([(2, 0), (4, 0), (4, 2), (2, 2)])
+    touching = safe_overlay(a, b, "intersection")
+    assert touching is not None
+    assert _collect_polygons(touching) == []


### PR DESCRIPTION
`mapsnap iiif` aborts on some page sets with

```
GEOSException: TopologyException: side location conflict at -82.942666550591369 42.38064817071465
```

from `_fill_concave_dents`. Hit while building an annotation page for the keymap-snap work; nothing about that channel is special, the poses just happened to produce a sliver GEOS won't difference.

Dent detection derives its operands from earlier overlays, so a slightly invalid intermediate is expected occasionally. Those candidates are heuristic convexity refinements — dropping one is cheap, and much cheaper than losing the run.

`safe_overlay()` retries with `make_valid` and returns `None` if GEOS still refuses, so the caller skips that candidate. The four boolean ops in the dent path go through it.

### One thing worth a look in review

The result is passed through **exactly as GEOS returns it**, including `GeometryCollection`s. My first version returned `None` for any non-polygonal result, which looked tidier but silently changed clip masks on **12 of 95 pages** — the callers were already filtering collections themselves via `_collect_polygons`, and swallowing them dropped real geometry. The test `test_safe_overlay_passes_through_non_polygon_result` pins that contract.

### Verification

- A run that previously succeeded (`kmsnap/*.georef.json` → 95 annotations) produces **byte-identical** output, timestamps aside.
- The previously-crashing run now completes.
- 885 tests pass; ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)