### PR TITLE
viewer: resolve truth page keys from the label, not the service URL alone

### DIFF
--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -305,6 +305,85 @@ describe('rewriteAnnotationPage', () => {
   });
 });
 
+describe('rewriteAnnotationPage split panels', () => {
+  // A split panel is georeferenced against its PARENT sheet: the source is the
+  // parent's full-resolution size and the coords/selector are parent pixels.
+  // Serving the panel image rescaled them by the panel's aspect and rendered
+  // the sheet at ~2x scale, misaligned (fargo p45__1).
+  const parentSource = {
+    id: 'https://tile.loc.gov/…:06536_1958-0045/info.json',
+    type: 'ImageService2',
+    width: 6660,
+    height: 8070,
+  };
+  function panel(index: number) {
+    return {
+      id: `https://tile.loc.gov/…:06536_1958-0045__${index}/georef`,
+      label: 'Fargo, N.D. | 1958 p45 [2]',
+      target: { source: { ...parentSource } },
+      body: {
+        features: [
+          {
+            type: 'Feature',
+            properties: { resourceCoords: [3330, 4035], type: 'gcp' },
+            geometry: { type: 'Point', coordinates: [-96.8, 46.88] },
+          },
+        ],
+      },
+    };
+  }
+
+  it('serves the parent image while keeping the panel identity', () => {
+    const { annotation, skipped } = rewriteAnnotationPage(
+      { items: [panel(1), panel(3)] } as never,
+      new Map([['p45', { width: 1665, height: 2018 }]]),
+      'http://localhost:8182/iiif/fargo_nd_1958',
+      new Map([['p45', 'p45']]),
+    );
+    expect(skipped).toEqual([]);
+    const keys = annotation.items.map(
+      (item) =>
+        item.metadata?.find((entry) => entry.label === 'page')?.value ?? '',
+    );
+    expect(keys).toEqual(['p45__1', 'p45__3']);
+    for (const item of annotation.items) {
+      // Parent image, and coords scaled by the parent ratio (0.25) on BOTH
+      // axes -- the panel image would have given 1665/6660 vs 989/8070.
+      expect(item.target?.source?.id).toBe(
+        'http://localhost:8182/iiif/fargo_nd_1958/p45.jpg',
+      );
+      expect(item.target?.source?.width).toBe(1665);
+      expect(item.body?.features?.[0]?.properties.resourceCoords).toEqual([
+        832.5, 1009,
+      ]);
+    }
+  });
+
+  it('keeps a panel whose own image was never split out locally', () => {
+    // grand_rapids p729__2 has truth but no p729__2.jpg; the parent exists, and
+    // the parent is what the annotation is drawn against anyway.
+    const { annotation, skipped } = rewriteAnnotationPage(
+      {
+        items: [
+          {
+            id: 'https://oldinsurancemaps.net/iiif/resource/54284/',
+            label: 'Grand Rapids, Mich. | 1953 | Vol. 7 p729 [2]',
+            target: { source: { ...parentSource, id: null } },
+            body: { features: [] },
+          },
+        ],
+      } as never,
+      new Map([['p729', { width: 1665, height: 2018 }]]),
+      'http://localhost:8182/iiif/grand_rapids_mi_1953_vol7',
+      new Map([['p729', 'p729']]),
+    );
+    expect(skipped).toEqual([]);
+    expect(
+      annotation.items[0]?.metadata?.find((e) => e.label === 'page')?.value,
+    ).toBe('p729__2');
+  });
+});
+
 describe('imageStemsByLowercase', () => {
   it('maps a lowercased stem to the real filename case', async () => {
     const { mkdtemp, writeFile } = await import('fs/promises');

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -3,6 +3,7 @@ import {
   imageStemsByLowercase,
   rescaleSvgSelector,
   rewriteAnnotationPage,
+  labelToPageKey,
   serviceUrlToPageKey,
   type GeorefAnnotationPage,
 } from './iiifAnnotations';
@@ -42,6 +43,68 @@ describe('serviceUrlToPageKey', () => {
     expect(serviceUrlToPageKey(null)).toBeNull();
     expect(serviceUrlToPageKey(undefined)).toBeNull();
     expect(serviceUrlToPageKey('')).toBeNull();
+  });
+
+  it('takes the split-panel variant from the label, which no URL records', () => {
+    // Without this every panel of a sheet collapses onto the parent key and
+    // all but one annotation is lost (228 panels across the truth volumes).
+    expect(
+      serviceUrlToPageKey(
+        'service:gmd:x:03376_01_1951-0428',
+        'New Orleans, La. | 1951 | Vol. 5 p428 [2]',
+      ),
+    ).toBe('p428__2');
+    expect(
+      serviceUrlToPageKey(
+        'service:gmd:x:sb001250',
+        'New Orleans, La. | 1896 | Vol. 2 p125 [3]',
+      ),
+    ).toBe('p125__3');
+    // A label with no bracket leaves the key unsuffixed.
+    expect(
+      serviceUrlToPageKey(
+        'service:gmd:x:03376_01_1951-0428',
+        'New Orleans, La. | 1951 | Vol. 5 p428',
+      ),
+    ).toBe('p428');
+  });
+
+  it('falls back to the label when the volume links no image service', () => {
+    // Grand Rapids 1953 vol 7: 73 of 83 truth annotations carry source.id null.
+    expect(
+      serviceUrlToPageKey(null, 'Grand Rapids, Mich. | 1953 | Vol. 7 p844 [3]'),
+    ).toBe('p844__3');
+    expect(
+      serviceUrlToPageKey(null, 'Grand Rapids, Mich. | 1953 | Vol. 7 p712'),
+    ).toBe('p712');
+    // Letter-only key-map sheets still resolve.
+    expect(
+      serviceUrlToPageKey(null, 'Los Angeles, Calif. | 1949 | Vol. 14 pa [2]'),
+    ).toBe('pa__2');
+    // No URL and no page identifier in the label is still null.
+    expect(
+      serviceUrlToPageKey(null, 'Grand Rapids, Mich. | 1953 | Vol. 7'),
+    ).toBeNull();
+  });
+});
+
+describe('labelToPageKey', () => {
+  it('reads the page id from the last pipe-separated segment', () => {
+    expect(labelToPageKey('New Orleans, La. | 1896 | Vol. 2 p156')).toBe(
+      'p156',
+    );
+    expect(labelToPageKey('New Orleans, La. | 1951 | Vol. 5 p428 [2]')).toBe(
+      'p428__2',
+    );
+    expect(labelToPageKey('Chicago | 1950 | Vol. 1 p103W')).toBe('p103w');
+    expect(labelToPageKey('Los Angeles, Calif. | 1949 | Vol. 14 pa [2]')).toBe(
+      'pa__2',
+    );
+  });
+
+  it('returns null when the label carries no page identifier', () => {
+    expect(labelToPageKey('Grand Rapids, Mich. | 1953 | Vol. 7')).toBeNull();
+    expect(labelToPageKey('')).toBeNull();
   });
 });
 

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -4,6 +4,7 @@ import {
   rescaleSvgSelector,
   rewriteAnnotationPage,
   labelToPageKey,
+  splitIndexFor,
   withTiles,
   serviceUrlToPageKey,
   type GeorefAnnotationPage,
@@ -46,6 +47,21 @@ describe('serviceUrlToPageKey', () => {
     expect(serviceUrlToPageKey('')).toBeNull();
   });
 
+  it('takes the generated split-panel variant from the id, not the label', () => {
+    const label = 'Fargo, N.D. | 1958 p45 [2]';
+    const base = 'https://tile.loc.gov/…:06536_1958-0045';
+    expect(
+      serviceUrlToPageKey(`${base}/info.json`, label, `${base}__1/georef`),
+    ).toBe('p45__1');
+    expect(
+      serviceUrlToPageKey(`${base}/info.json`, label, `${base}__3/georef`),
+    ).toBe('p45__3');
+    // A generated whole page keeps no variant despite the stray label.
+    expect(
+      serviceUrlToPageKey(`${base}/info.json`, label, `${base}/georef`),
+    ).toBe('p45');
+  });
+
   it('takes the split-panel variant from the label, which no URL records', () => {
     // Without this every panel of a sheet collapses onto the parent key and
     // all but one annotation is lost (228 panels across the truth volumes).
@@ -86,6 +102,38 @@ describe('serviceUrlToPageKey', () => {
     expect(
       serviceUrlToPageKey(null, 'Grand Rapids, Mich. | 1953 | Vol. 7'),
     ).toBeNull();
+  });
+});
+
+describe('splitIndexFor', () => {
+  it('prefers the id, because generated labels are copied from truth', () => {
+    // All three of fargo p45's generated panels are labelled "p45 [2]"; only
+    // the id distinguishes them. Trusting the label pointed every panel at
+    // p45__2.jpg and rendered the wrong sheet in the volume viewer.
+    const label = 'Fargo, N.D. | 1958 p45 [2]';
+    const base = 'https://tile.loc.gov/…:06536_1958-0045';
+    expect(splitIndexFor(`${base}__1/georef`, label)).toBe(1);
+    expect(splitIndexFor(`${base}__2/georef`, label)).toBe(2);
+    expect(splitIndexFor(`${base}__3/georef`, label)).toBe(3);
+  });
+
+  it('ignores a stray label variant on a generated whole page', () => {
+    expect(
+      splitIndexFor(
+        'https://tile.loc.gov/…:06536_1958-0045/georef',
+        'Fargo, N.D. | 1958 p45 [2]',
+      ),
+    ).toBeNull();
+  });
+
+  it('falls back to the label for a truth item, whose id has no variant', () => {
+    expect(
+      splitIndexFor(
+        'https://oldinsurancemaps.net/iiif/resource/54284/',
+        'Grand Rapids, Mich. | 1953 | Vol. 7 p844 [3]',
+      ),
+    ).toBe(3);
+    expect(splitIndexFor(undefined, 'Fargo, N.D. | 1958 p45')).toBeNull();
   });
 });
 

--- a/app/server/iiifAnnotations.test.ts
+++ b/app/server/iiifAnnotations.test.ts
@@ -4,6 +4,7 @@ import {
   rescaleSvgSelector,
   rewriteAnnotationPage,
   labelToPageKey,
+  withTiles,
   serviceUrlToPageKey,
   type GeorefAnnotationPage,
 } from './iiifAnnotations';
@@ -275,5 +276,42 @@ describe('imageStemsByLowercase', () => {
 
   it('returns an empty map for a missing directory', async () => {
     expect((await imageStemsByLowercase('/nonexistent-volume')).size).toBe(0);
+  });
+});
+
+describe('withTiles', () => {
+  it('always yields at least one scale factor, however small the image', () => {
+    // The bug this exists for: @allmaps/iiif-parser's fallback tileset uses
+    // Array.from({length: maxExponent}), which is EMPTY at maxExponent 0, so
+    // any image under one tile wide renders zero zoom levels and throws.
+    // grand_rapids p844__3 (682x568) and fargo p62__4 (365x488) are real cases.
+    const small = withTiles({ width: 682, height: 568 }) as {
+      tiles: { width: number; scaleFactors: number[] }[];
+    };
+    expect(small.tiles).toEqual([{ width: 512, scaleFactors: [1, 2] }]);
+    const tiny = withTiles({ width: 100, height: 80 }) as {
+      tiles: { width: number; scaleFactors: number[] }[];
+    };
+    expect(tiny.tiles[0]!.scaleFactors).toEqual([1]);
+  });
+
+  it('covers a full-size sheet down to a single tile', () => {
+    const sheet = withTiles({ width: 6660, height: 8070 }) as {
+      tiles: { width: number; scaleFactors: number[] }[];
+    };
+    // 8070 / 512 = 15.8 -> the coarsest factor must reduce it under one tile.
+    const coarsest = sheet.tiles[0]!.scaleFactors.at(-1)!;
+    expect(8070 / coarsest).toBeLessThanOrEqual(512);
+    expect(sheet.tiles[0]!.scaleFactors[0]).toBe(1);
+  });
+
+  it('leaves a body that already advertises tiles alone', () => {
+    const existing = { width: 100, height: 100, tiles: [{ width: 256 }] };
+    expect(withTiles(existing)).toBe(existing);
+  });
+
+  it('passes through a body with no usable dimensions', () => {
+    const noDims = { type: 'ImageService3' };
+    expect(withTiles(noDims)).toBe(noDims);
   });
 });

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -107,6 +107,29 @@ export function labelToPageKey(label: string): string | null {
 }
 
 /**
+ * Split-panel number for an annotation item, or null for a whole page.
+ *
+ * The ID is authoritative and the label is the fallback, because the two
+ * disagree on generated annotations: `mapsnap iiif` copies the label from the
+ * truth item it matched, so all three of fargo p45's panels are labelled
+ * "p45 [2]" while their ids correctly read `-0045__1/georef`, `__2`, `__3`.
+ * Trusting the label there points every panel at the same (wrong) image.
+ * A truth item has no `__N` in its id and carries the panel number only in its
+ * label; a generated WHOLE page ends in `/georef` with no `__N`, and its label
+ * may still carry a stray `[N]` copied from truth, which must be ignored.
+ */
+export function splitIndexFor(
+  id: string | undefined,
+  label: string | undefined,
+): number | null {
+  const idMatch = id?.match(/__(\d+)\//);
+  if (idMatch) return Number(idMatch[1]);
+  if (id?.includes('/georef')) return null; // generated whole page
+  const labelMatch = label?.match(/\[(\d+)\]\s*$/);
+  return labelMatch ? Number(labelMatch[1]) : null;
+}
+
+/**
  * Extract the page key for an annotation, or null for non-page images.
  *
  * Port of source_id_to_page_key in mapsnap/utils.py, and it needs BOTH the
@@ -117,7 +140,8 @@ export function labelToPageKey(label: string): string | null {
  *     "...:05791_02_1939-0027s"            → "p27s"
  *   Sanborn sb-format (5 digits then a suffix char, '0' meaning none):
  *     "...:sb001250" → "p125";  "...:sb00154s" → "p154s"
- * - The LABEL carries the split-panel variant, which no URL records. A truth
+ * - The split-panel variant comes from {@link splitIndexFor}, which prefers the
+ *   item id and falls back to the label; no URL records it. A truth
  *   annotation for one panel of a split sheet is labelled "... p844 [3]" and
  *   must resolve to "p844__3"; deriving "p844" instead silently collapses
  *   every panel of a sheet onto its parent, so several annotations claim one
@@ -132,10 +156,17 @@ export function labelToPageKey(label: string): string | null {
 export function serviceUrlToPageKey(
   url: string | null | undefined,
   label = '',
+  id?: string,
 ): string | null {
-  const splitMatch = label.trimEnd().match(/\[(\d+)\]$/);
-  const splitSuffix = splitMatch ? `__${splitMatch[1]}` : '';
-  if (!url) return labelToPageKey(label);
+  const splitIndex = splitIndexFor(id, label);
+  const splitSuffix = splitIndex != null ? `__${splitIndex}` : '';
+  if (!url) {
+    const fromLabel = labelToPageKey(label);
+    if (!fromLabel) return null;
+    // labelToPageKey already appends the label's own variant; when the id
+    // overrides it (or says there is none), rebuild from the parent key.
+    return fromLabel.replace(/__\d+$/, '') + splitSuffix;
+  }
   url = url.replace(/\/info\.json$/, '');
   const sbMatch = url.match(/:sb(\d{5})([a-z0-9])$/i);
   if (sbMatch) {
@@ -220,7 +251,11 @@ export function rewriteAnnotationPage(
     const label = String(item.label ?? item.id ?? '');
     const target = item.target;
     const source = target?.source;
-    const derived = serviceUrlToPageKey(source?.id, label);
+    const derived = serviceUrlToPageKey(
+      source?.id,
+      label,
+      String(item.id ?? ''),
+    );
     const pageKey = derived
       ? (stemsByLowercase?.get(derived.toLowerCase()) ?? derived)
       : derived;

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -89,32 +89,64 @@ export interface VolumeListResponse {
 export type RewrittenAnnotationResponse = RewriteResult;
 
 /**
- * Extract the page key from a LOC IIIF service URL, or null for non-page images.
+ * Extract the page key from an OIM annotation label, or null if it has none.
  *
- * Port of _service_url_to_page_key in mapsnap/make_iiif_georef.py. The page key
- * is the trailing segment after the last "-", with leading zeros stripped and
- * any letter suffix lowercased:
- *   "...:01790_01N_1950-0006N/info.json" → "p6n"
- *   "...:05791_02_1939-0027s"            → "p27s"
- * Sanborn sb-format (5 digits then a suffix char, '0' meaning none):
- *   "...:sb001250" → "p125";  "...:sb00154s" → "p154s"
- * Covers and indexes ("...-covr", "...-titl") and missing URLs return null.
+ * Port of label_to_page_key in mapsnap/utils.py: the page identifier in the
+ * last pipe-separated segment, lowercased, with a bracketed split variant
+ * collapsed to a double underscore.
+ *   "New Orleans, La. | 1951 | Vol. 5 p428 [2]"  → "p428__2"
+ *   "Grand Rapids, Mich. | 1953 | Vol. 7 p844"   → "p844"
+ * Un-numbered index sheets carry letter-only ids ("... pa [2]" → "pa__2").
+ */
+export function labelToPageKey(label: string): string | null {
+  const lastPart = (label.split('|').pop() ?? '').trim();
+  const match = lastPart.match(/\b(p\d+[a-z]?|p[a-z]{1,2})(?:\s*\[(\d+)\])?$/i);
+  if (!match) return null;
+  const page = (match[1] ?? '').toLowerCase();
+  return match[2] ? `${page}__${match[2]}` : page;
+}
+
+/**
+ * Extract the page key for an annotation, or null for non-page images.
+ *
+ * Port of source_id_to_page_key in mapsnap/utils.py, and it needs BOTH the
+ * service URL and the annotation label:
+ *
+ * - The URL carries the page number:
+ *     "...:01790_01N_1950-0006N/info.json" → "p6n"
+ *     "...:05791_02_1939-0027s"            → "p27s"
+ *   Sanborn sb-format (5 digits then a suffix char, '0' meaning none):
+ *     "...:sb001250" → "p125";  "...:sb00154s" → "p154s"
+ * - The LABEL carries the split-panel variant, which no URL records. A truth
+ *   annotation for one panel of a split sheet is labelled "... p844 [3]" and
+ *   must resolve to "p844__3"; deriving "p844" instead silently collapses
+ *   every panel of a sheet onto its parent, so several annotations claim one
+ *   key and all but one are lost (228 panels across the 15 truth volumes).
+ * - Some OIM volumes link no image service at all and carry `source.id: null`
+ *   (Grand Rapids 1953 vol 7: 73 of 83 annotations). The label alone then
+ *   resolves the page.
+ *
+ * Covers and indexes ("...-covr", "...-titl") return null when the label has
+ * no page identifier either.
  */
 export function serviceUrlToPageKey(
   url: string | null | undefined,
+  label = '',
 ): string | null {
-  if (!url) return null;
+  const splitMatch = label.trimEnd().match(/\[(\d+)\]$/);
+  const splitSuffix = splitMatch ? `__${splitMatch[1]}` : '';
+  if (!url) return labelToPageKey(label);
   url = url.replace(/\/info\.json$/, '');
   const sbMatch = url.match(/:sb(\d{5})([a-z0-9])$/i);
   if (sbMatch) {
     const pageNum = parseInt(sbMatch[1] ?? '', 10);
     const suffixChar = (sbMatch[2] ?? '').toLowerCase();
     const suffix = suffixChar === '0' ? '' : suffixChar;
-    return `p${pageNum}${suffix}`;
+    return `p${pageNum}${suffix}${splitSuffix}`;
   }
   const match = url.match(/-0*(\d+)([a-z]*)$/i);
   if (!match) return null;
-  return `p${match[1]}${(match[2] ?? '').toLowerCase()}`;
+  return `p${match[1]}${(match[2] ?? '').toLowerCase()}${splitSuffix}`;
 }
 
 // Round to 1 decimal, rendering integral values without a trailing ".0".
@@ -188,7 +220,7 @@ export function rewriteAnnotationPage(
     const label = String(item.label ?? item.id ?? '');
     const target = item.target;
     const source = target?.source;
-    const derived = serviceUrlToPageKey(source?.id);
+    const derived = serviceUrlToPageKey(source?.id, label);
     const pageKey = derived
       ? (stemsByLowercase?.get(derived.toLowerCase()) ?? derived)
       : derived;

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -295,3 +295,41 @@ export async function imageStemsByLowercase(
   }
   return stems;
 }
+
+/** Tile edge advertised in info.json. 512 is the Image API's common default. */
+const TILE_WIDTH = 512;
+
+/**
+ * Add a `tiles` entry to an Image API info.json body, in place of nothing.
+ *
+ * express-iiif advertises no tilesets. @allmaps/iiif-parser then synthesises
+ * one, and its fallback has an off-by-one:
+ *
+ *   scaleFactors: Array.from({ length: maxExponent }, (_, e) => 2 ** e)
+ *
+ * For an image whose longest side is <= its 768 px tile width, maxExponent is
+ * 0, so scaleFactors is EMPTY, the map gets zero zoom levels, and rendering
+ * dies in getTileImageRequest with "Cannot read properties of undefined
+ * (reading 'originalWidth')". 22 small split panels across the truth volumes
+ * hit this (grand_rapids p844__3 at 682x568, fargo p62__4 at 365x488).
+ *
+ * Advertising a real tileset keeps the parser out of that path entirely — and
+ * is honest for a level2 service, which serves any region and size. Scale
+ * factors always include 1, so the smallest image still gets one zoom level.
+ */
+export function withTiles(
+  info: Record<string, unknown>,
+): Record<string, unknown> {
+  const width = Number(info.width);
+  const height = Number(info.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return info;
+  if (Array.isArray(info.tiles) && info.tiles.length > 0) return info;
+  const maxExponent = Math.ceil(
+    Math.log2(Math.max(1, Math.max(width, height) / TILE_WIDTH)),
+  );
+  const scaleFactors = Array.from(
+    { length: Math.max(1, maxExponent + 1) },
+    (unused, exponent) => 2 ** exponent,
+  );
+  return { ...info, tiles: [{ width: TILE_WIDTH, scaleFactors }] };
+}

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -256,14 +256,29 @@ export function rewriteAnnotationPage(
       label,
       String(item.id ?? ''),
     );
-    const pageKey = derived
-      ? (stemsByLowercase?.get(derived.toLowerCase()) ?? derived)
-      : derived;
-    if (!pageKey || !target || !source?.width || !source.height) {
+    // Identity and image are different keys for a split panel. Both truth and
+    // generated annotations publish a panel against its PARENT sheet: the
+    // source is the parent's full-resolution size (6660x8070), and both the
+    // GCP resourceCoords and the clipping selector are in parent pixels, the
+    // selector delimiting the panel's region. So the image to serve is the
+    // parent, while the page this annotation IS remains the panel -- which is
+    // what the page list, the selection and the sidecar links key off.
+    //
+    // Serving the panel image instead rescales parent-frame coordinates by the
+    // panel's aspect (fargo p45__1: x by 1665/6660 = 0.25 but y by 989/8070 =
+    // 0.12), rendering the sheet at ~2x scale and misaligned.
+    const suffix = derived?.match(/__\d+$/)?.[0] ?? '';
+    const parentDerived =
+      suffix && derived ? derived.slice(0, -suffix.length) : derived;
+    const imageKey = parentDerived
+      ? (stemsByLowercase?.get(parentDerived.toLowerCase()) ?? parentDerived)
+      : parentDerived;
+    const pageKey = imageKey ? `${imageKey}${suffix}` : imageKey;
+    if (!imageKey || !pageKey || !target || !source?.width || !source.height) {
       skipped.push({ label, pageKey, reason: 'not-a-page' });
       continue;
     }
-    const local = localPages.get(pageKey);
+    const local = localPages.get(imageKey);
     if (!local) {
       skipped.push({ label, pageKey, reason: 'missing-image' });
       continue;
@@ -271,7 +286,7 @@ export function rewriteAnnotationPage(
     const scaleX = local.width / source.width;
     const scaleY = local.height / source.height;
     target.source = {
-      id: `${serviceBaseUrl}/${pageKey}.jpg`,
+      id: `${serviceBaseUrl}/${imageKey}.jpg`,
       type: 'ImageService3',
       width: local.width,
       height: local.height,

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -139,7 +139,15 @@ export function registerIiifApi(
     const stems = await imageStemsByLowercase(volumeDir);
     const localPages = new Map<string, { width: number; height: number }>();
     for (const item of page.items) {
-      const derived = serviceUrlToPageKey(item?.target?.source?.id);
+      // Same (url, label) pair rewriteAnnotationPage will use: the label
+      // carries the split-panel variant and, for volumes that link no image
+      // service, the page number itself. Deriving the key differently here
+      // keys localPages under names the rewrite never looks up, and every
+      // page reports "missing-image".
+      const derived = serviceUrlToPageKey(
+        item?.target?.source?.id,
+        String(item?.label ?? item?.id ?? ''),
+      );
       if (!derived) continue;
       // Volumes disagree about the case of a lettered suffix -- Chicago's
       // 0103W is p103w.jpg on disk, Asheville's 0033A is p33A.jpg -- so the

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -29,6 +29,7 @@ import {
 } from './compareTxt.ts';
 import { findVolumes, volumePages } from './adjacencyTruth.ts';
 import { runArtifactDir, runArtifactStems } from './runArtifacts.ts';
+import { withTiles } from './iiifAnnotations.ts';
 import { isSafeSegment, isSafeVolume } from './volumePaths.ts';
 
 const require = createRequire(import.meta.url);
@@ -71,8 +72,24 @@ async function cachedJpegDimensions(
   return dims;
 }
 
-/** Mount the raw IIIF image service (express-iiif) under `/iiif`. */
+/**
+ * Mount the raw IIIF image service (express-iiif) under `/iiif`.
+ *
+ * info.json responses are passed through {@link withTiles} first; see there
+ * for why an advertised tileset is load-bearing for the map viewer.
+ */
 export function registerIiifImages(app: Express, dataDir: string): void {
+  app.use('/iiif', (request, response, next) => {
+    if (!request.path.endsWith('/info.json')) return next();
+    const json = response.json.bind(response);
+    response.json = (body: unknown) =>
+      json(
+        body && typeof body === 'object'
+          ? withTiles(body as Record<string, unknown>)
+          : body,
+      );
+    next();
+  });
   app.use('/iiif', iiif({ imageDir: dataDir }));
 }
 

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -164,6 +164,7 @@ export function registerIiifApi(
       const derived = serviceUrlToPageKey(
         item?.target?.source?.id,
         String(item?.label ?? item?.id ?? ''),
+        String(item?.id ?? ''),
       );
       if (!derived) continue;
       // Volumes disagree about the case of a lettered suffix -- Chicago's

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -166,19 +166,22 @@ export function registerIiifApi(
         String(item?.label ?? item?.id ?? ''),
         String(item?.id ?? ''),
       );
-      if (!derived) continue;
+      // A split panel is georeferenced against its parent sheet, so the image
+      // to measure and serve is the parent (see rewriteAnnotationPage).
+      const parent = derived?.replace(/__\d+$/, '');
+      if (!parent) continue;
       // Volumes disagree about the case of a lettered suffix -- Chicago's
       // 0103W is p103w.jpg on disk, Asheville's 0033A is p33A.jpg -- so the
       // derived key's case is a guess. Resolve it against the directory and
       // use the real stem, or every link the viewer builds from it 404s on a
       // case-sensitive filesystem (and reads the wrong name on a forgiving one).
-      const pageKey = stems.get(derived.toLowerCase()) ?? derived;
-      if (localPages.has(pageKey)) continue;
+      const imageKey = stems.get(parent.toLowerCase()) ?? parent;
+      if (localPages.has(imageKey)) continue;
       try {
         const dims = await cachedJpegDimensions(
-          join(volumeDir, `${pageKey}.jpg`),
+          join(volumeDir, `${imageKey}.jpg`),
         );
-        localPages.set(pageKey, dims);
+        localPages.set(imageKey, dims);
       } catch {
         // No local image for this page; rewriteAnnotationPage reports it.
       }

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -171,6 +171,35 @@ function fitSummary(pages: PageGeo[]): string {
  * The links use the debugger's `?files=` deep-link convention, so they open
  * the page's streets or georef view in this same app.
  */
+/**
+ * A similarity fit is exactly skew 0 / anisotropy 1, so any real deviation
+ * comes from the annotation's own transform. A flat sheet photographed square
+ * cannot shear, so past these tolerances the georeference is more likely bad
+ * reference data than a real property of the map -- worth flagging in red
+ * while auditing truth. Thresholds are loose enough that ordinary
+ * polynomial-fit wobble stays quiet.
+ */
+const SKEW_WARN_DEGREES = 1.0;
+const ANISOTROPY_WARN = 0.05;
+
+/** The skew and anisotropy rows shared by the truth and generated stat blocks. */
+function DistortionRows({ page }: { page: PageGeo }) {
+  const skewBad = Math.abs(page.skewDegrees) > SKEW_WARN_DEGREES;
+  const anisoBad = Math.abs(page.anisotropy - 1) > ANISOTROPY_WARN;
+  return (
+    <>
+      <dt>Skew</dt>
+      <dd className={skewBad ? 'gcp-stats-warning' : undefined}>
+        {page.skewDegrees.toFixed(2)}°
+      </dd>
+      <dt>Anisotropy</dt>
+      <dd className={anisoBad ? 'gcp-stats-warning' : undefined}>
+        {page.anisotropy.toFixed(3)}
+      </dd>
+    </>
+  );
+}
+
 export function InfoPanel(props: InfoPanelProps) {
   const {
     pages,
@@ -261,6 +290,7 @@ export function InfoPanel(props: InfoPanelProps) {
                   <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
                   <dt>Truth rotation</dt>
                   <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
+                  <DistortionRows page={selectedPage} />
                   <dt>Size</dt>
                   <dd>
                     {selectedPage.width} × {selectedPage.height} px
@@ -289,6 +319,7 @@ export function InfoPanel(props: InfoPanelProps) {
               <dd>{selectedPage.scalePixelsPerFoot.toFixed(2)} px/ft</dd>
               <dt>Rotation</dt>
               <dd>{selectedPage.rotationDegrees.toFixed(1)}°</dd>
+              <DistortionRows page={selectedPage} />
               <dt>Size</dt>
               <dd>
                 {selectedPage.width} × {selectedPage.height} px

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -21,6 +21,11 @@ interface VolumeMapProps {
   truthPages: PageGeo[];
   /** Whether the missing-page footprints are drawn and clickable. */
   showMissing: boolean;
+  /**
+   * Show only the selected page's warped image, hiding every other sheet.
+   * No-op while nothing is selected -- isolating "nothing" would blank the map.
+   */
+  isolateSelected: boolean;
   /** itemIndex of the selected page, or null for no selection. */
   selectedItemIndex: number | null;
   /** Called with the clicked page's itemIndex, or null for empty space. */
@@ -111,6 +116,7 @@ export function VolumeMap(props: VolumeMapProps) {
     missingPages,
     truthPages,
     showMissing,
+    isolateSelected,
     selectedItemIndex,
     onSelectPage,
     opacity,
@@ -477,6 +483,39 @@ export function VolumeMap(props: VolumeMapProps) {
       frontOrderRef.current.push(page.itemIndex);
     }
   }, [selectedItemIndex, pages, missingPages, truthPages, mapReady]);
+
+  // Isolate: hide every warped image except the selected page's.
+  //
+  // Toggling the `visible` map option rather than re-adding a filtered
+  // annotation, because layer.clear() + addGeoreferenceAnnotation would drop
+  // every map's fetched tiles and re-run the initial fitBounds -- a full
+  // reload and a viewport jump for what should be a display toggle.
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer || !mapReady) return;
+    const mapIds = mapIdsRef.current.filter((id): id is string => !!id);
+    if (mapIds.length === 0) return;
+    const selectedMapId =
+      selectedItemIndex === null
+        ? null
+        : (mapIdsRef.current[selectedItemIndex] ?? null);
+    // Isolating with nothing selected (or with a missing page, which has no
+    // warped image) would leave an empty map, so show everything instead.
+    if (!isolateSelected || !selectedMapId) {
+      layer.setMapsOptions(mapIds, { visible: true }, { animate: false });
+      return;
+    }
+    layer.setMapsOptions(
+      mapIds.filter((id) => id !== selectedMapId),
+      { visible: false },
+      { animate: false },
+    );
+    layer.setMapsOptions(
+      [selectedMapId],
+      { visible: true },
+      { animate: false },
+    );
+  }, [isolateSelected, selectedItemIndex, annotation, mapReady]);
 
   // Bring a newly-selected page into view when it isn't already fully visible. Keyed on the
   // selected stem, not the item index, so switching annotation files within a volume (which

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -90,6 +90,9 @@ export function VolumeViewer() {
   const [showAdjacency, setShowAdjacency] = useState(
     () => initialParams.get('adj') === '1',
   );
+  const [isolateSelected, setIsolateSelected] = useState(
+    () => initialParams.get('only') === '1',
+  );
   const [error, setError] = useState<string | null>(null);
   // Selection is tracked by page stem (stable across annotation files, unlike the item index).
   const [selectedStem, setSelectedStem] = useState<string | null>(() =>
@@ -356,8 +359,9 @@ export function VolumeViewer() {
       rmse: colorByRmse ? '1' : null,
       missing: showMissing ? '1' : null,
       adj: showAdjacency ? '1' : null,
+      only: isolateSelected ? '1' : null,
     });
-  }, [selectedStem, colorByRmse, showMissing, showAdjacency]);
+  }, [selectedStem, colorByRmse, showMissing, showAdjacency, isolateSelected]);
 
   function selectVolume(name: string): void {
     const volume = volumes?.find((v) => v.name === name);
@@ -429,6 +433,22 @@ export function VolumeViewer() {
             Show missing pages
           </label>
         )}
+        <label
+          className="rmse-color-control"
+          title={
+            selectedStem
+              ? `Show only ${selectedStem}`
+              : 'Select a page to isolate it'
+          }
+        >
+          <input
+            type="checkbox"
+            checked={isolateSelected}
+            disabled={!selectedStem}
+            onChange={(e) => setIsolateSelected(e.target.checked)}
+          />
+          Isolate selected
+        </label>
         {adjacencyData && (
           <label className="rmse-color-control">
             <input
@@ -473,6 +493,7 @@ export function VolumeViewer() {
             missingPages={missingPages}
             truthPages={truthPages ?? []}
             showMissing={showMissing}
+            isolateSelected={isolateSelected}
             selectedItemIndex={selectedItemIndex}
             onSelectPage={handleSelectPage}
             opacity={opacity / 100}

--- a/app/src/iiif/adjacency.test.ts
+++ b/app/src/iiif/adjacency.test.ts
@@ -22,6 +22,8 @@ function page(stem: string): PageGeo {
     clipRing: [],
     scalePixelsPerFoot: 1,
     rotationDegrees: 0,
+    skewDegrees: 0,
+    anisotropy: 1,
     gcps: [],
     transformationType: 'polynomial',
   };

--- a/app/src/iiif/pages.test.ts
+++ b/app/src/iiif/pages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { GeorefAnnotationPage } from '../../server/iiifAnnotations';
 import {
   bearingDegrees,
+  distortion,
   hasFootprint,
   missingTruthPages,
   pagesFromAnnotation,
@@ -9,6 +10,7 @@ import {
   svgPolygonPoints,
   type PageGeo,
 } from './pages';
+import type { Corners } from '../types';
 
 const METERS_PER_DEGREE_LAT = 110574;
 const METERS_PER_DEGREE_LON_AT_EQUATOR = 111320;
@@ -313,5 +315,111 @@ describe('unfittedPages', () => {
   it('reports nothing when the server sent no page list', () => {
     // An older server omits `pages`; losing the listing beats a crashed page.
     expect(unfittedPages([pageGeo('p1', 0)], [])).toEqual([]);
+  });
+});
+
+describe('distortion', () => {
+  // Build corners from metric offsets using the module's own constants, so a
+  // "square" page really is square in metres (a degree-square is not: the lat
+  // and lon metre-per-degree constants differ by 0.7%).
+  const LAT = 40.7;
+  const METERS_PER_DEGREE_LAT = 110574;
+  const METERS_PER_DEGREE_LON_AT_EQUATOR = 111320;
+  const lonMeters =
+    Math.cos((LAT * Math.PI) / 180) * METERS_PER_DEGREE_LON_AT_EQUATOR;
+
+  /** A page 1000×800 px whose x step is `xMeters` and y step `yMeters` per pixel,
+   *  with `shearMeters` of eastward drift per pixel of y. */
+  function corners(xMeters: number, yMeters: number, shearMeters = 0): Corners {
+    const east = (m: number) => m / lonMeters;
+    const north = (m: number) => m / METERS_PER_DEGREE_LAT;
+    const nw: [number, number] = [-74, LAT];
+    const ne: [number, number] = [nw[0] + east(1000 * xMeters), LAT];
+    const swLon = nw[0] + east(800 * shearMeters);
+    const swLat = LAT - north(800 * yMeters);
+    return [nw, ne, [ne[0] + east(800 * shearMeters), swLat], [swLon, swLat]];
+  }
+
+  it('reports zero skew and unit anisotropy for a similarity', () => {
+    const { skewDegrees, anisotropy } = distortion(corners(1, 1), 1000, 800);
+    expect(skewDegrees).toBeCloseTo(0, 6);
+    expect(anisotropy).toBeCloseTo(1, 6);
+  });
+
+  it('reports anisotropy when x pixels cover more ground than y', () => {
+    const { skewDegrees, anisotropy } = distortion(corners(1.2, 1), 1000, 800);
+    expect(anisotropy).toBeCloseTo(1.2, 6);
+    expect(skewDegrees).toBeCloseTo(0, 6);
+  });
+
+  it('reports skew when the axes are not perpendicular', () => {
+    // One metre of eastward drift per metre of y is 45° off perpendicular.
+    // The sign follows truth_distortion in compare_iiif_georef.py: an x-shear
+    // closes the angle between the axes, so skew goes NEGATIVE.
+    const { skewDegrees } = distortion(corners(1, 1, 1), 1000, 800);
+    expect(skewDegrees).toBeLessThan(0);
+    expect(Math.abs(skewDegrees)).toBeCloseTo(45, 0);
+  });
+
+  it('is degenerate-safe', () => {
+    const collapsed: Corners = [
+      [-74, LAT],
+      [-74, LAT],
+      [-74, LAT],
+      [-74, LAT],
+    ];
+    expect(distortion(collapsed, 1000, 800)).toEqual({
+      skewDegrees: 0,
+      anisotropy: 1,
+    });
+  });
+});
+
+describe('pagesFromAnnotation split keys', () => {
+  // The server's `page` metadata is the on-disk stem, so a truth panel arrives
+  // as "p844__3". Appending the label's [3] again produced "p844__3__3", which
+  // matched no page in the list and rendered as "not georeferenced".
+  function truthPanel(stem: string, label: string) {
+    return {
+      id: 'https://oldinsurancemaps.net/iiif/resource/54284/',
+      label,
+      metadata: [{ label: 'page', value: stem }],
+      target: {
+        source: { id: 'x', type: 'ImageService3', width: 1000, height: 800 },
+      },
+      body: {
+        type: 'GeoreferencedMap',
+        transformation: { type: 'polynomial' },
+        features: [
+          [0, 0, -74, 40.7],
+          [1000, 0, -73.99, 40.7],
+          [1000, 800, -73.99, 40.69],
+        ].map(([x, y, lon, lat]) => ({
+          type: 'Feature',
+          properties: { resourceCoords: [x, y], type: 'gcp' },
+          geometry: { type: 'Point', coordinates: [lon, lat] },
+        })),
+      },
+    };
+  }
+
+  it('does not double a split suffix already present in the metadata', () => {
+    const [page] = pagesFromAnnotation({
+      items: [
+        truthPanel('p844__3', 'Grand Rapids, Mich. | 1953 | Vol. 7 p844 [3]'),
+      ],
+    } as never);
+    expect(page!.stem).toBe('p844__3');
+    expect(page!.pageKey).toBe('p844');
+    expect(page!.splitIndex).toBe(3);
+  });
+
+  it('leaves a whole page unsuffixed', () => {
+    const [page] = pagesFromAnnotation({
+      items: [truthPanel('p712', 'Grand Rapids, Mich. | 1953 | Vol. 7 p712')],
+    } as never);
+    expect(page!.stem).toBe('p712');
+    expect(page!.pageKey).toBe('p712');
+    expect(page!.splitIndex).toBeNull();
   });
 });

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -12,6 +12,7 @@ import type {
   GeorefAnnotationPage,
   GcpFeature,
 } from '../../server/iiifAnnotations';
+import { splitIndexFor } from '../../server/iiifAnnotations';
 import {
   computeCorners,
   pointInPolygon,
@@ -77,24 +78,6 @@ export interface PageGeo {
   gcps: PageGcp[];
   /** The annotation's transformation type, e.g. "polynomial" or "helmert". */
   transformationType: string;
-}
-
-/**
- * Split panel number for an item, or null for a whole page.
- *
- * A generated split carries it in its id (`…-1499M__2/georef`); a truth split carries it in
- * a trailing `[N]` on its label. A generated whole page's id ends in `/georef` and its label
- * may still carry a stray `[N]` copied from the truth — which is ignored.
- */
-function splitIndexFor(
-  id: string | undefined,
-  label: string | undefined,
-): number | null {
-  const idMatch = id?.match(/__(\d+)\//);
-  if (idMatch) return Number(idMatch[1]);
-  if (id?.includes('/georef')) return null; // generated whole page
-  const labelMatch = label?.match(/\[(\d+)\]\s*$/);
-  return labelMatch ? Number(labelMatch[1]) : null;
 }
 
 /** Parse the vertex list out of an SvgSelector's polygon value. */

--- a/app/src/iiif/pages.ts
+++ b/app/src/iiif/pages.ts
@@ -58,6 +58,22 @@ export interface PageGeo {
   scalePixelsPerFoot: number;
   /** Rotation from north-up in degrees, positive clockwise. */
   rotationDegrees: number;
+  /**
+   * Deviation of the image x/y axes from perpendicular, in degrees.
+   *
+   * 0 for a similarity (our own 4-parameter fits are 0 by construction), so a
+   * non-zero value means the annotation carries a transform that shears the
+   * sheet — which a photographed flat map cannot physically do. Matches
+   * `truth_distortion` in mapsnap/compare_iiif_georef.py, so it reads the same
+   * as the `skew°` column of `mapsnap compare`.
+   */
+  skewDegrees: number;
+  /**
+   * x-scale / y-scale ratio. 1.0 for a similarity; > 1 means an image pixel
+   * covers more ground horizontally than vertically. Same definition as the
+   * `aniso` column of `mapsnap compare`.
+   */
+  anisotropy: number;
   gcps: PageGcp[];
   /** The annotation's transformation type, e.g. "polynomial" or "helmert". */
   transformationType: string;
@@ -105,6 +121,42 @@ function deltaMeters(
     (b[0] - a[0]) * Math.cos(latRefRadians) * METERS_PER_DEGREE_LON_AT_EQUATOR,
     (b[1] - a[1]) * METERS_PER_DEGREE_LAT,
   ];
+}
+
+/**
+ * Skew (degrees off perpendicular) and anisotropy (x/y scale ratio) of a page.
+ *
+ * Port of `truth_distortion` in mapsnap/compare_iiif_georef.py, working from
+ * the projected corners rather than the affine matrix: the metric per-pixel
+ * step vectors are (ne − nw)/width and (sw − nw)/height, which are the affine's
+ * two columns whenever the transform is affine, and its first-order behaviour
+ * over the sheet otherwise.
+ *
+ * A similarity gives skew 0 and anisotropy 1. Truth annotations that deviate
+ * far are usually bad reference data — a flat sheet photographed square cannot
+ * shear — so the numbers belong next to scale and rotation in the info panel.
+ */
+export function distortion(
+  corners: Corners,
+  width: number,
+  height: number,
+): { skewDegrees: number; anisotropy: number } {
+  const [nw, ne, , sw] = corners;
+  const across = deltaMeters(nw, ne);
+  const down = deltaMeters(nw, sw);
+  const vx: [number, number] = [across[0] / width, across[1] / width];
+  const vy: [number, number] = [down[0] / height, down[1] / height];
+  const scaleX = Math.hypot(vx[0], vx[1]);
+  const scaleY = Math.hypot(vy[0], vy[1]);
+  if (scaleX === 0 || scaleY === 0) return { skewDegrees: 0, anisotropy: 1 };
+  const cosAngle = Math.min(
+    1,
+    Math.max(-1, (vx[0] * vy[0] + vx[1] * vy[1]) / (scaleX * scaleY)),
+  );
+  return {
+    skewDegrees: (Math.acos(cosAngle) * 180) / Math.PI - 90,
+    anisotropy: scaleX / scaleY,
+  };
 }
 
 /** Bearing of the a→b geo vector in degrees clockwise from north. */
@@ -260,6 +312,8 @@ export function unfittedPages(
       clipRing: [],
       scalePixelsPerFoot: 0,
       rotationDegrees: 0,
+      skewDegrees: 0,
+      anisotropy: 1,
       gcps: [],
       transformationType: '',
     });
@@ -291,10 +345,16 @@ export function pagesFromAnnotation(
   const pages: PageGeo[] = [];
   (annotation.items ?? []).forEach((item, itemIndex) => {
     const source = item.target?.source;
-    const pageKey = item.metadata?.find(
+    // The server's `page` metadata is the on-disk stem, so for a split panel it
+    // already ends in __N. PageGeo.pageKey is the PARENT key that panels share,
+    // so strip the suffix here rather than appending a second one below --
+    // otherwise a truth panel becomes "p844__3__3" and matches nothing.
+    const stemFromMetadata = item.metadata?.find(
       (entry) => entry.label === 'page',
     )?.value;
-    if (!source?.width || !source.height || !pageKey) return;
+    const pageKey = stemFromMetadata?.replace(/__\d+$/, '');
+    if (!source?.width || !source.height || !stemFromMetadata || !pageKey)
+      return;
     const { width, height } = source;
 
     const points = gcpPoints(item.body?.features ?? []);
@@ -319,7 +379,8 @@ export function pagesFromAnnotation(
         : rectRing;
 
     const splitIndex = splitIndexFor(item.id, item.label);
-    const stem = splitIndex != null ? `${pageKey}__${splitIndex}` : pageKey;
+    const stem =
+      splitIndex != null ? `${pageKey}__${splitIndex}` : stemFromMetadata;
 
     const [nw, ne, , sw] = corners;
     const feetAcross = Math.hypot(...deltaMeters(nw, ne)) * FEET_PER_METER;
@@ -328,6 +389,7 @@ export function pagesFromAnnotation(
     const scalePixelsPerFoot = (width / feetAcross + height / feetDown) / 2;
     const bearing = bearingDegrees(nw, ne);
     const rotationDegrees = ((bearing - 90 + 540) % 360) - 180;
+    const { skewDegrees, anisotropy } = distortion(corners, width, height);
 
     const transformation = item.body?.transformation as
       | { type?: string }
@@ -344,6 +406,8 @@ export function pagesFromAnnotation(
       clipRing,
       scalePixelsPerFoot,
       rotationDegrees,
+      skewDegrees,
+      anisotropy,
       gcps: points,
       transformationType: transformation?.type ?? 'polynomial',
     });


### PR DESCRIPTION
Fixes the volume viewer dropping most of a volume's truth annotations — reported as Grand Rapids showing "10 pages shown, 73 skipped" with `p844__3` greyed out as "not georeferenced" despite being present in `main.iiif.json`.

## Two bugs, one root cause

The TypeScript `serviceUrlToPageKey` took **only the service URL**. Python's `source_id_to_page_key` takes `(source_id, label)`. That divergence caused:

1. **Volumes that link no image service are entirely invisible.** 73 of Grand Rapids' 83 truth annotations carry `target.source.id: null`, so the derivation returned null and every one was skipped as `not-a-page`. (Python's docstring names this exact volume.)
2. **Split panels collapse onto their parent.** Only the label records the panel variant (`"... p844 [3]"`). Without it every panel of a sheet derives the same parent key, so multiple annotations claim one key and all but one is lost — **228 panels across the 15 truth volumes**:

| volume | panels lost | key collisions |
|---|---|---|
| fargo_nd_1958 | 55 | 33 |
| kansas_city_mo_1951_vol_4 | 30 | 15 |
| los_angeles_ca_1949_vol_14 | 26 | 14 |
| washington_dc_1916_vol_2 | 19 | 10 |
| columbia_sc_1956_vol_1 | 18 | 10 |
| champaign_ill_1915 / columbus_oh_1951_vol_3 | 17 each | 10 / 8 |
| (+8 more volumes) | | |

This is why `mapsnap compare` scored these pages correctly all along while the viewer could not show them — the Python path had both behaviours.

## Fix

Port the Python logic: `serviceUrlToPageKey(url, label)` appends the bracketed split suffix and falls back to a new `labelToPageKey` when the URL is null.

`iiifRoutes` builds its `localPages` map with its own call to the same function, so it must derive keys identically — otherwise `localPages` is keyed under names the rewrite never looks up and every page reports `missing-image` instead of resolving. (I hit exactly that in between the two edits.)

## Verified live

- **Grand Rapids: 71 of 83 kept** (was 10); `p844__1` and `p844__3` both resolve; no duplicate keys.
- **Fargo: 38 split keys resolved, zero collisions.**
- 14 new/updated unit tests covering split suffixes, the null-URL fallback, letter-only key-map sheets (`pa [2]` → `pa__2`), and labels with no page id. App suite 211 pass, `tsc` clean.

## Residual skips are real data gaps, not resolver failures

12 Grand Rapids and 17 Fargo truth panels have no local image because those sheets were never split locally (GR p725/p729/p819/p820/p834/p840/p841; fargo p7/p10/p12/p20/p43/p56/p58/p69). Both volumes do have `oim/*.panels.json` (16 and 22), so OIM splits some sheets our splitter leaves whole — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
