### PR TITLE
snap: refine ineligible on deferred/1-GCP incumbents (#277)

### DIFF
--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1800,6 +1800,18 @@ INCUMBENT_DEFENSIBLE_VERIFICATION = 0.1
 # points everywhere) and band-aware margins (their edge over flat 0.05 is
 # one train loss; zero holdout benefit for the extra shape).
 REFINE_VER_MARGIN = 0.05
+# ... and only when the incumbent is a real fit. The 93%-of-the-time
+# calibration above was measured on multi-GCP RANSAC incumbents; a
+# deferred/1-effective-GCP incumbent is a rung-guess free to swing about its
+# single anchor, and the candidate search for fitted pages is LOCAL around
+# that incumbent, so an "agreeing" challenger confirms the guess by
+# construction rather than by evidence. Nashville p4 (#277): both A/B arms
+# produced the identical half-scale deferred fit; one candidate roll had no
+# agreeing pose, fell through to rung_flip, and landed 26 ft — the other
+# rolled two agreeing half-scale poses, refine fired first, and blessed
+# 406 ft. Weak incumbents must fall through to the calibrated rung_flip /
+# keep-incumbent paths instead.
+REFINE_MIN_EFFECTIVE_GCPS = 2
 
 
 def refine_adoption(record: dict, margin: float = REFINE_VER_MARGIN) -> dict | None:
@@ -1816,6 +1828,13 @@ def refine_adoption(record: dict, margin: float = REFINE_VER_MARGIN) -> dict | N
     incumbent = record.get("incumbent")
     candidates = record.get("candidates") or []
     if not incumbent or not candidates:
+        return None
+    # Refinement's premise — agreement means the pose is right and the snap is
+    # merely more precise — requires an incumbent constrained enough to be
+    # worth agreeing with (see REFINE_MIN_EFFECTIVE_GCPS). Records cached
+    # before effective_gcps was recorded stay eligible.
+    effective_gcps = incumbent.get("effective_gcps")
+    if effective_gcps is not None and effective_gcps < REFINE_MIN_EFFECTIVE_GCPS:
         return None
     top = candidates[0]
     if top.get("select_score") is None:

--- a/mapsnap/osm_snap_experiment_test.py
+++ b/mapsnap/osm_snap_experiment_test.py
@@ -482,3 +482,20 @@ def test_stamp_corroborated_rescue_relaxes_the_gates():
         PRODUCTION_GATE_MARGIN,
     )
     assert choice["chosen"] is None and "score" in choice["reason"]
+
+
+def test_refine_ineligible_on_one_gcp_incumbent():
+    # #277: a deferred/1-effective-GCP incumbent is a rung-guess; an agreeing
+    # challenger from the local search confirms it by construction, so refine
+    # must decline and let rung_flip / keep-incumbent decide (nashville p4:
+    # refine blessed the half-scale pose at 406 ft that rung_flip had been
+    # flipping to 26 ft).
+    record = fitted_record(incumbent_ver=0.2, challenger_ver=0.35, shift_m=15.0)
+    record["incumbent"]["effective_gcps"] = 1
+    assert refine_adoption(record) is None
+    # Two distinct intersections is a real fit: refinement applies again.
+    record["incumbent"]["effective_gcps"] = 2
+    assert refine_adoption(record) is not None
+    # Records cached before effective_gcps existed keep the old behavior.
+    del record["incumbent"]["effective_gcps"]
+    assert refine_adoption(record) is not None


### PR DESCRIPTION
Fixes #277 — the pre-ship dependency for #279 (see its rollout section).

## The defect

`refine_adoption` adopts a challenger that agrees with the incumbent and beats its verification. Its 93%-of-the-time calibration was measured on **multi-GCP RANSAC incumbents**; applied to a **deferred/1-effective-GCP** incumbent it is circular — the candidate search for fitted pages is *local around the incumbent*, so agreeing candidates confirm the rung-guess by construction. Nashville p4 demonstrated both rolls of the dice from the **identical** half-scale deferred fit: one candidate list had no agreeing pose → fell through to `rung_flip` → 26 ft (a page `rung_flip`'s own calibration names); the other had two agreeing half-scale poses → refine fired first → blessed 406 ft.

## The fix

`REFINE_MIN_EFFECTIVE_GCPS = 2`: refine declines when `incumbent.effective_gcps < 2` (the field the candidates pass already records), letting weak incumbents fall through to the calibrated `challenge → rung_flip → keep` paths. Records cached before `effective_gcps` existed keep the old behavior.

## Validation

- New unit test: 1-GCP incumbent declines, 2-GCP refines, legacy record unchanged. Full snap suites green (37).
- Re-ran `mapsnap fit` on both #265 A/B volumes over the crnn sidecars: **p4 flips `refine: candidate #1 accepted` (406 ft) → `incumbent kept`** (the correct 26 ft pose is absent from this candidate roll, so declining is the right call); fargo bit-identical (0 regressions, 0 improvements), nashville otherwise one sub-foot pair. Tags `277-check` archived on both.

The class this protects against is corpus-wide: every deferred/1-GCP incumbent is one candidate-reroll away from silent confirmation, independent of the OCR change that exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
