### PR TITLE
volume viewer: link a run's own sidecars, not the volume's latest

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -123,6 +123,25 @@ export interface KeymapInfo {
   hasGeoref: boolean;
 }
 
+/**
+ * Response of GET /iiif-api/run-artifacts — where a run's own sidecars live.
+ *
+ * A tagged run may keep per-page sidecars under `artifacts/<tag>/`, in which
+ * case the viewer should link there: the top-level `<stem>.georef.json` is
+ * whatever the last run wrote and need not be what produced the annotation
+ * being looked at. Not every run saves them, so this reports what is actually
+ * present rather than assuming.
+ *
+ * `dir` is the artifact directory, repo-root-relative, or null when the run has
+ * none. `stems` lists the page stems it holds a sidecar for, so the viewer can
+ * fall back per page instead of all-or-nothing — a run that saved only its
+ * failures still links those correctly.
+ */
+export interface RunArtifactsResponse {
+  dir: string | null;
+  stems: string[];
+}
+
 /** Response of GET /iiif-api/keymaps — a volume's key-map sheets, for the info-panel links. */
 export interface KeymapsResponse {
   keymaps: KeymapInfo[];
@@ -170,6 +189,9 @@ export interface API {
   };
   '/iiif-api/adjacency': {
     get: GetEndpoint<AdjacencyResponse, VolumeQuery>;
+  };
+  '/iiif-api/run-artifacts': {
+    get: GetEndpoint<RunArtifactsResponse, AnnotationQuery>;
   };
   '/iiif-api/keymaps': {
     get: GetEndpoint<KeymapsResponse, VolumeQuery>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -27,6 +27,7 @@ import {
   parseMissingTruthKeys,
 } from './compareTxt.ts';
 import { volumePages } from './adjacencyTruth.ts';
+import { runArtifactDir } from './runArtifacts.ts';
 
 const require = createRequire(import.meta.url);
 const iiif = require('express-iiif').default;
@@ -155,6 +156,39 @@ export function registerIiifApi(
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
     return rewriteAnnotationPage(page, localPages, serviceBaseUrl);
+  });
+
+  // Where a run's own per-page sidecars live, so the viewer can link to the files
+  // that produced the annotation being looked at rather than to whatever the last
+  // run happened to leave at the top level.
+  router.get('/iiif-api/run-artifacts', async (_params, request) => {
+    const rawPath = request.query.path;
+    const relativePath = rawPath.replace(/^data\//, '');
+    const parts = relativePath.split('/');
+    if (
+      !relativePath.endsWith('.iiif.json') ||
+      parts.length < 2 ||
+      !parts.every(isSafeName)
+    ) {
+      throw new HTTPError(400, `invalid path: ${rawPath}`);
+    }
+    const artifactDir = runArtifactDir(relativePath);
+    if (!artifactDir) return { dir: null, stems: [] };
+
+    let files: string[];
+    try {
+      files = await readdir(join(dataDir, artifactDir));
+    } catch {
+      // A run with no saved sidecars is the common case, not an error.
+      return { dir: null, stems: [] };
+    }
+    const stems = files
+      .map((file) => file.match(/^(p[^.]+)\.georef\.json$/)?.[1])
+      .filter((stem): stem is string => stem !== undefined)
+      .sort();
+    return stems.length > 0
+      ? { dir: `data/${artifactDir}`, stems }
+      : { dir: null, stems: [] };
   });
 
   // Per-page truth comparison from the annotation's `mapsnap compare` sidecar table

--- a/app/server/runArtifacts.test.ts
+++ b/app/server/runArtifacts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { runArtifactDir } from './runArtifacts.ts';
+
+describe('runArtifactDir', () => {
+  it('maps a volume-root annotation to its artifacts directory', () => {
+    expect(
+      runArtifactDir('detroit_mich_1929_vol_11/2026-07-30-full.iiif.json'),
+    ).toBe('detroit_mich_1929_vol_11/artifacts/2026-07-30-full');
+  });
+
+  it('returns the directory an annotation already sits in', () => {
+    // Opening the copy inside the run's own directory is its own answer; going
+    // up to the volume and back down would resolve to the same place, but only
+    // by luck of the tag matching the folder name.
+    expect(
+      runArtifactDir(
+        'detroit_mich_1929_vol_11/artifacts/2026-07-30-full/2026-07-30-full.iiif.json',
+      ),
+    ).toBe('detroit_mich_1929_vol_11/artifacts/2026-07-30-full');
+  });
+
+  it('handles nested volume paths', () => {
+    expect(runArtifactDir('brooklyn_1904-1908/vol13/b175.iiif.json')).toBe(
+      'brooklyn_1904-1908/vol13/artifacts/b175',
+    );
+  });
+
+  it('returns null for a non-annotation path', () => {
+    expect(
+      runArtifactDir('detroit_mich_1929_vol_11/p1.georef.json'),
+    ).toBeNull();
+    expect(runArtifactDir('main.iiif.json')).toBeNull();
+  });
+});

--- a/app/server/runArtifacts.ts
+++ b/app/server/runArtifacts.ts
@@ -1,0 +1,36 @@
+/**
+ * Locate the artifact directory that produced a given IIIF annotation page.
+ *
+ * `mapsnap fit --tag <tag>` writes `<volume>/<tag>.iiif.json` and, for some
+ * runs, a matching `<volume>/artifacts/<tag>/` holding the per-page sidecars
+ * that run produced. Those sidecars are the ones worth linking to from the
+ * viewer: the top-level `<stem>.georef.json` is whatever ran most recently and
+ * may have nothing to do with the annotation on screen.
+ */
+
+/**
+ * The `artifacts/<tag>` directory for an annotation, volume-relative, or null.
+ *
+ * Handles both ways an annotation is addressed: `<volume>/<tag>.iiif.json` (the
+ * copy at the volume root) and `<volume>/artifacts/<tag>/<tag>.iiif.json` (the
+ * one inside the run's own directory, which is its own answer).
+ *
+ * Returns a path only; whether it exists, and whether it holds anything useful,
+ * is the caller's to check.
+ */
+export function runArtifactDir(relativePath: string): string | null {
+  const parts = relativePath.split('/');
+  const file = parts[parts.length - 1];
+  if (!file?.endsWith('.iiif.json')) return null;
+  const tag = file.slice(0, -'.iiif.json'.length);
+
+  // Already inside the run's directory: `<volume>/artifacts/<tag>/<tag>.iiif.json`.
+  if (parts.length >= 3 && parts[parts.length - 2] === tag) {
+    return parts.slice(0, -1).join('/');
+  }
+  // At the volume root: `<volume>/<tag>.iiif.json`.
+  if (parts.length >= 2) {
+    return [...parts.slice(0, -1), 'artifacts', tag].join('/');
+  }
+  return null;
+}

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -4,6 +4,12 @@ import type { SkippedItem } from '../../server/iiifAnnotations';
 import type { PageCompareStats } from '../iiif/compare';
 import { hasFootprint, type PageGeo } from '../iiif/pages';
 
+/** A run's own artifact directory and the pages it saved sidecars for. */
+export interface RunArtifacts {
+  dir: string;
+  stems: string[];
+}
+
 interface InfoPanelProps {
   /** All pages in the loaded annotation, or [] before one is loaded. */
   pages: PageGeo[];
@@ -33,6 +39,13 @@ interface InfoPanelProps {
   keymaps: KeymapInfo[];
   /** Volume directory name, e.g. "brooklyn_ny_1906_vol_6". */
   volume: string;
+  /**
+   * The run's own artifact directory and the page stems it holds sidecars for,
+   * from GET /iiif-api/run-artifacts. Links prefer these over the top-level
+   * sidecars, which belong to whatever ran most recently rather than to the
+   * annotation on screen.
+   */
+  runArtifacts?: RunArtifacts;
   onClose: () => void;
 }
 
@@ -127,11 +140,18 @@ export function InfoPanel(props: InfoPanelProps) {
     compareFooter,
     keymaps,
     volume,
+    runArtifacts,
     onClose,
   } = props;
 
   if (selectedPage) {
-    const base = `data/${volume}/${selectedPage.stem}`;
+    // Prefer the run's own sidecar for this page; fall back to the volume root
+    // when this run did not save one, and say so rather than linking silently
+    // to a file that may have come from a different run.
+    const fromRun = !!runArtifacts?.stems.includes(selectedPage.stem);
+    const base = fromRun
+      ? `${runArtifacts!.dir}/${selectedPage.stem}`
+      : `data/${volume}/${selectedPage.stem}`;
     return (
       <div className="page-info-panel">
         <div className="page-info-header">
@@ -197,6 +217,19 @@ export function InfoPanel(props: InfoPanelProps) {
             <span className="page-info-note-label">📓 Note</span>
             <p>{selectedNote}</p>
           </div>
+        )}
+        {runArtifacts?.dir && !fromRun && (
+          <p className="page-info-fallback">
+            This run saved no sidecar for this page; the links below point at
+            the volume&rsquo;s top-level files, which may come from a different
+            run.
+          </p>
+        )}
+        {!runArtifacts?.dir && (
+          <p className="page-info-fallback">
+            This run has no artifact directory; the links below point at the
+            volume&rsquo;s top-level files, which may come from a different run.
+          </p>
         )}
         <div className="page-info-links">
           <a href={`?files=${base}.jpg,${base}.streets.json`}>streets view</a>

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -17,6 +17,7 @@ import {
   fetchCompare,
   fetchKeymaps,
   fetchRewrittenAnnotation,
+  fetchRunArtifacts,
   fetchVolumePageFiles,
   fetchVolumes,
 } from '../iiif/api';
@@ -29,7 +30,7 @@ import {
   pagesFromAnnotation,
   unfittedPages,
 } from '../iiif/pages';
-import { InfoPanel } from './InfoPanel';
+import { InfoPanel, type RunArtifacts } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
 
@@ -113,6 +114,9 @@ export function VolumeViewer() {
   const [compareMissing, setCompareMissing] = useState<string[]>([]);
   // The compare table's summary footer ("N/M pages georeferenced", RMSE stats), or "" if none.
   const [compareFooter, setCompareFooter] = useState<string>('');
+  // The annotation's own artifact directory, so page links point at the files
+  // that produced it rather than at whatever the last run left at the top level.
+  const [runArtifacts, setRunArtifacts] = useState<RunArtifacts | undefined>();
   // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
   const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
     null,
@@ -157,6 +161,7 @@ export function VolumeViewer() {
     // Per-page truth error and summary footer from this annotation's `mapsnap compare` sidecar.
     setCompareRows(null);
     setCompareFooter('');
+    setRunArtifacts(undefined);
     fetchCompare(selectedPath)
       .then(({ pages, missing, footer }) => {
         if (cancelled) return;
@@ -168,6 +173,17 @@ export function VolumeViewer() {
         if (cancelled) return;
         setCompareRows([]);
         setCompareMissing([]);
+      });
+
+    fetchRunArtifacts(selectedPath)
+      .then(({ dir, stems }) => {
+        if (cancelled) return;
+        setRunArtifacts(dir ? { dir, stems } : undefined);
+      })
+      .catch(() => {
+        // An older server without this endpoint degrades to the top-level
+        // links, which is what the viewer did before this existed.
+        if (!cancelled) setRunArtifacts(undefined);
       });
 
     // Truth annotation, rewritten into the same local pixel frame, for the missing-page
@@ -469,6 +485,7 @@ export function VolumeViewer() {
           onLoadResult={setLoadResult}
         />
         <InfoPanel
+          runArtifacts={runArtifacts}
           pages={pages}
           missingCount={missingPages.length}
           skipped={skipped}

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -1,6 +1,6 @@
 import { typedApi } from 'crosswalk';
 import { jsonFetch } from '../apiFetch';
-import type { API, KeymapInfo } from '../../server/api';
+import type { API, KeymapInfo, RunArtifactsResponse } from '../../server/api';
 import type { CompareResponse } from '../../server/compareTxt';
 import type {
   RewrittenAnnotationResponse,
@@ -67,6 +67,19 @@ export async function fetchAdjacency(
 }
 
 /** Fetch a volume's key-map sheets (raw/*.keymap.json) and which sidecars each has. */
+/**
+ * Where the run that produced `path` kept its own per-page sidecars.
+ *
+ * Returns `{ dir: null, stems: [] }` when the run saved none, which is the
+ * common case and not an error — the caller then falls back to the volume's
+ * top-level sidecars and says so.
+ */
+export async function fetchRunArtifacts(
+  path: string,
+): Promise<RunArtifactsResponse> {
+  return api.get('/iiif-api/run-artifacts')(null, { path });
+}
+
 export async function fetchKeymaps(volume: string): Promise<KeymapInfo[]> {
   const { keymaps } = await api.get('/iiif-api/keymaps')(null, { volume });
   return keymaps;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -760,3 +760,15 @@ tr.relaxed {
   color: #666;
   gap: 6px;
 }
+
+/* Shown when a page's debugger links fall back to the volume's top-level sidecars
+   because the run being viewed did not save its own. Worth stating: those files
+   belong to whatever ran last, which need not be the run on screen. */
+.page-info-fallback {
+  margin: 6px 0;
+  padding: 4px 6px;
+  border-left: 3px solid #f0ad4e;
+  background: rgba(255, 200, 0, 0.1);
+  font-size: 0.8em;
+  color: #555;
+}


### PR DESCRIPTION
Closes #230.

The page links in the volume viewer pointed at `data/<volume>/<stem>.georef.json` — whatever ran most recently — even when you were looking at a tagged run from days earlier. Clicking through to a sidecar from a *different* run is a quiet way to draw a wrong conclusion, and there was no indication it had happened.

## What it does

`GET /iiif-api/run-artifacts` resolves an annotation to its `artifacts/<tag>/` directory and reports which page stems it actually holds. The viewer links there when the run saved a sidecar for that page.

Two details worth review:

**The preference is per page, not per run.** A run that saved sidecars for only some pages still links those correctly and falls back for the rest, rather than being all-or-nothing.

**When a link falls back, the panel says so.** Pointing silently at a possibly-unrelated file is the bug being fixed, so doing it without a word would just relocate it.

`runArtifactDir` handles both ways an annotation gets addressed: the copy at the volume root (`<volume>/<tag>.iiif.json`) and the one inside the run's own directory (`<volume>/artifacts/<tag>/<tag>.iiif.json`), which is its own answer rather than something to resolve upward from.

An older server without the endpoint degrades to the previous behaviour instead of failing.

## Verification

- Live against both cases: a run **with** sidecars (`brooklyn_ny_1939_vol_1/8c4ee719-76104e4f` → 50+ stems) and the not-a-run case (returns `{dir: null, stems: []}`).
- 188 app tests pass (4 new for `runArtifactDir`), tsc and prettier clean.

## Scope note

Of 484 artifact directories in the corpus, **419 carry per-page sidecars**. The 65 that don't are feature directories (`edge_join`, `osm_snap`, `notes`) that are never a run tag — so for a real run the fallback path is rare. I'd initially believed it was common, from an `ls | head -3` that only showed the three files sorted before `p*`; the endpoint's live output corrected that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)