### PR TITLE
streets view: reflect the gate georef actually applies

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,7 @@ import {
   directionThroughCorners,
   projectThroughCorners,
 } from './geometry';
+import type { GeorefParameters } from './detections';
 import {
   detectionFromAdjacency,
   filterDetections,
@@ -77,6 +78,58 @@ function findPairRecord(
 // Whether a URL/path points at an image we can load (matched by extension).
 function isImageUrl(url: string): boolean {
   return /\.(jpe?g|png|webp|gif|tiff?)(\?.*)?$/i.test(url);
+}
+
+/**
+ * Read the thresholds georef ran with from a page's own `<stem>.georef.json`.
+ *
+ * The streets view is opened on `<stem>.streets.json`, which records the reads
+ * but not the gate that judged them; the sidecar next to it carries both, at
+ * `inputs.parameters`. Fetching it means the sliders start where the run
+ * actually was — min_short_side in particular is auto-calibrated per volume
+ * from the p25 of its confident detections, so any fixed default is wrong for
+ * most volumes. Returns null when there is no sibling sidecar (an un-georef'd
+ * page), leaving the defaults alone.
+ */
+async function fetchGeorefParameters(
+  files: string[],
+): Promise<GeorefParameters | null> {
+  const streets = files.find((f) => f.endsWith('.streets.json'));
+  if (!streets) return null;
+  const sidecar = streets.replace(/\.streets\.json$/, '.georef.json');
+  try {
+    const response = await fetch(resolveDataUrl(sidecar));
+    if (!response.ok) return null;
+    const doc = await response.json();
+    const parameters = doc?.inputs?.parameters;
+    return parameters && typeof parameters === 'object' ? parameters : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The subset of {@link DetectionFilters} a georef run pins down.
+ *
+ * Only keys the sidecar actually carries are returned, so a partial
+ * `inputs.parameters` leaves the rest of the sliders at their defaults rather
+ * than snapping them to zero.
+ */
+export function filtersFromParameters(
+  parameters: GeorefParameters,
+): Partial<DetectionFilters> {
+  const out: Partial<DetectionFilters> = {};
+  if (parameters.min_confidence !== undefined)
+    out.minConfidence = parameters.min_confidence;
+  if (parameters.min_short_side !== undefined)
+    out.minShortSide = parameters.min_short_side;
+  if (parameters.min_long_side !== undefined)
+    out.minLongSide = parameters.min_long_side;
+  if (parameters.min_aspect_ratio !== undefined)
+    out.minAspectRatio = parameters.min_aspect_ratio;
+  if (parameters.high_confidence_size_fraction !== undefined)
+    out.highConfidenceSizeFraction = parameters.high_confidence_size_fraction;
+  return out;
 }
 
 // Resolve a `?files=` entry to a fetchable URL, leaving absolute URLs/paths as
@@ -200,9 +253,27 @@ export function App() {
     minConfidence: 0.15,
     minShortSide: 20,
     minLongSide: 20,
+    minAspectRatio: 1,
+    relaxation: true,
+    highConfidenceSizeFraction: 0.7,
     showIgnored: false,
     text: '',
   });
+  // The thresholds georef actually ran with for this page, once its sibling
+  // sidecar has been read. Shown so a slider that has drifted from the run is
+  // visible as such, and restorable.
+  const [georefParameters, setGeorefParameters] =
+    useState<GeorefParameters | null>(null);
+
+  // Whether the sliders still sit where this page's georef run had them, so a
+  // drifted view says so instead of quietly showing a different gate.
+  const atRunThresholds = useMemo(() => {
+    if (!georefParameters) return true;
+    const pinned = filtersFromParameters(georefParameters);
+    return (Object.entries(pinned) as [keyof DetectionFilters, number][]).every(
+      ([key, value]) => Math.abs((filters[key] as number) - value) < 1e-9,
+    );
+  }, [georefParameters, filters]);
 
   const prevObjectUrlRef = useRef<string | null>(null);
 
@@ -558,6 +629,11 @@ export function App() {
       .filter(Boolean);
     setNoteContext(noteContextFromFiles(files));
     void loadFromUrls(files).finally(() => setInitialViewPending(false));
+    void fetchGeorefParameters(files).then((parameters) => {
+      if (!parameters) return;
+      setGeorefParameters(parameters);
+      setFilters((prev) => ({ ...prev, ...filtersFromParameters(parameters) }));
+    });
     // Runs once on mount; loadFromUrls closes over the initial (empty) state.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -635,6 +711,17 @@ export function App() {
         setColorByInlier={setColorByInlier}
         filters={filters}
         setFilters={setFilters}
+        georefParameters={georefParameters}
+        atRunThresholds={atRunThresholds}
+        onRestoreRunThresholds={
+          georefParameters
+            ? () =>
+                setFilters((prev) => ({
+                  ...prev,
+                  ...filtersFromParameters(georefParameters),
+                }))
+            : undefined
+        }
         onFiles={handleFiles}
       />
       <div className="map-column">

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -371,8 +371,14 @@ export function App() {
   }, [selectedPair, activePair, streets.length]);
 
   const filteredDetections = useMemo(
-    () => filterDetections(detections, filters),
-    [detections, filters],
+    // Key-map page numbers are not street reads and never face georef's
+    // admission gate, so they are shown unfiltered rather than judged by
+    // thresholds that do not apply to them.
+    () =>
+      keymapSheet
+        ? detections.map((det, i) => ({ det, i }))
+        : filterDetections(detections, filters),
+    [detections, filters, keymapSheet],
   );
 
   // Boxes mode: apply the short/long-side sliders, then hide the toggled-off rotations.
@@ -681,6 +687,7 @@ export function App() {
       </nav>
       <ImageColumn
         mode={mode}
+        keymapSheet={keymapSheet}
         imageSrc={imageSrc}
         roadMapSrc={roadMapSrc}
         showRoadMap={showRoadMap}

--- a/app/src/components/DetectionsTable.tsx
+++ b/app/src/components/DetectionsTable.tsx
@@ -63,7 +63,7 @@ export function DetectionsTable(props: DetectionsTableProps) {
           </tr>
         </thead>
         <tbody>
-          {visible.map(({ det, i }, rowIdx) => {
+          {visible.map(({ det, i, relaxed }, rowIdx) => {
             const onFill = isOnBuildingFill(det);
             const classes = [
               selectedIndices.has(i) ? 'selected' : '',
@@ -71,6 +71,7 @@ export function DetectionsTable(props: DetectionsTableProps) {
               det.hint ? 'hint' : '',
               det.fallback ? 'fallback' : '',
               onFill ? 'on-fill' : '',
+              relaxed ? 'relaxed' : '',
             ]
               .filter(Boolean)
               .join(' ');
@@ -87,6 +88,14 @@ export function DetectionsTable(props: DetectionsTableProps) {
                 <td>{det.confidence.toFixed(3)}</td>
                 <td>
                   {type}
+                  {relaxed && (
+                    <span
+                      className="relaxed-badge"
+                      title="Below the strict size floor; admitted because its confidence bought a lower one."
+                    >
+                      relaxed
+                    </span>
+                  )}
                   {det.fallback && (
                     <span
                       className="fallback-badge"

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import type { IndexedBox } from '../boxes';
-import type { DetectionFilters, IndexedDetection } from '../detections';
+import type {
+  DetectionFilters,
+  GeorefParameters,
+  IndexedDetection,
+} from '../detections';
 import { pointInPolygon } from '../geometry';
 import type { IntersectionPoint, PanelPolygon, Street } from '../types';
 import { useElementSize } from '../hooks/useElementSize';
@@ -9,6 +13,11 @@ import { BoxesOverlay } from './BoxesOverlay';
 import { DetectionsOverlay } from './DetectionsOverlay';
 import { GeorefOverlay } from './GeorefOverlay';
 import { PanelsOverlay } from './PanelsOverlay';
+
+const RELAXATION_HELP =
+  'georef trades confidence for size: a detection at the confidence floor must meet the full ' +
+  'size floor, while one at confidence 1.0 need only meet a fraction of it, interpolated as a ' +
+  'power law. Detections admitted only this way are marked "relaxed".';
 
 export type Mode =
   | 'georef'
@@ -49,6 +58,11 @@ interface ImageColumnProps {
   setColorByInlier: (value: boolean) => void;
   filters: DetectionFilters;
   setFilters: (filters: DetectionFilters) => void;
+  /** Thresholds this page's georef run recorded, when its sidecar had them. */
+  georefParameters?: GeorefParameters | null;
+  /** Whether the sliders still match that run. */
+  atRunThresholds?: boolean;
+  onRestoreRunThresholds?: () => void;
   onFiles: (files: File[]) => void;
 }
 
@@ -86,6 +100,9 @@ export function ImageColumn(props: ImageColumnProps) {
     colorByInlier,
     setColorByInlier,
     filters,
+    georefParameters,
+    atRunThresholds,
+    onRestoreRunThresholds,
     setFilters,
     onFiles,
   } = props;
@@ -334,6 +351,56 @@ export function ImageColumn(props: ImageColumnProps) {
               }
             />
           </div>
+          <div className="filter-row">
+            <label htmlFor="filter-aspect">
+              Min aspect ratio: <span>{filters.minAspectRatio.toFixed(2)}</span>
+            </label>
+            <input
+              type="range"
+              id="filter-aspect"
+              min={0}
+              max={6}
+              step={0.05}
+              value={filters.minAspectRatio}
+              onChange={(e) =>
+                setFilters({
+                  ...filters,
+                  minAspectRatio: parseFloat(e.target.value),
+                })
+              }
+            />
+          </div>
+          <div className="filter-row">
+            <input
+              type="checkbox"
+              id="relaxation"
+              checked={filters.relaxation}
+              onChange={(e) =>
+                setFilters({ ...filters, relaxation: e.target.checked })
+              }
+            />
+            <label htmlFor="relaxation" title={RELAXATION_HELP}>
+              Confidence relaxation (to{' '}
+              {(filters.highConfidenceSizeFraction * 100).toFixed(0)}% of the
+              size floor)
+            </label>
+          </div>
+          {georefParameters && (
+            <div className="filter-row filter-provenance">
+              <span>
+                georef ran at short{' '}
+                {georefParameters.min_short_side?.toFixed(0)}
+                px, long {georefParameters.min_long_side?.toFixed(0)}px, conf{' '}
+                {georefParameters.min_confidence}
+                {atRunThresholds ? '' : ' (sliders changed)'}
+              </span>
+              {!atRunThresholds && onRestoreRunThresholds && (
+                <button type="button" onClick={onRestoreRunThresholds}>
+                  restore
+                </button>
+              )}
+            </div>
+          )}
           <div className="filter-row">
             <input
               type="checkbox"

--- a/app/src/components/ImageColumn.tsx
+++ b/app/src/components/ImageColumn.tsx
@@ -29,6 +29,8 @@ export type Mode =
 
 interface ImageColumnProps {
   mode: Mode;
+  /** True when the loaded JSON is a key map's page-number sidecar. */
+  keymapSheet?: boolean;
   imageSrc: string;
   /** URL of this page's road-probability map, when one exists; enables the toggle below. */
   roadMapSrc: string | null;
@@ -75,6 +77,7 @@ interface ImageColumnProps {
 export function ImageColumn(props: ImageColumnProps) {
   const {
     mode,
+    keymapSheet = false,
     imageSrc,
     roadMapSrc,
     showRoadMap,
@@ -115,6 +118,12 @@ export function ImageColumn(props: ImageColumnProps) {
   const boxesMode = mode === 'boxes';
   // Adjacency mode renders detections just like streets mode (overlay + click select).
   const detectionsMode = streetsMode || mode === 'adjacency';
+  // A key map's detections are its page numbers, not street reads: the size,
+  // confidence and aspect thresholds all describe georef's street-admission
+  // gate, which never runs on them. The sliders are hidden rather than left to
+  // invite tuning a gate that does not exist -- but the detections themselves
+  // still render and stay selectable, so this gates the panel only.
+  const showFilters = streetsMode && !keymapSheet;
 
   // In streets/panels/boxes mode, select the shapes under the click point. The wrapper
   // (currentTarget) tightly wraps the image, so its rect matches the image's.
@@ -271,7 +280,7 @@ export function ImageColumn(props: ImageColumnProps) {
         </>
       )}
 
-      {streetsMode && (
+      {showFilters && (
         <div id="detection-filters">
           <div className="filter-row">
             <label htmlFor="filter-text">

--- a/app/src/detections.test.ts
+++ b/app/src/detections.test.ts
@@ -6,6 +6,7 @@ import {
   filterDetections,
   isOnBuildingFill,
   matchesTextQuery,
+  relaxedShortSide,
   previewOrientation,
 } from './detections';
 import type { Detection } from './types';
@@ -122,6 +123,9 @@ describe('filterDetections', () => {
       minConfidence: 0,
       minShortSide: 0,
       minLongSide: 0,
+      minAspectRatio: 0,
+      relaxation: false,
+      highConfidenceSizeFraction: 0.7,
       showIgnored: true,
       text: '',
     });
@@ -133,6 +137,9 @@ describe('filterDetections', () => {
       minConfidence: 0.5,
       minShortSide: 20,
       minLongSide: 50,
+      minAspectRatio: 0,
+      relaxation: false,
+      highConfidenceSizeFraction: 0.7,
       showIgnored: true,
       text: '',
     });
@@ -144,6 +151,9 @@ describe('filterDetections', () => {
       minConfidence: 0,
       minShortSide: 0,
       minLongSide: 0,
+      minAspectRatio: 0,
+      relaxation: false,
+      highConfidenceSizeFraction: 0.7,
       showIgnored: false,
       text: '',
     });
@@ -289,5 +299,133 @@ describe('matchesTextQuery', () => {
   it('treats regex metacharacters literally', () => {
     expect(matchesTextQuery('6', '.')).toBe(false);
     expect(matchesTextQuery('N. MAIN', '.')).toBe(true);
+  });
+});
+
+describe('relaxedShortSide', () => {
+  it('returns the full floor at or below min confidence', () => {
+    expect(relaxedShortSide(0.15, 0.15, 20, 0.7)).toBe(20);
+    expect(relaxedShortSide(0.1, 0.15, 20, 0.7)).toBe(20);
+  });
+
+  it('returns the high-confidence floor at confidence 1', () => {
+    expect(relaxedShortSide(1, 0.15, 20, 0.7)).toBeCloseTo(14, 6);
+  });
+
+  it('interpolates monotonically between the two', () => {
+    const mid = relaxedShortSide(0.5, 0.15, 20, 0.7);
+    expect(mid).toBeLessThan(20);
+    expect(mid).toBeGreaterThan(14);
+  });
+
+  it('is disabled when the fraction would not lower the floor', () => {
+    expect(relaxedShortSide(1, 0.15, 20, 1)).toBe(20);
+  });
+});
+
+describe('filterDetections aspect ratio and relaxation', () => {
+  const wide = makeDetection({
+    text: 'BROADWAY',
+    confidence: 0.9,
+    short_side: 10,
+    long_side: 90,
+  });
+  const squat = makeDetection({
+    text: 'ELM',
+    confidence: 0.9,
+    short_side: 40,
+    long_side: 50,
+  });
+
+  it('rejects a detection below the aspect-ratio floor', () => {
+    const base = {
+      minConfidence: 0,
+      minShortSide: 0,
+      minLongSide: 0,
+      relaxation: false,
+      highConfidenceSizeFraction: 0.7,
+      showIgnored: true,
+      text: '',
+    };
+    expect(
+      filterDetections([wide, squat], { ...base, minAspectRatio: 0 }),
+    ).toHaveLength(2);
+    expect(
+      filterDetections([wide, squat], { ...base, minAspectRatio: 2 }),
+    ).toHaveLength(1);
+  });
+
+  it('admits an undersized but confident detection only with relaxation on', () => {
+    const small = makeDetection({
+      text: 'OAK',
+      confidence: 1,
+      short_side: 15,
+      long_side: 40,
+    });
+    const base = {
+      minConfidence: 0.15,
+      minShortSide: 20,
+      minLongSide: 40,
+      minAspectRatio: 0,
+      highConfidenceSizeFraction: 0.7,
+      showIgnored: true,
+      text: '',
+    };
+    expect(
+      filterDetections([small], { ...base, relaxation: false }),
+    ).toHaveLength(0);
+    const relaxed = filterDetections([small], { ...base, relaxation: true });
+    expect(relaxed).toHaveLength(1);
+    expect(relaxed[0].relaxed).toBe(true);
+  });
+
+  it('does not mark a detection that clears the strict floors', () => {
+    const big = makeDetection({
+      text: 'MAIN',
+      confidence: 1,
+      short_side: 30,
+      long_side: 90,
+    });
+    const result = filterDetections([big], {
+      minConfidence: 0.15,
+      minShortSide: 20,
+      minLongSide: 40,
+      minAspectRatio: 0,
+      relaxation: true,
+      highConfidenceSizeFraction: 0.7,
+      showIgnored: true,
+      text: '',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].relaxed).toBeUndefined();
+  });
+
+  it('relaxes the long side in the same proportion as the short side', () => {
+    // georef scales min_long_side by required_short/min_short; a detection just
+    // under both floors must clear both relaxed floors, not only the short one.
+    const shortOnly = makeDetection({
+      text: 'PINE',
+      confidence: 1,
+      short_side: 15,
+      long_side: 39,
+    });
+    const both = makeDetection({
+      text: 'CEDAR',
+      confidence: 1,
+      short_side: 15,
+      long_side: 30,
+    });
+    const base = {
+      minConfidence: 0.15,
+      minShortSide: 20,
+      minLongSide: 40,
+      minAspectRatio: 0,
+      relaxation: true,
+      highConfidenceSizeFraction: 0.7,
+      showIgnored: true,
+      text: '',
+    };
+    expect(filterDetections([shortOnly], base)).toHaveLength(1);
+    expect(filterDetections([both], base)).toHaveLength(1);
   });
 });

--- a/app/src/detections.ts
+++ b/app/src/detections.ts
@@ -5,15 +5,76 @@ export interface DetectionFilters {
   minConfidence: number;
   minShortSide: number;
   minLongSide: number;
+  /** Minimum long/short side ratio, matching georef's `--min-aspect-ratio`. */
+  minAspectRatio: number;
+  /**
+   * Whether to apply georef's confidence-for-size trade (see
+   * {@link relaxedShortSide}). Off shows the strict floors only.
+   */
+  relaxation: boolean;
+  /**
+   * Size floor a confidence-1.0 detection must meet, as a fraction of
+   * minShortSide. georef's `--high-confidence-size-fraction`, default 0.7.
+   */
+  highConfidenceSizeFraction: number;
   showIgnored: boolean;
   /** Text query; empty shows everything. See {@link matchesTextQuery}. */
   text: string;
+}
+
+/**
+ * The thresholds georef actually ran with, read from a page's
+ * `<stem>.georef.json` at `inputs.parameters`. Every sidecar carries these, and
+ * min_short_side is usually auto-calibrated from the volume's own detections
+ * (the p25 of confident reads), so a hand-set slider will not match the run.
+ */
+export interface GeorefParameters {
+  min_confidence?: number;
+  min_short_side?: number;
+  min_long_side?: number;
+  min_aspect_ratio?: number;
+  high_confidence_size_fraction?: number;
+}
+
+/**
+ * The short side a detection must have at this confidence.
+ *
+ * georef trades confidence for size: a detection at `minConfidence` must meet
+ * the full `minShortSide`, while one at confidence 1.0 need only meet
+ * `minShortSide * highConfidenceSizeFraction`. Between those it interpolates as
+ * a power law, linear in log-confidence against log-threshold. Mirrors
+ * `confidence_relaxed_threshold` in georef_from_labels.py.
+ */
+export function relaxedShortSide(
+  confidence: number,
+  minConfidence: number,
+  minShortSide: number,
+  highConfidenceSizeFraction: number,
+): number {
+  const floor = minShortSide * highConfidenceSizeFraction;
+  if (
+    confidence <= minConfidence ||
+    floor >= minShortSide ||
+    minConfidence <= 0
+  ) {
+    return minShortSide;
+  }
+  const capped = Math.min(confidence, 1);
+  const exponent = Math.log(floor / minShortSide) / Math.log(minConfidence);
+  return minShortSide * Math.pow(minConfidence / capped, exponent);
 }
 
 /** A detection paired with its index in the original, unfiltered list. */
 export interface IndexedDetection {
   det: Detection;
   i: number;
+  /**
+   * True when this detection clears the size gate only because relaxation
+   * lowered it — i.e. it would be rejected at the strict floors. Worth marking:
+   * these are the reads georef admitted on the strength of their confidence
+   * rather than their size.
+   */
+  relaxed?: boolean;
 }
 
 /** Map confidence in [0, 1] to a CSS color string (red → yellow → green). */
@@ -75,21 +136,57 @@ export function detectionFromAdjacency(
   };
 }
 
-/** Return detections passing the given filters, paired with their original indices. */
+/**
+ * Return detections passing the given filters, paired with their original indices.
+ *
+ * Mirrors georef's admission gate: the confidence floor, the size floors (both
+ * scaled together when relaxation is on, exactly as `passes_admission_gate`
+ * scales min_long_side by the ratio the short side was relaxed by), and the
+ * aspect-ratio floor. Detections admitted only by relaxation are flagged rather
+ * than silently mixed in.
+ *
+ * The word-level rejections georef also applies (number-only, bare letters,
+ * direction words) are deliberately not reproduced here: those depend on the
+ * volume's street vocabulary, which the viewer does not load.
+ */
 export function filterDetections(
   detections: Detection[],
   filters: DetectionFilters,
 ): IndexedDetection[] {
-  return detections
-    .map((det, i) => ({ det, i }))
-    .filter(
-      ({ det }) =>
-        det.confidence >= filters.minConfidence &&
-        det.short_side >= filters.minShortSide &&
-        det.long_side >= filters.minLongSide &&
-        (!det.ignore || filters.showIgnored) &&
-        matchesTextQuery(det.text, filters.text),
+  const out: IndexedDetection[] = [];
+  for (let i = 0; i < detections.length; i++) {
+    const det = detections[i];
+    if (det.confidence < filters.minConfidence) continue;
+    if (det.ignore && !filters.showIgnored) continue;
+    if (!matchesTextQuery(det.text, filters.text)) continue;
+    if (det.long_side < filters.minAspectRatio * det.short_side) continue;
+
+    const strict =
+      det.short_side >= filters.minShortSide &&
+      det.long_side >= filters.minLongSide;
+    if (strict) {
+      out.push({ det, i });
+      continue;
+    }
+    if (!filters.relaxation) continue;
+
+    const requiredShort = relaxedShortSide(
+      det.confidence,
+      filters.minConfidence,
+      filters.minShortSide,
+      filters.highConfidenceSizeFraction,
     );
+    // georef scales the long-side floor by whatever fraction the short side was
+    // relaxed by, so a relaxed detection is not held to the full long side.
+    const requiredLong =
+      filters.minShortSide > 0
+        ? filters.minLongSide * (requiredShort / filters.minShortSide)
+        : filters.minLongSide;
+    if (det.short_side >= requiredShort && det.long_side >= requiredLong) {
+      out.push({ det, i, relaxed: true });
+    }
+  }
+  return out;
 }
 
 // Escape a query term for use inside a RegExp.

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -737,3 +737,26 @@ tr.on-fill td {
   color: #777;
   font-variant-numeric: tabular-nums;
 }
+
+/* A detection admitted only by georef's confidence-for-size trade, not by clearing
+   the strict floors. Marked rather than blended in: these are the reads whose
+   acceptance rests on confidence, so they are the ones to look at when a fit is
+   built from small labels. */
+tr.relaxed {
+  background: rgba(255, 200, 0, 0.12);
+}
+
+.relaxed-badge {
+  margin-left: 4px;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: #f0ad4e;
+  color: #222;
+  font-size: 0.75em;
+}
+
+.filter-provenance {
+  font-size: 0.8em;
+  color: #666;
+  gap: 6px;
+}


### PR DESCRIPTION
Closes #205 

The streets view's sliders were an approximation of georef's admission gate — close enough to look right, different enough to mislead. This brings them in line with `passes_admission_gate`.

This visualizes the work of #78 / #79. Here's Brooklyn p28, the prototypical example of why relaxation is helpful:

<img width="1476" height="997" alt="image" src="https://github.com/user-attachments/assets/ee175018-41ac-4ae5-9fe1-97ffc04ec9c4" />

## What was off

- **`min_short_side` is auto-calibrated per volume** (the p25 of that volume's confident detections), so the hardcoded default of 20 was wrong for most volumes and there was no way to know what a run had used.
- **`min_long_side` was defaulting to 20** when georef derives it as `2 × min_short_side` — so the view was showing detections georef had rejected.
- **No aspect-ratio filter at all**, though georef applies `long_side >= min_aspect_ratio * short_side`.
- **No relaxation**, though georef trades confidence for size: a detection at the confidence floor must meet the full size floor, one at confidence 1.0 only `min_short_side × high_confidence_size_fraction` (0.7), interpolated as a power law.

## What it does now

Those thresholds are already recorded — `<stem>.georef.json` → `inputs.parameters`, on every sidecar. The view fetches the sibling sidecar and seeds the sliders from it, so they start where the run actually was.

I did this rather than pass them through the "streets view" link because `InfoPanel` doesn't have them: they live in the per-page sidecar, not the IIIF annotation, so a link couldn't carry them without a fetch anyway. This also works for a hand-typed URL.

Added:
- an **aspect-ratio slider**
- a **relaxation toggle** (on by default, matching georef), with detections admitted *only* by it marked `relaxed` and tinted — these are the reads whose acceptance rests on confidence rather than size, which is what you want to see when a fit is built from small labels
- a **provenance line** — `georef ran at short 20px, long 40px, conf 0.15` — which appends *(sliders changed)* and offers **restore** once you move off those values, so a drifted view can't masquerade as the run

The long-side floor is relaxed by the same proportion as the short side, matching `required_long_side = min_long_side * (required_short_side / min_short_side)`.

## Key maps show everything

The same component backs the key-map view, where none of this applies: a key map's detections are page numbers, not street reads, and georef's street gate never runs on them. The sliders are hidden there and every detection is shown.

Worth a look in review: my first version of that gated `streetsMode`, which `detectionsMode` derives from — so it also silently disabled the detection overlay and selection. Caught by checking the rendered DOM (`overlayShapes: 0`), not by the screenshot, since the key-map boxes are small and green on a busy sheet. A separate `showFilters` now gates the panel alone.

## Verification

- The relaxation curve is a port of `confidence_relaxed_threshold`; I checked it numerically against Python across the confidence range rather than assuming — identical to six decimals.
- 184 app tests pass (13 new), `tsc` clean, prettier applied.
- Checked in the browser on both views: Detroit p1 streets (sliders auto-set to short 20 / long 40, two relaxed rows) and Columbia's key map (no panel, all 70 detections, overlay intact).

## Deliberately not included

georef also rejects number-only text, bare single letters, and direction words. Those depend on the volume's street vocabulary, which the viewer never loads — noted in `filterDetections` rather than half-implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)