### PR TITLE
volume viewer: open page views inline, and fix their image paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@
 - Write unit tests for all public functions.
 - Functions should never take more than four positional arguments. To avoid this factor out dataclasses/interfaces, use keyword-only arguments or an options object, or group x/y parameters into  `(x, y)` tuples (or lat/lng, width/height, etc.).
 - All boolean variables (function parameters, command-line flags) should default to `false`.
+- Use American English:
+  - "Color" not "colour"
+  - "Penalize" not "penalise"
 
 ### Python
 

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  imageStemsByLowercase,
   rescaleSvgSelector,
   rewriteAnnotationPage,
   serviceUrlToPageKey,
@@ -189,5 +190,27 @@ describe('rewriteAnnotationPage', () => {
     const input = fixturePage();
     rewriteAnnotationPage(input, localPages, baseUrl);
     expect(input).toEqual(fixturePage());
+  });
+});
+
+describe('imageStemsByLowercase', () => {
+  it('maps a lowercased stem to the real filename case', async () => {
+    const { mkdtemp, writeFile } = await import('fs/promises');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const dir = await mkdtemp(join(tmpdir(), 'stems-'));
+    // The two conventions that coexist in the corpus: Chicago writes p103w.jpg
+    // for a URL ending 0103W, Asheville writes p33A.jpg for one ending 0033A.
+    await writeFile(join(dir, 'p103w.jpg'), '');
+    await writeFile(join(dir, 'p33A.jpg'), '');
+    await writeFile(join(dir, 'p7.jpg'), '');
+    const stems = await imageStemsByLowercase(dir);
+    expect(stems.get('p103w')).toBe('p103w');
+    expect(stems.get('p33a')).toBe('p33A');
+    expect(stems.get('p7')).toBe('p7');
+  });
+
+  it('returns an empty map for a missing directory', async () => {
+    expect((await imageStemsByLowercase('/nonexistent-volume')).size).toBe(0);
   });
 });

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -168,6 +168,18 @@ export function rewriteAnnotationPage(
   page: GeorefAnnotationPage,
   localPages: Map<string, LocalPageImage>,
   serviceBaseUrl: string,
+  /**
+   * Real page stems by lowercased form, from {@link imageStemsByLowercase}.
+   *
+   * The case of a lettered suffix cannot be derived from the annotation --
+   * Chicago's `...-0103W` is `p103w.jpg` on disk, Asheville's `...-0033A` is
+   * `p33A.jpg` -- so the derived key is resolved against the volume's actual
+   * filenames. Resolving here rather than in the caller keeps the keys this
+   * function emits and the keys it looks up in `localPages` the same; splitting
+   * that across two places silently turns every lettered page into
+   * "missing-image".
+   */
+  stemsByLowercase?: Map<string, string>,
 ): RewriteResult {
   const result: GeorefAnnotationPage = structuredClone(page);
   const kept: GeorefAnnotationItem[] = [];
@@ -176,7 +188,10 @@ export function rewriteAnnotationPage(
     const label = String(item.label ?? item.id ?? '');
     const target = item.target;
     const source = target?.source;
-    const pageKey = serviceUrlToPageKey(source?.id);
+    const derived = serviceUrlToPageKey(source?.id);
+    const pageKey = derived
+      ? (stemsByLowercase?.get(derived.toLowerCase()) ?? derived)
+      : derived;
     if (!pageKey || !target || !source?.width || !source.height) {
       skipped.push({ label, pageKey, reason: 'not-a-page' });
       continue;
@@ -219,4 +234,32 @@ export function rewriteAnnotationPage(
   }
   result.items = kept;
   return { annotation: result, skipped };
+}
+
+/**
+ * A volume's page-image stems, indexed by their lowercased form.
+ *
+ * The case of a lettered page suffix is not derivable from the annotation:
+ * Chicago's `...-0103W` is `p103w.jpg` on disk while Asheville's `...-0033A` is
+ * `p33A.jpg`, so the same URL shape maps to different filenames in different
+ * volumes. Rather than guess, callers derive a candidate key and look up the
+ * real stem here.
+ *
+ * Returns an empty map for an unreadable directory, so a caller falls back to
+ * its candidate rather than failing.
+ */
+export async function imageStemsByLowercase(
+  volumeDir: string,
+): Promise<Map<string, string>> {
+  const { readdir } = await import('fs/promises');
+  const stems = new Map<string, string>();
+  try {
+    for (const file of await readdir(volumeDir)) {
+      const match = file.match(/^(p[^/]*)\.jpg$/);
+      if (match?.[1]) stems.set(match[1].toLowerCase(), match[1]);
+    }
+  } catch {
+    /* no such directory; caller uses its candidate */
+  }
+  return stems;
 }

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -13,6 +13,7 @@ import type { Express } from 'express';
 import { HTTPError, type TypedRouter } from 'crosswalk';
 import type { API } from './api.ts';
 import {
+  imageStemsByLowercase,
   rewriteAnnotationPage,
   serviceUrlToPageKey,
   type AnnotationFileInfo,
@@ -140,10 +141,18 @@ export function registerIiifApi(
       );
     }
     const volumeDir = dirname(annotationPath);
+    const stems = await imageStemsByLowercase(volumeDir);
     const localPages = new Map<string, { width: number; height: number }>();
     for (const item of page.items) {
-      const pageKey = serviceUrlToPageKey(item?.target?.source?.id);
-      if (!pageKey || localPages.has(pageKey)) continue;
+      const derived = serviceUrlToPageKey(item?.target?.source?.id);
+      if (!derived) continue;
+      // Volumes disagree about the case of a lettered suffix -- Chicago's
+      // 0103W is p103w.jpg on disk, Asheville's 0033A is p33A.jpg -- so the
+      // derived key's case is a guess. Resolve it against the directory and
+      // use the real stem, or every link the viewer builds from it 404s on a
+      // case-sensitive filesystem (and reads the wrong name on a forgiving one).
+      const pageKey = stems.get(derived.toLowerCase()) ?? derived;
+      if (localPages.has(pageKey)) continue;
       try {
         const dims = await cachedJpegDimensions(
           join(volumeDir, `${pageKey}.jpg`),
@@ -155,7 +164,7 @@ export function registerIiifApi(
     }
     const volumePath = parts.slice(0, -1).join('/');
     const serviceBaseUrl = `${request.protocol}://${request.get('host')}/iiif/${volumePath}`;
-    return rewriteAnnotationPage(page, localPages, serviceBaseUrl);
+    return rewriteAnnotationPage(page, localPages, serviceBaseUrl, stems);
   });
 
   // Where a run's own per-page sidecars live, so the viewer can link to the files

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -184,12 +184,32 @@ declare global {
  * (text detections), panels (page-split polygons), and boxes (raw CRAFT
  * detection boxes per rotation).
  */
-export function App() {
-  const [mode, setMode] = useState<Mode>(() =>
-    new URLSearchParams(window.location.search).get('view') === 'iiif'
-      ? 'iiif'
-      : 'georef',
-  );
+/** Which files a debug view shows, and how it is being displayed. */
+export interface DebugViewProps {
+  /**
+   * Files to open, as `?files=` would name them. Omitted for the standalone
+   * page, which reads the URL instead.
+   */
+  files?: string[];
+  /**
+   * Shown as an "x" when given, for the embedded case. Its presence is also
+   * what tells the view it is embedded: the standalone page has nothing to
+   * close back to.
+   */
+  onClose?: () => void;
+}
+
+/**
+ * The debugger proper: one page's image with its overlay, table and controls.
+ *
+ * Rendered two ways. Standalone it is the whole page, reading `?files=` from
+ * the URL. Embedded in the volume viewer it takes `files` as a prop and sits
+ * where the map was, so that following a page's "streets view" link does not
+ * lose the volume, its page list or its selection.
+ */
+export function DebugView({ files: filesProp, onClose }: DebugViewProps = {}) {
+  const embedded = onClose !== undefined;
+  const [mode, setMode] = useState<Mode>('georef');
   const [streets, setStreets] = useState<Street[]>([]);
   const [intersections, setIntersections] = useState<IntersectionPoint[]>([]);
   const [keymap, setKeymap] = useState<KeymapLocation | null>(null);
@@ -627,7 +647,9 @@ export function App() {
   // On first load, honor a `?files=data/image.jpg,data/streets.json` deep link
   // by fetching those files from the dev server and entering the matching view.
   useEffect(() => {
-    const filesParam = new URLSearchParams(window.location.search).get('files');
+    const filesParam =
+      filesProp?.join(',') ??
+      new URLSearchParams(window.location.search).get('files');
     if (!filesParam) return;
     const files = filesParam
       .split(',')
@@ -660,19 +682,12 @@ export function App() {
     return () => window.removeEventListener('keydown', onKeydown);
   }, [mode]);
 
-  if (mode === 'iiif') {
-    return (
-      <div className="container container-iiif">
-        <VolumeViewer />
-      </div>
-    );
-  }
-
   // A key-map sheet is thousands of pixels wide and its marks are a few dozen
   // across, so it gets the full column width with a fixed table beside it --
   // whether it arrived as page regions or as page-number detections (#215).
   const containerClass = [
     'container',
+    embedded ? 'container-embedded' : '',
     mode === 'panels' || keymapSheet ? 'container-wide' : '',
     mode === 'streets' && keymapSheet ? 'container-keymap' : '',
   ]
@@ -682,7 +697,19 @@ export function App() {
   return (
     <div className={containerClass}>
       <nav className="view-nav">
-        <a href="?view=iiif">volume viewer</a>
+        {embedded ? (
+          <button
+            type="button"
+            className="debug-close"
+            onClick={onClose}
+            title="Close this view and show the map again"
+            aria-label="Close debug view"
+          >
+            ×
+          </button>
+        ) : (
+          <a href="?view=iiif">volume viewer</a>
+        )}
         {noteContext && <NoteButton ctx={noteContext} />}
       </nav>
       <ImageColumn
@@ -848,4 +875,24 @@ export function App() {
       </div>
     </div>
   );
+}
+
+/**
+ * Route between the volume viewer and the standalone debugger.
+ *
+ * `?view=iiif` gets the volume viewer, which now embeds {@link DebugView}
+ * itself when a page's view is opened; anything else is the standalone
+ * debugger reading `?files=` from the URL.
+ */
+export function App() {
+  const isVolumeViewer =
+    new URLSearchParams(window.location.search).get('view') === 'iiif';
+  if (isVolumeViewer) {
+    return (
+      <div className="container container-iiif">
+        <VolumeViewer />
+      </div>
+    );
+  }
+  return <DebugView />;
 }

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -4,6 +4,47 @@ import type { SkippedItem } from '../../server/iiifAnnotations';
 import type { PageCompareStats } from '../iiif/compare';
 import { hasFootprint, type PageGeo } from '../iiif/pages';
 
+/**
+ * One page view, offered both inline and as a standalone tab.
+ *
+ * Clicking the label opens it in place of the map, which keeps the volume, its
+ * page list and the current selection on screen. The adjacent arrow is a real
+ * link, so ctrl/cmd-click and "open in new tab" keep working exactly as before
+ * -- that was the habit this replaces, not one to take away.
+ */
+function DebugViewLink({
+  label,
+  files,
+  onOpen,
+}: {
+  label: string;
+  files: string[];
+  onOpen?: (files: string[], label: string) => void;
+}): ReactElement {
+  const href = `?files=${files.join(',')}`;
+  return (
+    <span className="debug-view-link">
+      {onOpen ? (
+        <button type="button" onClick={() => onOpen(files, label)}>
+          {label}
+        </button>
+      ) : (
+        <a href={href}>{label}</a>
+      )}
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className="debug-view-newtab"
+        title={`Open ${label} in a new tab`}
+        aria-label={`Open ${label} in a new tab`}
+      >
+        ↗
+      </a>
+    </span>
+  );
+}
+
 /** A run's own artifact directory and the pages it saved sidecars for. */
 export interface RunArtifacts {
   dir: string;
@@ -39,6 +80,11 @@ interface InfoPanelProps {
   keymaps: KeymapInfo[];
   /** Volume directory name, e.g. "brooklyn_ny_1906_vol_6". */
   volume: string;
+  /**
+   * Opens a page view inline, in place of the map. Absent in contexts with
+   * nowhere to put it, in which case the labels stay plain links.
+   */
+  onOpenDebugView?: (files: string[], label: string) => void;
   /**
    * The run's own artifact directory and the page stems it holds sidecars for,
    * from GET /iiif-api/run-artifacts. Links prefer these over the top-level
@@ -141,6 +187,7 @@ export function InfoPanel(props: InfoPanelProps) {
     keymaps,
     volume,
     runArtifacts,
+    onOpenDebugView,
     onClose,
   } = props;
 
@@ -148,10 +195,51 @@ export function InfoPanel(props: InfoPanelProps) {
     // Prefer the run's own sidecar for this page; fall back to the volume root
     // when this run did not save one, and say so rather than linking silently
     // to a file that may have come from a different run.
+    //
+    // Only the sidecar moves. An artifact directory holds a run's json and txt
+    // output, never page images -- those exist once, at the volume root -- so
+    // the image and its sidecar cannot share a base path.
     const fromRun = !!runArtifacts?.stems.includes(selectedPage.stem);
-    const base = fromRun
+    const imageBase = `data/${volume}/${selectedPage.stem}`;
+    const sidecarBase = fromRun
       ? `${runArtifacts!.dir}/${selectedPage.stem}`
-      : `data/${volume}/${selectedPage.stem}`;
+      : imageBase;
+
+    // A not-georeferenced page has no `<stem>.georef.json`; it has whichever
+    // failure sidecar the fit wrote, so link that instead of a missing file.
+    const georefFiles = selectedMissing
+      ? selectedFailedGeorefType
+        ? [
+            `${imageBase}.jpg`,
+            `${sidecarBase}.georef-${selectedFailedGeorefType}.json`,
+          ]
+        : null
+      : [`${imageBase}.jpg`, `${sidecarBase}.georef.json`];
+    const debugViews: { label: string; files: string[] }[] = [
+      {
+        label: 'streets view',
+        files: [`${imageBase}.jpg`, `${sidecarBase}.streets.json`],
+      },
+      ...(georefFiles
+        ? [
+            {
+              label: selectedMissing
+                ? `georef view (${selectedFailedGeorefType})`
+                : 'georef view',
+              files: georefFiles,
+            },
+          ]
+        : []),
+      ...(hasAdjacency
+        ? [
+            {
+              label: 'adjacency view',
+              // Adjacency is volume-wide, not per run.
+              files: [`${imageBase}.jpg`, `data/${volume}/adjacency.json`],
+            },
+          ]
+        : []),
+    ];
     return (
       <div className="page-info-panel">
         <div className="page-info-header">
@@ -232,23 +320,14 @@ export function InfoPanel(props: InfoPanelProps) {
           </p>
         )}
         <div className="page-info-links">
-          <a href={`?files=${base}.jpg,${base}.streets.json`}>streets view</a>
-          {selectedMissing ? (
-            selectedFailedGeorefType && (
-              <a
-                href={`?files=${base}.jpg,${base}.georef-${selectedFailedGeorefType}.json`}
-              >
-                georef view ({selectedFailedGeorefType})
-              </a>
-            )
-          ) : (
-            <a href={`?files=${base}.jpg,${base}.georef.json`}>georef view</a>
-          )}
-          {hasAdjacency && (
-            <a href={`?files=${base}.jpg,data/${volume}/adjacency.json`}>
-              adjacency view
-            </a>
-          )}
+          {debugViews.map(({ label, files }) => (
+            <DebugViewLink
+              key={label}
+              label={label}
+              files={files}
+              onOpen={onOpenDebugView}
+            />
+          ))}
         </div>
       </div>
     );

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -469,15 +469,12 @@ export function VolumeViewer() {
           selectedItemIndex={selectedItemIndex}
           onSelectPage={handleSelectPage}
         />
-        {debugView ? (
-          <div className="volume-viewer-debug">
-            <DebugView
-              key={debugView.files.join(',')}
-              files={debugView.files}
-              onClose={() => setDebugView(null)}
-            />
-          </div>
-        ) : (
+        {/* The map stays mounted while a debug view is open, hidden rather than
+            unmounted. Unmounting destroys the maplibre instance, and remounting
+            re-runs its initial fitBounds and refetches every tile -- a visible
+            jump and reload on what should be a return to where you were. Hiding
+            it keeps its layout box, so nothing resizes either. */}
+        <div className="volume-map-slot" aria-hidden={debugView !== null}>
           <VolumeMap
             annotation={annotation}
             pages={pages}
@@ -501,7 +498,16 @@ export function VolumeViewer() {
             }
             onLoadResult={setLoadResult}
           />
-        )}
+          {debugView && (
+            <div className="volume-viewer-debug">
+              <DebugView
+                key={debugView.files.join(',')}
+                files={debugView.files}
+                onClose={() => setDebugView(null)}
+              />
+            </div>
+          )}
+        </div>
         <InfoPanel
           onOpenDebugView={(files, label) => setDebugView({ files, label })}
           runArtifacts={runArtifacts}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -30,6 +30,7 @@ import {
   pagesFromAnnotation,
   unfittedPages,
 } from '../iiif/pages';
+import { DebugView } from '../App';
 import { InfoPanel, type RunArtifacts } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
@@ -117,6 +118,13 @@ export function VolumeViewer() {
   // The annotation's own artifact directory, so page links point at the files
   // that produced it rather than at whatever the last run left at the top level.
   const [runArtifacts, setRunArtifacts] = useState<RunArtifacts | undefined>();
+  // A page view opened in place of the map. Null shows the map. The volume,
+  // page list and selection are deliberately untouched by this, so closing the
+  // view returns to exactly what was on screen before.
+  const [debugView, setDebugView] = useState<{
+    files: string[];
+    label: string;
+  } | null>(null);
   // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
   const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
     null,
@@ -461,30 +469,41 @@ export function VolumeViewer() {
           selectedItemIndex={selectedItemIndex}
           onSelectPage={handleSelectPage}
         />
-        <VolumeMap
-          annotation={annotation}
-          pages={pages}
-          missingPages={missingPages}
-          truthPages={truthPages ?? []}
-          showMissing={showMissing}
-          selectedItemIndex={selectedItemIndex}
-          onSelectPage={handleSelectPage}
-          opacity={opacity / 100}
-          awaitingView={!!selectedPath && !error}
-          pageColors={pageColors}
-          adjacencyClaims={showAdjacency ? adjacencyClaims : []}
-          selectedStem={selectedPage?.stem ?? null}
-          initialViewport={initialViewport}
-          fitVolumeKey={volumeName ?? null}
-          onViewportChange={(center, zoom) =>
-            updateUrl({
-              center: `${center[0].toFixed(5)},${center[1].toFixed(5)}`,
-              zoom: zoom.toFixed(2),
-            })
-          }
-          onLoadResult={setLoadResult}
-        />
+        {debugView ? (
+          <div className="volume-viewer-debug">
+            <DebugView
+              key={debugView.files.join(',')}
+              files={debugView.files}
+              onClose={() => setDebugView(null)}
+            />
+          </div>
+        ) : (
+          <VolumeMap
+            annotation={annotation}
+            pages={pages}
+            missingPages={missingPages}
+            truthPages={truthPages ?? []}
+            showMissing={showMissing}
+            selectedItemIndex={selectedItemIndex}
+            onSelectPage={handleSelectPage}
+            opacity={opacity / 100}
+            awaitingView={!!selectedPath && !error}
+            pageColors={pageColors}
+            adjacencyClaims={showAdjacency ? adjacencyClaims : []}
+            selectedStem={selectedPage?.stem ?? null}
+            initialViewport={initialViewport}
+            fitVolumeKey={volumeName ?? null}
+            onViewportChange={(center, zoom) =>
+              updateUrl({
+                center: `${center[0].toFixed(5)},${center[1].toFixed(5)}`,
+                zoom: zoom.toFixed(2),
+              })
+            }
+            onLoadResult={setLoadResult}
+          />
+        )}
         <InfoPanel
+          onOpenDebugView={(files, label) => setDebugView({ files, label })}
           runArtifacts={runArtifacts}
           pages={pages}
           missingCount={missingPages.length}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -772,3 +772,73 @@ tr.relaxed {
   font-size: 0.8em;
   color: #555;
 }
+
+/* A page view opened inside the volume viewer, in the space the map occupies.
+   It is the same component the standalone debugger renders, so it keeps its own
+   scrolling and just needs to be told how much room it has. */
+.volume-viewer-debug {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  /* Anchors the embedded view's own nav, which would otherwise inherit
+     .view-nav's `position: fixed` and land over the info panel. */
+  position: relative;
+}
+
+/* Standalone, .view-nav is fixed to the window's top-right corner. Embedded, it
+   belongs to the view's own corner -- fixed positioning would put the close
+   button outside the box it closes. */
+.container-embedded .view-nav {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+}
+
+/* Embedded, the debugger drops the standalone page's outer padding and max
+   width: the volume viewer already positions it. */
+.container-embedded {
+  padding: 0;
+  max-width: none;
+  height: 100%;
+}
+
+.debug-close {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.3em;
+  line-height: 1;
+  padding: 0 6px;
+  color: #666;
+}
+.debug-close:hover {
+  color: #000;
+}
+
+/* Label opens the view inline; the arrow beside it is a plain link, so the
+   ctrl-click-for-a-new-tab habit still works. */
+.debug-view-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-right: 10px;
+}
+.debug-view-link button {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: #0066cc;
+  font: inherit;
+  text-decoration: underline;
+}
+.debug-view-newtab {
+  font-size: 0.85em;
+  text-decoration: none;
+  opacity: 0.6;
+}
+.debug-view-newtab:hover {
+  opacity: 1;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -776,15 +776,34 @@ tr.relaxed {
 /* A page view opened inside the volume viewer, in the space the map occupies.
    It is the same component the standalone debugger renders, so it keeps its own
    scrolling and just needs to be told how much room it has. */
-.volume-viewer-debug {
+/* Holds the map and, when one is open, a debug view laid over it. The map keeps
+   its box either way: it is hidden, never unmounted, so returning to it costs no
+   camera move and no tile refetch. */
+.volume-map-slot {
   flex: 1;
   min-width: 0;
+  display: flex;
+  position: relative;
+}
+
+.volume-map-slot > #map {
+  flex: 1;
+  min-width: 0;
+}
+
+/* A child with `visibility: visible` would defeat this, but the map only ever
+   sets its own visibility to hidden or leaves it unset, so it inherits. */
+.volume-map-slot[aria-hidden='true'] > #map {
+  visibility: hidden;
+}
+
+.volume-viewer-debug {
+  position: absolute;
+  inset: 0;
   overflow: auto;
+  background: #fff;
   border-left: 1px solid #ddd;
   border-right: 1px solid #ddd;
-  /* Anchors the embedded view's own nav, which would otherwise inherit
-     .view-nav's `position: fixed` and land over the info panel. */
-  position: relative;
 }
 
 /* Standalone, .view-nav is fixed to the window's top-right corner. Embedded, it


### PR DESCRIPTION
Two changes to the volume viewer's page links: the feature that was asked for, and a bug it exposed in already-merged code.

Inline streets view:

<img width="2151" height="1216" alt="image" src="https://github.com/user-attachments/assets/c6f0d1f9-4396-484f-9087-d6544324bea2" />

Inline georef view:

<img width="2140" height="1186" alt="image" src="https://github.com/user-attachments/assets/d8f97dad-afc3-4a0b-a70a-6e2fc1e3be03" />

Fixes #130 for real this time

## Inline views

Clicking **streets view** (or georef/adjacency) navigated away, losing the volume, page list and selection — so the workaround was ctrl-click and manage tabs. The view now renders where the map is, with the volume selector, page list and page info staying exactly where they were, and an **×** to dismiss it.

The **↗** beside each label is still a plain link with `target="_blank"`. This adds a way to stay put; it doesn't take away the way that already worked.

**Refactor**: `App` was 851 lines of debugger state with the volume-viewer branch at line 663. Rather than move 660 lines, it becomes a props-driven `DebugView` — `files` as a prop when embedded, `?files=` from the URL when standalone — under a ~15-line `App` that routes. `onClose`'s presence is what marks it embedded, since a standalone page has nothing to close back to and the two then can't disagree.

## The bug in #233

#233 built one `base` per page and used it for **both the image and the sidecar**. But an artifact directory holds a run's `json`/`txt` output and **never page images** — those exist once, at the volume root. So for any run that had saved sidecars, every link pointed at a jpg that doesn't exist. **The new-tab links were equally broken**; the inline view just surfaced it immediately.

```ts
const imageBase = `data/${volume}/${selectedPage.stem}`;
const sidecarBase = fromRun ? `${runArtifacts!.dir}/${selectedPage.stem}` : imageBase;
```

Two things about how it got through, since both are reusable lessons:

- I verified #233 by checking the endpoint's output and reading the constructed hrefs. Both were correct. I never followed one to see whether a page rendered — the endpoint being right and the links being wrong were independent failures, and I only tested the half I'd built.
- A `curl` status check would **not** have caught it: vite's dev server serves `index.html` for unknown paths, so the broken image URL returns **200**.

## Also

`.view-nav` is `position: fixed`, right for the standalone page's corner and wrong embedded — the close button landed 180px outside the container it closes, over the info panel. Now scoped to the standalone case.

## Verification

On the reported URL (`brooklyn_ny_1939_vol_1/2026-07-30-full`, p32): image loads from `data/brooklyn_ny_1939_vol_1/p32.jpg` at 1370×2067, sidecar from `artifacts/2026-07-30-full/p32.streets.json`, 9 detection rows, no error. Map hidden while open, restored with selection and URL intact on close. Standalone page keeps its "volume viewer" link, has no close button, and keeps its filter panel.

188 tests pass; tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)