### PR TITLE
Fix the circular import that broke `mapsnap fit`

### DIFF
--- a/mapsnap/archive.py
+++ b/mapsnap/archive.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 
 from mapsnap import experiments
+from mapsnap.experiments import is_complete
 from mapsnap.fit import find_centerlines, find_ref_iiif
 
 
@@ -46,17 +47,6 @@ def archived_stems(run_dir: Path) -> set[str]:
         for path in run_dir.glob("p*.georef.json")
         if path.name.startswith("p")
     }
-
-
-def is_complete(run_dir: Path) -> bool:
-    """Whether a run directory holds a finished archive.
-
-    The manifest is written last, so its presence -- not the directory's --
-    is what says the copy finished. A directory alone can be the remains of an
-    interrupted archive, and treating that as done would silently skip the work
-    that would have filled it.
-    """
-    return (run_dir / "manifest.json").exists()
 
 
 def main() -> None:

--- a/mapsnap/cli_test.py
+++ b/mapsnap/cli_test.py
@@ -1,0 +1,34 @@
+"""Tests for the command registry itself."""
+
+import importlib
+import sys
+
+import pytest
+
+from mapsnap.cli import SUBCOMMANDS
+
+
+@pytest.mark.parametrize("name", sorted(SUBCOMMANDS))
+def test_every_command_module_imports(name: str) -> None:
+    """Each registered command's module imports on its own and has a main().
+
+    Every mapsnap.* module is evicted from sys.modules first, so each command
+    is imported the way its own invocation would: first, into a clean
+    interpreter. That is what makes this catch a circular import.
+
+    `mapsnap fit` broke exactly this way -- fit imported archive while archive
+    imported fit -- and nothing caught it. Unit tests import leaf functions, not
+    whole modules; and an earlier version of this test imported modules in
+    alphabetical order, where `archive` lands first and resolves the cycle
+    before `fit` is reached. The break only appears when the module that owns
+    the cycle is imported first, which is precisely what running the command
+    does.
+    """
+    for module_name in [key for key in sys.modules if key.startswith("mapsnap")]:
+        del sys.modules[module_name]
+
+    module_name, _ = SUBCOMMANDS[name]
+    module = importlib.import_module(module_name)
+    assert callable(getattr(module, "main", None)), (
+        f"{module_name} has no main() for `mapsnap {name}`"
+    )

--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -288,6 +288,20 @@ def archive_streets(dir_path: Path, run_dir: Path, dedup_source: Path | None) ->
         shutil.copy2(streets, dest)
 
 
+def is_complete(run_dir: Path) -> bool:
+    """Whether a run directory holds a finished archive.
+
+    :func:`archive_run` creates the directory before copying into it, so an
+    interrupted archive leaves one behind with nothing (or half) in it. The
+    manifest is written last, which makes its presence -- not the directory's --
+    the honest completion marker.
+
+    Lives here rather than in ``mapsnap.archive`` because ``mapsnap.fit`` needs
+    it too, and ``mapsnap.archive`` imports from ``mapsnap.fit``.
+    """
+    return (run_dir / "manifest.json").exists()
+
+
 def archive_run(
     dir_path: Path,
     run_id: str,

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from mapsnap import archive, experiments
+from mapsnap import experiments
 from mapsnap.utils import default_centerlines, list_pages, run_cmd
 
 
@@ -141,7 +141,7 @@ def main() -> None:
     # into it, so an interrupted run leaves an empty one; treating that as done
     # would skip this run's computation for good and leave the tag permanently
     # empty.
-    if archive.is_complete(archive_dir):
+    if experiments.is_complete(archive_dir):
         print(f"Run {run_id} already archived at {archive_dir}; skipping computation.")
         return
 


### PR DESCRIPTION
**`mapsnap fit` does not run on `main`.** #236 (mine) introduced a circular import: `fit` imports `archive` for `is_complete`, while `archive` imports `fit` for `find_centerlines`/`find_ref_iiif`. Importing `fit` first — which is what running the command does — reaches `archive` while `fit` is still initialising and fails.

```
$ mapsnap fit --help
ImportError: cannot import name 'find_centerlines' from partially initialized
module 'mapsnap.fit' (most likely due to a circular import)
```

I found it when a Detroit pipeline run died on startup.

## Fix

`is_complete` moves to `experiments`, beside the `archive_run` whose mkdir-then-copy behaviour it describes. Both `fit` and `archive` already depend on `experiments`, so the cycle is removed rather than reordered.

## Why nothing caught it

The suite imports leaf functions, never a command module as a whole — 937 tests passed against a CLI whose main pipeline command couldn't start. `cli_test.py` now imports every registered command's module and checks it exposes `main()`.

**The first version of that test did not work**, and it's worth saying why. It imported modules in parametrised (alphabetical) order, so `archive` was imported before `fit` and populated `sys.modules`, resolving the cycle — it passed against the broken code. Circular imports only fail when the module that owns the cycle is imported *first*. The test now evicts every `mapsnap.*` module before each case, reproducing a cold interpreter per command.

Verified both directions: with the fix stashed it fails on `[fit]`; with the fix it passes.

966 tests pass; ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)