### PR TITLE
Score every sheet equally, split by paper area

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,11 @@ Test data comes from hand-geocoding by volunteers on OldInsuranceMaps.net:
   </tbody>
 </table>
 
-**Score** is the land-weighted share of each volume georeferenced to within 25ft, minus the share placed 200ft or worse — so a volume is rewarded for accurate coverage and penalised for confident mistakes. Pages left unplaced count against coverage but are not penalised as errors. RMSE is measured over a grid of points inside each page's own truth footprint (split sheets are graded per panel).
+**Score** is the weighted share of each volume georeferenced to within 25ft, minus the share placed 200ft or worse — so a volume is rewarded for accurate coverage and penalised for confident mistakes. Pages left unplaced count against coverage but are not penalised as errors. RMSE is measured over a grid of points inside each page's own truth footprint (split sheets are graded per panel).
+
+Each **sheet** carries the same weight, split across its panels by the paper area each occupies, and discounted by the share of the sheet that is usable land (approximated by proximity to an OSM street). So a sheet counts for no more because it is physically large, but a sheet that is mostly harbour counts for less than a dense downtown one.
+
+> **Note:** the table above predates this weighting and is not comparable to it; it will be regenerated from the next full corpus run.
 
 You can view the fits on Allmaps or get the IIIF files from the `gallery` directory. For notes on poor fits, see [test data notes].
 

--- a/mapsnap/score.py
+++ b/mapsnap/score.py
@@ -1,16 +1,39 @@
-"""Land-weighted success score for georeferenced volumes.
+"""Success score for georeferenced volumes: every sheet counts once.
 
-The project's success metric: **the share of truth land area on pages
-georeferenced to within a good-fit threshold (default 25ft RMSE), minus the
-share placed disastrously (default >=200ft)** — placing a page 2000ft off is
-worse than not placing it at all, so a disaster subtracts what a success adds.
-Unplaced truth pages stay in the denominator and earn nothing.
+The project's success metric: **the weighted share of truth pages georeferenced
+to within a good-fit threshold (default 25ft RMSE), minus the share placed
+disastrously (default >=200ft)** — placing a page 2000ft off is worse than not
+placing it at all, so a disaster subtracts what a success adds. Unplaced truth
+pages stay in the denominator and earn nothing.
 
-Weighting by *land* area (rather than counting pages) downweights small split
-panels and waterfront sheets that are mostly water. Land is approximated by
-street proximity: the fraction of a page's footprint within STREET_NEAR_M of an
-OSM street centerline. Streets only exist on usable land, so this needs no
+A page's weight is::
+
+    sheet_portion x land_fraction
+
+**sheet_portion** normalizes each SHEET to weight 1, split across its panels by
+the paper area each occupies (so a four-way split still totals one sheet, and a
+95/5 split weighs 0.95/0.05). Portions come from the OIM region boundaries in
+``oim/pN.panels.json`` — the same source ``mapsnap compare`` matches splits
+with — not from the truth SvgSelector, which is a clip MASK and so conflates
+masking with splitting.
+
+**land_fraction** is the share of the page's footprint within STREET_NEAR_M of
+an OSM street centerline. Streets only exist on usable land, so this needs no
 separate water dataset and also discounts rail yards and other unmapped ground.
+A sheet that is mostly harbour is worth proportionally less than a dense
+downtown sheet.
+
+This replaced weighting by absolute land AREA, which let a physically enormous
+low-density sheet outweigh a compact dense one. Hudson scored 50.5% with 76% of
+its pages placed, because its unplaced sheets carried 1.45x the land of its
+typical placed sheet: 24% of the sheets consumed 43% of the weight. Normalizing
+per sheet scores it 72.9% — much closer to what the volume actually looks like —
+while keeping the water discount that the land fraction was already providing
+(brooklyn moves only -1.5 with the fraction retained, against -9.3 without it).
+
+Across volumes the aggregate is a SIMPLE MEAN of per-volume scores: a volume is
+the unit of work, and pooling pages let the biggest volumes set the corpus
+number.
 
 Each GENERATED_IIIF argument is scored against the ``main.iiif.json`` truth and
 ``centerlines.geojson`` in its own directory; pages are matched and RMSE
