### PR TITLE
Skip low-resolution key maps for vocabulary restriction

### DIFF
--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -65,6 +65,75 @@ def keymap_georef_path(keymap_json: Path) -> Path:
     )
 
 
+MIN_KEYMAP_MEGAPIXELS = 35.0
+"""Below this, a key map's page numbers are not read reliably enough to use.
+
+The corpus splits cleanly in two: Columbia at 24.3 MP and Asheville at 23.8,
+then nothing until Chicago at 43.0 and everything else 43.8-53.7. The threshold
+sits in a 1.8x gap with no sheet anywhere near it, so it is a separation of two
+populations rather than a tuned constant.
+
+What goes wrong below it is specific. Scale normalisation still delivers a digit
+to the recognizer at the right size -- 10.5 px on Columbia against Detroit's
+10.4 -- but from ~20% less ink, and a weak activation fires one CTC timestep
+instead of two. The detection box is then half a glyph wide, "17" reads as "1",
+and because 1 is a real page in a volume numbered 1-53 nothing downstream
+objects. That page is then handed page 1's neighbourhood, so its OCR vocabulary
+excludes the streets it actually contains: worse than no key map at all.
+
+Measured on Columbia, the only sub-threshold volume with truth data: dropping
+the restriction moves the volume from 45.7% to 63.0%, +12 pages placed and none
+lost.
+
+The floor applies only to the OCR/georef vocabulary restriction, which is the
+one consumer that needs each page's number read correctly. osm-snap and
+street-solve also build locators, and keep working on a sheet this bad: they
+use the key map's georeferenced rectangle (on Columbia, 22% of the volume's
+centerlines -- a property of the drawing, not of any number on it), and
+street-solve rejects a per-page prior whose detections disagree by more than
+400 m before using it. Gating them too costs 3.1 points, measured.
+
+Resolution is a correlate here, not the mechanism: a high-resolution sheet can
+read badly as well (Grand Rapids, 53.7 MP, is worth +3.3 to drop). This removes
+the sheets we know mislocate pages; it is not a claim that megapixels predict
+key-map quality.
+"""
+
+
+def keymap_megapixels(georef_path: Path) -> float | None:
+    """A key map's scan size in megapixels, or None if its sidecar omits it.
+
+    Read from the georef sidecar rather than the image, since it records the
+    dimensions and :func:`usable_keymaps` has already required it to exist --
+    no decode, and no second source of truth about the sheet's size.
+    """
+    try:
+        doc = json.loads(georef_path.read_text())
+        return float(doc["width"]) * float(doc["height"]) / 1e6
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def above_megapixel_floor(
+    keymap_json: Path, min_megapixels: float = MIN_KEYMAP_MEGAPIXELS
+) -> bool:
+    """Whether a key map is scanned finely enough to restrict a page's vocabulary.
+
+    A sheet whose sidecar does not record its dimensions passes: an unreadable
+    size is not evidence of a bad scan.
+    """
+    megapixels = keymap_megapixels(keymap_georef_path(keymap_json))
+    if megapixels is None or megapixels >= min_megapixels:
+        return True
+    print(
+        f"Ignoring key map {keymap_json.name} for vocabulary restriction: "
+        f"{megapixels:.1f} MP is under the {min_megapixels:g} MP floor, below "
+        "which page numbers are truncated often enough to mislocate pages.",
+        file=sys.stderr,
+    )
+    return False
+
+
 def usable_keymaps(directory: Path) -> list[Path]:
     """Key-map detections files in one directory that a locator can actually load.
 
@@ -72,6 +141,10 @@ def usable_keymaps(directory: Path) -> list[Path]:
     beside a ``-misscale``/``-nofit`` sidecar rather than the ``<stem>.georef.json``
     :func:`KeymapLocator.from_keymap` reads, so it is skipped here instead of
     raising when the locator gets around to opening it.
+
+    Deliberately not filtered by scan resolution: osm-snap and street-solve build
+    locators through here and get real value from a low-resolution sheet even when
+    its page numbers are unreliable (see :data:`MIN_KEYMAP_MEGAPIXELS`).
     """
     return [
         keymap_json
@@ -165,8 +238,13 @@ def resolve_keymaps(
     if ignore:
         return []
     if explicit:
+        # An explicit --keymap is the caller overriding the defaults, floor included.
         return [Path(path) for path in explicit]
-    return discover_keymaps(image_paths)
+    return [
+        keymap_json
+        for keymap_json in discover_keymaps(image_paths)
+        if above_megapixel_floor(keymap_json)
+    ]
 
 
 def keymap_regions_path(keymap_json: Path) -> Path:

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -1,13 +1,19 @@
+import json
 import math
 from pathlib import Path
 
+import pytest
+
 from mapsnap.keymap.locate import (
+    MIN_KEYMAP_MEGAPIXELS,
     KeymapLocator,
+    above_megapixel_floor,
     bilinear_pixel_to_world,
     discover_keymaps,
     estimate_radius,
     geometry_segments,
     geometry_vertices,
+    keymap_megapixels,
     meters_between,
     page_key,
     page_number,
@@ -386,3 +392,87 @@ def test_redundant_keymaps_drops_only_one_of_three_duplicates():
     b = {"1", "2", "3", "4", "5", "6"}
     multi = a | {"154", "823", "7217", "911"}
     assert redundant_keymaps([a, b, multi], VOLUME_KEYS) == {2}
+
+
+def write_keymap_pair(directory, stem, width, height):
+    """A <stem>.keymap.json with the georef sidecar usable_keymaps requires."""
+    (directory / f"{stem}.keymap.json").write_text(json.dumps({"streets": []}))
+    (directory / f"{stem}.georef.json").write_text(
+        json.dumps({"width": width, "height": height, "corners": []})
+    )
+
+
+def test_keymap_megapixels_reads_the_sidecar(tmp_path):
+    write_keymap_pair(tmp_path, "p0", 6447, 7795)
+    assert keymap_megapixels(tmp_path / "p0.georef.json") == pytest.approx(
+        50.3, abs=0.1
+    )
+
+
+def test_keymap_megapixels_returns_none_without_dimensions(tmp_path):
+    (tmp_path / "p0.georef.json").write_text(json.dumps({"corners": []}))
+    assert keymap_megapixels(tmp_path / "p0.georef.json") is None
+
+
+def test_above_megapixel_floor_splits_the_two_populations(tmp_path):
+    """Columbia's 4400x5517 is under the floor; Detroit's 6447x7795 is over it."""
+    write_keymap_pair(tmp_path, "columbia", 4400, 5517)
+    write_keymap_pair(tmp_path, "detroit", 6447, 7795)
+    assert not above_megapixel_floor(tmp_path / "columbia.keymap.json")
+    assert above_megapixel_floor(tmp_path / "detroit.keymap.json")
+
+
+def test_above_megapixel_floor_passes_a_sheet_with_no_recorded_size(tmp_path):
+    """An unreadable size is not evidence of a bad scan, so the sheet passes."""
+    (tmp_path / "p0.keymap.json").write_text(json.dumps({"streets": []}))
+    (tmp_path / "p0.georef.json").write_text(json.dumps({"corners": []}))
+    assert above_megapixel_floor(tmp_path / "p0.keymap.json")
+
+
+def test_usable_keymaps_ignores_resolution(tmp_path):
+    """The locator itself keeps low-resolution sheets.
+
+    osm-snap and street-solve build locators through usable_keymaps and get real
+    value from a sheet whose page numbers are unreliable -- its georeferenced
+    rectangle alone cuts Columbia's candidate streets to 22%. Only the
+    vocabulary restriction, which needs each page's number read correctly,
+    applies the floor.
+    """
+    write_keymap_pair(tmp_path, "columbia", 4400, 5517)
+    assert [p.name for p in usable_keymaps(tmp_path)] == ["columbia.keymap.json"]
+
+
+def test_usable_keymaps_still_requires_a_georef(tmp_path):
+    """The pre-existing rule is unchanged: no sidecar, no locator."""
+    (tmp_path / "p0.keymap.json").write_text(json.dumps({"streets": []}))
+    assert usable_keymaps(tmp_path) == []
+
+
+def test_resolve_keymaps_applies_the_floor_to_discovery(tmp_path):
+    """The vocabulary path drops a sub-floor sheet; the locator path kept it."""
+    write_keymap_pair(tmp_path, "p0", 4400, 5517)
+    (tmp_path / "p0.jpg").write_bytes(b"")
+    assert usable_keymaps(tmp_path) != []
+    assert resolve_keymaps(None, False, [str(tmp_path / "p0.jpg")]) == []
+
+
+def test_resolve_keymaps_honours_an_explicit_keymap(tmp_path):
+    """--keymap is the caller overriding the defaults, floor included."""
+    write_keymap_pair(tmp_path, "p0", 4400, 5517)
+    explicit = [str(tmp_path / "p0.keymap.json")]
+    assert resolve_keymaps(explicit, False, []) == [tmp_path / "p0.keymap.json"]
+
+
+def test_resolve_keymaps_still_honours_ignore(tmp_path):
+    write_keymap_pair(tmp_path, "p0", 6447, 7795)
+    (tmp_path / "p0.jpg").write_bytes(b"")
+    assert resolve_keymaps(None, True, [str(tmp_path / "p0.jpg")]) == []
+
+
+def test_megapixel_floor_sits_in_the_corpus_gap():
+    """The two populations are 23.8-24.3 MP and 43.0-53.7 MP; the floor is between.
+
+    Pinned because the value's justification is that gap, not the number itself:
+    a future sheet landing near the floor means the assumption needs rechecking.
+    """
+    assert 25.0 < MIN_KEYMAP_MEGAPIXELS < 42.0


### PR DESCRIPTION
Columbia's key map costs the volume **17 points**. This declines to use it for OCR vocabulary restriction, which is worth **45.7% → 63.0%** — 12 pages recovered, none lost.

## The mechanism

Columbia is scanned at **24.3 MP** where the corpus norm is 43–54. Scale normalisation still hands the recognizer a digit at the right *size* — 10.5 px against Detroit's 10.4 — but from ~20% less ink, so a weak activation fires one CTC timestep instead of two. The detection box is then **half a glyph wide**, `17` reads as `1`, and since 1 is a real page in a volume numbered 1–53, **nothing downstream objects**. That page is handed page 1's neighbourhood, and its OCR vocabulary excludes the streets it actually contains — worse than having no key map at all.

## The threshold

| | MP |
|---|---|
| Asheville | 23.8 |
| Columbia | 24.3 |
| *— 1.8× gap —* | |
| Chicago | 43.0 |
| … 21 others … | 43.8–53.1 |
| Grand Rapids | 53.7 |

35 MP sits in a hole with no sheet near it, so it separates two populations rather than being fitted to the data. A test pins **the gap** rather than the constant (`25.0 < MIN_KEYMAP_MEGAPIXELS < 42.0`), so a future sheet landing near the floor fails loudly instead of quietly changing behaviour.

## Where the floor applies, and where it deliberately doesn't

Only `resolve_keymaps` — the `ocr`/`georef` path, and the one consumer that needs each page's number read correctly.

**Not** `usable_keymaps`, which osm-snap and street-solve build locators through. Those get real value from a sheet this bad, because they don't depend on the numbers: the key map's **georeferenced rectangle** is a property of the drawing and cuts Columbia's candidate streets from 13,238 to 2,949 (**22%**), and street-solve already rejects a per-page prior whose detections disagree by more than 400 m — 10 of Columbia's 47 keys, leaving 37 usable.

I implemented the broad version first and measured the difference:

| arm | Score | pages |
|---|---|---|
| key map on | 45.7% | 61/87 |
| floor in `usable_keymaps` (broad) | 59.9% | 72/87 |
| **floor in `resolve_keymaps`** | **63.0%** | **73/87** |
| `--ignore-keymap` (reference) | 63.0% | 73/87 |

Gating the geometry channels too costs **3.1 points**. The narrow version matches the reference on every figure — `≤25ft 66.2%`, `≥200ft 3.1%` — not just the headline.

Tests pin the asymmetry (`test_usable_keymaps_ignores_resolution` beside `test_resolve_keymaps_applies_the_floor_to_discovery`), so a later tidy-up that unifies the two paths fails rather than silently costing those points back.

## Details

- An explicit `--keymap` still wins, matching the flag precedence already documented.
- A sidecar with no recorded dimensions passes: an unreadable size is not evidence of a bad scan.
- The check reads `width`/`height` from the georef sidecar `usable_keymaps` already requires — no image decode, no second source of truth.

## Scope, stated plainly

**Resolution is a correlate, not the mechanism.** Grand Rapids is the highest-resolution key map in the corpus at 53.7 MP and is still worth +3.3 to drop, from ordinary misreads rather than truncation. This removes the sheets we know mislocate pages; it is not a claim that megapixels predict key-map quality.

**Asheville is the other volume affected and has no truth data**, so its improvement is inferred from Columbia rather than measured. The image is still downloaded and kept, so it can be reconsidered without re-fetching once truth exists.

## Alternatives tried and rejected

This gate is the fourth thing tried on Columbia. Recording the other three so they don't get retried, and because two of them failed in instructive ways.

### 1. Fixing the recognizer with low-resolution training augmentation

The most principled option: if the CRNN has never seen a low-DPI scan, show it some. `train_crnn --lowres-prob` (already on main from #225) resamples whole sheets to a low-resolution scan and carries their labels along, so a degraded copy yields identical targets — free training data. It reproduces the real degradation: Detroit degraded to a 4400 px long side lands at strip sharpness 3851, between real Columbia (3675) and real Asheville (3819), and takes `working_scale`'s resampling branch.

Four arms at convergence (120 epochs), every arm excluding Asheville so its score is honestly held out:

| `--lowres-prob` | Asheville per-number | high-res held-out |
|---|---|---|
| **0.0 (control)** | **0.617** | 0.987 |
| 0.35 | 0.543 | 0.997 |
| 0.7 | 0.574 | 0.986 |
| 1.0 | 0.500 | 0.980 |

**Every augmented arm is worse than the control.** Synthetic degradation does not teach the model to read real low-DPI scans.

An earlier 40-epoch run appeared to show +10.6 points. That was confounded: the augmentation roughly doubles the dataset, so at a fixed epoch count the control got 1440 gradient steps against the prob-1.0 arm's 2840, and the control's loss was still 0.211 where the augmented arms reached 0.05. At equal convergence the sign reverses.

A follow-up hypothesis — that *real* low-resolution data would help where synthetic didn't — was also tested and **also failed**: training with Asheville included (everything else identical) made Columbia *worse*, 36/78 pages against the control's 36 → 28.

One caveat on that table: the Columbia "pages found" column used in those runs turned out to be a poor metric. Across six checkpoints it correlates with detections emitted at **r = 0.961** and with high-res accuracy at **r = −0.753** — it rewards a model for guessing more, not for guessing better. The Asheville per-number column is labelled, held out and precision-aware, and is what the conclusion rests on.

### 2. Detecting truncation from box geometry

The failure has a visible signature — boxes half a glyph wide — so three gates were tried on it:

- **px-per-character against the sheet median.** Flagged 2–44% of detections but did not separate Columbia (44%) from Detroit (17%) or Philadelphia (28%). Per-character width falls with label length, so it flagged Philadelphia's `206S`/`219S` and DC's `144`/`213`, plus every narrow `1`.
- **Normalised within character count.** Cut false positives to 0–5% but **broke on the one sheet that matters**: Columbia's truncated boxes are the *majority* of its single-character detections, so the within-length median becomes the truncated width. It dropped to 7 flags and caught none of the duplicates.
- **Aspect ratio, `width / (height × chars)`.** Correctly identifies Columbia (bimodal, p75/p25 = 1.98, with a mode at exactly half the dominant one) but produced 2 false alarms out of 25 sheets — Champaign and Ellenville, which are fine (23/24 and 14/15 pages found; the statistic is noisy at n=31 and n=21).

### 3. A per-page contradiction gate

Drop the vocabulary restriction for a page whose key-map detections disagree about where it is. Measured across four volumes:

| volume | key map on | contradiction gate | key map off |
|---|---|---|---|
| Columbia | 45.7% | 50.9% | 63.0% |
| Grand Rapids | 71.1% | 72.8% | 74.4% |
| Philadelphia | 82.9% | 82.9% | 83.3% |
| Miami | 67.1% | 67.9% | 63.5% |

It never regressed and is arguably still worth having — but it recovers only about a third of Columbia's available gain. The reason is diagnosable: a truncated `17` → `1` is only *contradicted* if page 1's own number is also read somewhere. **32 of Columbia's 78 pages have no read at all**, so the truncated `1` stands alone, looks perfectly clean, and still mislocates page 17.

### Why not a volume-level "ignore bad key maps" switch

Because the same four-volume A/B shows it would be a net loss. Dropping the key map is worth **+17.3** on Columbia and **−3.6 on Miami** — and Miami has the *worst* key-map georeference in the corpus (99 of 507 GCPs self-contradictory, 132 ft spline residual) while still being a volume whose key map earns its place. Key-map *reading* quality and *georeference* quality are independent, and only the first is what this gate keys on.

Two trust metrics were also tried and discarded: key-map coverage and duplicate-read rate. Both scored Chicago and Cincinnati at **0%**, which turned out to be artifacts of my own matching — Chicago's page keys carry direction suffixes (`10n`, `100w`) the key map doesn't print, and Cincinnati's pages are `10L`/`10R` half-sheets that one printed `10` legitimately serves. Both key maps are healthy.

931 tests pass; ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
