### PR TITLE
mapsnap archive: record a hand-assembled run

### DIFF
--- a/mapsnap/archive.py
+++ b/mapsnap/archive.py
@@ -1,0 +1,196 @@
+"""Archive an already-produced run into ``data/<volume>/artifacts/<tag>/``.
+
+``mapsnap fit`` archives what it computes, but a run is often assembled by hand:
+when only the last stage changed, re-running georef and snap to get a comparable
+number is minutes of work for no new information, so the shortcut is to run
+``mapsnap iiif`` and ``mapsnap compare`` against the sidecars already on disk.
+That leaves ``<volume>/<tag>.iiif.json`` and ``<volume>/<tag>.txt`` at the volume
+root with no artifact directory, so the run has no manifest, no provenance, and
+no per-page sidecars of its own -- and the volume viewer, which links a run's
+pages to the files that produced them, falls back to whatever ran most recently.
+
+This command closes that gap: it takes a tag whose IIIF and compare output
+already exist and archives them the same way ``fit`` would, with the same
+manifest. It computes nothing, so what it records is what is on disk right now.
+
+    mapsnap archive data/detroit_mich_1929_vol_11 --tag 2026-08-05-kmsnap
+
+Because it archives the *current* sidecars, it is only meaningful straight after
+the run that produced them; archiving a tag whose sidecars have since been
+overwritten records the wrong files, which ``--check`` reports rather than
+guesses about.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from mapsnap import experiments
+from mapsnap.fit import find_centerlines, find_ref_iiif
+
+
+def run_outputs(dir_path: Path, tag: str) -> tuple[Path | None, Path | None]:
+    """The ``<tag>.iiif.json`` and ``<tag>.txt`` a run left at the volume root."""
+    iiif_path = dir_path / f"{tag}.iiif.json"
+    compare_txt = dir_path / f"{tag}.txt"
+    return (
+        iiif_path if iiif_path.exists() else None,
+        compare_txt if compare_txt.exists() else None,
+    )
+
+
+def archived_stems(run_dir: Path) -> set[str]:
+    """Page stems whose georef sidecar is already in an archive directory."""
+    return {
+        path.name.split(".")[0]
+        for path in run_dir.glob("p*.georef.json")
+        if path.name.startswith("p")
+    }
+
+
+def is_complete(run_dir: Path) -> bool:
+    """Whether a run directory holds a finished archive.
+
+    The manifest is written last, so its presence -- not the directory's --
+    is what says the copy finished. A directory alone can be the remains of an
+    interrupted archive, and treating that as done would silently skip the work
+    that would have filled it.
+    """
+    return (run_dir / "manifest.json").exists()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Archive an already-produced run's sidecars into "
+            "data/<volume>/artifacts/<tag>/, as mapsnap fit does for runs it "
+            "computes itself."
+        )
+    )
+    parser.add_argument("dir", metavar="DIR", help="Volume directory")
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help=(
+            "Run tag, naming <tag>.iiif.json and <tag>.txt at the volume root "
+            "and the artifacts/<tag>/ directory to write."
+        ),
+    )
+    parser.add_argument(
+        "--label",
+        default=None,
+        metavar="NAME",
+        help="Human-readable name recorded alongside the run id in the manifest.",
+    )
+    parser.add_argument(
+        "--note",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "Recorded in the manifest as how this run was produced. A hand-run "
+            "sequence is otherwise unreconstructable: unlike a fit run, the "
+            "command line here does not describe what made the sidecars."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report what would be archived and exit without writing anything.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-archive over a complete existing archive for this tag.",
+    )
+    args = parser.parse_args()
+
+    dir_path = Path(args.dir)
+    if not dir_path.is_dir():
+        sys.exit(f"No such volume directory: {dir_path}")
+
+    iiif_path, compare_txt = run_outputs(dir_path, args.tag)
+    if iiif_path is None:
+        sys.exit(
+            f"No {args.tag}.iiif.json in {dir_path}. This command archives a run "
+            "that has already been produced; it does not compute one."
+        )
+
+    run_dir = dir_path / experiments.ARTIFACTS_DIRNAME / args.tag
+    sidecars = sorted(dir_path.glob("p*.georef*.json"))
+    # --check reports the state rather than acting on it, including the state
+    # that would otherwise stop the run: being told "already archived" and
+    # nothing else is exactly what a dry run should not do.
+    if args.check:
+        print(f"Would archive run {args.tag} from {dir_path}:")
+        print(f"  iiif    : {iiif_path.name}")
+        print(f"  compare : {compare_txt.name if compare_txt else '(none)'}")
+        print(
+            f"  sidecars: {len(sidecars)} georef, {len(list(dir_path.glob('p*.streets.json')))} streets"
+        )
+        print(f"  into    : {run_dir}")
+        if is_complete(run_dir):
+            print("  status  : already archived; archiving needs --force")
+        elif run_dir.exists():
+            print(
+                "  status  : directory exists but has no manifest (interrupted); would complete it"
+            )
+        else:
+            print("  status  : not archived yet")
+        return
+
+    if is_complete(run_dir) and not args.force:
+        sys.exit(
+            f"Run {args.tag} is already archived at {run_dir}; pass --force to replace."
+        )
+
+    if not sidecars:
+        sys.exit(
+            f"No p*.georef*.json in {dir_path}; there is nothing to archive. "
+            "Run the fit stages first."
+        )
+
+    centerlines = find_centerlines(dir_path)
+    if find_ref_iiif(dir_path) is None:
+        sys.exit(f"No reference IIIF found in {dir_path}")
+    truth = dir_path / "main.iiif.json"
+    git = experiments.git_head_info(dir_path)
+    inputs = experiments.gather_inputs(
+        dir_path, centerlines, truth if truth.exists() else None
+    )
+    command = [*sys.argv[0].split(), *sys.argv[1:]]
+
+    manifest = experiments.build_manifest(
+        dir_path,
+        args.tag,
+        [],
+        inputs,
+        git,
+        command,
+        truth if truth.exists() else None,
+        iiif_path,
+        args.label,
+    )
+    # A fit run's command line reproduces it; a hand-assembled one's does not,
+    # so record that this was archived after the fact rather than computed here.
+    manifest["archived_by"] = "mapsnap archive"
+    if args.note:
+        manifest["note"] = args.note
+
+    archived = experiments.archive_run(
+        dir_path, args.tag, manifest, iiif_path, compare_txt
+    )
+    stems = archived_stems(archived)
+    truth = (manifest.get("metrics") or {}).get("truth") or {}
+    placed = len(truth.get("per_page", {}))
+    print(f"Archived run {args.tag} to {archived} ({len(stems)} page sidecars)")
+    if placed:
+        print(f"  {placed} pages have a truth comparison in the manifest.")
+    if compare_txt is None:
+        print(
+            f"No {args.tag}.txt found, so the archive has no compare table.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mapsnap/archive_test.py
+++ b/mapsnap/archive_test.py
@@ -1,0 +1,54 @@
+"""Tests for `mapsnap archive`."""
+
+import json
+
+from mapsnap.archive import archived_stems, is_complete, run_outputs
+
+
+def test_run_outputs_finds_both(tmp_path):
+    (tmp_path / "run-a.iiif.json").write_text("{}")
+    (tmp_path / "run-a.txt").write_text("table")
+    iiif, compare = run_outputs(tmp_path, "run-a")
+    assert iiif == tmp_path / "run-a.iiif.json"
+    assert compare == tmp_path / "run-a.txt"
+
+
+def test_run_outputs_tolerates_a_missing_compare_table(tmp_path):
+    """A volume with no truth has no compare output; the run is still archivable."""
+    (tmp_path / "run-a.iiif.json").write_text("{}")
+    iiif, compare = run_outputs(tmp_path, "run-a")
+    assert iiif is not None
+    assert compare is None
+
+
+def test_run_outputs_returns_none_for_an_unknown_tag(tmp_path):
+    assert run_outputs(tmp_path, "nope") == (None, None)
+
+
+def test_is_complete_requires_the_manifest(tmp_path):
+    """A directory alone is not a finished archive.
+
+    archive_run creates the directory before copying into it, so an interrupted
+    run leaves one behind. The manifest is written last, which is what makes it
+    the honest completion marker -- and why `fit` checks for it rather than for
+    the directory, which would skip the run's computation for good.
+    """
+    run_dir = tmp_path / "artifacts" / "run-a"
+    run_dir.mkdir(parents=True)
+    assert not is_complete(run_dir)
+    (run_dir / "p1.georef.json").write_text("{}")
+    assert not is_complete(run_dir)
+    (run_dir / "manifest.json").write_text(json.dumps({"run_id": "run-a"}))
+    assert is_complete(run_dir)
+
+
+def test_is_complete_on_a_missing_directory(tmp_path):
+    assert not is_complete(tmp_path / "artifacts" / "never-ran")
+
+
+def test_archived_stems_lists_canonical_georefs(tmp_path):
+    for name in ("p1.georef.json", "p2.georef.json", "p33A.georef.json"):
+        (tmp_path / name).write_text("{}")
+    # Failure variants describe the same page and would double-count it.
+    (tmp_path / "p9.georef-nofit.json").write_text("{}")
+    assert archived_stems(tmp_path) == {"p1", "p2", "p33A"}

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -67,6 +67,10 @@ SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "mapsnap.make_iiif_georef",
         "Combine georeferences into a IIIF AnnotationPage",
     ),
+    "archive": (
+        "mapsnap.archive",
+        "Archive an already-produced run's sidecars under artifacts/<tag>/",
+    ),
     "compare": (
         "mapsnap.compare_iiif_georef",
         "Compare human vs computer IIIF georeferencing",

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from mapsnap import experiments
+from mapsnap import archive, experiments
 from mapsnap.utils import default_centerlines, list_pages, run_cmd
 
 
@@ -136,7 +136,12 @@ def main() -> None:
     run_id = resolve_run_id(dir_path, args.tag, id_tokens, inputs, git)
 
     archive_dir = dir_path / experiments.ARTIFACTS_DIRNAME / run_id
-    if archive_dir.exists():
+    # The manifest is written last, so it -- not the directory -- is what says a
+    # previous run finished. archive_run creates the directory before copying
+    # into it, so an interrupted run leaves an empty one; treating that as done
+    # would skip this run's computation for good and leave the tag permanently
+    # empty.
+    if archive.is_complete(archive_dir):
         print(f"Run {run_id} already archived at {archive_dir}; skipping computation.")
         return
 


### PR DESCRIPTION
Formalises the shortcut we've both been using, and fixes a latent bug it exposed in `fit`.

## The gap

`mapsnap fit` archives what it computes. But when only the last stage changed, re-running georef and snap to get a comparable number is minutes of work for no new information — so the shortcut is `mapsnap iiif` + `mapsnap compare` against the sidecars already on disk.

That leaves `<tag>.iiif.json` and `<tag>.txt` at the volume root with **no artifact directory**: no manifest, no provenance, no per-page sidecars of the run's own. The volume viewer then falls back to whatever ran most recently, which is exactly what #233 was meant to stop.

This isn't hypothetical: **seven volumes are in that state for `2026-08-02-gate` alone**, and every comparison run in this session's key-map work was built that way.

## `mapsnap archive <volume> --tag <tag>`

Computes nothing; archives what's on disk with the same manifest `fit` writes.

- `--check` reports what would be archived and stops. It deliberately reports the *already-archived* state rather than exiting on it — being told only "already archived" is what a dry run should not do. (I wrote it the other way first and immediately hit it.)
- `--note` is recorded in the manifest. A hand-assembled run's command line doesn't describe what produced it, and without this the manifest would read as though `mapsnap archive` had computed the run. `archived_by` marks it too.
- `--force` to replace a complete archive.

## The latent bug in `fit`

```python
if archive_dir.exists():   # ← before
    print(f"Run {run_id} already archived ...")
    return
```

`archive_run` calls `run_dir.mkdir()` **before** copying anything into it. A run interrupted between those two points leaves an empty directory, and every later `fit` with that tag then skips computation and returns — permanently, silently. The manifest is written last, so `is_complete()` checks for that instead.

Nothing in the corpus is in that state today; this keeps it that way.

## Verified end to end

Archived a real unarchived run (`brooklyn_ny_1939_vol_1 --tag 2026-07-30b`): 216 files, manifest carrying `archived_by`, the note, git provenance and 55 per-page truth comparisons, and `GET /iiif-api/run-artifacts` then resolving the run to 53 page stems — i.e. the viewer picks it up. I removed that test archive afterwards rather than leave it in `data/`, since the current sidecars are not necessarily the ones that produced that tag.

Error paths checked: unknown tag, missing volume, no sidecars.

937 tests pass (6 new); ruff and pyright clean.

## One thing found, not fixed

**No manifest in the corpus has `metrics.score`**, so `fit`'s score-printing block has never fired. I've left it alone rather than fix it in an unrelated change, but I did leave the same block out of this command instead of copying it in dead. Worth a separate look.

## Known limitation

The command archives the sidecars that are on disk *now*, so it's only meaningful straight after the run that produced them. Archiving a tag whose sidecars have since been overwritten records the wrong files. `--check` shows what it would take so that's visible before writing, but nothing verifies the sidecars actually match the annotation — that would need a content hash comparison against the IIIF, which I haven't attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)