@@ -38,6 +61,7 @@ from mapsnap.compare_iiif_georef import (
     compare_pages,
     extract_gcps,
     fit_transform,
+    load_split_polygons,
     truth_polygon_world,
 )
 from mapsnap.utils import default_centerlines, source_id_to_page_key
@@ -71,29 +95,40 @@ class PageScore:
     area_m2: float
     land_m2: float
     rmse_ft: float | None  # None = truth page with no generated fit
+    sheet_portion: float = 1.0  # share of its SHEET's weight (1.0 if unsplit)
+
+    @property
+    def land_fraction(self) -> float:
+        """Share of this page's footprint that is usable land."""
+        return self.land_m2 / self.area_m2 if self.area_m2 else 0.0
+
+    @property
+    def weight(self) -> float:
+        """This page's weight in the score: its slice of a sheet, less its water."""
+        return self.sheet_portion * self.land_fraction
 
 
 @dataclass
 class ScoreSummary:
-    """Land-weighted totals for a set of pages (one volume or the aggregate)."""
+    """Weighted totals for a set of pages (one volume)."""
 
     n_pages: int
     n_placed: int
-    land_m2: float
-    good_m2: float  # rmse <= good threshold
-    disaster_m2: float  # placed at rmse >= disaster threshold
+    weight: float
+    good_weight: float  # rmse <= good threshold
+    disaster_weight: float  # placed at rmse >= disaster threshold
 
     @property
     def good_share(self) -> float:
-        return self.good_m2 / self.land_m2 if self.land_m2 else 0.0
+        return self.good_weight / self.weight if self.weight else 0.0
 
     @property
     def disaster_share(self) -> float:
-        return self.disaster_m2 / self.land_m2 if self.land_m2 else 0.0
+        return self.disaster_weight / self.weight if self.weight else 0.0
 
     @property
     def net_score(self) -> float:
-        """The success metric: good land share minus disaster land share."""
+        """The success metric: good share minus disaster share."""
         return self.good_share - self.disaster_share
 
 
