### PR TITLE
Make subvolumes first-class in the volume viewer (#228)

### DIFF
--- a/app/server/adjacencyTruth.ts
+++ b/app/server/adjacencyTruth.ts
@@ -20,13 +20,13 @@
  */
 
 import { readFile, readdir, writeFile } from 'fs/promises';
+import { MAX_VOLUME_DEPTH, isSafeVolume } from './volumePaths.ts';
+
+export { isSafeVolume };
 import { join } from 'path';
 
 /** A page image at the volume root: a whole sheet (p12, p33B, p101w) or a panel (p12__1). */
 const PAGE_IMAGE = /^p\d+[A-Za-z]{0,2}(?:__\d+)?\.jpe?g$/;
-
-/** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
-const MAX_VOLUME_DEPTH = 2;
 
 /** One volume that has labelable pages. */
 export interface AdjacencyVolume {
@@ -42,16 +42,6 @@ export interface AdjacencyPageTruth {
   width: number;
   height: number;
   labels: { x: number; y: number; text: string }[];
-}
-
-/** Reject a volume path that could escape the data directory. */
-export function isSafeVolume(volume: string): boolean {
-  const parts = volume.split('/');
-  if (parts.length < 1 || parts.length > MAX_VOLUME_DEPTH) return false;
-  return parts.every(
-    (part) =>
-      part !== '' && part !== '.' && part !== '..' && !part.includes('\\'),
-  );
 }
 
 /** Reject a page stem that is not a whole-sheet stem or a split panel. */

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -27,8 +27,9 @@ import {
   parseLandByPage,
   parseMissingTruthKeys,
 } from './compareTxt.ts';
-import { volumePages } from './adjacencyTruth.ts';
+import { findVolumes, volumePages } from './adjacencyTruth.ts';
 import { runArtifactDir } from './runArtifacts.ts';
+import { isSafeSegment, isSafeVolume } from './volumePaths.ts';
 
 const require = createRequire(import.meta.url);
 const iiif = require('express-iiif').default;
@@ -38,16 +39,6 @@ const PAGE_IMAGE_PATTERN = /^p\d+[a-z]?\.jpg$/i;
 // A failed-georef sidecar name -> [full, stem, kind], e.g.
 // "p1452.georef-nofit.json" -> ["…", "p1452", "nofit"].
 const FAILED_GEOREF_PATTERN = /^(.+)\.georef-([a-z0-9]+)\.json$/i;
-
-// Reject a path segment that could escape the data directory.
-function isSafeName(name: string): boolean {
-  return (
-    name !== '' &&
-    !name.includes('/') &&
-    !name.includes('\\') &&
-    !name.includes('..')
-  );
-}
 
 // Read a *.iiif.json if it is a georeference AnnotationPage, else null.
 async function readAnnotationPage(
@@ -90,17 +81,21 @@ export function registerIiifApi(
   router: TypedRouter<API>,
   dataDir: string,
 ): void {
-  // List volume directories that have local page images and annotation files.
+  // Volume directories that have local page images and annotation files.
+  //
+  // findVolumes descends into a multi-volume atlas, so `brooklyn_1904-1908/vol13`
+  // is listed under that name rather than being missed because its parent holds no
+  // page images (#228). It stops at the first page-bearing directory on a branch,
+  // so a volume's own `raw/` is never listed as a volume.
   router.get('/iiif-api/volumes', async () => {
-    const entries = await readdir(dataDir, { withFileTypes: true });
     const volumes: VolumeInfo[] = [];
-    for (const entry of entries.filter((e) => e.isDirectory())) {
-      const files = await readdir(join(dataDir, entry.name));
+    for (const name of await findVolumes(dataDir)) {
+      const files = await readdir(join(dataDir, name));
       const pageCount = files.filter((f) => PAGE_IMAGE_PATTERN.test(f)).length;
       if (pageCount === 0) continue;
       const annotations: AnnotationFileInfo[] = [];
       for (const file of files.filter((f) => f.endsWith('.iiif.json'))) {
-        const path = join(dataDir, entry.name, file);
+        const path = join(dataDir, name, file);
         const page = await readAnnotationPage(path);
         if (!page) continue;
         const { mtimeMs } = await stat(path);
@@ -112,7 +107,7 @@ export function registerIiifApi(
       }
       if (annotations.length === 0) continue;
       annotations.sort((a, b) => b.modifiedMs - a.modifiedMs);
-      volumes.push({ name: entry.name, pageCount, annotations });
+      volumes.push({ name, pageCount, annotations });
     }
     volumes.sort((a, b) => a.name.localeCompare(b.name));
     return { volumes };
@@ -128,7 +123,7 @@ export function registerIiifApi(
     if (
       !relativePath.endsWith('.iiif.json') ||
       parts.length < 2 ||
-      !parts.every(isSafeName)
+      !parts.every(isSafeSegment)
     ) {
       throw new HTTPError(400, `invalid path: ${rawPath}`);
     }
@@ -177,7 +172,7 @@ export function registerIiifApi(
     if (
       !relativePath.endsWith('.iiif.json') ||
       parts.length < 2 ||
-      !parts.every(isSafeName)
+      !parts.every(isSafeSegment)
     ) {
       throw new HTTPError(400, `invalid path: ${rawPath}`);
     }
@@ -209,7 +204,7 @@ export function registerIiifApi(
     if (
       !relativePath.endsWith('.iiif.json') ||
       parts.length < 2 ||
-      !parts.every(isSafeName)
+      !parts.every(isSafeSegment)
     ) {
       throw new HTTPError(400, `invalid path: ${rawPath}`);
     }
@@ -236,7 +231,7 @@ export function registerIiifApi(
   // for the viewer's adjacency overlay. Null when the volume has no adjacency data.
   router.get('/iiif-api/adjacency', async (_params, request) => {
     const { volume } = request.query;
-    if (!isSafeName(volume)) {
+    if (!isSafeVolume(volume)) {
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
     try {
@@ -257,7 +252,7 @@ export function registerIiifApi(
   // { pages: ["p1", …], failed: { "p1452": "nofit", "p1427": "misscale" } }.
   router.get('/iiif-api/failed-georefs', async (_params, request) => {
     const { volume } = request.query;
-    if (!isSafeName(volume)) {
+    if (!isSafeVolume(volume)) {
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
     let files: string[];
@@ -284,7 +279,7 @@ export function registerIiifApi(
   // <stem>.georef.json are the region and georef views. ?volume=<dir> → { keymaps: [...] }.
   router.get('/iiif-api/keymaps', async (_params, request) => {
     const { volume } = request.query;
-    if (!isSafeName(volume)) {
+    if (!isSafeVolume(volume)) {
       throw new HTTPError(400, `invalid volume: ${volume}`);
     }
     let files: string[];

--- a/app/server/keymapPages.ts
+++ b/app/server/keymapPages.ts
@@ -11,12 +11,10 @@
 
 import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
+import { MAX_VOLUME_DEPTH } from './volumePaths.ts';
 
 /** Extensions a raw page image may use, in the order they are probed. */
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png'];
-
-/** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
-const MAX_VOLUME_DEPTH = 2;
 
 /** A key-map page: where its files live and which of them exist. */
 export interface KeymapPage {

--- a/app/server/notes.test.ts
+++ b/app/server/notes.test.ts
@@ -14,9 +14,20 @@ describe('isValidNoteTarget', () => {
     expect(isValidNoteTarget('brooklyn_1904-1908', 'p6N')).toBe(true);
   });
 
+  it('accepts a subvolume of a multi-volume atlas', () => {
+    expect(isValidNoteTarget('brooklyn_1904-1908/vol13', 'p6')).toBe(true);
+    expect(isValidNoteTarget('queens_1950/vol2', 'p1401__2')).toBe(true);
+  });
+
+  it('rejects a path deeper than a volume', () => {
+    // Otherwise a volume's own subdirectories could be addressed as volumes.
+    expect(isValidNoteTarget('brooklyn_1904-1908/vol13/raw', 'p6')).toBe(false);
+  });
+
   it('rejects path escapes and separators', () => {
     expect(isValidNoteTarget('..', 'p1')).toBe(false);
-    expect(isValidNoteTarget('vol/sub', 'p1')).toBe(false);
+    expect(isValidNoteTarget('vol/..', 'p1')).toBe(false);
+    expect(isValidNoteTarget('vol//sub', 'p1')).toBe(false);
     expect(isValidNoteTarget('vol', '../secret')).toBe(false);
     expect(isValidNoteTarget('vol', 'p1/p2')).toBe(false);
     expect(isValidNoteTarget('vol', 'p1.json')).toBe(false); // no dots in page

--- a/app/server/notes.ts
+++ b/app/server/notes.ts
@@ -7,6 +7,7 @@
  */
 
 import { join } from 'path';
+import { isSafeVolume } from './volumePaths.ts';
 
 /** On-disk shape of a note sidecar. */
 export interface NoteFile {
@@ -15,25 +16,16 @@ export interface NoteFile {
   updated: string;
 }
 
-// A path segment safe to join under the data directory: non-empty, no slashes
-// or parent-directory escapes. (Same rule the image/label servers use.)
-function isSafeSegment(name: string): boolean {
-  return (
-    name !== '' &&
-    !name.includes('/') &&
-    !name.includes('\\') &&
-    !name.includes('..')
-  );
-}
-
 /**
  * Whether ``volume`` and ``page`` are safe to use as path segments.
  *
- * ``page`` must additionally be a bare page key (letters, digits, underscores —
- * e.g. "p1401__2"), so the only file it can name is ``<page>.json``.
+ * ``volume`` may name a subvolume of a multi-volume atlas
+ * (``brooklyn_1904-1908/vol13``); ``page`` must be a bare page key (letters,
+ * digits, underscores — e.g. "p1401__2"), so the only file it can name is
+ * ``<page>.json``.
  */
 export function isValidNoteTarget(volume: string, page: string): boolean {
-  return isSafeSegment(volume) && /^[A-Za-z0-9_]+$/.test(page);
+  return isSafeVolume(volume) && /^[A-Za-z0-9_]+$/.test(page);
 }
 
 /** Directory holding a volume's note sidecars, under ``dataDir``. */

--- a/app/server/volumePaths.test.ts
+++ b/app/server/volumePaths.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeSegment, isSafeVolume, MAX_VOLUME_DEPTH } from './volumePaths';
+
+describe('isSafeSegment', () => {
+  it('accepts an ordinary directory name', () => {
+    expect(isSafeSegment('detroit_mich_1929_vol_11')).toBe(true);
+    expect(isSafeSegment('brooklyn_1904-1908')).toBe(true);
+  });
+
+  it('rejects anything that could escape the data directory', () => {
+    expect(isSafeSegment('')).toBe(false);
+    expect(isSafeSegment('..')).toBe(false);
+    expect(isSafeSegment('a/b')).toBe(false);
+    expect(isSafeSegment('a\\b')).toBe(false);
+    expect(isSafeSegment('../etc')).toBe(false);
+    expect(isSafeSegment('.')).toBe(false);
+  });
+});
+
+describe('isSafeVolume', () => {
+  it('accepts a single-directory volume', () => {
+    expect(isSafeVolume('detroit_mich_1929_vol_11')).toBe(true);
+  });
+
+  it('accepts a subvolume of a multi-volume atlas', () => {
+    expect(isSafeVolume('brooklyn_1904-1908/vol13')).toBe(true);
+    expect(isSafeVolume('queens_1950/vol2')).toBe(true);
+  });
+
+  it('rejects a path deeper than a volume', () => {
+    // A volume's own subdirectories are not volumes: allowing this would let
+    // ?volume=<vol>/raw address the key-map directory as a volume.
+    expect(isSafeVolume('brooklyn_1904-1908/vol13/raw')).toBe(false);
+    expect(isSafeVolume('a/b/c/d')).toBe(false);
+  });
+
+  it('rejects escapes in any segment', () => {
+    expect(isSafeVolume('..')).toBe(false);
+    expect(isSafeVolume('brooklyn_1904-1908/..')).toBe(false);
+    expect(isSafeVolume('../brooklyn_1904-1908')).toBe(false);
+    expect(isSafeVolume('brooklyn_1904-1908/.')).toBe(false);
+    // "a/" is depth 2 with an empty second segment and must still be rejected.
+    expect(isSafeVolume('a/')).toBe(false);
+    expect(isSafeVolume('')).toBe(false);
+  });
+
+  it('agrees with the documented depth limit', () => {
+    expect(MAX_VOLUME_DEPTH).toBe(2);
+    expect(isSafeVolume(Array(MAX_VOLUME_DEPTH).fill('v').join('/'))).toBe(
+      true,
+    );
+    expect(
+      isSafeVolume(
+        Array(MAX_VOLUME_DEPTH + 1)
+          .fill('v')
+          .join('/'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/server/volumePaths.ts
+++ b/app/server/volumePaths.ts
@@ -1,0 +1,35 @@
+/**
+ * Where a volume lives under `data/`, and what counts as a safe volume name.
+ *
+ * A volume is usually one directory (`data/detroit_mich_1929_vol_11`), but a
+ * multi-volume atlas is split into subdirectories: `data/brooklyn_1904-1908/vol13`,
+ * `data/queens_1950/vol2`. Both forms are first-class -- every API that takes a
+ * `volume` accepts either -- so the depth rule and the safety check live here
+ * instead of being re-derived per route (issue #228).
+ */
+
+/** How many directory levels below `data/` a volume may sit (`data/queens_1950/vol2`). */
+export const MAX_VOLUME_DEPTH = 2;
+
+/** Reject a path segment that could escape or re-enter the data directory. */
+export function isSafeSegment(name: string): boolean {
+  return (
+    name !== '' &&
+    name !== '.' &&
+    name !== '..' &&
+    !name.includes('/') &&
+    !name.includes('\\')
+  );
+}
+
+/**
+ * Whether ``volume`` is a safe, correctly shaped volume directory name.
+ *
+ * Accepts a subvolume up to {@link MAX_VOLUME_DEPTH} segments deep. A deeper path
+ * is rejected rather than joined, so a volume's own subdirectories (`raw/`,
+ * `artifacts/`) can never be addressed as volumes in their own right.
+ */
+export function isSafeVolume(volume: string): boolean {
+  const parts = volume.split('/');
+  return parts.length <= MAX_VOLUME_DEPTH && parts.every(isSafeSegment);
+}

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -34,15 +34,7 @@ import { DebugView } from '../App';
 import { InfoPanel, type RunArtifacts } from './InfoPanel';
 import { PageList } from './PageList';
 import { VolumeMap } from './VolumeMap';
-
-// Split a repo-root-relative annotation path like
-// "data/brooklyn_ny_1906_vol_6/generated.iiif.json" into volume + file name.
-function parseAnnotationPath(
-  path: string | null,
-): { volume: string; file: string } | null {
-  const match = path?.match(/^data\/([^/]+)\/([^/]+)$/);
-  return match ? { volume: match[1] ?? '', file: match[2] ?? '' } : null;
-}
+import { parseAnnotationPath } from '../iiif/volumePath';
 
 // Map viewport from the URL's `center=lng,lat` and `zoom=Z` params, or null when absent/invalid.
 function parseViewport(

--- a/app/src/iiif/volumePath.test.ts
+++ b/app/src/iiif/volumePath.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseAnnotationPath } from './volumePath';
+
+describe('parseAnnotationPath', () => {
+  it('splits a single-directory volume', () => {
+    expect(
+      parseAnnotationPath(
+        'data/detroit_mich_1929_vol_11/2026-08-05-base.iiif.json',
+      ),
+    ).toEqual({
+      volume: 'detroit_mich_1929_vol_11',
+      file: '2026-08-05-base.iiif.json',
+    });
+  });
+
+  it('splits a subvolume of a multi-volume atlas (#228)', () => {
+    expect(
+      parseAnnotationPath('data/brooklyn_1904-1908/vol13/2026-08-04.iiif.json'),
+    ).toEqual({
+      volume: 'brooklyn_1904-1908/vol13',
+      file: '2026-08-04.iiif.json',
+    });
+  });
+
+  it('does not parse a path deeper than the server would accept', () => {
+    // Mirrors MAX_VOLUME_DEPTH: parsing this would have the UI query a volume
+    // every volume-scoped endpoint rejects.
+    expect(parseAnnotationPath('data/a/b/c/x.iiif.json')).toBeNull();
+  });
+
+  it('returns null for a non-data or incomplete path', () => {
+    expect(parseAnnotationPath(null)).toBeNull();
+    expect(parseAnnotationPath('data/x.iiif.json')).toBeNull();
+    expect(parseAnnotationPath('other/vol/x.iiif.json')).toBeNull();
+  });
+});

--- a/app/src/iiif/volumePath.ts
+++ b/app/src/iiif/volumePath.ts
@@ -1,0 +1,28 @@
+/**
+ * Splitting a repo-root-relative annotation path into volume + file name.
+ *
+ * Its own module because it is pure and worth testing directly: importing
+ * VolumeViewer to reach it pulls in maplibre-gl, which will not load under jsdom.
+ */
+
+/** How many directory levels below `data/` a volume may sit; mirrors the server. */
+export const MAX_VOLUME_DEPTH = 2;
+
+/**
+ * Split "data/<volume>/<file>.iiif.json" into its volume and file name.
+ *
+ * The volume may be a subdirectory of a multi-volume atlas, so
+ * "data/brooklyn_1904-1908/vol13/2026-08-04.iiif.json" yields the volume
+ * "brooklyn_1904-1908/vol13". Matching only single-segment volumes left every
+ * volume-scoped fetch -- key maps, notes, adjacency, failed georefs -- unmade for
+ * those files, which is why their page links came up broken (#228).
+ *
+ * The depth limit mirrors the server's, so a path the API would reject never
+ * parses into a volume the UI then queries for.
+ */
+export function parseAnnotationPath(
+  path: string | null,
+): { volume: string; file: string } | null {
+  const match = path?.match(/^data\/([^/]+(?:\/[^/]+)?)\/([^/]+)$/);
+  return match ? { volume: match[1] ?? '', file: match[2] ?? '' } : null;
+}


### PR DESCRIPTION
Fixes #228.

A multi-volume atlas keeps each volume in a subdirectory (`data/brooklyn_1904-1908/vol13`, `data/queens_1950/vol2`). Those rendered images but were otherwise second-class: absent from the volume dropdown, and with every page link broken.

## Two independent causes

**The listing never saw them.** `/iiif-api/volumes` read only the top level of `data/`. It now uses `findVolumes`, which already descends into an atlas and stops at the first page-bearing directory on each branch — so a volume's own `raw/` is still never listed as a volume. 18 nested volumes appear; the 28 flat ones are unchanged.

**The client never parsed them.** `parseAnnotationPath` matched a single-segment volume only, so a subvolume's path yielded `null` and every volume-scoped fetch — key maps, notes, adjacency, failed georefs — went unmade. That is what left the page links broken, not the links themselves.

## Consolidating the volume-path rule

The volume-scoped endpoints were validating `?volume=` with a rule that rejects any slash. `adjacencyTruth` already had an `isSafeVolume` that allows one, so rather than add a second copy this moves the depth rule and the segment check into `server/volumePaths.ts` and points `adjacencyTruth`, `keymapPages`, `notes` and `iiifRoutes` at it — three separate `MAX_VOLUME_DEPTH` constants and two `isSafeVolume` implementations collapse to one each.

The depth limit is load-bearing: it is what keeps `<volume>/raw` from being addressable as a volume. The client mirrors it, so a path the API would reject never parses into a volume the UI then queries for.

`parseAnnotationPath` moves to `src/iiif/volumePath.ts` to be testable — reaching it through `VolumeViewer` pulls in maplibre-gl, which will not load under jsdom.

## Verification

Browser-tested against `data/brooklyn_1904-1908/vol13`:

- listed and selectable as `brooklyn_1904-1908/vol13 (131 pages)`, with all 5 of its annotation files
- 104 pages shown, 27 missing, key maps `p0L`/`p0R` linked
- streets / georef / adjacency / key-map links all fetch **200 with `image/jpeg` or `application/json`** — checked by following them, since the dev server returns 200 with the SPA's HTML for a missing file (the trap in #233) -- filed #241
- streets view renders inline with its detections; no console errors
- `?volume=brooklyn_1904-1908/vol13/raw` still 400s

203 tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)