### PR TITLE
fit --reconcile: publish through the arbiter (#270 phase 2)

### DIFF
--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -139,6 +139,15 @@ def main() -> None:
         help="Human-readable name recorded alongside the run id in the manifest.",
     )
     parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        help=(
+            "Publish through the reconcile arbiter (#270): after the channels "
+            "run, weigh all their poses jointly and publish the winners. "
+            "Report-only without this flag."
+        ),
+    )
+    parser.add_argument(
         "--no-snap",
         action="store_true",
         help=(
@@ -205,6 +214,14 @@ def main() -> None:
         # with) the snap channel; skipped with --no-snap for the same reason.
         run_cmd(["mapsnap", "street-solve", str(dir_path)])
 
+    # The arbiter (#270): weigh every pose the channels produced -- including
+    # the ones they rejected -- against each other and against not publishing
+    # at all, jointly across the volume. Its pN.georef-reconcile.json sidecars
+    # take top priority in the glob below, and a page it arbitrates to
+    # unplaced leaves a marker that suppresses the channel sidecars entirely.
+    if args.reconcile:
+        run_cmd(["mapsnap", "reconcile", str(dir_path), "--publish"])
+
     output_iiif = dir_path / f"{run_id}.iiif.json"
     # Pass the glob as a literal string; make_iiif_georef does its own glob
     # expansion (first glob wins per page, so the channel priority is
@@ -216,6 +233,11 @@ def main() -> None:
             f"{dir_path / '*.georef-streets.json'},"
             f"{dir_path / '*.georef-osm.json'},{dir_path / '*.georef.json'}"
         )
+    if args.reconcile:
+        # Reconcile's sidecars win over every channel. Pages it arbitrated to
+        # unplaced have had their channel sidecars renamed aside by `publish`,
+        # so no glob entry matches them at all.
+        georef_glob = f"{dir_path / '*.georef-reconcile.json'},{georef_glob}"
     run_cmd(
         [
             "mapsnap",

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -936,6 +936,67 @@ def write_outputs(
     return len(flips), rows
 
 
+def publish(
+    volume: Path, nodes: dict[str, PageNode], assignment: dict[str, int]
+) -> tuple[int, int]:
+    """Write the arbitrated poses as ``pN.georef-reconcile.json`` sidecars.
+
+    The ONLY mode that writes to the volume root. Each file records the pose
+    the joint solve chose plus its provenance, and takes top priority in
+    ``fit``'s IIIF glob — so a page whose arbitration agrees with the existing
+    publication is simply republished, and one that flipped is republished
+    from whichever channel won. A page arbitrated to UNPLACED gets no file
+    and no other channel can supply one, because the reconcile glob is
+    consulted first and the pipeline's own sidecars for that page remain
+    where they are (unpublishing is expressed by writing nothing here AND by
+    fit's glob, see write_unplaced_marker).
+    """
+    written = unplaced = 0
+    for stale in volume.glob("p*.georef-reconcile.json"):
+        stale.unlink()
+    for stale in volume.glob("p*.reconcile-unplaced"):
+        stale.unlink()
+    for stem in sorted(nodes):
+        node = nodes[stem]
+        hypothesis = node.hypotheses[assignment[stem]]
+        if hypothesis.affine is None:
+            if node.published_index is not None:
+                for channel in CHANNEL_ORDER:
+                    sidecar = volume / f"{stem}.{channel}.json"
+                    if sidecar.exists():
+                        sidecar.rename(volume / f"{stem}.{channel}-reconcile-held.json")
+                unplaced += 1
+            continue
+        a = hypothesis.affine
+        w, h = node.unit.width, node.unit.height
+        corners = [
+            [a[0, 0] * x + a[0, 1] * y + a[0, 2], a[1, 0] * x + a[1, 1] * y + a[1, 2]]
+            for x, y in [(0, 0), (w, 0), (w, h), (0, h)]
+        ]
+        (volume / f"{stem}.georef-reconcile.json").write_text(
+            json.dumps(
+                {
+                    "width": w,
+                    "height": h,
+                    "corners": corners,
+                    "streets": [],
+                    "intersections": [],
+                    "reconcile": {
+                        "source": hypothesis.source,
+                        "merged": hypothesis.merged_sources,
+                        "unary": round(hypothesis.unary, 4),
+                        "terms": {
+                            k: round(v, 4) for k, v in hypothesis.unary_terms.items()
+                        },
+                    },
+                },
+                indent=1,
+            )
+        )
+        written += 1
+    return written, unplaced
+
+
 def materialize_and_grade(
     volume: Path, nodes: dict[str, PageNode], assignment: dict[str, int], out_dir: Path
 ) -> None:
@@ -1004,6 +1065,13 @@ def main() -> None:
         metavar="DIR",
         help="Read georef sidecars from this dir (e.g. artifacts/reconcile-base) "
         "instead of the volume root — the archived-baseline mode.",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Write the arbitrated poses as pN.georef-reconcile.json in the "
+        "volume root (the only mode that writes there). fit --reconcile does "
+        "this for you.",
     )
     parser.add_argument(
         "--grade",
@@ -1075,6 +1143,9 @@ def main() -> None:
     out_dir = volume / "artifacts" / "reconcile"
     flips, _ = write_outputs(volume, nodes, assignment, out_dir)
     print(f"{flips} decisions flipped -> {out_dir / 'report.md'}")
+    if args.publish:
+        written, unplaced = publish(volume, nodes, assignment)
+        print(f"published {written} reconcile sidecars, {unplaced} unplaced markers")
     if args.grade:
         materialize_and_grade(volume, nodes, assignment, out_dir)
 

--- a/mapsnap/reconcile_test.py
+++ b/mapsnap/reconcile_test.py
@@ -354,3 +354,42 @@ def test_keep_bar_is_lower_than_enter_bar():
     assert kept.unary < unplaced.unary
     assert entrant.unary > unplaced.unary
     assert strong_entrant.unary < unplaced.unary
+
+
+def test_publish_writes_sidecars_and_holds_unplaced(tmp_path):
+    # --publish is the only mode that writes to the volume root: chosen poses
+    # become pN.georef-reconcile.json (top of fit's glob), and a page
+    # arbitrated to unplaced has its channel sidecars renamed aside, since a
+    # glob can only skip a page that has no sidecar at all.
+    from mapsnap.reconcile import publish
+
+    write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
+    write_sidecar(tmp_path, "p2", "georef-osm", georef_doc(affine(500)))
+    keep = make_node("p1", [scored("georef", affine(0), verification=1.9, gcps=4)])
+    drop = make_node(
+        "p2",
+        [
+            scored("georef-osm", affine(500), verification=0.1),
+            scored(UNPLACED, None, 0),
+        ],
+    )
+    written, unplaced = publish(tmp_path, {"p1": keep, "p2": drop}, {"p1": 0, "p2": 1})
+    assert (written, unplaced) == (1, 1)
+    assert (tmp_path / "p1.georef-reconcile.json").exists()
+    assert not (tmp_path / "p2.georef-reconcile.json").exists()
+    # p2's channel sidecar is held aside, so no glob entry can match it...
+    assert not (tmp_path / "p2.georef-osm.json").exists()
+    assert (tmp_path / "p2.georef-osm-reconcile-held.json").exists()
+    # ...and both live under fit's clear-glob, so the next run starts clean.
+    assert len(list(tmp_path.glob("p*.georef*.json"))) == 3
+
+
+def test_publish_records_provenance(tmp_path):
+    from mapsnap.reconcile import publish
+
+    write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
+    node = make_node("p1", [scored("georef", affine(0), verification=1.9, gcps=4)])
+    publish(tmp_path, {"p1": node}, {"p1": 0})
+    doc = json.loads((tmp_path / "p1.georef-reconcile.json").read_text())
+    assert doc["reconcile"]["source"] == "georef"
+    assert "terms" in doc["reconcile"] and "corners" in doc

--- a/scripts/reconcile_gates.py
+++ b/scripts/reconcile_gates.py
@@ -55,6 +55,11 @@ RECOVERY = [
 ]
 
 GOOD_FT, MID_FT, DISASTER_FT = 25.0, 50.0, 200.0
+# G1 asks whether the change DESTROYS pages, so its predicate is the severe
+# one (good -> >50 ft or unplaced). That is not the same question as "what did
+# this cost": a page sliding 24.7 -> 25.1 ft is invisible to G1 and cost
+# grand_rapids 1.89 points, more than all three G1 offenders combined. Both
+# are reported; neither is presented as the other.
 
 
 def band(rmse: float | None) -> str:
@@ -122,6 +127,7 @@ def run_volume(name: str) -> dict:
     base = compare_rows(truth, base_iiif, volume)
     recon = compare_rows(truth, recon_iiif, volume)
     g1_offenders = []
+    any_worse = []
     band_moves = 0
     new_disasters = []
     for key in set(base) | set(recon):
@@ -129,8 +135,10 @@ def run_volume(name: str) -> dict:
         if b != r:
             band_moves += 1
         base_good = base.get(key) is not None and base[key] <= GOOD_FT
-        if base_good and (recon.get(key) is None or recon[key] > MID_FT):
-            g1_offenders.append((key, base[key], recon.get(key)))
+        if base_good and (recon.get(key) is None or recon[key] > GOOD_FT):
+            any_worse.append((key, base[key], recon.get(key)))
+            if recon.get(key) is None or recon[key] > MID_FT:
+                g1_offenders.append((key, base[key], recon.get(key)))
         if r == "disaster" and b != "disaster":
             new_disasters.append((key, base.get(key), recon[key]))
     return {
@@ -138,6 +146,7 @@ def run_volume(name: str) -> dict:
         "base_rows": base,
         "recon_rows": recon,
         "g1_offenders": sorted(g1_offenders),
+        "any_worse": sorted(any_worse),
         "band_moves": band_moves,
         "new_disasters": sorted(new_disasters),
         "net_base": net_score(volume, base_iiif),
@@ -159,6 +168,15 @@ def main() -> None:
                 f"- {r['volume']} {key}: {was:.1f} -> "
                 f"{now if now is None else f'{now:.1f}'} ft"
             )
+    lines.append("")
+    lines.append("### every page that got worse (good -> anything worse), for scale")
+    total_worse = sum(len(r["any_worse"]) for r in results.values())
+    lines.append(f"{total_worse} pages, of which {sum(len(r['g1_offenders']) for r in results.values())} are G1 offenders:")
+    for r in results.values():
+        for key, was, now in r["any_worse"]:
+            severe = " (G1)" if (now is None or now > MID_FT) else ""
+            lines.append(f"- {r['volume']} {key}: {was:.1f} -> "
+                         f"{'unplaced' if now is None else f'{now:.1f}'} ft{severe}")
     lines.append("")
     # G2
     recovered = 0

--- a/scripts/reconcile_gates.py
+++ b/scripts/reconcile_gates.py
@@ -171,12 +171,16 @@ def main() -> None:
     lines.append("")
     lines.append("### every page that got worse (good -> anything worse), for scale")
     total_worse = sum(len(r["any_worse"]) for r in results.values())
-    lines.append(f"{total_worse} pages, of which {sum(len(r['g1_offenders']) for r in results.values())} are G1 offenders:")
+    lines.append(
+        f"{total_worse} pages, of which {sum(len(r['g1_offenders']) for r in results.values())} are G1 offenders:"
+    )
     for r in results.values():
         for key, was, now in r["any_worse"]:
             severe = " (G1)" if (now is None or now > MID_FT) else ""
-            lines.append(f"- {r['volume']} {key}: {was:.1f} -> "
-                         f"{'unplaced' if now is None else f'{now:.1f}'} ft{severe}")
+            lines.append(
+                f"- {r['volume']} {key}: {was:.1f} -> "
+                f"{'unplaced' if now is None else f'{now:.1f}'} ft{severe}"
+            )
     lines.append("")
     # G2
     recovered = 0


### PR DESCRIPTION
Phase 2 of #270. The arbiter can now publish, behind a flag, and the corpus A/B says it is safe to turn on: **+0.4 land-weighted across all 18 volumes**, with the sequential pipeline reproduced exactly on 14 of them.

## What ships

`reconcile --publish` writes `pN.georef-reconcile.json` at the top of `fit`'s IIIF glob. A page the arbiter declines has its channel sidecars renamed to `*-reconcile-held.json` — first-glob-wins can only skip a page that has *no* sidecar, so "publish nothing here" has to be expressed by moving the alternatives out of the way. Both forms match `fit`'s existing `p*.georef*.json` clear-glob, so every run starts clean; no #258-style residue. `fit --reconcile` wires it in after street-solve. **Report-only remains the default.**

## Publication A/B: full fits, both arms, same reads

| volume | control | reconcile | Δ |
|---|---|---|---|
| miami | 72.0 | **77.5** | **+5.5** |
| detroit | 69.4 | **71.4** | **+2.0** |
| fargo | 64.4 | 65.2 | +0.8 |
| new_orleans_1951 | 93.6 | 93.3 | −0.3 |
| *the other 14* | | | **+0.0** |
| **land-weighted total** | **76.5** | **76.9** | **+0.4** |

## What it actually does, stated plainly

Reconcile published 55–102 sidecars per volume — it runs everywhere — and **agrees with the sequential pipeline on essentially every page**. All 11 band moves in the corpus:

| move | n | examples |
|---|---|---|
| → unplaced | **9** | fargo p63__4 (29,384 ft), miami p4 (3,642), detroit p50 (333), miami p30 (306) |
| repaired to good | **1** | miami p76 **891 ft → 4.3 ft** |
| good → unplaced (severe) | 2 | detroit p21 (22.8 ft), NO-1951 p434 (22.7 ft) |

So on this corpus the arbiter's value is overwhelmingly **the ability to refuse**, which the pipeline has never had — not the cross-channel pose selection that motivated #270. Exactly one page was repaired by choosing a better existing pose.

The two severe regressions are the known coin-flip cell: 0–1 effective GCPs with no P(road) support, where the measured expected value of publishing is 0.224 good land against 0.224 disaster land. Both were correct fits; the evidence available cannot distinguish them from the junk in the same bucket.

## Also in this PR: the harm metric

The gate harness and A/B scorer now count **any** good page that stopped being good, with G1's severe subset (good → >50 ft or unplaced) broken out. The old predicate answered "did this change destroy pages" and was being reported as if it answered "what did this cost" — it hid grand_rapids p728__1 sliding **24.7 → 25.1 ft**, which cost 1.89 points, more than all three G1 offenders of that run combined.

Even the corrected counters miss a category, so the band-move table above is the honest view: `disaster → unplaced` is a real gain that neither a "harmed" nor a "gained" column captures, which is why detroit reads as `+2.0` with zero pages in either column.

## Verified

- 1,094 tests (2 new: publish writes sidecars and holds unplaced pages; provenance recorded), ruff + pyright clean.
- End-to-end smoke on champaign before the corpus run: 27 published, 1 held, score unchanged at 98.0, flips were p2__1 (152.9 ft → held) and p3__3 (unplaced → 5.3 ft).
- 36 full fits, two-up, all rc=0. No #296 segfaults this run.

## What this means for phase 3

The absorption table in #270 assumes the arbiter can replace the gates because it makes *better* decisions from the same evidence. This run says it mostly makes the *same* decisions, plus a few refusals. That still supports deleting the gates — the case is **simplification and debuggability at equal score**, which is the point of #270 — but each deletion should carry its own flat-or-better check rather than leaning on an accuracy claim this A/B does not make.

Separately worth recording: richmond was re-OCR'd onto the fine-tuned recognizer for this run (it had never seen it). On the *same* sequential pipeline that moved it **64.9 → 73.4 (+8.5)**, shrinking the 25–200 ft band from 17 pages to 12 and placing 4 of its 15 unplaced pages. Second clean holdout for #265 after fargo's +13.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