@@ -161,6 +196,63 @@ def land_fraction(
     return float(len(np.unique(hits)) / len(inside))
 
 
+def sheet_of(page_key: str) -> str:
+    """The sheet a page key belongs to ('p59__2' -> 'p59')."""
+    return page_key.split("__")[0]
+
+
+def split_index(page_key: str) -> int | None:
+    """1-based panel index in a split page key, or None when the page is unsplit."""
+    if "__" not in page_key:
+        return None
+    try:
+        return int(page_key.split("__")[1])
+    except ValueError:
+        return None
+
+
+def sheet_portions(oim_dir: Path, page_keys: list[str]) -> dict[str, float]:
+    """Each page key's share of its own sheet's weight, summing to 1 per sheet.
+
+    Split portions are the PAPER area of each OIM region boundary
+    (``oim/pN.panels.json``), normalized within the sheet. Paper, not ground:
+    an inset is small on the sheet however much ground it covers, and that is
+    what "a fraction of a page" means.
+
+    Panels are normalized to sum to 1 rather than divided by the raw sheet
+    rectangle, so that a sheet whose panels do not quite tile it still carries
+    the same total weight as an unsplit one. Measured across the 18 truth
+    volumes, the OIM panels tile their sheet almost exactly (median coverage
+    1.000), so the normalization is a safeguard rather than a correction.
+    """
+    by_sheet: dict[str, list[str]] = {}
+    for key in page_keys:
+        by_sheet.setdefault(sheet_of(key), []).append(key)
+
+    portions: dict[str, float] = {}
+    for sheet, keys in by_sheet.items():
+        if len(keys) == 1 and split_index(keys[0]) is None:
+            portions[keys[0]] = 1.0
+            continue
+        polygons = load_split_polygons(oim_dir / f"{sheet}.panels.json")
+        areas = {}
+        for key in keys:
+            index = split_index(key)
+            polygon = polygons.get(index) if index is not None else None
+            areas[key] = polygon.area if polygon is not None else 0.0
+        total = sum(areas.values())
+        if total <= 0:
+            # No usable boundaries: split the sheet evenly rather than drop it.
+            print(
+                f"  {sheet}: no panel boundaries; weighting its "
+                f"{len(keys)} panels equally",
+                file=sys.stderr,
+            )
+        for key in keys:
+            portions[key] = areas[key] / total if total > 0 else 1.0 / len(keys)
+    return portions
+
+
 def volume_page_scores(
     generated_iiif: Path,
     *,
@@ -226,6 +318,7 @@ def volume_page_scores(
     )
     streets = street_tree(centerlines, frame)
 
+    portions = sheet_portions(volume / "oim", sorted(rings))
     scores = []
     for key, ring in sorted(rings.items()):
         footprint = Polygon([frame.to_xy(lon, lat) for lon, lat in ring]).buffer(0)
@@ -238,6 +331,7 @@ def volume_page_scores(
                 area_m2=footprint.area,
                 land_m2=footprint.area * fraction,
                 rmse_ft=rmse_by_key[key],
+                sheet_portion=portions.get(key, 1.0),
             )
         )
     return scores
@@ -249,16 +343,16 @@ def summarize(
     good_ft: float = GOOD_FT,
     disaster_ft: float = DISASTER_FT,
 ) -> ScoreSummary:
-    """Land-weighted totals over a set of page scores."""
+    """Weighted totals over a set of page scores (one volume)."""
     return ScoreSummary(
         n_pages=len(pages),
         n_placed=sum(1 for p in pages if p.rmse_ft is not None),
-        land_m2=sum(p.land_m2 for p in pages),
-        good_m2=sum(
-            p.land_m2 for p in pages if p.rmse_ft is not None and p.rmse_ft <= good_ft
+        weight=sum(p.weight for p in pages),
+        good_weight=sum(
+            p.weight for p in pages if p.rmse_ft is not None and p.rmse_ft <= good_ft
         ),
-        disaster_m2=sum(
-            p.land_m2
+        disaster_weight=sum(
+            p.weight
             for p in pages
             if p.rmse_ft is not None and p.rmse_ft >= disaster_ft
         ),
@@ -268,8 +362,10 @@ def summarize(
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Land-weighted success score: share of truth land area georeferenced "
-            "to <=GOOD ft RMSE, minus the share placed at >=DISASTER ft."
+            "Success score: weighted share of truth pages georeferenced to "
+            "<=GOOD ft RMSE, minus the share placed at >=DISASTER ft. Each "
+            "sheet weighs 1 (split across its panels by paper area), less its "
+            "water. Several volumes print a simple mean."
         )
     )
     parser.add_argument(
@@ -331,6 +427,7 @@ def main() -> None:
     print(header)
     print("-" * len(header))
     all_pages: list[tuple[str, PageScore]] = []
+    summaries: list[ScoreSummary] = []
     for path in args.generated:
         generated = Path(path)
         pages = volume_page_scores(
@@ -338,26 +435,39 @@ def main() -> None:
         )
         all_pages.extend((generated.parent.name, p) for p in pages)
         s = summarize(pages, good_ft=args.good_ft, disaster_ft=args.disaster_ft)
+        summaries.append(s)
         print(
             f"{generated.parent.name:<30} {s.n_pages:>5} {s.n_placed:>6} "
             f"{s.good_share:>7.1%} {s.disaster_share:>7.1%} {s.net_score:>6.1%}"
         )
-    if len(args.generated) > 1:
-        s = summarize(
-            [p for _, p in all_pages],
-            good_ft=args.good_ft,
-            disaster_ft=args.disaster_ft,
-        )
+    if len(summaries) > 1:
+        # A SIMPLE MEAN, not a pooled total: a volume is the unit of work, and
+        # pooling let the largest volumes decide the corpus number.
+        n = len(summaries)
         print("-" * len(header))
         print(
-            f"{'AGGREGATE':<30} {s.n_pages:>5} {s.n_placed:>6} "
-            f"{s.good_share:>7.1%} {s.disaster_share:>7.1%} {s.net_score:>6.1%}"
+            f"{'MEAN OF ' + str(n) + ' VOLUMES':<30} "
+            f"{sum(s.n_pages for s in summaries):>5} "
+            f"{sum(s.n_placed for s in summaries):>6} "
+            f"{sum(s.good_share for s in summaries) / n:>7.1%} "
+            f"{sum(s.disaster_share for s in summaries) / n:>7.1%} "
+            f"{sum(s.net_score for s in summaries) / n:>6.1%}"
         )
 
     if args.csv:
         with open(args.csv, "w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(["volume", "page_key", "area_m2", "land_m2", "rmse_ft"])
+            writer.writerow(
+                [
+                    "volume",
+                    "page_key",
+                    "area_m2",
+                    "land_m2",
+                    "sheet_portion",
+                    "weight",
+                    "rmse_ft",
+                ]
+            )
             for volume_name, p in all_pages:
                 writer.writerow(
                     [
@@ -365,6 +475,8 @@ def main() -> None:
                         p.page_key,
                         round(p.area_m2, 1),
                         round(p.land_m2, 1),
+                        round(p.sheet_portion, 4),
+                        round(p.weight, 4),
                         "" if p.rmse_ft is None else round(p.rmse_ft, 1),
                     ]
                 )

--- a/mapsnap/score_test.py
+++ b/mapsnap/score_test.py
@@ -1,5 +1,9 @@
 """Tests for mapsnap.score."""
 
+import json
+from pathlib import Path
+
+import pytest
 import shapely
 from shapely.geometry import Polygon
 from shapely.strtree import STRtree
@@ -8,6 +12,7 @@ from mapsnap.score import (
     LocalFrame,
     PageScore,
     land_fraction,
+    sheet_portions,
     summarize,
     truth_footprint_ring,
 )
@@ -111,18 +116,70 @@ def test_summarize_net_score_subtracts_disasters():
     assert s.net_score == 0.0  # the disaster cancels the success
 
 
-def test_summarize_weights_by_land_not_pages():
-    pages = [
+def test_summarize_ignores_sheet_size():
+    # A sheet's SIZE must not decide anything: one placed and one unplaced
+    # sheet is 0.5 whether the placed one is four times the other's area or
+    # a quarter of it. Under land-AREA weighting this was 0.8 and 0.2 --
+    # which is how hudson scored 50.5% while placing 76% of its pages.
+    big_good = [
         PageScore("big", area_m2=400.0, land_m2=400.0, rmse_ft=10.0),
         PageScore("small", area_m2=100.0, land_m2=100.0, rmse_ft=None),
     ]
-    s = summarize(pages)
-    assert s.net_score == 0.8  # 400 of 500 land, not 1 of 2 pages
+    small_good = [
+        PageScore("big", area_m2=400.0, land_m2=400.0, rmse_ft=None),
+        PageScore("small", area_m2=100.0, land_m2=100.0, rmse_ft=10.0),
+    ]
+    assert summarize(big_good).net_score == 0.5
+    assert summarize(small_good).net_score == 0.5
+
+
+def test_summarize_still_discounts_water():
+    # Size is out, but the water discount stays: a half-water sheet carries
+    # half the weight of a dry one. This is what keeps brooklyn's mostly-water
+    # unplaced sheets from costing a full page each (-1.5 rather than -9.3).
+    pages = [
+        PageScore("dry", area_m2=100.0, land_m2=100.0, rmse_ft=10.0),
+        PageScore("harbour", area_m2=100.0, land_m2=50.0, rmse_ft=None),
+    ]
+    assert summarize(pages).net_score == pytest.approx(1.0 / 1.5)
+
+
+def test_split_panels_share_one_sheet():
+    # Four panels of one sheet weigh the same, in total, as one unsplit sheet:
+    # a volume cannot gain or lose score by how finely its sheets were cut.
+    quarters = [
+        PageScore(
+            f"p1__{i}", area_m2=25.0, land_m2=25.0, rmse_ft=10.0, sheet_portion=0.25
+        )
+        for i in range(1, 5)
+    ]
+    whole = [PageScore("p2", area_m2=100.0, land_m2=100.0, rmse_ft=None)]
+    assert sum(p.weight for p in quarters) == pytest.approx(1.0)
+    assert summarize(quarters + whole).net_score == pytest.approx(0.5)
+
+
+def test_split_panels_weigh_by_paper_share():
+    # A 95/5 split weighs 0.95/0.05: losing the sliver costs almost nothing,
+    # losing the main panel costs almost the whole sheet.
+    lost_sliver = [
+        PageScore(
+            "p1__1", area_m2=95.0, land_m2=95.0, rmse_ft=10.0, sheet_portion=0.95
+        ),
+        PageScore("p1__2", area_m2=5.0, land_m2=5.0, rmse_ft=None, sheet_portion=0.05),
+    ]
+    lost_main = [
+        PageScore(
+            "p1__1", area_m2=95.0, land_m2=95.0, rmse_ft=None, sheet_portion=0.95
+        ),
+        PageScore("p1__2", area_m2=5.0, land_m2=5.0, rmse_ft=10.0, sheet_portion=0.05),
+    ]
+    assert summarize(lost_sliver).net_score == pytest.approx(0.95)
+    assert summarize(lost_main).net_score == pytest.approx(0.05)
 
 
 def test_summarize_empty_is_zero():
     s = summarize([])
-    assert s.net_score == 0.0 and s.land_m2 == 0.0
+    assert s.net_score == 0.0 and s.weight == 0.0
 
 
 # LocalFrame sanity
@@ -132,3 +189,47 @@ def test_local_frame_metres_scale():
     frame = LocalFrame(lon0=-118.0, lat0=34.0)
     x, y = frame.to_xy(-118.0, 34.01)
     assert abs(x) < 1e-6 and 1000 < y < 1200  # ~1.1km per 0.01 deg lat
+
+
+# sheet_portions
+
+
+def write_panels(oim: Path, sheet: str, rings: list[list[list[float]]]) -> None:
+    oim.mkdir(parents=True, exist_ok=True)
+    (oim / f"{sheet}.panels.json").write_text(
+        json.dumps({"width": 100, "height": 100, "panels": rings})
+    )
+
+
+def box(x0: float, y0: float, x1: float, y1: float) -> list[list[float]]:
+    return [[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+
+
+def test_sheet_portions_unsplit_sheet_is_one(tmp_path):
+    assert sheet_portions(tmp_path / "oim", ["p1", "p2"]) == {"p1": 1.0, "p2": 1.0}
+
+
+def test_sheet_portions_split_by_paper_area(tmp_path):
+    # A sheet cut 80/20 by paper area, from the OIM region boundaries.
+    write_panels(tmp_path / "oim", "p1", [box(0, 0, 80, 100), box(80, 0, 100, 100)])
+    portions = sheet_portions(tmp_path / "oim", ["p1__1", "p1__2"])
+    assert portions["p1__1"] == pytest.approx(0.8)
+    assert portions["p1__2"] == pytest.approx(0.2)
+    assert sum(portions.values()) == pytest.approx(1.0)
+
+
+def test_sheet_portions_normalize_when_panels_overlap(tmp_path):
+    # miami p62's shape: two panels each covering nearly the whole sheet. The
+    # sheet still carries weight 1, shared between them, rather than 2.
+    write_panels(tmp_path / "oim", "p1", [box(0, 0, 100, 100), box(0, 0, 100, 100)])
+    portions = sheet_portions(tmp_path / "oim", ["p1__1", "p1__2"])
+    assert sum(portions.values()) == pytest.approx(1.0)
+    assert portions["p1__1"] == pytest.approx(0.5)
+
+
+def test_sheet_portions_missing_boundaries_split_evenly(tmp_path, capsys):
+    # No panels.json: weight the panels equally and SAY so, rather than
+    # silently dropping the sheet out of the denominator.
+    portions = sheet_portions(tmp_path / "oim", ["p1__1", "p1__2", "p1__3"])
+    assert portions == {"p1__1": 1 / 3, "p1__2": 1 / 3, "p1__3": 1 / 3}
+    assert "no panel boundaries" in capsys.readouterr().err


### PR DESCRIPTION
## The problem

Weighting by absolute land **area** let a physically enormous low-density sheet outweigh a compact dense one. Hudson scores 50.5% while placing 76% of its pages:

| hudson | n | median land | total land |
|---|---|---|---|
| good | 62 | 0.058 km² | 3.78 |
| **unplaced** | **22** | **0.084 km²** | **2.82** |

Its unplaced sheets carry 1.45× the land of a typical placed one, so 24% of the sheets consumed 43% of the weight. The land fraction *was* discounting their water — it just could not stop a huge waterfront sheet outweighing a compact downtown one in absolute terms. The score was reporting sheet size as much as fit quality.

## The change

A page's weight becomes `sheet_portion × land_fraction`:

- **`sheet_portion`** normalizes each SHEET to weight 1, split across its panels by the paper area each occupies. A four-way split totals one sheet; a 95/5 split weighs 0.95/0.05. A volume can no longer gain or lose score by how finely it was cut.
- **`land_fraction`** is unchanged, and it is doing real work: without it brooklyn falls 9.3 points, because its unplaced sheets are genuinely mostly water. With it, 1.5.

Split portions come from `oim/pN.panels.json` — the OIM region boundaries `mapsnap compare` already matches splits with — **not** the truth `SvgSelector`, which is a clip mask and conflates masking with splitting (unsplit sheets' selectors cover only 0.69–0.79 of their source rectangle). All 122 split sheets across the 18 truth volumes have boundaries, and they tile their sheet almost exactly (median coverage 1.000); the equal-share fallback never fires.

The multi-volume aggregate is now a **simple mean**, not a pooled total: a volume is the unit of work, and pooling let the largest volumes decide the corpus number.

## Effect, same fits (last night's `pubab-reconcile`)

| volume | land-area | **new** | Δ | | volume | land-area | **new** | Δ |
|---|---|---|---|---|---|---|---|---|
| champaign | 98.0 | 97.6 | −0.4 | | chicago | 75.1 | 80.0 | +4.9 |
| new_orleans_1951 | 93.3 | 93.4 | +0.1 | | miami | 77.5 | 77.9 | +0.3 |
| columbus | 77.8 | **89.5** | **+11.7** | | detroit | 71.4 | 76.5 | +5.1 |
| brooklyn | 89.6 | 88.2 | −1.5 | | grand_rapids | 76.8 | 74.5 | −2.3 |
| los_angeles | 79.2 | **87.6** | **+8.4** | | columbia | 69.1 | 74.3 | +5.2 |
| philadelphia | 82.2 | 83.4 | +1.2 | | richmond | 73.4 | 74.0 | +0.5 |
| washington_dc | 81.3 | 82.7 | +1.4 | | **hudson** | **50.5** | **72.9** | **+22.3** |
| new_orleans_1896 | 83.3 | 82.0 | −1.4 | | fargo | 65.2 | 69.3 | +4.2 |
| kansas_city | 80.6 | 81.4 | +0.8 | | nashville | 64.7 | 66.7 | +2.0 |

**Corpus 76.9 (land-weighted) → 80.6 (mean of 18).** Fourteen volumes up, four down, none by more than 2.3. The spread compresses from 47.5 points (50.5–98.0) to 30.9 (66.7–97.6), and hudson stops being a lone outlier — the work now concentrates visibly in nashville, fargo, hudson, richmond and columbia.

## Before merging

- **Regenerate the README results table.** Its numbers predate this weighting and are not comparable; I added a note saying so rather than hand-editing figures that need a corpus run behind them.
- Historical reports (`docs/baseline.md`, `data/2026-08-10-rerun.md`) quote old-metric scores. They are dated records of runs, so I left them alone; worth deciding whether to annotate.
- One truth-data oddity surfaced: miami p62 has two panels each covering ~98% of the sheet (normalized to 0.492/0.492) plus two slivers. Handled correctly by normalization, but it looks like duplicated OIM regions and may deserve its own look.

## Verified

1,101 tests, ruff and pyright clean. The old `test_summarize_weights_by_land_not_pages` asserted the very behaviour being removed and was replaced by tests pinning the new contract: size must not decide anything, water still discounts, splits share one sheet, a 95/5 split weighs 95/5, and the missing-boundaries fallback announces itself. `mapsnap score` over all 18 volumes reproduces the prototype's numbers exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
