### PR TITLE
fit: clear derived georef sidecars before regenerating them (#240)

### DIFF
--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -81,6 +81,39 @@ def resolve_run_id(
     )
 
 
+# Every `p<stem>.georef*.json` at the volume root is produced by one of the
+# stages below -- georef writes the plain fit and its failure variants, the
+# adjacency gate the contradicted ones, snap the -osm ones, street-solve the
+# -streets ones. Nothing else writes them.
+DERIVED_SIDECAR_GLOB = "p*.georef*.json"
+
+
+def clear_derived_sidecars(dir_path: Path) -> int:
+    """Remove the georef sidecars this run is about to regenerate; return the count.
+
+    Without this a run is not idempotent. `mapsnap iiif` publishes whatever
+    sidecars are on disk, and a stage that declines to write one this time
+    leaves the *previous* run's file in place to be published instead. Worse,
+    snap's `ransac-neighbor` rotation prior reads neighbouring pages' published
+    fits, so a single leftover file perturbs its neighbours' searches and
+    cascades outward.
+
+    Measured on Grand Rapids: consecutive runs alternated between two fixed
+    points, 69.8% and 71.8%, differing by two stale sidecars and 33 of 60
+    published pages. Clearing first makes two consecutive runs byte-identical
+    (issue #240). Note this is not a fix for nondeterminism -- the pipeline was
+    always deterministic given its inputs; the stale files simply *were* part of
+    the input.
+    """
+    removed = 0
+    for path in sorted(dir_path.glob(DERIVED_SIDECAR_GLOB)):
+        path.unlink()
+        removed += 1
+    if removed:
+        print(f"Cleared {removed} derived georef sidecar(s) from {dir_path}")
+    return removed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Georeference images, build IIIF annotation page, and compare against reference."
@@ -144,6 +177,8 @@ def main() -> None:
     if experiments.is_complete(archive_dir):
         print(f"Run {run_id} already archived at {archive_dir}; skipping computation.")
         return
+
+    clear_derived_sidecars(dir_path)
 
     run_cmd(
         ["mapsnap", "georef", *images, "--centerlines", str(centerlines), *georef_extra]

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -1,6 +1,8 @@
-"""Tests for the `mapsnap fit` driver's flag handling."""
+"""Tests for the `mapsnap fit` driver's flag handling and run hygiene."""
 
-from mapsnap.fit import worker_flag
+from pathlib import Path
+
+from mapsnap.fit import clear_derived_sidecars, worker_flag
 
 
 def test_worker_flag_extracts_both_spellings():
@@ -19,3 +21,46 @@ def test_worker_flag_absent_or_malformed_yields_nothing():
     # A trailing --num-workers with no value: leave it to georef's parser to
     # reject rather than forwarding half a flag.
     assert worker_flag(["--debug", "--num-workers"]) == []
+
+
+def test_clear_derived_sidecars_removes_every_variant(tmp_path: Path):
+    """All georef sidecar variants go, and nothing else does."""
+    for name in (
+        "p1.georef.json",
+        "p2.georef-nofit.json",
+        "p3.georef-osm.json",
+        "p4.georef-streets.json",
+        "p5.georef-contradicted.json",
+        "p6.georef-keymap-outlier.json",
+        "p7__2.georef.json",
+    ):
+        (tmp_path / name).write_text("{}")
+    # Inputs and unrelated outputs must survive: a run regenerates sidecars from
+    # these, so deleting them would destroy work no stage recreates.
+    keep = (
+        "p1.streets.json",
+        "p1.boxes.json",
+        "p1.jpg",
+        "centerlines.geojson",
+        "main.iiif.json",
+        "adjacency.json",
+    )
+    for name in keep:
+        (tmp_path / name).write_text("{}")
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "raw" / "p0.georef.json").write_text("{}")  # key-map georef, not ours
+
+    removed = clear_derived_sidecars(tmp_path)
+
+    assert removed == 7
+    assert not list(tmp_path.glob("p*.georef*.json"))
+    for name in keep:
+        assert (tmp_path / name).exists(), name
+    assert (tmp_path / "raw" / "p0.georef.json").exists(), (
+        "key-map sidecar must survive"
+    )
+
+
+def test_clear_derived_sidecars_on_empty_dir(tmp_path: Path):
+    """A first run has nothing to clear and must not fail."""
+    assert clear_derived_sidecars(tmp_path) == 0


### PR DESCRIPTION
Fixes #240.

## The bug

`mapsnap fit` never cleaned the sidecars it regenerates, and `mapsnap iiif` publishes whatever is on disk. A stage that declined to write a sidecar this time left the **previous run's file** in place to be published instead — so a run's output depended on what ran before it.

On Grand Rapids, consecutive runs alternated between two fixed points:

| state | sidecars | score |
|---|---|---|
| A | 122, incl. `p827.georef-osm.json`, `p828.georef.json` | 69.8% |
| B | 120, both absent | 71.8% |

Two stale files move **33 of 60 published pages**, because snap's `ransac-neighbor` rotation prior reads neighbouring pages' *published* fits — flip two pages and their neighbours' searches shift, cascading outward.

## It was never nondeterminism

I originally reported this as nondeterminism and was wrong. Six runs under three conditions all alternated identically, and run-*a* was byte-for-byte equal to run-*a* across conditions:

| condition | run a | run b |
|---|---|---|
| `PYTHONHASHSEED=0` | 69.8% | 71.8% |
| unpinned | 69.8% | 71.8% |
| single-threaded* | 69.8% | 71.8% |

\* `OMP`/`OPENBLAS`/`MKL`/`VECLIB_MAXIMUM_THREADS=1` plus `cv2.setNumThreads(0)`.

Also ruled out: unseeded RNG (every RNG in the repo is explicitly seeded, and the fit path — `georef_from_labels`, `osm_snap_experiment`, `snap`, `street_solve*` — contains none at all) and multiprocessing order (`--num-workers` defaults to 1). The pipeline is deterministic given its inputs; the stale files simply *were* part of the input.

## The change

One helper, called before the georef pass. Every `p<stem>.georef*.json` at the volume root is produced by a stage `fit` drives — georef (plain fit + failure variants), adjacency-gate (contradicted), snap (`-osm`), street-solve (`-streets`) — so clearing them all is safe.

Untouched: inputs (`streets.json`, `boxes.json`, images, `centerlines.geojson`, `adjacency.json`) and the key map's own sidecars under `raw/`. Both are covered by tests.

## Verification

Two consecutive runs on Grand Rapids with **no manual cleanup**:

```
fixed-a  63 placed  <=25ft 71.9%  >=200ft 2.1%  69.8%
fixed-b  63 placed  <=25ft 71.9%  >=200ft 2.1%  69.8%
fixed-a vs fixed-b: 0 of 60 pages differ  — IDENTICAL
```

Before this change the same two commands alternated between 69.8% and 71.8%.

## Follow-ups, deliberately not in this PR

- **#246** — snap's candidates cache keys on mtimes rather than content, causing false invalidation and (within a one-second window) false freshness. Independent change, independent risk.
- One design question worth deciding: snap's incumbent arbitration and the `ransac-neighbor` prior may *intend* to read prior fits. Today they see a mixture of this run's and the last run's. If cross-run input is wanted, it should be named explicitly and come from a pinned run rather than from whatever was left on disk.
- The `2026-08-05` rerun's small per-volume deltas were each measured from an arbitrary prior state and should be re-measured now that runs are reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)