### PR TITLE
Collapse the georef sidecars: verdicts inside the file, one publisher (#270 phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ The four arguments here are:
 - `mapsnap ocr`: runs OCR over the downscaled images, saving candidate detections to `boxes.json` and `streets.json` files.
 - `mapsnap fit`: another pipeline that runs:
   - `mapsnap georef`: georeferences images based on street detections, writing out `georef.json` files where it can find a good fit.
-  - `mapsnap snap`: the geometry-first channel — matches each page's road-UNet mask directly against OSM street geometry to rescue pages the street-name georeferencer couldn't place, replace fits that OSM actively contradicts, and refine mid-tier fits to street-grid precision. Writes `georef-osm.json` sidecars that take priority in the next step. Skip with `--no-snap`.
+  - `mapsnap snap`: the geometry-first channel — matches each page's road-UNet mask directly against OSM street geometry to rescue pages the street-name georeferencer couldn't place, replace fits that OSM actively contradicts, and refine mid-tier fits to street-grid precision. Writes `georef-snap.json` sidecars for the arbiter to weigh. Skip with `--no-snap`.
   - `mapsnap iiif`: produces a IIIF Georeference Extension with clipping masks. You can find examples of these in the `gallery` directory. View them on Allmaps.
   - `mapsnap compare`: compares the generated IIIF file with the human-generated one from OIM, producing a report on the accuracy of the fit.
 

--- a/app/server/runArtifacts.ts
+++ b/app/server/runArtifacts.ts
@@ -35,15 +35,15 @@ export function runArtifactDir(relativePath: string): string | null {
   return null;
 }
 
-/** Page sidecars a run archived: `p12.georef.json`, `p12.georef-osm.json`, `p12.streets.json`. */
+/** Page sidecars a run archived: `p12.georef.json`, `p12.georef-snap.json`, `p12.streets.json`. */
 const PAGE_SIDECAR = /^(p[^.]+)\.(?:georef(?:-[a-z0-9-]+)?|streets)\.json$/;
 
 /**
  * Page stems a run saved any sidecar for, from that directory's file names.
  *
  * Every per-page artifact counts, not only the plain georef. A page the run
- * demoted or rescued has `georef-osm.json` or `georef-nofit.json` and no plain
- * `georef.json`, and a page that never fitted still has `streets.json`. Matching
+ * rescued has `georef-snap.json` as well as its plain `georef.json`, and a page
+ * that never fitted still has `streets.json`. Matching
  * only `p<stem>.georef.json` reported "this run saved no sidecar for this page"
  * for 54 of 112 pages on one Fargo run -- precisely the unfitted pages someone
  * opening the viewer is most likely to be looking at.

--- a/docs/fit-pipeline.md
+++ b/docs/fit-pipeline.md
@@ -1,35 +1,54 @@
 # How a page gets its fit — and every way it can be rejected
 
-As of the `2026-08-07` run (main @ `31146e1`). Every gate below is illustrated
-with a page from that run; grep the page's `<stem>.txt` sidecar or the run's
-fit log for the quoted messages.
+Stage structure as of #270 phase 3; the per-gate examples are from the
+`2026-08-07` run (main @ `31146e1`) and still name the right pages, though a
+rejection that used to rename a file now records a `status` inside it. Grep
+the page's `<stem>.txt` sidecar or the run's fit log for the quoted messages.
 
-`mapsnap fit DIR --tag T` runs five stages in a fixed order. Each stage
+`mapsnap fit DIR --tag T` runs six stages in a fixed order. Each stage
 communicates with the next entirely through per-page sidecar files:
 
 ```
 clear_derived_sidecars          (#247: delete p*.georef*.json so nothing stale survives)
         │
         ▼
-1. mapsnap georef               writes p*.georef.json … or a rejection sidecar
+1. mapsnap georef               RANSAC pose           → p*.georef.json
         │
         ▼
-2. mapsnap adjacency-gate       renames contradicted fits, leaves re-search hints
+2. mapsnap adjacency-gate       contradiction verdict + re-search hints
         │
         ▼
-3. mapsnap snap                 rescue / arbitrate / refine → p*.georef-osm.json
+3. mapsnap snap                 rescue / arbitrate / refine → p*.georef-snap.json
         │
         ▼
-4. mapsnap street-solve         referee-approved poses → p*.georef-streets.json
+4. mapsnap street-solve         street-constraint pose     → p*.georef-street.json
         │
         ▼
-5. mapsnap iiif                 first glob wins: streets > osm > georef
+5. mapsnap reconcile --publish  weighs every pose jointly  → p*.georef-final.json
+        │
+        ▼
+6. mapsnap iiif                 publishes p*.georef-final.json, and only that
 ```
 
-A page is **published** iff it ends the run with a `georef-streets.json`,
-`georef-osm.json`, or plain `georef.json`. Every other sidecar
-(`-misscale`, `-1gcp`, `-nofit`, `-keymap-outlier`, `-outlier`,
-`-contradicted`) is invisible to the IIIF glob: the page is unplaced.
+**One sidecar per channel, one verdict inside it** (#270 phase 3). A channel
+writes its pose to its own file and records what it concluded in a `status`
+field; `status: fitted` (or no status at all) means the channel stands behind
+the pose, and anything else — `misscale`, `outlier`, `keymap-outlier`, `1gcp`,
+`nofit`, `contradicted` — is a pose the channel produced and declined. The
+pose stays readable either way, which is the point: the arbiter weighs
+declined poses too, and the fargo p55 class is precisely a declined pose that
+was right. A channel that reached more than one pose (georef's key-map retry)
+keeps the loser under `rejected` in the same file.
+
+A page is **published** iff its `georef-final.json` carries corners. The
+arbiter writes one for *every* page, so declining to place a page is a
+recorded decision (`corners: null`) rather than the absence of a file.
+
+This replaced a scheme where the *filename* carried the judgement — a page
+had up to nine kinds of `p*.georef*.json` and publication was first-glob-wins
+over them. That made stage ORDER the thing that decided what got published,
+gave each stage a reason to hide its predecessors' files, and let a reader
+that didn't know the whole variant vocabulary drop pages silently.
 
 ---
 
@@ -73,7 +92,7 @@ against progressively wider street sets until something fits:
 
 **Key-map-outlier rejection + retry (#259):** a rectangle-tier fit placed
 beyond the key-map radius, when the location is anchored and confident
-in-radius streets exist, is renamed `georef-keymap-outlier.json`, then the
+in-radius streets exist, is recorded `status: keymap-outlier`, then the
 neighborhood is retried at relaxed floors; the retry publishes only if it has
 at least as many inliers as the rejected fit.
 
@@ -91,7 +110,7 @@ Admitted labels are extrapolated along their text direction; label pairs whose
 streets intersect near the page **and** in OSM become intersection GCPs
 (deduped). Then `ransac_hybrid`:
 
-- **< 1 GCP** → `georef-nofit.json` (minimal sidecar so the debugger can show
+- **< 1 GCP** → `status: nofit` (a neighborhood-only sidecar so the debugger can show
   the key-map expectation). *Example: fargo p59__2.*
 - **exactly 1 distinct intersection** → **deferred** for median-scale
   processing (see 1e). Log: `Only 1 distinct intersection: 10TH x 14TH;
@@ -118,7 +137,7 @@ kept, never un-rejected later:
    `keep` verdict overrides the bands (requires an over-determined fit); a
    mismatch against the note drops a fit the bands would have kept.
    *Drop example: washington_dc p227 — `15.4838 px/ft is 12.31x the page's
-   PRINTED scale note → p227.georef-misscale.json`.*
+   PRINTED scale note` → p227.georef.json gets `status: misscale`.*
 2. **Neighbor corroboration** (`scale_corroborated_by_neighbors`): if the
    page's scale is within the SAME band of the median of ≥ 2 *adjacent* fitted
    pages, the off-rung scale is treated as a real local drawing scale.
@@ -134,20 +153,20 @@ kept, never un-rejected later:
    within stage 1. What can resurrect a rejected page is stage 3.
 
    *Plain band rejection example: champaign p1 — `0.3726 px/ft vs reference
-   1.4504 (0.26×) → p1.georef-misscale.json`.*
+   1.4504 (0.26×)` → p1.georef.json gets `status: misscale`.*
 
 **Deferred (1-intersection) processing.** Each deferred page is fitted at
 every scale candidate (volume reference, key-map region rung, adjacent-page
 rungs) × rotation candidates (from its own two labels, validated against ≥ 2
 neighbors within 1.5× page dimensions); the page's own labels arbitrate.
 Confirmed fits (≥ 2 agreeing neighbors) publish as `georef.json`; unconfirmed
-ones write `georef-1gcp.json` and stay unplaced (snap may rescue them).
+ones are marked `status: 1gcp` and stay unplaced (snap may rescue them).
 *Example: chicago p1n — `Deferred: 2 / 3 inlier labels`, unconfirmed →
-`p1n.georef-1gcp.json`.*
+`status: 1gcp` on p1n.georef.json.*
 
 **Location outlier.** With ≥ 5 fitted pages, any page whose center is more
-than `--min-distance-for-outlier-km` from every other page is renamed
-`georef-outlier.json`. *Examples: grand_rapids p819 (`1.6 km from closest
+than `--min-distance-for-outlier-km` from every other page is marked
+`status: outlier`. *Examples: grand_rapids p819 (`1.6 km from closest
 map`), miami p91__3 (1.9 km).*
 
 ### Stage-1 outcome summary
@@ -155,11 +174,11 @@ map`), miami p91__3 (1.9 km).*
 | sidecar | meaning | 08-07 example |
 |---|---|---|
 | `georef.json` | published RANSAC fit | fargo p64 (11.1 ft) |
-| `georef-misscale.json` | scale off the volume rungs / printed note | champaign p1; dc p227 |
-| `georef-1gcp.json` | deferred fit, unconfirmed by neighbors | chicago p1n |
-| `georef-nofit.json` | key-map-placed page, no usable fit | fargo p59__2 |
-| `georef-keymap-outlier.json` | rectangle fit far from anchored key-map location | fargo p55 |
-| `georef-outlier.json` | center km from every other page | grand_rapids p819 |
+| `misscale` | scale off the volume rungs / printed note | champaign p1; dc p227 |
+| `1gcp` | deferred fit, unconfirmed by neighbors | chicago p1n |
+| `nofit` | key-map-placed page, no usable fit | fargo p59__2 |
+| `keymap-outlier` | rectangle fit far from anchored key-map location | fargo p55 |
+| `outlier` | center km from every other page | grand_rapids p819 |
 
 ---
 
@@ -184,7 +203,7 @@ a contradiction and arbitration names a suspect:
 A named suspect is demoted only with a **hard signal**: effective GCPs ≤ 2, or
 rotation/scale deviation from the *volume median* beyond 15° / 0.2 log (known
 flaw on multi-family volumes, #256). Demotion renames every channel sidecar to
-`*-contradicted.json` and writes `p*.contradiction.json` with the partners'
+`status: contradicted` on each channel sidecar and writes `p*.contradiction.json` with the partners'
 stamp positions — which stage 3 reads as extra search centers. (These hint
 files currently outlive the run; #258.)
 
@@ -199,7 +218,7 @@ alignment). What happens next depends on the page's state:
 
 **Unplaced pages** (`nofit`, `misscale`, `1gcp`, `outlier`, `none` — including
 gate-demoted pages) get **rescue**: the top candidate publishes as
-`georef-osm.json` if `select_score ≥ 1.25` and `margin ≥ 0.25`.
+`georef-snap.json` if `select_score ≥ 1.25` and `margin ≥ 0.25`.
 *Example: fargo p31 (prev=none) rescued at score 2.19 → 6.5 ft.*
 
 - **Stamp-corroborated rescue**: for a contradiction-demoted page whose
@@ -239,7 +258,7 @@ intersections needed. The channel alone is a coin flip, so a pose is adopted
 **only where an independent referee** (`osm_snap.evaluate_pose`: road-skeleton
 chamfer + name alignment, derived from neither channel) prefers it over the
 currently-published pose by a clear margin. Adopted poses write
-`georef-streets.json`, the top-priority channel.
+`georef-street.json`.
 
 *08-07 adoptions (13 pages corpus-wide): new_orleans_1896 p125/p164/p181,
 kansas_city p453/p470/p548, grand_rapids p703/p711, philadelphia p237/p238,
@@ -247,15 +266,26 @@ los_angeles p1499j, nashville p66, washington_dc p166.*
 
 ---
 
-## Stage 5: publication
+## Stage 5: arbitration (`reconcile.py`)
 
-`mapsnap iiif` expands the glob
-`*.georef-streets.json,*.georef-osm.json,*.georef.json` — **first match wins
-per page**. Consequences worth knowing:
+Every pose the channels produced — including the ones they declined, the top
+snap candidates, and the street-solve pose — is weighed against every other
+and against not placing the page at all, jointly across the volume (#270).
+The winner is written to `p*.georef-final.json`; a page the arbiter declines
+gets one with `corners: null`.
 
-- A page can end the run with several sidecars; only the highest-priority one
-  publishes. *Example: fargo p55 has `georef-keymap-outlier.json` (the correct
-  pose, rejected) and `georef-osm.json` (the wrong pose, published).*
+This is the stage that fixes the pathology stage 5 used to have: fargo p55
+ended a run holding both `keymap-outlier` (the correct pose, declined) and a
+snap pose (wrong, published) and *nothing ever compared them*, because
+publication was glob precedence and precedence does not look inside files.
+
+## Stage 6: publication
+
+`mapsnap iiif` expands one glob, `*.georef-final.json`. There is no
+precedence left to reason about: exactly one sidecar answers for each page.
+
+- A poseless `georef-final.json` leaves the page unplaced *and* claims its
+  page key, so nothing else can supply a pose for it.
 - Truth comparison then cross-matches split panels: a truth panel with no fit
   of its own is scored against another panel's fit — the `(p59__1)`-style
   marker in compare output (#267). This is how an *unfitted* page (fargo
@@ -272,15 +302,15 @@ Reject paths, in the order a page can hit them:
 |---|---|---|---|---|
 | 1 | detection admission (conf/size/aspect/words/fill) | 1a | label dropped | fargo p58__2's 14 px cross-streets (strict tier) |
 | 2 | seed rotation outlier | 1c | candidate pair vetoed | (debug-only message; see `ransac_hybrid` tests) |
-| 3 | < 2 GCPs | 1c | defer or `-nofit` | fargo p59__2 |
+| 3 | < 2 GCPs | 1c | defer or `nofit` | fargo p59__2 |
 | 4 | relaxed-fit region-scale check | 1b | relaxed fit discarded | — |
 | 5 | broadened-fit scale prior (0.1–6.0×) | 1b | fit removed | — |
-| 6 | key-map outlier (+ retry) | 1b | `-keymap-outlier`, maybe retried | fargo p55 (stays), p58__2 (retry wins) |
-| 7 | printed-scale-note mismatch | 1d | `-misscale` | dc p227 (12.31×) |
-| 8 | scale bands vs reference | 1d | `-misscale` unless note/neighbors keep it | champaign p1 (0.26×); fargo p59__1 **kept** |
-| 9 | deferred fit unconfirmed | 1d | `-1gcp` | chicago p1n |
-| 10 | location outlier | 1d | `-outlier` | grand_rapids p819 |
-| 11 | adjacency contradiction + hard signal | 2 | `*-contradicted` + hints | fargo p32, kansas_city p551 |
+| 6 | key-map outlier (+ retry) | 1b | `keymap-outlier`, maybe retried | fargo p55 (stays), p58__2 (retry wins) |
+| 7 | printed-scale-note mismatch | 1d | `misscale` | dc p227 (12.31×) |
+| 8 | scale bands vs reference | 1d | `misscale` unless note/neighbors keep it | champaign p1 (0.26×); fargo p59__1 **kept** |
+| 9 | deferred fit unconfirmed | 1d | `1gcp` | chicago p1n |
+| 10 | location outlier | 1d | `outlier` | grand_rapids p819 |
+| 11 | adjacency contradiction + hard signal | 2 | `contradicted` + hints | fargo p32, kansas_city p551 |
 | 12 | snap rescue bars (1.25 / 0.7 / margin) | 3 | candidate not published | fargo p60__1 in pre-#263 runs |
 | 13 | snap challenge bars | 3 | incumbent kept | (default outcome for most fitted pages) |
 | 14 | snap refine margin (0.05) | 3 | incumbent kept | — |
@@ -296,6 +326,6 @@ Resurrection paths — the only ways a rejected page returns:
 | any published pose | street-solve referee adoption (replacement, not resurrection) | nashville p66 |
 
 Note what is *not* on the resurrection list: nothing ever un-renames a
-`-misscale`/`-outlier`/`-contradicted` sidecar back to `georef.json`. All
+demoted sidecar's `status` back to `fitted`. All
 recovery flows through a different channel's sidecar outranking or standing in
 for the lost one.

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -23,8 +23,8 @@ this combination names the wrong page on 18 of 19 decidable contradictions and
 demotes 10 true disasters against one false demotion (Nashville p8, a genuine
 odd-scale sheet whose five mutual edges are all junk single-digit reciprocation).
 
-Demotion renames every channel sidecar (pN.georef*.json ->
-pN.<channel>-contradicted.json, invisible to the IIIF globs) and writes
+Demotion records ``status: contradicted`` on every channel sidecar the page has
+-- the pose stays where it is, the channel simply stops claiming it -- and writes
 pN.contradiction.json carrying the partner-side stamp positions — the trusted
 neighbors' printed claims of this page, each a world point on the shared seam.
 Snap's rescue reads those as extra search centers (see build_page_context), so a
@@ -49,6 +49,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mapsnap import sidecar
 from mapsnap.keymap.locate import page_key
 from mapsnap.road_model import effective_gcp_count, page_world_affine
 from mapsnap.utils import haversine_m
@@ -107,6 +108,14 @@ class Verdict:
     partners: list[dict] = field(default_factory=list)  # re-search hints
 
 
+def _accepted(path: Path) -> bool:
+    """Whether a channel sidecar holds a pose its channel stands behind."""
+    try:
+        return sidecar.accepted(json.loads(path.read_text()))
+    except (OSError, ValueError):
+        return False
+
+
 def load_fitted_pages(volume: Path, adjacency: dict) -> dict[str, FittedPage]:
     """Parent pages with a published fit, keyed by stem.
 
@@ -117,10 +126,12 @@ def load_fitted_pages(volume: Path, adjacency: dict) -> dict[str, FittedPage]:
     """
     pages: dict[str, FittedPage] = {}
     for stem in adjacency.get("pages", {}):
+        # A channel sidecar exists whether or not the channel stands behind its
+        # pose, so "published" is the recorded verdict, not the file's presence.
         paths = [
-            volume / f"{stem}.{channel}.json"
+            path
             for channel in CHANNELS
-            if (volume / f"{stem}.{channel}.json").exists()
+            if (path := volume / f"{stem}.{channel}.json").exists() and _accepted(path)
         ]
         if not paths:
             continue
@@ -276,9 +287,13 @@ def arbitrate_suspects(adjacency: dict, pages: dict[str, FittedPage]) -> list[Ve
 
 
 def demote(volume: Path, page: FittedPage, verdict: Verdict) -> None:
-    """Rename the page's channel sidecars and write the re-search hint file."""
+    """Record the contradiction on the page's channel sidecars, write the hint file."""
     for path in page.channel_paths:
-        path.rename(path.with_name(path.name[: -len(".json")] + "-contradicted.json"))
+        sidecar.demote(
+            path,
+            sidecar.CONTRADICTED,
+            {"reason": verdict.reason, "signal": verdict.signal},
+        )
     hint = {
         "timestamp": datetime.now(UTC).isoformat(),
         "reason": verdict.reason,

--- a/mapsnap/adjacency_gate.py
+++ b/mapsnap/adjacency_gate.py
@@ -71,7 +71,7 @@ be demoted even with many GCPs (NO-1896 p125: 12 GCPs, 46 deg and 0.76 off —
 a confidently wrong fit). Both thresholds clear every healthy suspect measured
 across the corpus."""
 
-CHANNELS = ("georef-streets", "georef-osm", "georef")
+CHANNELS = ("georef-street", "georef-snap", "georef")
 
 
 @dataclass

--- a/mapsnap/adjacency_gate_test.py
+++ b/mapsnap/adjacency_gate_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from mapsnap import sidecar
 from mapsnap.adjacency_gate import (
     arbitrate_suspects,
     contradiction_centers,
@@ -91,8 +92,14 @@ def test_displaced_weak_page_is_demoted_with_hints(tmp_path):
     assert abs(lat - (LAT0 - 0.004)) < 1e-6
 
     demote(volume, pages["p3"], verdict)
-    assert not (volume / "p3.georef.json").exists()
-    assert (volume / "p3.georef-contradicted.json").exists()
+    # The pose stays in its own sidecar; what changes is that georef no longer
+    # claims it, so it stops counting as a published fit and the arbiter can
+    # still weigh it (with the contradiction against it).
+    doc = json.loads((volume / "p3.georef.json").read_text())
+    assert sidecar.status(doc) == sidecar.CONTRADICTED
+    assert not sidecar.accepted(doc)
+    assert doc["status_detail"]["reason"] == "uncorroborated"
+    assert doc["corners"]
     centers = contradiction_centers(volume, "p3")
     assert len(centers) == 1 and abs(centers[0][0] - lon) < 1e-9
     assert contradiction_centers(volume, "p2") == []

--- a/mapsnap/edge_join_experiment.py
+++ b/mapsnap/edge_join_experiment.py
@@ -36,7 +36,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from mapsnap import edge_join
+from mapsnap import edge_join, sidecar
 from mapsnap.compare_iiif_georef import (
     annotation_transform_type,
     extract_gcps,
@@ -186,13 +186,33 @@ def load_truth_units(volume: Path) -> tuple[dict[str, dict], set[str]]:
     return unsplit, split_parents
 
 
+# Verdicts that GEOREF_VARIANTS never listed, so a page carrying one used to
+# fall through page_fit_state to ("none", None): rescue-eligible, and denied the
+# key-map centers in its own sidecar. Preserved here deliberately -- collapsing
+# the variants into one file must not quietly change what snap searches (#270
+# phase 3). Withholding a key-map prior from a page demoted FOR being far from
+# its key map is worth revisiting, but as its own measured change.
+LEGACY_UNLISTED_VERDICTS = ("keymap-outlier", "contradicted")
+
+
 def page_fit_state(volume: Path, stem: str) -> tuple[str, dict | None]:
-    """(fit state, georef-variant JSON) for a base page stem."""
-    for variant in GEOREF_VARIANTS:
+    """(fit state, georef JSON) for a base page stem.
+
+    The state is the verdict recorded in ``p<stem>.georef.json``; "fitted"
+    means georef stands behind the pose. Older volumes encoded the verdict as a
+    filename suffix instead, so those are still recognized.
+    """
+    path = volume / f"{stem}.georef.json"
+    if path.exists():
+        doc = json.loads(path.read_text())
+        state = sidecar.status(doc)
+        if state in LEGACY_UNLISTED_VERDICTS:
+            return "none", None
+        return ("fitted" if state == sidecar.ACCEPTED else state), doc
+    for variant in GEOREF_VARIANTS[1:]:  # legacy renamed-aside layout
         path = volume / f"{stem}.{variant}.json"
         if path.exists():
-            state = variant.removeprefix("georef-") if "-" in variant else "fitted"
-            return state, json.loads(path.read_text())
+            return variant.removeprefix("georef-"), json.loads(path.read_text())
     # Split pieces (p239__1.georef*.json) mean the base page was split.
     if list(volume.glob(f"{stem}__*.georef*.json")):
         return "split", None

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -200,7 +200,7 @@ def main() -> None:
     run_cmd(["mapsnap", "adjacency-gate", str(dir_path)])
 
     # The geometry-first snap channel: rescue unplaced pages, arbitrate fits
-    # OSM contradicts, refine mid-tier fits. Its pN.georef-osm.json sidecars
+    # OSM contradicts, refine mid-tier fits. Its pN.georef-snap.json sidecars
     # take priority over plain georefs in the hybrid glob below.
     if not args.no_snap:
         # Both passes are per-page and CPU-bound, so one --num-workers governs
@@ -209,14 +209,14 @@ def main() -> None:
         # The street-constraint channel: fit key-map-prior pages from their
         # street labels and adopt a pose only where the independent referee
         # prefers it over whatever snap/georef published. Its
-        # pN.georef-streets.json sidecars take top priority in the glob. Runs
+        # pN.georef-street.json sidecars take top priority in the glob. Runs
         # after snap because the referee judges against (and shares machinery
         # with) the snap channel; skipped with --no-snap for the same reason.
         run_cmd(["mapsnap", "street-solve", str(dir_path)])
 
     # The arbiter (#270): weigh every pose the channels produced -- including
     # the ones they rejected -- against each other and against not publishing
-    # at all, jointly across the volume. Its pN.georef-reconcile.json sidecars
+    # at all, jointly across the volume. Its pN.georef-final.json sidecars
     # take top priority in the glob below, and a page it arbitrates to
     # unplaced leaves a marker that suppresses the channel sidecars entirely.
     if args.reconcile:
@@ -230,14 +230,14 @@ def main() -> None:
         georef_glob = str(dir_path / "*.georef.json")
     else:
         georef_glob = (
-            f"{dir_path / '*.georef-streets.json'},"
-            f"{dir_path / '*.georef-osm.json'},{dir_path / '*.georef.json'}"
+            f"{dir_path / '*.georef-street.json'},"
+            f"{dir_path / '*.georef-snap.json'},{dir_path / '*.georef.json'}"
         )
     if args.reconcile:
         # Reconcile's sidecars win over every channel. Pages it arbitrated to
         # unplaced have had their channel sidecars renamed aside by `publish`,
         # so no glob entry matches them at all.
-        georef_glob = f"{dir_path / '*.georef-reconcile.json'},{georef_glob}"
+        georef_glob = f"{dir_path / '*.georef-final.json'},{georef_glob}"
     run_cmd(
         [
             "mapsnap",

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -139,21 +139,12 @@ def main() -> None:
         help="Human-readable name recorded alongside the run id in the manifest.",
     )
     parser.add_argument(
-        "--reconcile",
-        action="store_true",
-        help=(
-            "Publish through the reconcile arbiter (#270): after the channels "
-            "run, weigh all their poses jointly and publish the winners. "
-            "Report-only without this flag."
-        ),
-    )
-    parser.add_argument(
         "--no-snap",
         action="store_true",
         help=(
             "Skip the geometry channels — OSM snap (rescue/arbitrate/refine) "
             "and the street-constraint solver, whose referee rides on snap's "
-            "machinery — and build the IIIF from RANSAC georefs alone."
+            "machinery — so the arbiter weighs RANSAC's poses alone."
         ),
     )
     args, georef_extra = parser.parse_known_args()
@@ -200,44 +191,30 @@ def main() -> None:
     run_cmd(["mapsnap", "adjacency-gate", str(dir_path)])
 
     # The geometry-first snap channel: rescue unplaced pages, arbitrate fits
-    # OSM contradicts, refine mid-tier fits. Its pN.georef-snap.json sidecars
-    # take priority over plain georefs in the hybrid glob below.
+    # OSM contradicts, refine mid-tier fits. Writes pN.georef-snap.json.
     if not args.no_snap:
         # Both passes are per-page and CPU-bound, so one --num-workers governs
         # both; the rest of the georef passthrough is georef-only.
         run_cmd(["mapsnap", "snap", str(dir_path), *worker_flag(georef_extra)])
         # The street-constraint channel: fit key-map-prior pages from their
-        # street labels and adopt a pose only where the independent referee
-        # prefers it over whatever snap/georef published. Its
-        # pN.georef-street.json sidecars take top priority in the glob. Runs
-        # after snap because the referee judges against (and shares machinery
-        # with) the snap channel; skipped with --no-snap for the same reason.
+        # street labels. Writes pN.georef-street.json. Runs after snap because
+        # its referee shares machinery with the snap channel; skipped with
+        # --no-snap for the same reason.
         run_cmd(["mapsnap", "street-solve", str(dir_path)])
 
-    # The arbiter (#270): weigh every pose the channels produced -- including
+    # The arbiter (#270) weighs every pose the channels produced -- including
     # the ones they rejected -- against each other and against not publishing
-    # at all, jointly across the volume. Its pN.georef-final.json sidecars
-    # take top priority in the glob below, and a page it arbitrates to
-    # unplaced leaves a marker that suppresses the channel sidecars entirely.
-    if args.reconcile:
-        run_cmd(["mapsnap", "reconcile", str(dir_path), "--publish"])
+    # at all, jointly across the volume, and writes the answer for EVERY page
+    # as pN.georef-final.json (poseless when it declines to place the page).
+    run_cmd(["mapsnap", "reconcile", str(dir_path), "--publish"])
 
     output_iiif = dir_path / f"{run_id}.iiif.json"
-    # Pass the glob as a literal string; make_iiif_georef does its own glob
-    # expansion (first glob wins per page, so the channel priority is
-    # streets, then snap, then plain georefs).
-    if args.no_snap:
-        georef_glob = str(dir_path / "*.georef.json")
-    else:
-        georef_glob = (
-            f"{dir_path / '*.georef-street.json'},"
-            f"{dir_path / '*.georef-snap.json'},{dir_path / '*.georef.json'}"
-        )
-    if args.reconcile:
-        # Reconcile's sidecars win over every channel. Pages it arbitrated to
-        # unplaced have had their channel sidecars renamed aside by `publish`,
-        # so no glob entry matches them at all.
-        georef_glob = f"{dir_path / '*.georef-final.json'},{georef_glob}"
+    # One glob, one channel. Publication used to be first-glob-wins over three
+    # channel sidecars, which made stage ORDER the thing that decided what got
+    # published and gave every stage a reason to hide its predecessors' files.
+    # The arbiter answers for every page instead, so there is nothing to
+    # prioritize between (#270 phase 3).
+    georef_glob = str(dir_path / "*.georef-final.json")
     run_cmd(
         [
             "mapsnap",

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -28,8 +28,8 @@ def test_clear_derived_sidecars_removes_every_variant(tmp_path: Path):
     for name in (
         "p1.georef.json",
         "p2.georef-nofit.json",
-        "p3.georef-osm.json",
-        "p4.georef-streets.json",
+        "p3.georef-snap.json",
+        "p4.georef-street.json",
         "p5.georef-contradicted.json",
         "p6.georef-keymap-outlier.json",
         "p7__2.georef.json",

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -66,30 +66,49 @@ def test_clear_derived_sidecars_on_empty_dir(tmp_path: Path):
     assert clear_derived_sidecars(tmp_path) == 0
 
 
-def test_channel_writers_and_arbiter_agree_on_names():
+def test_channel_writers_and_arbiter_agree_on_names(tmp_path):
     """Every channel the pipeline WRITES is one the arbiter LOOKS FOR.
 
-    These names live in three places -- the writer, reconcile's CHANNEL_ORDER,
-    and fit's glob -- and a mismatch is silent: the sidecar is still globbed as
-    a hypothesis, so the arbiter sees the pose, but the channel stops counting
-    as the incumbent and every keep_prior/entry decision on that page shifts.
-    Renaming the channels once already produced exactly this: street-solve's
-    suffix lived in an argparse DEFAULT ("streets"), which a rename of the
-    literal names did not touch, and washington_dc p166 went 14 -> 115 ft.
-    """
+    These names live in the writer, in reconcile's CHANNEL_ORDER and in fit's
+    glob, and a mismatch is silent: the sidecar is still globbed as a
+    hypothesis, so the arbiter sees the pose, but the channel stops counting as
+    the incumbent and every keep_prior/entry decision on that page shifts.
 
+    Renaming the channels produced exactly this twice. The first miss was an
+    argparse DEFAULT ("streets"); the second was a bare positional literal at
+    the one call site `mapsnap fit` actually uses -- so a test that only read
+    the CLI default passed while production still wrote the old name. This
+    calls the writer the way cmd_select does, taking every default.
+    """
     from mapsnap.osm_snap_experiment import osm_variant_path
     from mapsnap.reconcile import CHANNEL_ORDER
-    from mapsnap.street_solve_experiment import build_parser
+    from mapsnap.street_solve_experiment import (
+        PriorLocation,
+        StreetGates,
+        write_georef_streets,
+    )
 
-    volume = Path("/vol")
-    assert osm_variant_path(volume, "p1").name == "p1.georef-snap.json"
+    assert osm_variant_path(tmp_path, "p1").name == "p1.georef-snap.json"
 
-    parser = build_parser()
-    suffix = parser.parse_args(["materialize", str(volume), "--pages", "p1"]).suffix
-    assert f"p1.georef-{suffix}.json" == "p1.georef-street.json"
+    from mapsnap.reconcile_test import make_unit
 
-    written = {"georef-snap", f"georef-{suffix}", "georef"}
-    assert written == set(CHANNEL_ORDER), (
-        f"channels written {written} != channels arbitrated {set(CHANNEL_ORDER)}"
+    unit = make_unit("p1")
+    written = write_georef_streets(
+        tmp_path,
+        unit,
+        PriorLocation(
+            center=(-77.0, 38.9),
+            radius_m=500.0,
+            centers=[(-77.0, 38.9)],
+            source="keymap-exact",
+        ),
+        [],
+        (0.0, 1.0, -77.0, 38.9),
+        StreetGates(),
+        (unit.width, unit.height),
+        {},
+    )
+    channels = {"georef", "georef-snap", written.name[len("p1.") : -len(".json")]}
+    assert channels == set(CHANNEL_ORDER), (
+        f"channels written {channels} != channels arbitrated {set(CHANNEL_ORDER)}"
     )

--- a/mapsnap/fit_test.py
+++ b/mapsnap/fit_test.py
@@ -64,3 +64,32 @@ def test_clear_derived_sidecars_removes_every_variant(tmp_path: Path):
 def test_clear_derived_sidecars_on_empty_dir(tmp_path: Path):
     """A first run has nothing to clear and must not fail."""
     assert clear_derived_sidecars(tmp_path) == 0
+
+
+def test_channel_writers_and_arbiter_agree_on_names():
+    """Every channel the pipeline WRITES is one the arbiter LOOKS FOR.
+
+    These names live in three places -- the writer, reconcile's CHANNEL_ORDER,
+    and fit's glob -- and a mismatch is silent: the sidecar is still globbed as
+    a hypothesis, so the arbiter sees the pose, but the channel stops counting
+    as the incumbent and every keep_prior/entry decision on that page shifts.
+    Renaming the channels once already produced exactly this: street-solve's
+    suffix lived in an argparse DEFAULT ("streets"), which a rename of the
+    literal names did not touch, and washington_dc p166 went 14 -> 115 ft.
+    """
+
+    from mapsnap.osm_snap_experiment import osm_variant_path
+    from mapsnap.reconcile import CHANNEL_ORDER
+    from mapsnap.street_solve_experiment import build_parser
+
+    volume = Path("/vol")
+    assert osm_variant_path(volume, "p1").name == "p1.georef-snap.json"
+
+    parser = build_parser()
+    suffix = parser.parse_args(["materialize", str(volume), "--pages", "p1"]).suffix
+    assert f"p1.georef-{suffix}.json" == "p1.georef-street.json"
+
+    written = {"georef-snap", f"georef-{suffix}", "georef"}
+    assert written == set(CHANNEL_ORDER), (
+        f"channels written {written} != channels arbitrated {set(CHANNEL_ORDER)}"
+    )

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -30,6 +30,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
+from mapsnap import sidecar
 from mapsnap.compare_iiif_georef import truth_distortion, truth_polygons_by_page
 from mapsnap.keymap.locate import (
     KeymapLocator,
@@ -243,6 +244,19 @@ def fit_keymap_affine(
 
 
 _FT_PER_DEG_LAT: float = math.pi * 20_925_524.0 / 180.0  # feet per degree latitude
+
+
+def _restore_demoted(output_path: str, demoted_doc: dict) -> None:
+    """Put a demoted pose back as the page's sidecar after a retry lost to it."""
+    Path(output_path).write_text(json.dumps(demoted_doc, indent=2))
+
+
+def _accepted(georef_path: str) -> bool:
+    """Whether a georef sidecar on disk holds a pose this channel stands behind."""
+    try:
+        return sidecar.accepted(json.loads(Path(georef_path).read_text()))
+    except (OSError, json.JSONDecodeError):
+        return False
 
 
 def _dist_km(a: tuple[float, float], b: tuple[float, float]) -> float:
@@ -2343,6 +2357,10 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     labels_path, output_path, log_path = derive_paths(image_path)
     if os.path.exists(output_path):
         os.remove(output_path)
+    # Legacy cleanup: these verdicts are recorded inside p<stem>.georef.json now,
+    # but a volume last fitted by an older build still has the renamed-aside
+    # files, and the arbiter globs p<stem>.georef*.json — a leftover would enter
+    # as a duplicate hypothesis of a pose this run has superseded.
     for stale_suffix in (
         ".georef-misscale.json",
         ".georef-outlier.json",
@@ -2510,12 +2528,22 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                                 f"the key-map location ({distance_m / radius_m:.1f}x the "
                                 f"{radius_m:.0f} m radius) despite confident in-radius streets"
                             )
-                            # Keep the fit as a key-map-outlier sidecar (it records where the
-                            # page was wrongly placed) instead of a plain georef.json.
-                            outlier_path = output_path.replace(
-                                ".georef.json", ".georef-keymap-outlier.json"
+                            # Keep the pose (it records where the page was wrongly
+                            # placed) but stop claiming it: the arbiter weighs this
+                            # pose against the others, and for the p55 class it is
+                            # sometimes the right one.
+                            sidecar.demote(
+                                output_path,
+                                sidecar.KEYMAP_OUTLIER,
+                                {
+                                    "distance_m": round(distance_m),
+                                    "radius_m": round(radius_m),
+                                },
                             )
-                            os.replace(output_path, outlier_path)
+                            # Hold the demoted pose in memory: the retry below
+                            # writes over the same sidecar, and whichever pose
+                            # loses still has to survive for the arbiter.
+                            demoted_doc = json.loads(Path(output_path).read_text())
                             # Failure with nofit_written set: the page stays unplaced and the
                             # redundant nofit sidecar is suppressed (the outlier one stands in).
                             result = ProcessResult(success=False, nofit_written=True)
@@ -2534,7 +2562,11 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                                 size_fraction=KEYMAP_RETRY_SIZE_FRACTION,
                             )
                             if retried.success:
-                                rejected_inliers = _doc_inlier_count(outlier_path)
+                                rejected_inliers = sum(
+                                    1
+                                    for street in demoted_doc.get("streets") or []
+                                    if street.get("inlier")
+                                )
                                 retried_inliers = _doc_inlier_count(output_path)
                                 retried_scale = (
                                     deg_per_px_to_px_per_ft(retried.scale_deg_per_px)
@@ -2554,22 +2586,24 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
                                         f"{retried_scale / prior:.2f}x the key-map "
                                         f"region prior {prior:.3f} px/ft"
                                     )
-                                    if os.path.exists(output_path):
-                                        os.remove(output_path)
+                                    _restore_demoted(output_path, demoted_doc)
                                 elif retried_inliers < rejected_inliers:
                                     print(
                                         "  rejecting in-radius retry: "
                                         f"{retried_inliers} inliers < the rejected "
                                         f"fit's {rejected_inliers}"
                                     )
-                                    if os.path.exists(output_path):
-                                        os.remove(output_path)
+                                    _restore_demoted(output_path, demoted_doc)
                                 else:
                                     print(
                                         "  accepting in-radius retry: "
                                         f"{retried_inliers} inliers >= the rejected "
                                         f"fit's {rejected_inliers}"
                                     )
+                                    # The retry's pose is the channel's answer;
+                                    # the key-map outlier rides along as a
+                                    # rejected pose for the arbiter to weigh.
+                                    sidecar.attach_rejected(output_path, [demoted_doc])
                                     result = retried
                         else:
                             result = broadened
@@ -2581,17 +2615,22 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
     if result.deferred is not None:
         result.deferred["log_path"] = log_path
     # A key-map-placed page that produced neither a fit nor a deferred sidecar leaves no georef
-    # file at all. Write a minimal .georef-nofit.json holding just the neighborhood so the
-    # debugger can still show where the key map expected this page. Skip this when process_image
-    # already wrote a richer --debug nofit sidecar (with seed-pair fits) to the same path.
+    # file at all. Write a minimal sidecar holding just the neighborhood, marked nofit, so the
+    # debugger can still show where the key map expected this page and the arbiter can see that
+    # the channel was asked and had no answer. Skip this when process_image already wrote a
+    # richer --debug nofit sidecar (with seed-pair fits) to the same path.
     if (
         keymap is not None
         and not result.success
         and result.deferred is None
         and not result.nofit_written
     ):
-        nofit_path = output_path.replace(".georef.json", ".georef-nofit.json")
-        nofit: dict = {"keymap": keymap, "streets": [], "intersections": []}
+        nofit: dict = {
+            "status": sidecar.NOFIT,
+            "keymap": keymap,
+            "streets": [],
+            "intersections": [],
+        }
         from mapsnap.printed_scale import printed_scale_ft as _note_read
 
         _note = _note_read(Path(derive_paths(image_path)[0]))
@@ -2602,7 +2641,7 @@ def _process_one_image(image_path: str) -> tuple[str, ProcessResult]:
             }
         if truth_polygons:
             nofit["truth"] = truth_polygons
-        with open(nofit_path, "w") as f:
+        with open(output_path, "w") as f:
             json.dump(nofit, f, indent=2)
     return image_path, result
 
@@ -3110,9 +3149,9 @@ def process_image(
     if A is None:
         print("RANSAC failed: no valid affine found.", file=sys.stderr)
         # Under --debug the pipeline still scored every seed pair before rejecting them all.
-        # Surface those fits in a .georef-nofit.json so the debugger's interactive explorer
-        # can show why the page failed and let the user try each candidate. Frame the map on
-        # the best-scoring (still-rejected) pair; mark none as `initial`, since the pipeline
+        # Surface those fits, marked nofit, so the debugger's interactive explorer can show
+        # why the page failed and let the user try each candidate. Frame the map on the
+        # best-scoring (still-rejected) pair; mark none as `initial`, since the pipeline
         # selected no pair.
         scored_pairs = [rec for rec in (pair_records or []) if "affine" in rec]
         if scored_pairs:
@@ -3121,9 +3160,8 @@ def process_image(
             best_residuals = _inlier_residuals(
                 features, block_index, best_A, best["inlier_streets"]
             )
-            nofit_path = output_path.replace(".georef.json", ".georef-nofit.json")
             print(
-                f"Writing {len(scored_pairs)} rejected seed-pair fits to {nofit_path} "
+                f"Writing {len(scored_pairs)} rejected seed-pair fits to {output_path} "
                 "for the interactive debugger.",
                 file=sys.stderr,
             )
@@ -3134,11 +3172,11 @@ def process_image(
                 best["inlier_streets"],
                 best_residuals,
                 image_path,
-                nofit_path,
+                output_path,
                 labels_path,
                 centerlines_path,
                 initial_pair=None,
-                extra_fields={"nofit": True},
+                extra_fields={"nofit": True, "status": sidecar.NOFIT},
                 parameters=parameters,
                 keymap=keymap,
                 truth_polygons=truth_polygons,
@@ -3426,11 +3464,6 @@ def process_deferred_image(
         file=sys.stderr,
     )
 
-    actual_output_path = (
-        output_path
-        if decision.confirmed
-        else output_path.replace(".georef.json", ".georef-1gcp.json")
-    )
     one_gcp_extra = {
         "one_gcp": {
             "method": decision.method,
@@ -3448,7 +3481,7 @@ def process_deferred_image(
         inlier_feat_indices,
         residuals,
         image_path,
-        actual_output_path,
+        output_path,
         labels_path,
         centerlines_path,
         extra_fields=one_gcp_extra,
@@ -3456,6 +3489,15 @@ def process_deferred_image(
         keymap=keymap,
         truth_polygons=truth_polygons,
     )
+    if not decision.confirmed:
+        # The pose exists but nothing corroborated its single GCP. It stays in
+        # the page's own sidecar, unclaimed, for the arbiter to weigh against
+        # the geometry channels' poses and against leaving the page unplaced.
+        sidecar.demote(
+            output_path,
+            sidecar.ONE_GCP,
+            {"method": decision.method, "n_agree": decision.n_agree},
+        )
     return ProcessResult(
         success=decision.confirmed, scale_deg_per_px=scale, center=center
     )
@@ -4075,33 +4117,36 @@ def main() -> None:
                             file=sys.stderr,
                         )
                         continue
-                    misscale_path = out_path.replace(
-                        ".georef.json", ".georef-misscale.json"
-                    )
                     if os.path.exists(out_path):
-                        os.rename(out_path, misscale_path)
+                        sidecar.demote(
+                            out_path,
+                            sidecar.MISSCALE,
+                            {"px_per_ft": round(px_per_ft, 4), "gcps": n_gcps},
+                        )
                         n_success -= 1
                         n_dropped += 1
                         print(
                             f"Dropped scale outlier {img_path}: {px_per_ft:.4f} px/ft "
                             f"matches its PRINTED note ({note_ratio:.2f}x) but only "
-                            f"{n_gcps} inlier GCP(s) support the pose "
-                            f"-> {misscale_path}",
+                            f"{n_gcps} inlier GCP(s) support the pose",
                             file=sys.stderr,
                         )
                     continue
                 _, out_path, _ = derive_paths(img_path)
-                misscale_path = out_path.replace(
-                    ".georef.json", ".georef-misscale.json"
-                )
                 if os.path.exists(out_path):
-                    os.rename(out_path, misscale_path)
+                    sidecar.demote(
+                        out_path,
+                        sidecar.MISSCALE,
+                        {
+                            "px_per_ft": round(px_per_ft, 4),
+                            "note_ratio": round(note_ratio, 3),
+                        },
+                    )
                     n_success -= 1
                     n_dropped += 1
                     print(
                         f"Dropped scale outlier {img_path}: {px_per_ft:.4f} px/ft is "
-                        f"{note_ratio:.2f}x the page's PRINTED scale note "
-                        f"-> {misscale_path}",
+                        f"{note_ratio:.2f}x the page's PRINTED scale note",
                         file=sys.stderr,
                     )
                 continue
@@ -4124,17 +4169,22 @@ def main() -> None:
                         )
                         continue
                 _, out_path, _ = derive_paths(img_path)
-                misscale_path = out_path.replace(
-                    ".georef.json", ".georef-misscale.json"
-                )
                 if os.path.exists(out_path):
-                    os.rename(out_path, misscale_path)
+                    sidecar.demote(
+                        out_path,
+                        sidecar.MISSCALE,
+                        {
+                            "px_per_ft": round(px_per_ft, 4),
+                            "reference_px_per_ft": round(ref_scale_px_per_ft, 4),
+                            "ratio": round(ratio, 3),
+                        },
+                    )
                     n_success -= 1
                     n_dropped += 1
                     print(
                         f"Dropped scale outlier {img_path}: "
                         f"{px_per_ft:.4f} px/ft vs reference {ref_scale_px_per_ft:.4f} "
-                        f"({ratio:.2f}×) → {misscale_path}",
+                        f"({ratio:.2f}×)",
                         file=sys.stderr,
                     )
         if n_dropped:
@@ -4147,9 +4197,14 @@ def main() -> None:
     # perfectly-fit halves. Five georeferenced pages is the floor for calling
     # anything an outlier.
     if args.min_distance_for_outlier_km > 0 and len(location_records) >= 5:
-        # Only pages whose .georef.json still exists (not already renamed by scale check).
+        # Only pages RANSAC still stands behind: a page the scale check just
+        # demoted must not anchor "far from the rest" for anybody else. That
+        # used to follow from the file having been renamed away; now it is the
+        # recorded verdict that says so.
         active = [
-            (p, c) for p, c in location_records if os.path.exists(derive_paths(p)[1])
+            (p, c)
+            for p, c in location_records
+            if os.path.exists(derive_paths(p)[1]) and _accepted(derive_paths(p)[1])
         ]
         n_dropped = 0
         for img_path, center in active:
@@ -4157,13 +4212,16 @@ def main() -> None:
             min_dist_km = min(_dist_km(center, other) for other in other_centers)
             if min_dist_km > args.min_distance_for_outlier_km:
                 _, out_path, _ = derive_paths(img_path)
-                outlier_path = out_path.replace(".georef.json", ".georef-outlier.json")
-                os.rename(out_path, outlier_path)
+                sidecar.demote(
+                    out_path,
+                    sidecar.OUTLIER,
+                    {"km_from_closest": round(min_dist_km, 2)},
+                )
                 n_success -= 1
                 n_dropped += 1
                 print(
                     f"Dropped location outlier {img_path}: "
-                    f"{min_dist_km:.1f} km from closest map → {outlier_path}",
+                    f"{min_dist_km:.1f} km from closest map",
                     file=sys.stderr,
                 )
         if n_dropped:

--- a/mapsnap/keymap/locate.py
+++ b/mapsnap/keymap/locate.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mapsnap import sidecar
 from mapsnap.feature_index import FeatureIndex
 from mapsnap.keymap.fit_keymap import (
     key_stem,
@@ -138,9 +139,11 @@ def usable_keymaps(directory: Path) -> list[Path]:
     """Key-map detections files in one directory that a locator can actually load.
 
     A key map whose own georeferencing failed leaves a bare ``<stem>.keymap.json``
-    beside a ``-misscale``/``-nofit`` sidecar rather than the ``<stem>.georef.json``
+    beside a sidecar that records a demotion rather than the accepted pose
     :func:`KeymapLocator.from_keymap` reads, so it is skipped here instead of
-    raising when the locator gets around to opening it.
+    raising when the locator gets around to opening it. The check is on the
+    recorded verdict, not the file's existence: a demoted sidecar is still on
+    disk (#270 phase 3).
 
     Deliberately not filtered by scan resolution: osm-snap and street-solve build
     locators through here and get real value from a low-resolution sheet even when
@@ -149,8 +152,16 @@ def usable_keymaps(directory: Path) -> list[Path]:
     return [
         keymap_json
         for keymap_json in sorted(directory.glob("*.keymap.json"))
-        if keymap_georef_path(keymap_json).exists()
+        if _georef_accepted(keymap_georef_path(keymap_json))
     ]
+
+
+def _georef_accepted(path: Path) -> bool:
+    """Whether a georef sidecar exists and holds a pose its channel stands behind."""
+    try:
+        return sidecar.accepted(json.loads(path.read_text()))
+    except (OSError, ValueError):
+        return False
 
 
 def foreign_key_fraction(keys: set[str], volume_keys: set[str]) -> float:

--- a/mapsnap/keymap/locate_test.py
+++ b/mapsnap/keymap/locate_test.py
@@ -281,7 +281,20 @@ def make_keymap(directory: Path, stem: str, *, with_georef: bool = True) -> Path
     keymap = directory / f"{stem}.keymap.json"
     keymap.write_text("{}")
     if with_georef:
-        (directory / f"{stem}.georef.json").write_text("{}")
+        # A georeferenced key map: usable_keymaps tests the recorded pose, not
+        # merely the sidecar's existence (a demoted sidecar is still on disk).
+        (directory / f"{stem}.georef.json").write_text(
+            json.dumps(
+                {
+                    "corners": [
+                        [-81.0, 34.1],
+                        [-80.9, 34.1],
+                        [-80.9, 34.0],
+                        [-81.0, 34.0],
+                    ]
+                }
+            )
+        )
     return keymap
 
 
@@ -398,7 +411,15 @@ def write_keymap_pair(directory, stem, width, height):
     """A <stem>.keymap.json with the georef sidecar usable_keymaps requires."""
     (directory / f"{stem}.keymap.json").write_text(json.dumps({"streets": []}))
     (directory / f"{stem}.georef.json").write_text(
-        json.dumps({"width": width, "height": height, "corners": []})
+        json.dumps(
+            {
+                "width": width,
+                "height": height,
+                # A real pose: usable_keymaps requires a georeferenced key map,
+                # and a cornerless sidecar is a page georef could not place.
+                "corners": [[-81.0, 34.1], [-80.9, 34.1], [-80.9, 34.0], [-81.0, 34.0]],
+            }
+        )
     )
 
 

--- a/mapsnap/keymap/snap.py
+++ b/mapsnap/keymap/snap.py
@@ -599,7 +599,7 @@ def volume_pose_medians(volume: Path) -> tuple[float, float] | None:
     for page in sorted(volume.glob("p*.jpg")):
         if "__" in page.stem:
             continue
-        for channel in ("georef-streets", "georef-osm", "georef"):
+        for channel in ("georef-street", "georef-snap", "georef"):
             path = volume / f"{page.stem}.{channel}.json"
             if path.exists():
                 affine = page_world_affine(json.loads(path.read_text()))
@@ -633,7 +633,7 @@ def published_rotations(volume: Path) -> dict[int, float]:
         number = page_number(page.stem)
         if "__" in page.stem or number is None:
             continue
-        for channel in ("georef-streets", "georef-osm", "georef"):
+        for channel in ("georef-street", "georef-snap", "georef"):
             path = volume / f"{page.stem}.{channel}.json"
             if path.exists():
                 rotations[number] = metric_theta(

--- a/mapsnap/make_iiif_georef.py
+++ b/mapsnap/make_iiif_georef.py
@@ -49,11 +49,15 @@ def georef_path_to_page_key(path: str) -> str | None:
     """Extract page key like 'p428__2' from a georef filename.
 
     Accepts filenames ending in '_p16s.georef.json', '_p16.georef.json',
-    '_p16s.gcps.georef.json' (the '.gcps' infix is optional), or the
-    neighbor-fit / OSM-snap / street-constraint variants
-    '_p16.georef-neighbor.json', '_p16.georef-osm.json' and
-    '_p16.georef-streets.json'. A variant missing from this list is dropped
-    silently -- the glob matches the file but no page key comes out of it.
+    '_p16s.gcps.georef.json' (the '.gcps' infix is optional), and ANY
+    '-<variant>' sidecar: '_p16.georef-final.json', '_p16.georef-snap.json',
+    '_p16.georef-street.json', '_p16.georef-neighbor.json', …
+
+    The variant list used to be a whitelist, which made a renamed or new
+    sidecar fail *silently*: the glob matched the file, no page key came out,
+    and the page simply left the manifest. Callers choose which sidecars to
+    publish by passing explicit globs, so the parser has no business
+    second-guessing them.
 
     Any letter page suffix is kept (Sanborn sheets run 'a', 'b', … past the
     directional 's'/'n'/'e'/'w'/'l'/'r' letters), not just a known few — a
@@ -62,7 +66,7 @@ def georef_path_to_page_key(path: str) -> str | None:
     still parse here; drop_redundant_skeletons raises on them rather than guess.
     """
     m = re.search(
-        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-neighbor|-osm|-streets)?\.json$",
+        r"(?:\b|_)(p\d+)([a-z]*)((?:__\d+)?)(?:\.[^.]+)?\.georef(?:2|-[a-z0-9-]+)?\.json$",
         path,
         re.IGNORECASE,
     )
@@ -70,6 +74,21 @@ def georef_path_to_page_key(path: str) -> str | None:
         return None
     page_num, suffix, split = m.groups()
     return f"{page_num}{suffix.lower()}{split}"
+
+
+def has_pose(path: str) -> bool:
+    """Whether a georef sidecar carries a pose (four world corners) to publish.
+
+    A sidecar without corners is a recorded *decision not to place* the page,
+    not a malformed file: the arbiter writes one for every page it leaves
+    unplaced, and georef has always written neighborhood-only sidecars for
+    pages it could not fit.
+    """
+    try:
+        doc = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(doc.get("corners"))
 
 
 def expand_georef_globs(pattern: str) -> list[str]:
@@ -87,6 +106,7 @@ def expand_georef_globs(pattern: str) -> list[str]:
     """
     chosen: dict[str, str] = {}
     ordered: list[str] = []
+    unplaced = 0
     for sub_pattern in pattern.split(","):
         for path in sorted(glob.glob(sub_pattern.strip())):
             page_key = georef_path_to_page_key(path)
@@ -99,8 +119,19 @@ def expand_georef_globs(pattern: str) -> list[str]:
                 continue
             if page_key in chosen:
                 continue
+            if not has_pose(path):
+                # An explicit non-fit: the sidecar exists and records a
+                # decision, but there is no pose to publish. This is how the
+                # arbiter says "unplaced" (and what a bare neighborhood-only
+                # sidecar has always been). Claim the page key regardless, so a
+                # later glob cannot resurrect a pose this one declined.
+                chosen[page_key] = path
+                unplaced += 1
+                continue
             chosen[page_key] = path
             ordered.append(path)
+    if unplaced:
+        print(f"{unplaced} page(s) had a sidecar but no pose; left unplaced.")
     return ordered
 
 

--- a/mapsnap/make_iiif_georef_test.py
+++ b/mapsnap/make_iiif_georef_test.py
@@ -1,5 +1,6 @@
 """Unit tests for make_iiif_georef helpers."""
 
+import json
 from pathlib import Path
 
 from shapely.geometry import box
@@ -15,6 +16,9 @@ from mapsnap.make_iiif_georef import (
     make_annotation,
 )
 from mapsnap.split import write_panels_json
+
+# A minimal sidecar that carries a pose (expand_georef_globs skips poseless ones).
+_POSED = {"corners": [[0, 0], [1, 0], [1, 1], [0, 1]]}
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -305,17 +309,37 @@ def test_georef_path_neighbor_variant():
 
 
 def test_georef_path_osm_variant():
-    assert georef_path_to_page_key("data/vol/p147.georef-osm.json") == "p147"
-    assert georef_path_to_page_key("data/vol/p4l__2.georef-osm.json") == "p4l__2"
+    assert georef_path_to_page_key("data/vol/p147.georef-snap.json") == "p147"
+    assert georef_path_to_page_key("data/vol/p4l__2.georef-snap.json") == "p4l__2"
     # A variant absent from the pattern yields no page key, so the glob matches the
     # file and the annotation silently omits the page -- worth a test per variant.
-    assert georef_path_to_page_key("data/vol/p147.georef-streets.json") == "p147"
-    assert georef_path_to_page_key("data/vol/p4l__2.georef-streets.json") == "p4l__2"
+    assert georef_path_to_page_key("data/vol/p147.georef-street.json") == "p147"
+    assert georef_path_to_page_key("data/vol/p4l__2.georef-street.json") == "p4l__2"
 
 
-def test_georef_path_other_variants_do_not_match():
-    assert georef_path_to_page_key("data/vol/p16.georef-nofit.json") is None
-    assert georef_path_to_page_key("data/vol/p16.georef-misscale.json") is None
+def test_georef_path_parses_any_variant():
+    # The variant list used to be a whitelist, so renaming a channel silently
+    # dropped every page of it. Parsing is now general; what must not be
+    # published is decided by the sidecar's CONTENT (has_pose), not its name.
+    assert georef_path_to_page_key("data/vol/p16.georef-final.json") == "p16"
+    assert georef_path_to_page_key("data/vol/p16.georef-nofit.json") == "p16"
+    assert georef_path_to_page_key("data/vol/p16.georef-misscale.json") == "p16"
+    assert georef_path_to_page_key("data/vol/p16.notgeoref.json") is None
+
+
+def test_expand_globs_skips_and_claims_poseless_sidecars(tmp_path):
+    """A poseless sidecar leaves the page unplaced AND blocks later globs."""
+    (tmp_path / "p1.georef-final.json").write_text(json.dumps({"corners": None}))
+    (tmp_path / "p1.georef.json").write_text(
+        json.dumps({"corners": [[0, 0], [1, 0], [1, 1], [0, 1]]})
+    )
+    (tmp_path / "p2.georef-final.json").write_text(
+        json.dumps({"corners": [[0, 0], [1, 0], [1, 1], [0, 1]]})
+    )
+    pattern = f"{tmp_path}/p*.georef-final.json,{tmp_path}/p*.georef.json"
+    assert [Path(p).name for p in expand_georef_globs(pattern)] == [
+        "p2.georef-final.json"
+    ]
 
 
 def test_expand_georef_globs_first_glob_wins(tmp_path):
@@ -324,7 +348,7 @@ def test_expand_georef_globs_first_glob_wins(tmp_path):
         "p1.georef-neighbor.json",
         "p2.georef-neighbor.json",
     ]:
-        (tmp_path / name).write_text("{}")
+        (tmp_path / name).write_text(json.dumps(_POSED))
     pattern = f"{tmp_path}/p*.georef.json,{tmp_path}/p*.georef-neighbor.json"
     paths = [Path(p).name for p in expand_georef_globs(pattern)]
     assert paths == ["p1.georef.json", "p2.georef-neighbor.json"]
@@ -334,8 +358,8 @@ def test_expand_georef_globs_warns_on_unparsable_key(tmp_path, capsys):
     # A file whose name encodes no page key must not vanish silently: it is
     # skipped, but with a warning naming the file (regression guard for the
     # suffix bug that once dropped pages with no trace).
-    (tmp_path / "p16.georef.json").write_text("{}")
-    (tmp_path / "key.georef.json").write_text("{}")
+    (tmp_path / "p16.georef.json").write_text(json.dumps(_POSED))
+    (tmp_path / "key.georef.json").write_text(json.dumps(_POSED))
     paths = [Path(p).name for p in expand_georef_globs(f"{tmp_path}/*.georef.json")]
     assert paths == ["p16.georef.json"]
     err = capsys.readouterr().err

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1495,7 +1495,7 @@ def build_hybrid_iiif(volume: Path, output: Path) -> None:
     """Build the osm-first hybrid IIIF for the volume's current sidecars."""
     import subprocess
 
-    georef_glob = f"{volume / '*.georef-osm.json'},{volume / '*.georef.json'}"
+    georef_glob = f"{volume / '*.georef-snap.json'},{volume / '*.georef.json'}"
     subprocess.run(
         [
             "mapsnap",
@@ -2902,11 +2902,11 @@ def cmd_reannotate(volume: Path) -> None:
 
 
 def osm_variant_path(volume: Path, stem: str) -> Path:
-    return volume / f"{stem}.georef-osm.json"
+    return volume / f"{stem}.georef-snap.json"
 
 
 def cmd_materialize(volume: Path, mode: str) -> None:
-    """Write pN.georef-osm.json sidecars for the selection's accepted pages."""
+    """Write pN.georef-snap.json sidecars for the selection's accepted pages."""
     from mapsnap.edge_join_experiment import page_fit_state
 
     records = {r["target"]: r for r in load_candidates(volume)}
@@ -2915,7 +2915,7 @@ def cmd_materialize(volume: Path, mode: str) -> None:
         sys.exit(f"{selection_path} missing; run `select --mode {mode}` first")
     # Remove every sidecar this channel owns before writing: a stale one from
     # a looser gate would silently keep scoring.
-    for stale in volume.glob("p*.georef-osm.json"):
+    for stale in volume.glob("p*.georef-snap.json"):
         stale.unlink()
     written = 0
     for line in selection_path.read_text().splitlines():
@@ -2939,7 +2939,7 @@ def cmd_materialize(volume: Path, mode: str) -> None:
             # A panel with no own sidecar borrows the keymap block from any
             # sibling variant of the same sheet (the sheet is what the keymap
             # places). The stale-osm cleanup above already ran, so a sibling's
-            # georef-osm sidecar can only be one written earlier this loop.
+            # georef-snap sidecar can only be one written earlier this loop.
             base = panel_base(choice["target"])
             if base is not None:
                 for sibling in sorted(volume.glob(f"{base}__*.georef*.json")):
@@ -2981,7 +2981,7 @@ def cmd_materialize(volume: Path, mode: str) -> None:
             doc["keymap"] = georef["keymap"]
         osm_variant_path(volume, choice["target"]).write_text(json.dumps(doc, indent=2))
         written += 1
-    print(f"{written} pN.georef-osm.json sidecars written in {volume}")
+    print(f"{written} pN.georef-snap.json sidecars written in {volume}")
 
 
 def main() -> None:
@@ -3048,7 +3048,7 @@ def main() -> None:
         "--arbitrate-gate", type=float, default=PRODUCTION_ARBITRATE_GATE
     )
 
-    p_mat = sub.add_parser("materialize", help="write pN.georef-osm.json sidecars")
+    p_mat = sub.add_parser("materialize", help="write pN.georef-snap.json sidecars")
     p_mat.add_argument("volume", type=Path)
     p_mat.add_argument(
         "--mode",

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -3,7 +3,7 @@
 The fit pipeline publishes by stage precedence: each stage gates its
 predecessors, publication is first-glob-wins over channel sidecars, and no
 step ever compares two candidate poses for the same page (fargo p55:
-``georef-keymap-outlier.json`` correct, ``georef-osm.json`` published, never
+``georef-keymap-outlier.json`` correct, ``georef-snap.json`` published, never
 weighed against each other). Every regression autopsied on the 2026-08-10 run
 was an ordering artifact of exactly this shape — displaced rescues enjoying
 incumbency (washington_dc), a rank-2 pose at 11 ft losing to name score
@@ -139,7 +139,7 @@ DISTINCT_M = 100.0
 ICM_MAX_ROUNDS = 25
 EXHAUSTIVE_LIMIT = 20_000
 # Published-channel precedence, mirroring fit.py's IIIF glob order.
-CHANNEL_ORDER = ("georef-streets", "georef-osm", "georef")
+CHANNEL_ORDER = ("georef-street", "georef-snap", "georef")
 
 UNPLACED = "unplaced"
 
@@ -148,7 +148,7 @@ UNPLACED = "unplaced"
 class Hypothesis:
     """One candidate pose for a page (or the explicit unplaced state)."""
 
-    source: str  # "georef" | "georef-osm" | ... | "snap:0" | "streets" | UNPLACED
+    source: str  # "georef" | "georef-snap" | ... | "snap:0" | "streets" | UNPLACED
     affine: np.ndarray | None  # page px -> (lon, lat); None iff unplaced
     effective_gcps: int = 0
     merged_sources: list[str] = field(default_factory=list)
@@ -314,8 +314,8 @@ def keep_prior(effective_gcps: int, verification: float | None) -> float:
 def carries_gcp_evidence(source: str) -> bool:
     """Whether a hypothesis's GCP count is meaningful (georef-family sidecars)."""
     return source.startswith("georef") and source not in (
-        "georef-osm",
-        "georef-streets",
+        "georef-snap",
+        "georef-street",
     )
 
 
@@ -939,7 +939,7 @@ def write_outputs(
 def publish(
     volume: Path, nodes: dict[str, PageNode], assignment: dict[str, int]
 ) -> tuple[int, int]:
-    """Write the arbitrated poses as ``pN.georef-reconcile.json`` sidecars.
+    """Write the arbitrated poses as ``pN.georef-final.json`` sidecars.
 
     The ONLY mode that writes to the volume root. Each file records the pose
     the joint solve chose plus its provenance, and takes top priority in
@@ -952,7 +952,7 @@ def publish(
     fit's glob, see write_unplaced_marker).
     """
     written = unplaced = 0
-    for stale in volume.glob("p*.georef-reconcile.json"):
+    for stale in volume.glob("p*.georef-final.json"):
         stale.unlink()
     for stale in volume.glob("p*.reconcile-unplaced"):
         stale.unlink()
@@ -973,7 +973,7 @@ def publish(
             [a[0, 0] * x + a[0, 1] * y + a[0, 2], a[1, 0] * x + a[1, 1] * y + a[1, 2]]
             for x, y in [(0, 0), (w, 0), (w, h), (0, h)]
         ]
-        (volume / f"{stem}.georef-reconcile.json").write_text(
+        (volume / f"{stem}.georef-final.json").write_text(
             json.dumps(
                 {
                     "width": w,
@@ -1069,7 +1069,7 @@ def main() -> None:
     parser.add_argument(
         "--publish",
         action="store_true",
-        help="Write the arbitrated poses as pN.georef-reconcile.json in the "
+        help="Write the arbitrated poses as pN.georef-final.json in the "
         "volume root (the only mode that writes there). fit --reconcile does "
         "this for you.",
     )

--- a/mapsnap/reconcile.py
+++ b/mapsnap/reconcile.py
@@ -44,6 +44,7 @@ from pathlib import Path
 
 import numpy as np
 
+from mapsnap import sidecar
 from mapsnap.adjacency_gate import (
     GATE_STAMP_M,
     FittedPage,
@@ -152,6 +153,7 @@ class Hypothesis:
     affine: np.ndarray | None  # page px -> (lon, lat); None iff unplaced
     effective_gcps: int = 0
     merged_sources: list[str] = field(default_factory=list)
+    status: str = sidecar.ACCEPTED  # the writing channel's verdict on this pose
     scores: dict = field(default_factory=dict)
     unary_terms: dict = field(default_factory=dict)
     unary: float = 0.0
@@ -176,10 +178,22 @@ def sidecar_pose(doc: dict) -> np.ndarray | None:
 
 
 def published_channel(sidecar_dir: Path, stem: str) -> str | None:
-    """Which channel first-glob-wins publishes for this stem, or None."""
+    """Which channel would publish this stem on its own account, or None.
+
+    A channel sidecar now exists whether or not that channel stands behind the
+    pose inside it (a demotion is a recorded verdict, not a rename), so the
+    incumbent is the highest-precedence channel whose verdict is ACCEPTED —
+    exactly the set the old glob-over-renamed-files arrangement published.
+    """
     for channel in CHANNEL_ORDER:
-        if (sidecar_dir / f"{stem}.{channel}.json").exists():
-            return channel
+        path = sidecar_dir / f"{stem}.{channel}.json"
+        if not path.exists():
+            continue
+        try:
+            if sidecar.accepted(json.loads(path.read_text())):
+                return channel
+        except (OSError, ValueError):
+            continue
     return None
 
 
@@ -210,16 +224,22 @@ def collect_hypotheses(
     hypotheses: list[Hypothesis] = []
     for name, path in ordered:
         doc = json.loads(path.read_text())
-        affine = sidecar_pose(doc)
-        if affine is None:
-            continue
-        hypotheses.append(
-            Hypothesis(
-                source=name,
-                affine=affine,
-                effective_gcps=effective_gcp_count(doc),
+        # A channel's own sidecar plus any pose it reached and set aside (the
+        # key-map retry keeps both). All of them are hypotheses; the status is
+        # what the channel concluded, not whether the pose is worth weighing.
+        for variant in (doc, *sidecar.rejected_poses(doc)):
+            affine = sidecar_pose(variant)
+            if affine is None:
+                continue
+            status = sidecar.status(variant)
+            hypotheses.append(
+                Hypothesis(
+                    source=name if status == sidecar.ACCEPTED else f"{name}:{status}",
+                    affine=affine,
+                    effective_gcps=effective_gcp_count(variant),
+                    status=status,
+                )
             )
-        )
     if snap_record is not None:
         record_margin = snap_record.get("margin")
         rank = 0
@@ -461,7 +481,7 @@ def unary_energy(
             terms["rung"] = 0.0 if rung_distance < 0.25 else W_RUNG_OFF
     if hypothesis.scores.get("ambiguous"):
         terms["ambiguity"] = W_AMBIG
-    if "contradicted" in hypothesis.source:
+    if hypothesis.status == sidecar.CONTRADICTED:
         terms["contradicted"] = W_CONTRADICTED
     if not page_placed and hypothesis.scores.get("entry_barred"):
         terms["entry_barred"] = 10.0
@@ -939,40 +959,38 @@ def write_outputs(
 def publish(
     volume: Path, nodes: dict[str, PageNode], assignment: dict[str, int]
 ) -> tuple[int, int]:
-    """Write the arbitrated poses as ``pN.georef-final.json`` sidecars.
+    """Write the arbitrated answer as ``pN.georef-final.json``, one per page.
 
-    The ONLY mode that writes to the volume root. Each file records the pose
-    the joint solve chose plus its provenance, and takes top priority in
-    ``fit``'s IIIF glob — so a page whose arbitration agrees with the existing
-    publication is simply republished, and one that flipped is republished
-    from whichever channel won. A page arbitrated to UNPLACED gets no file
-    and no other channel can supply one, because the reconcile glob is
-    consulted first and the pipeline's own sidecars for that page remain
-    where they are (unpublishing is expressed by writing nothing here AND by
-    fit's glob, see write_unplaced_marker).
+    The ONLY mode that writes to the volume root, and the only sidecar
+    ``fit`` publishes from. Every arbitrated page gets a file, including the
+    ones left unplaced: those carry ``corners: null``, which
+    ``expand_georef_globs`` skips while still claiming the page key.
+
+    An explicit non-fit is what lets the arbiter *unpublish*. Previously that
+    took renaming each channel's sidecar out of the glob's way — the pipeline
+    could only express "unplaced" as the absence of a file, so suppressing a
+    pose meant hiding it. Here the decision is a written record, and the
+    channels' own sidecars stay exactly where they are.
     """
     written = unplaced = 0
     for stale in volume.glob("p*.georef-final.json"):
         stale.unlink()
-    for stale in volume.glob("p*.reconcile-unplaced"):
-        stale.unlink()
     for stem in sorted(nodes):
         node = nodes[stem]
         hypothesis = node.hypotheses[assignment[stem]]
-        if hypothesis.affine is None:
-            if node.published_index is not None:
-                for channel in CHANNEL_ORDER:
-                    sidecar = volume / f"{stem}.{channel}.json"
-                    if sidecar.exists():
-                        sidecar.rename(volume / f"{stem}.{channel}-reconcile-held.json")
-                unplaced += 1
-            continue
-        a = hypothesis.affine
         w, h = node.unit.width, node.unit.height
-        corners = [
-            [a[0, 0] * x + a[0, 1] * y + a[0, 2], a[1, 0] * x + a[1, 1] * y + a[1, 2]]
-            for x, y in [(0, 0), (w, 0), (w, h), (0, h)]
-        ]
+        a = hypothesis.affine
+        corners = (
+            None
+            if a is None
+            else [
+                [
+                    a[0, 0] * x + a[0, 1] * y + a[0, 2],
+                    a[1, 0] * x + a[1, 1] * y + a[1, 2],
+                ]
+                for x, y in [(0, 0), (w, 0), (w, h), (0, h)]
+            ]
+        )
         (volume / f"{stem}.georef-final.json").write_text(
             json.dumps(
                 {
@@ -993,7 +1011,10 @@ def publish(
                 indent=1,
             )
         )
-        written += 1
+        if corners is None:
+            unplaced += 1
+        else:
+            written += 1
     return written, unplaced
 
 

--- a/mapsnap/reconcile_test.py
+++ b/mapsnap/reconcile_test.py
@@ -357,10 +357,11 @@ def test_keep_bar_is_lower_than_enter_bar():
 
 
 def test_publish_writes_sidecars_and_holds_unplaced(tmp_path):
-    # --publish is the only mode that writes to the volume root: chosen poses
-    # become pN.georef-final.json (top of fit's glob), and a page
-    # arbitrated to unplaced has its channel sidecars renamed aside, since a
-    # glob can only skip a page that has no sidecar at all.
+    # --publish is the only mode that writes to the volume root, and it answers
+    # for EVERY page: a chosen pose becomes pN.georef-final.json with corners,
+    # a page arbitrated to unplaced becomes one with corners: null. The channel
+    # sidecars are left exactly where they are -- unpublishing is a written
+    # decision now, not the absence of a file.
     from mapsnap.reconcile import publish
 
     write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
@@ -375,13 +376,17 @@ def test_publish_writes_sidecars_and_holds_unplaced(tmp_path):
     )
     written, unplaced = publish(tmp_path, {"p1": keep, "p2": drop}, {"p1": 0, "p2": 1})
     assert (written, unplaced) == (1, 1)
-    assert (tmp_path / "p1.georef-final.json").exists()
-    assert not (tmp_path / "p2.georef-final.json").exists()
-    # p2's channel sidecar is held aside, so no glob entry can match it...
-    assert not (tmp_path / "p2.georef-snap.json").exists()
-    assert (tmp_path / "p2.georef-snap-reconcile-held.json").exists()
-    # ...and both live under fit's clear-glob, so the next run starts clean.
-    assert len(list(tmp_path.glob("p*.georef*.json"))) == 3
+    assert json.loads((tmp_path / "p1.georef-final.json").read_text())["corners"]
+    assert (
+        json.loads((tmp_path / "p2.georef-final.json").read_text())["corners"] is None
+    )
+    # p2's own channel sidecar is untouched: the pose stays readable.
+    assert (tmp_path / "p2.georef-snap.json").exists()
+    # expand_georef_globs skips the poseless one, so p2 goes unpublished.
+    from mapsnap.make_iiif_georef import expand_georef_globs
+
+    chosen = expand_georef_globs(f"{tmp_path}/p*.georef-final.json")
+    assert [Path(p).name for p in chosen] == ["p1.georef-final.json"]
 
 
 def test_publish_records_provenance(tmp_path):
@@ -393,3 +398,62 @@ def test_publish_records_provenance(tmp_path):
     doc = json.loads((tmp_path / "p1.georef-final.json").read_text())
     assert doc["reconcile"]["source"] == "georef"
     assert "terms" in doc["reconcile"] and "corners" in doc
+
+
+def test_demoted_channel_is_not_the_incumbent(tmp_path):
+    # A demotion is a verdict inside the file now, not a rename, so the sidecar
+    # exists either way. The incumbent must follow the verdict: this is the
+    # exact set the old glob-over-renamed-files arrangement published.
+    from mapsnap import sidecar
+
+    doc = georef_doc(affine(0))
+    write_sidecar(tmp_path, "p1", "georef", doc)
+    assert published_channel(tmp_path, "p1") == "georef"
+    sidecar.demote(tmp_path / "p1.georef.json", sidecar.MISSCALE)
+    assert published_channel(tmp_path, "p1") is None
+    # ...but the pose is still a hypothesis, carrying its verdict.
+    hypotheses, published = collect_hypotheses(tmp_path, "p1", None, None)
+    assert published is None
+    assert [h.source for h in hypotheses] == ["georef:misscale", UNPLACED]
+    assert hypotheses[0].status == sidecar.MISSCALE
+
+
+def test_rejected_poses_become_hypotheses(tmp_path):
+    # The p55 shape under the collapsed layout: georef's key-map retry kept one
+    # pose and set the other aside, both inside p55.georef.json. Both have to
+    # reach the arbiter -- weighing them against each other is the point.
+    from mapsnap import sidecar
+
+    doc = georef_doc(affine(0))
+    write_sidecar(tmp_path, "p55", "georef", doc)
+    sidecar.attach_rejected(
+        tmp_path / "p55.georef.json",
+        [{**georef_doc(affine(5000)), "status": sidecar.KEYMAP_OUTLIER}],
+    )
+    hypotheses, published = collect_hypotheses(tmp_path, "p55", None, None)
+    assert [h.source for h in hypotheses] == [
+        "georef",
+        "georef:keymap-outlier",
+        UNPLACED,
+    ]
+    assert published == 0
+
+
+def test_contradicted_term_follows_the_verdict_not_the_filename():
+    # W_CONTRADICTED used to key off "contradicted" appearing in the sidecar's
+    # NAME; it keys off the recorded status now.
+    from mapsnap import sidecar
+    from mapsnap.reconcile import W_CONTRADICTED
+
+    plain = Hypothesis(source="georef", affine=affine(0), effective_gcps=2)
+    plain.scores["verification"] = 1.0
+    unary_energy(plain, False, 600.0, None, None)
+    flagged = Hypothesis(
+        source="georef",
+        affine=affine(0),
+        effective_gcps=2,
+        status=sidecar.CONTRADICTED,
+    )
+    flagged.scores["verification"] = 1.0
+    unary_energy(flagged, False, 600.0, None, None)
+    assert flagged.unary - plain.unary == pytest.approx(W_CONTRADICTED)

--- a/mapsnap/reconcile_test.py
+++ b/mapsnap/reconcile_test.py
@@ -106,21 +106,21 @@ def test_collect_globs_all_variants(tmp_path):
     # The p55 case: a rejected keymap-outlier pose and a published osm pose
     # must BOTH become hypotheses (GEOREF_VARIANTS omits -keymap-outlier).
     write_sidecar(tmp_path, "p55", "georef-keymap-outlier", georef_doc(affine(0)))
-    write_sidecar(tmp_path, "p55", "georef-osm", georef_doc(affine(5000)))
+    write_sidecar(tmp_path, "p55", "georef-snap", georef_doc(affine(5000)))
     hypotheses, published = collect_hypotheses(tmp_path, "p55", None, None)
     sources = [h.source for h in hypotheses]
     assert "georef-keymap-outlier" in sources
-    assert "georef-osm" in sources
+    assert "georef-snap" in sources
     assert sources[-1] == UNPLACED
-    assert published is not None and hypotheses[published].source == "georef-osm"
+    assert published is not None and hypotheses[published].source == "georef-snap"
 
 
 def test_published_channel_resolution_follows_glob_order(tmp_path):
     write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
-    write_sidecar(tmp_path, "p1", "georef-osm", georef_doc(affine(5000)))
-    assert published_channel(tmp_path, "p1") == "georef-osm"
-    write_sidecar(tmp_path, "p1", "georef-streets", georef_doc(affine(9000)))
-    assert published_channel(tmp_path, "p1") == "georef-streets"
+    write_sidecar(tmp_path, "p1", "georef-snap", georef_doc(affine(5000)))
+    assert published_channel(tmp_path, "p1") == "georef-snap"
+    write_sidecar(tmp_path, "p1", "georef-street", georef_doc(affine(9000)))
+    assert published_channel(tmp_path, "p1") == "georef-street"
 
 
 def test_dedupe_merges_near_identical_and_keeps_max_gcps():
@@ -358,28 +358,28 @@ def test_keep_bar_is_lower_than_enter_bar():
 
 def test_publish_writes_sidecars_and_holds_unplaced(tmp_path):
     # --publish is the only mode that writes to the volume root: chosen poses
-    # become pN.georef-reconcile.json (top of fit's glob), and a page
+    # become pN.georef-final.json (top of fit's glob), and a page
     # arbitrated to unplaced has its channel sidecars renamed aside, since a
     # glob can only skip a page that has no sidecar at all.
     from mapsnap.reconcile import publish
 
     write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
-    write_sidecar(tmp_path, "p2", "georef-osm", georef_doc(affine(500)))
+    write_sidecar(tmp_path, "p2", "georef-snap", georef_doc(affine(500)))
     keep = make_node("p1", [scored("georef", affine(0), verification=1.9, gcps=4)])
     drop = make_node(
         "p2",
         [
-            scored("georef-osm", affine(500), verification=0.1),
+            scored("georef-snap", affine(500), verification=0.1),
             scored(UNPLACED, None, 0),
         ],
     )
     written, unplaced = publish(tmp_path, {"p1": keep, "p2": drop}, {"p1": 0, "p2": 1})
     assert (written, unplaced) == (1, 1)
-    assert (tmp_path / "p1.georef-reconcile.json").exists()
-    assert not (tmp_path / "p2.georef-reconcile.json").exists()
+    assert (tmp_path / "p1.georef-final.json").exists()
+    assert not (tmp_path / "p2.georef-final.json").exists()
     # p2's channel sidecar is held aside, so no glob entry can match it...
-    assert not (tmp_path / "p2.georef-osm.json").exists()
-    assert (tmp_path / "p2.georef-osm-reconcile-held.json").exists()
+    assert not (tmp_path / "p2.georef-snap.json").exists()
+    assert (tmp_path / "p2.georef-snap-reconcile-held.json").exists()
     # ...and both live under fit's clear-glob, so the next run starts clean.
     assert len(list(tmp_path.glob("p*.georef*.json"))) == 3
 
@@ -390,6 +390,6 @@ def test_publish_records_provenance(tmp_path):
     write_sidecar(tmp_path, "p1", "georef", georef_doc(affine(0)))
     node = make_node("p1", [scored("georef", affine(0), verification=1.9, gcps=4)])
     publish(tmp_path, {"p1": node}, {"p1": 0})
-    doc = json.loads((tmp_path / "p1.georef-reconcile.json").read_text())
+    doc = json.loads((tmp_path / "p1.georef-final.json").read_text())
     assert doc["reconcile"]["source"] == "georef"
     assert "terms" in doc["reconcile"] and "corners" in doc

--- a/mapsnap/sidecar.py
+++ b/mapsnap/sidecar.py
@@ -1,0 +1,94 @@
+"""The georef sidecar contract: one file per channel per page, verdict inside.
+
+A fit pipeline stage records its verdict on a pose *in* the sidecar it wrote,
+not by renaming the file aside. The rename convention it replaces
+(``p12.georef.json`` -> ``p12.georef-misscale.json``) had three costs:
+
+- it made the file NAME the carrier of a judgement, so every reader had to
+  know the full variant vocabulary, and one that didn't silently skipped
+  pages (``GEOREF_VARIANTS`` omitted ``-keymap-outlier``, which is exactly the
+  pose the p55 class needed weighed);
+- it made a demotion indistinguishable from an absence, so a stage could
+  refuse to publish but never explain itself to a later stage; and
+- it grew a species per judgement -- a volume carried up to nine kinds of
+  ``p*.georef*.json`` -- with publication decided by glob precedence over
+  them, which is the "ordering is load-bearing" problem #270 exists to remove.
+
+Under this contract a page has at most one sidecar per channel:
+``p<stem>.georef.json`` (RANSAC), ``p<stem>.georef-snap.json`` (OSM snap),
+``p<stem>.georef-street.json`` (street solver), and ``p<stem>.georef-final.json``
+(the arbiter's answer, which is what gets published). ``status`` says what the
+writing stage concluded; ``ACCEPTED`` means "this channel stands behind this
+pose". Anything else is a pose the channel produced and declined -- still on
+disk, still weighable, no longer publishable by that channel.
+"""
+
+import json
+from pathlib import Path
+
+# The channel stands behind this pose.
+ACCEPTED = "fitted"
+
+# Verdicts a channel can record against its own pose. Each was once a filename.
+MISSCALE = "misscale"  # scale disagrees with the volume family / printed note
+OUTLIER = "outlier"  # placed far from every other page in the volume
+KEYMAP_OUTLIER = "keymap-outlier"  # placed far from the key map's expectation
+ONE_GCP = "1gcp"  # single-GCP pose the confirmation pass could not confirm
+NOFIT = "nofit"  # no pose at all (the sidecar records only the neighborhood)
+CONTRADICTED = "contradicted"  # the page's printed adjacency claims say otherwise
+
+
+def status(doc: dict) -> str:
+    """The verdict recorded in a sidecar doc; ACCEPTED when it records none.
+
+    Absent means accepted: a stage that has nothing to complain about writes no
+    status, so pre-existing sidecars and the common case both read as ACCEPTED.
+    """
+    return doc.get("status") or ACCEPTED
+
+
+def accepted(doc: dict) -> bool:
+    """Whether this doc is a pose its own channel stands behind.
+
+    Requires both a pose (corners) and an unblemished verdict, so a
+    neighborhood-only sidecar is never mistaken for a fit.
+    """
+    return bool(doc.get("corners")) and status(doc) == ACCEPTED
+
+
+def rejected_poses(doc: dict) -> list[dict]:
+    """Poses this channel produced for the page and then set aside.
+
+    A channel can reach more than one pose for a page — georef's key-map
+    retry fits a second time with a different vocabulary and keeps whichever
+    it prefers. Both belong to the same channel, so both live in the same
+    sidecar: the kept one at the top level, the others here, each a complete
+    pose doc carrying its own ``status``. They are still real hypotheses (the
+    p55 class is exactly a rejected pose that was right), so the arbiter reads
+    them; they are simply not what the channel would publish.
+    """
+    return doc.get("rejected") or []
+
+
+def attach_rejected(path: str | Path, poses: list[dict]) -> None:
+    """Append already-demoted pose docs to the sidecar's rejected list."""
+    path = Path(path)
+    doc = json.loads(path.read_text())
+    doc["rejected"] = [*rejected_poses(doc), *poses]
+    path.write_text(json.dumps(doc, indent=2))
+
+
+def demote(path: str | Path, verdict: str, detail: dict | None = None) -> None:
+    """Record ``verdict`` against an existing sidecar, in place.
+
+    Replaces ``os.rename(georef.json, georef-<verdict>.json)``. The pose stays
+    exactly where a reader expects to find it; what changes is that the channel
+    no longer claims it. ``detail`` is merged under ``status_detail`` so the
+    reason survives for the arbiter's report and for a human reading the file.
+    """
+    path = Path(path)
+    doc = json.loads(path.read_text())
+    doc["status"] = verdict
+    if detail:
+        doc["status_detail"] = {**(doc.get("status_detail") or {}), **detail}
+    path.write_text(json.dumps(doc, indent=2))

--- a/mapsnap/sidecar_test.py
+++ b/mapsnap/sidecar_test.py
@@ -1,0 +1,66 @@
+"""Tests for the georef sidecar contract (verdict inside the file, #270 phase 3)."""
+
+import json
+
+from mapsnap import sidecar
+
+
+def posed_doc() -> dict:
+    return {
+        "width": 100,
+        "height": 80,
+        "corners": [[0, 1], [1, 1], [1, 0], [0, 0]],
+        "intersections": [],
+    }
+
+
+def test_absent_status_reads_as_accepted():
+    # A stage with nothing to complain about writes no status, so every
+    # pre-existing sidecar in the corpus reads as accepted.
+    assert sidecar.status(posed_doc()) == sidecar.ACCEPTED
+    assert sidecar.accepted(posed_doc())
+
+
+def test_poseless_doc_is_never_accepted():
+    # A neighborhood-only sidecar records that the channel was asked and had no
+    # answer; it must not be mistaken for a fit just because no status is set.
+    assert not sidecar.accepted({"keymap": {"lat": 1, "lon": 2}})
+
+
+def test_demote_keeps_the_pose_and_records_why(tmp_path):
+    path = tmp_path / "p1.georef.json"
+    path.write_text(json.dumps(posed_doc()))
+    sidecar.demote(path, sidecar.MISSCALE, {"px_per_ft": 0.5})
+    doc = json.loads(path.read_text())
+    assert sidecar.status(doc) == sidecar.MISSCALE
+    assert not sidecar.accepted(doc)
+    # The whole point: the pose survives its demotion, so the arbiter can weigh
+    # it. Under the rename convention this file simply ceased to exist.
+    assert doc["corners"] == posed_doc()["corners"]
+    assert doc["status_detail"]["px_per_ft"] == 0.5
+
+
+def test_demote_twice_merges_detail(tmp_path):
+    # georef demotes on scale, then the adjacency gate demotes the same page:
+    # the later verdict wins but neither reason is lost.
+    path = tmp_path / "p1.georef.json"
+    path.write_text(json.dumps(posed_doc()))
+    sidecar.demote(path, sidecar.MISSCALE, {"px_per_ft": 0.5})
+    sidecar.demote(path, sidecar.CONTRADICTED, {"reason": "uncorroborated"})
+    doc = json.loads(path.read_text())
+    assert sidecar.status(doc) == sidecar.CONTRADICTED
+    assert doc["status_detail"] == {"px_per_ft": 0.5, "reason": "uncorroborated"}
+
+
+def test_attach_rejected_carries_a_second_pose(tmp_path):
+    # One channel, two poses: the key-map retry's winner at the top level and
+    # the pose it beat alongside it, each with its own verdict.
+    path = tmp_path / "p55.georef.json"
+    path.write_text(json.dumps(posed_doc()))
+    loser = {**posed_doc(), "status": sidecar.KEYMAP_OUTLIER}
+    sidecar.attach_rejected(path, [loser])
+    doc = json.loads(path.read_text())
+    assert sidecar.accepted(doc)
+    (rejected,) = sidecar.rejected_poses(doc)
+    assert sidecar.status(rejected) == sidecar.KEYMAP_OUTLIER
+    assert not sidecar.accepted(rejected)

--- a/mapsnap/snap.py
+++ b/mapsnap/snap.py
@@ -3,7 +3,7 @@
 The production entry point for the osm_snap channel (see osm_snap.py for the
 matcher and osm_snap_experiment.py for the underlying commands). Matches each
 page's road-UNet P(road) map against OSM centerlines rasterized in a local
-metre frame — no street-name OCR required — and writes pN.georef-osm.json
+metre frame — no street-name OCR required — and writes pN.georef-snap.json
 sidecars for three kinds of placements:
 
   - RESCUE: pages the RANSAC georeferencer left unplaced (nofit/misscale/
@@ -22,7 +22,7 @@ diagnostics. Road-UNet P(road) maps are inferred on demand (cached under
 artifacts/edge_join/roadprob/). Build the volume IIIF with the osm-first
 hybrid glob so the sidecars win where they exist:
 
-    mapsnap iiif <ref> '<dir>/*.georef-osm.json,<dir>/*.georef.json' ...
+    mapsnap iiif <ref> '<dir>/*.georef-snap.json,<dir>/*.georef.json' ...
 
 (`mapsnap fit` does this automatically.) First run costs UNet inference plus
 NCC matching (roughly 10-30 minutes per volume); candidates are cached in
@@ -41,7 +41,7 @@ def main() -> None:
         description=(
             "Geometry-first OSM snap: rescue unplaced pages, arbitrate "
             "OSM-contradicted fits, and refine mid-tier fits. Writes "
-            "pN.georef-osm.json sidecars; include them osm-first in the "
+            "pN.georef-snap.json sidecars; include them osm-first in the "
             "IIIF glob."
         )
     )

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -453,7 +453,7 @@ def write_georef_streets(
     extra: dict,
     raw_soups: dict | None = None,
 ) -> Path:
-    """Write one <stem>.georef-streets*.json in the pipeline's sidecar schema."""
+    """Write one <stem>.georef-street*.json in the pipeline's sidecar schema."""
     size = (unit.width, unit.height)
     label_scale = (size[0] / label_size[0], size[1] / label_size[1])
     doc = {
@@ -575,7 +575,7 @@ def incumbent_pose(volume: Path, unit: PageUnit) -> tuple[np.ndarray | None, str
     Snap's sidecar takes priority in the production glob, so on a page it acted on
     that -- not the RANSAC fit -- is what a challenger has to beat.
     """
-    osm_path = volume / f"{unit.stem}.georef-osm.json"
+    osm_path = volume / f"{unit.stem}.georef-snap.json"
     if osm_path.exists():
         try:
             return page_world_affine(json.loads(osm_path.read_text())), "snap"
@@ -614,7 +614,7 @@ def cmd_select(args: argparse.Namespace) -> None:
     if not posed:
         sys.exit(f"no posed candidates in {path}; run `candidates` first")
 
-    for stale in volume.glob("p*.georef-streets.json"):
+    for stale in volume.glob("p*.georef-street.json"):
         stale.unlink()  # this command owns them; never leave a previous run's pick
 
     vctx = load_volume_context(volume, units)
@@ -739,7 +739,7 @@ def cmd_report(args: argparse.Namespace) -> None:
 
 
 def cmd_materialize(args: argparse.Namespace) -> None:
-    """Write .georef-streets.json (and the truth-pose twin) for chosen pages."""
+    """Write .georef-street.json (and the truth-pose twin) for chosen pages."""
     volume = Path(args.volume)
     locator, centerlines, filter_params, scale = volume_context(volume)
     gates = StreetGates(**parse_gate_overrides(args.gates))
@@ -875,7 +875,7 @@ def main() -> None:
     candidates.set_defaults(func=cmd_candidates)
 
     materialize = sub.add_parser(
-        "materialize", help="Write .georef-streets.json sidecars for chosen pages."
+        "materialize", help="Write .georef-street.json sidecars for chosen pages."
     )
     materialize.add_argument("volume")
     materialize.add_argument("--pages", required=True)

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -441,6 +441,16 @@ def truth_rings(volume: Path, unit: PageUnit) -> list | None:
     return [[[float(x), float(y)] for x, y in ring] for ring in polygons]
 
 
+STREET_SUFFIX = "street"
+"""This channel's sidecar name: p<stem>.georef-street.json.
+
+A constant, not a literal at each call site: the name has to agree with
+reconcile's CHANNEL_ORDER and fit's glob, and when it was spelled out three
+times a rename reached two of them. The one it missed still wrote a valid
+sidecar, so nothing failed -- the pose just stopped counting as the incumbent.
+"""
+
+
 def write_georef_streets(
     volume: Path,
     unit: PageUnit,
@@ -449,9 +459,10 @@ def write_georef_streets(
     pose,
     gates: StreetGates,
     label_size: tuple[int, int],
-    suffix: str,
     extra: dict,
     raw_soups: dict | None = None,
+    *,
+    suffix: str = STREET_SUFFIX,
 ) -> Path:
     """Write one <stem>.georef-street*.json in the pipeline's sidecar schema."""
     size = (unit.width, unit.height)
@@ -614,7 +625,7 @@ def cmd_select(args: argparse.Namespace) -> None:
     if not posed:
         sys.exit(f"no posed candidates in {path}; run `candidates` first")
 
-    for stale in volume.glob("p*.georef-street.json"):
+    for stale in volume.glob(f"p*.georef-{STREET_SUFFIX}.json"):
         stale.unlink()  # this command owns them; never leave a previous run's pick
 
     vctx = load_volume_context(volume, units)
@@ -667,7 +678,6 @@ def cmd_select(args: argparse.Namespace) -> None:
             tuple(record["pose"]),
             gates,
             label_size,
-            "streets",
             {
                 "pose": record["pose"],
                 "adopted_over": source,
@@ -817,7 +827,6 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                     result.pose,
                     gates,
                     label_size,
-                    args.suffix,
                     {
                         "pose": [round(v, 6) for v in result.pose],
                         "psi_source": result.psi_source,
@@ -830,6 +839,7 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                         ),
                     },
                     raw_soups,
+                    suffix=args.suffix,
                 )
             )
         else:
@@ -845,7 +855,6 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                     truth_pose,
                     gates,
                     label_size,
-                    f"{args.suffix}-truth",
                     {
                         "pose": [round(v, 6) for v in truth_pose],
                         "source": "truth",
@@ -853,6 +862,7 @@ def cmd_materialize(args: argparse.Namespace) -> None:
                         "note": "detections scored against the human georeference",
                     },
                     raw_soups,
+                    suffix=f"{args.suffix}-truth",
                 )
             )
         for path in written:
@@ -887,7 +897,7 @@ def build_parser() -> argparse.ArgumentParser:
     materialize.add_argument("--truth-prior", action="store_true")
     materialize.add_argument(
         "--suffix",
-        default="street",
+        default=STREET_SUFFIX,
         help="Sidecar suffix: <stem>.georef-<suffix>.json (default: %(default)s).",
     )
     materialize.set_defaults(func=cmd_materialize)

--- a/mapsnap/street_solve_experiment.py
+++ b/mapsnap/street_solve_experiment.py
@@ -859,7 +859,11 @@ def cmd_materialize(args: argparse.Namespace) -> None:
             print(path)
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """The CLI parser, separated from main() so its defaults are testable.
+
+    The sidecar suffix in particular is a default, not a literal, and a channel
+    rename that misses it fails silently (see fit_test's channel-name test)."""
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -883,7 +887,7 @@ def main() -> None:
     materialize.add_argument("--truth-prior", action="store_true")
     materialize.add_argument(
         "--suffix",
-        default="streets",
+        default="street",
         help="Sidecar suffix: <stem>.georef-<suffix>.json (default: %(default)s).",
     )
     materialize.set_defaults(func=cmd_materialize)
@@ -905,7 +909,11 @@ def main() -> None:
     report.add_argument("volumes", nargs="+")
     report.set_defaults(func=cmd_report)
 
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
     args.func(args)
 
 

--- a/mapsnap/street_solve_run.py
+++ b/mapsnap/street_solve_run.py
@@ -11,11 +11,11 @@ prefers it by a clear margin. Measured over every disagreement in the twelve
 truth volumes that picks the closer pose 85% of the time and never costs a page
 its <=25 ft placement.
 
-Writes pN.georef-streets.json sidecars for the adopted pages, deleting the
+Writes pN.georef-street.json sidecars for the adopted pages, deleting the
 previous run's first. Build the volume IIIF with the streets-first hybrid glob
 so the sidecars win where they exist:
 
-    mapsnap iiif <ref> '<dir>/*.georef-streets.json,<dir>/*.georef-osm.json,<dir>/*.georef.json' ...
+    mapsnap iiif <ref> '<dir>/*.georef-street.json,<dir>/*.georef-snap.json,<dir>/*.georef.json' ...
 
 (`mapsnap fit` does this automatically.) The referee shares the snap channel's
 machinery (P(road) maps, OSM rasters), so run this after `mapsnap snap` — the
@@ -35,7 +35,7 @@ def main() -> None:
         description=(
             "Fit street-constraint poses for every key-map-prior page and adopt "
             "each one only where the independent referee prefers it. Writes "
-            "pN.georef-streets.json sidecars; include them streets-first in the "
+            "pN.georef-street.json sidecars; include them streets-first in the "
             "IIIF glob."
         )
     )


### PR DESCRIPTION
Phase 3 of #270. A page carried up to nine kinds of `p*.georef*.json`, and **which one existed** was how a stage said what it thought of a pose. That made publication a glob-precedence race, made a demotion indistinguishable from an absence, and forced every reader to know the whole variant vocabulary.

Now: at most four sidecars per page, and no gate decides publication.

| file | written by | carries |
|---|---|---|
| `p*.georef.json` | RANSAC | its pose, a `status` verdict, and any `rejected` poses |
| `p*.georef-snap.json` | OSM snap | its pose |
| `p*.georef-street.json` | street solver | its pose |
| `p*.georef-final.json` | **reconcile** | the arbitrated answer, or `corners: null` for a non-fit |

`mapsnap/sidecar.py` holds the contract. `status: fitted` (or none) means the channel stands behind the pose; `misscale`, `outlier`, `keymap-outlier`, `1gcp`, `nofit` and `contradicted` are poses a channel produced and declined — still on disk, still weighable, no longer publishable by that channel. A channel that reached two poses (georef's key-map retry) keeps the loser under `rejected` in the same file. `mapsnap iiif` reads one glob, so there is no stage order left to be load-bearing, and `--reconcile` is gone as a flag: the arbiter answers for every page.

On washington_dc that is 9 sidecar species down to 3.

## This is NOT a no-op, because #297 had a publication bug

`make_iiif_georef`'s page-key regex was a whitelist — `\.georef(?:2|-neighbor|-osm|-streets)?\.json$` — and `georef-reconcile.json` is not in it. **Every reconcile sidecar was silently dropped** and the IIIF fell through to the old channel glob. A base-commit control prints the proof, 27 warnings on champaign alone:

```
Warning: could not parse a page key from '…/p10.georef-reconcile.json'; omitting it from the output.
```

So of the arbiter's two powers, only one reached the output. **Refusing worked** (publish renamed channel sidecars aside, which no glob matched). **Choosing a different pose did not.** That is why the phase-2 A/B showed 9 of 11 band moves as `→ unplaced` with a single repair — refusal was the only thing that *could* take effect. Its **+0.4 measures refusals, not arbitration**, and its largest contributor (miami, +5.5) is contaminated by #299 besides; excluding miami leaves +0.15.

Phase 3 fixes the regex — parsing is general now, and what may be published is decided by the sidecar's *content* (`has_pose`), which is also how `georef-final.json` expresses a non-fit.

## Measured, with the hash seed pinned in both arms

The pipeline is only reproducible given a fixed `PYTHONHASHSEED` (#299), so both arms ran at `PYTHONHASHSEED=0`. Any difference left is the code.

| volume | base (`aba7caf`) | phase 3 | Δ | band crossings |
|---|---|---|---|---|
| champaign | 97.99 | 98.08 | +0.10 | unplaced → good: p3__1 |
| **washington_dc** | 81.31 | **84.71** | **+3.40** | DISASTER → good: p217; mid → good: p174, p203 |
| fargo | 66.26 | 67.64 | +1.38 | unplaced → good: **p55**, p38__2, p54; mid → DISASTER: p9__1 |
| | | | **+1.63 mean** | |

**fargo p55 is the case #270 was written for.** Its correct RANSAC pose was demoted as a key-map outlier (its key-map location is ~2.9 km wrong), a wrong snap pose was published, and nothing ever compared them. It now publishes from `georef:keymap-outlier` and lands ≤25 ft. The arbiter had *already* been choosing that pose in the base run — the sidecar was just being thrown away.

DC's wins are the pre-registered G2 recovery targets from #270 v1 (p174, p203, p217).

One real regression: fargo p9__1, 82.6 → 1677.9 ft.

## Two bugs I introduced, and the test that missed one

The rename missed street-solve's channel name **twice**: first an argparse default (`"streets"`), then a bare positional literal at the one call site `mapsnap fit` actually uses. The first fix came with a test that read the CLI default — so the test passed while production still wrote the old name, and I reported a fix that had not landed.

The failure is silent by construction: a wrong channel name still writes a valid sidecar, the pose still enters as a hypothesis, only *incumbency* shifts. On DC it moved two pages in opposite directions (p174 98→18, p166 14→115) — exactly the shape that reads like a real result.

`STREET_SUFFIX` is now the only spelling and `write_georef_streets` takes it keyword-only. The test calls the writer the way `cmd_select` does, taking every default, and asserts the channels *written* equal reconcile's `CHANNEL_ORDER`. I verified it fails when the constant is reverted.

## Preserved deliberately, not quietly improved

Two couplings keyed on which variant file existed:

- `page_fit_state` reported "fitted" for any `georef.json` — which is now every page. It reads the verdict instead, and `keymap-outlier`/`contradicted` still map to `("none", None)`, their old fall-through, so snap's rescue targets and priors do not move. Withholding a key-map prior from a page demoted *for being far from its key map* is worth revisiting, but as its own measured change.
- `usable_keymaps` skipped key maps whose georef failed by testing for the file; it tests the verdict now.

## Verified

1,104 tests (11 new), ruff and pyright clean. `docs/fit-pipeline.md` rewritten for the new stage structure. Six seed-pinned full fits, all rc=0, each verified from its artifacts to have run the intended code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
