### PR TITLE
Sort canonical street matches: fix the pipeline's nondeterminism (#299)

### DIFF
--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from mapsnap import sidecar
 from mapsnap.compare_iiif_georef import compare_pages
 from mapsnap.score import summarize, volume_page_scores
 from mapsnap.utils import default_centerlines, list_pages
@@ -34,12 +35,11 @@ ARTIFACTS_DIRNAME = "artifacts"
 # config hash — otherwise `-j2` and `-j1` would fragment a shared baseline into two archives.
 HASH_EXCLUDED_VALUE_FLAGS = frozenset({"--num-workers"})
 
-# Suffixes distinguishing the non-canonical georef variants the pipeline can emit.
-GEOREF_VARIANT_SUFFIXES = {
-    "misscale": "-misscale",
-    "outlier": "-outlier",
-    "deferred_unconfirmed": "-1gcp",
-}
+# Verdicts georef can record against its own pose (mapsnap.sidecar). These were
+# filename suffixes until #270 phase 3; counting them by glob now silently
+# reports zero, since every page has exactly one p<stem>.georef.json whatever
+# the verdict inside it.
+COUNTED_VERDICTS = ("misscale", "outlier", "1gcp", "keymap-outlier", "nofit")
 
 
 def file_sha256(path: Path) -> str:
@@ -161,16 +161,30 @@ def auto_run_id(git_sha: str, config_hash: str) -> str:
 def coverage_counts(dir_path: Path) -> dict:
     """Count pages and georef outcomes from the live sidecar files in ``dir_path``.
 
-    ``georeferenced`` counts canonical ``p*.georef.json``; the variant suffixes
-    (``-misscale`` / ``-outlier`` / ``-1gcp``) are counted under their status names.
-    ``pages`` is the number of effective input page images.
+    ``georeferenced`` counts pages whose RANSAC sidecar holds a pose georef
+    STANDS BEHIND, and each verdict is counted under its own name. Both read
+    the recorded status rather than the filename: after #270 phase 3 every page
+    has a ``p<stem>.georef.json`` whatever georef concluded about it, so
+    counting files reported every page as georeferenced and every verdict as
+    zero. ``pages`` is the number of effective input page images.
     """
-    counts = {
+    counts: dict[str, int] = {
         "pages": len(list_pages(dir_path)),
-        "georeferenced": len(list(dir_path.glob("p*.georef.json"))),
+        "georeferenced": 0,
     }
-    for status, suffix in GEOREF_VARIANT_SUFFIXES.items():
-        counts[status] = len(list(dir_path.glob(f"p*.georef{suffix}.json")))
+    for verdict in COUNTED_VERDICTS:
+        counts[verdict] = 0
+    for path in dir_path.glob("p*.georef.json"):
+        try:
+            doc = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        if sidecar.accepted(doc):
+            counts["georeferenced"] += 1
+        else:
+            verdict = sidecar.status(doc)
+            if verdict in counts:
+                counts[verdict] += 1
     return counts
 
 
@@ -430,7 +444,7 @@ def diff_volume(man_a: dict, man_b: dict) -> dict:
     cov_b = man_b.get("metrics", {})
     coverage = {
         key: cov_b.get(key, 0) - cov_a.get(key, 0)
-        for key in ("georeferenced", *GEOREF_VARIANT_SUFFIXES)
+        for key in ("georeferenced", *COUNTED_VERDICTS)
     }
 
     truth_a = (cov_a.get("truth") or {}).get("per_page", {})

--- a/mapsnap/experiments_test.py
+++ b/mapsnap/experiments_test.py
@@ -112,19 +112,34 @@ def test_gather_inputs_no_truth(tmp_path):
     assert inputs["boxes_sha"] is None
 
 
-def test_coverage_counts_classifies_variants(tmp_path):
+POSED = {"corners": [[0, 1], [1, 1], [1, 0], [0, 0]], "width": 10, "height": 10}
+
+
+def test_coverage_counts_classifies_verdicts(tmp_path):
+    # Every page has a p<stem>.georef.json since #270 phase 3, so the counts
+    # must read each one's recorded verdict. Counting FILES reported all three
+    # of these as georeferenced and every verdict as zero.
     for stem in ("p1", "p2", "p3"):
         (tmp_path / f"{stem}.jpg").touch()
-    _write(tmp_path / "p1.georef.json", "{}")
-    _write(tmp_path / "p2.georef-misscale.json", "{}")
-    _write(tmp_path / "p3.georef-1gcp.json", "{}")
+    _write(tmp_path / "p1.georef.json", json.dumps(POSED))
+    _write(tmp_path / "p2.georef.json", json.dumps({**POSED, "status": "misscale"}))
+    _write(tmp_path / "p3.georef.json", json.dumps({**POSED, "status": "1gcp"}))
 
     counts = coverage_counts(tmp_path)
     assert counts["pages"] == 3
     assert counts["georeferenced"] == 1
     assert counts["misscale"] == 1
-    assert counts["deferred_unconfirmed"] == 1
+    assert counts["1gcp"] == 1
     assert counts["outlier"] == 0
+
+
+def test_coverage_counts_poseless_sidecar_is_not_georeferenced(tmp_path):
+    # A neighborhood-only sidecar records that georef was asked and had no
+    # answer; it must not count as a fit just because the file exists.
+    (tmp_path / "p1.jpg").touch()
+    _write(tmp_path / "p1.georef.json", json.dumps({"status": "nofit", "keymap": {}}))
+    counts = coverage_counts(tmp_path)
+    assert counts["georeferenced"] == 0 and counts["nofit"] == 1
 
 
 # --- manifest ---
@@ -132,7 +147,7 @@ def test_coverage_counts_classifies_variants(tmp_path):
 
 def test_build_manifest_coverage_only_without_truth(tmp_path):
     (tmp_path / "p1.jpg").touch()
-    _write(tmp_path / "p1.georef.json", "{}")
+    _write(tmp_path / "p1.georef.json", json.dumps(POSED))
     manifest = build_manifest(
         tmp_path,
         run_id="abc-123",

--- a/mapsnap/georef_from_labels.py
+++ b/mapsnap/georef_from_labels.py
@@ -3002,7 +3002,10 @@ def prepare_label_features(
         # map to the *same list object* in block_index (set by build_block_index), so
         # id() detects them as duplicates and keeps only the longest (most specific) name.
         seen_block_ids: set[int] = set()
-        for canonical in sorted(canonicals, key=len, reverse=True):
+        # Longest (most specific) name first, ties broken by name: equal-length
+        # aliases map to the same block list, so which one survives the id()
+        # dedup below is decided here -- by hash order, until #299.
+        for canonical in sorted(canonicals, key=lambda c: (-len(c), c)):
             bid = id(block_index[canonical])
             if bid in seen_block_ids:
                 continue

--- a/mapsnap/streets.py
+++ b/mapsnap/streets.py
@@ -465,10 +465,17 @@ def canonical_street_matches(
     """Return all keys from normalized_streets that match text.
 
     Returns every key with at least one prefix-compatible candidate matching
-    normalize_street(text). Collects all matches rather than returning whichever
-    the set iteration yields first, eliminating nondeterminism when a bare label
-    (e.g. "CLINTON") could match multiple full names (e.g. "CLINTON AVENUE" and
-    "CLINTON STREET").
+    normalize_street(text), SORTED. Collects all matches rather than returning
+    whichever the set iteration yields first, eliminating nondeterminism when a
+    bare label (e.g. "CLINTON") could match multiple full names (e.g. "CLINTON
+    AVENUE" and "CLINTON STREET").
+
+    The sort matters as much as the collection. ``normalized_streets`` is a set,
+    so the order matches come out in is Python's per-process string hash order:
+    returning them unsorted made the whole pipeline non-reproducible across
+    runs (#299) even though the SET of matches was stable. Callers rank these
+    by length, and equal-length names -- "NORTHWEST FIRST AVENUE" against
+    "SOUTHEAST FIRST STREET" -- then tied and resolved by hash.
 
     When normalization expands a direction abbreviation (e.g. "W"→"WEST") and the
     raw text is itself a known alias (e.g. "W" for "AVENUE W"), only that alias is
@@ -494,7 +501,7 @@ def canonical_street_matches(
                 and s[prefix_len:].split(" ", 1)[0] in STREET_TYPES
             ):
                 matches.append(s)
-        return matches
+        return sorted(matches)
     matches: list[str] = []
     for s in normalized_streets:
         for candidate in _match_candidates(s):
@@ -508,7 +515,7 @@ def canonical_street_matches(
             ):
                 matches.append(s)
                 break  # count each key at most once
-    return matches
+    return sorted(matches)
 
 
 def polygon_side_lengths(polygon: list[list[int]]) -> list[float]:

--- a/mapsnap/streets_test.py
+++ b/mapsnap/streets_test.py
@@ -258,3 +258,24 @@ def test_printed_letters_ignores_punctuation_and_spaces():
     assert printed_letters("CLYDE") == 5
     assert printed_letters("VAN BRUNT") == 8
     assert printed_letters("3RD") == 3
+
+
+def test_canonical_street_matches_returns_sorted():
+    """Matches come back sorted, so callers can break ties deterministically.
+
+    ``normalized_streets`` is a set, so its iteration order is Python's
+    per-process string hash order and there is no order to preserve -- sorting
+    is the only way the return can be stable. Returning it unsorted made the
+    whole fit pipeline non-reproducible across runs (#299): callers rank
+    candidates by length, and equal-length names then tied and resolved by
+    hash. Miami fitted 83 pages one run and 82 the next, moving that volume's
+    score by 5.5 points.
+    """
+    names = {
+        "NORTHWEST FIRST AVENUE",
+        "SOUTHEAST FIRST STREET",
+        "SOUTHWEST FIRST AVENUE",
+        "NORTHEAST FIRST STREET",
+    }
+    assert len({len(n) for n in names}) == 1, "the tie is the point: all equal length"
+    assert canonical_street_matches("FIRST", names) == sorted(names)


### PR DESCRIPTION
Closes #299. Two runs of `mapsnap fit` on identical inputs could differ, which put an unquantified noise floor under every A/B this project has run. This is the cause, not a workaround — no `PYTHONHASHSEED` pinning needed.

## The bug

`canonical_street_matches` builds its result by iterating `normalized_streets`, a **set**, so the returned order was Python's per-process string hash order. Its caller ranked candidates by length alone:

```python
for canonical in sorted(canonicals, key=len, reverse=True):
```

so equal-length names — `NORTHWEST FIRST AVENUE` against `SOUTHEAST FIRST STREET`, both 22 characters — tied, and the tie resolved by hash. Which alias survived the `id()`-based dedup that follows, and therefore which GCP pairs RANSAC saw and in what order, followed from that.

The function's docstring already claimed to *"eliminat[e] nondeterminism when a bare label could match multiple full names"*. It had fixed **which** matches are returned — collect all rather than take the first — and left their **order** hash-dependent. A half-fix that read as a whole one.

## How it was narrowed

1. One page, run alone, four times across two seeds → **byte-identical**. The per-page solver was never the problem.
2. Two full-volume runs at different seeds → **12 of 94 pages** with different poses.
3. Diffing the per-page decision logs, the first differing line was always the label list — *same 69 labels, same members, different order* — and every reordered name was exactly the same length as the one it swapped with.

## The fix

`canonical_street_matches` returns `sorted(matches)` on both paths, and the caller breaks length ties by name (`key=lambda c: (-len(c), c)`), so neither side depends on the other.

## Verified

**Reproducible now.** Three full-volume georef runs on miami at `PYTHONHASHSEED` 0, 31337 and 999:

| seed | sidecars | digest of every pose |
|---|---|---|
| 0 | 94 | `4529a853b2b24bdb` |
| 31337 | 94 | `4529a853b2b24bdb` |
| 999 | 94 | `4529a853b2b24bdb` |

Zero differing pages, against 12 before the fix.

**Score-neutral.** Full fits, seed pinned identically on both sides so only the sort differs:

| volume | before | after | |
|---|---|---|---|
| champaign | 98.08 | 98.08 | no page moved |
| washington_dc | 84.71 | 84.71 | no page moved |
| miami | 79.78 | 79.78 | 18 pages shift within-band, **no band crossings** |

Miami's shifts are the tie-break picking a different equal-length alias; the largest is p36 7.3 → 10.3 ft, and nothing crosses 25 or 200 ft.

1,106 tests, ruff and pyright clean. The regression test fails when the `sorted()` is reverted — verified.

## Also here: the manifest counts #270 phase 3 broke

Phase 3 gave every page a `p<stem>.georef.json` whatever georef concluded, which silently broke `experiments.coverage_counts`. `georeferenced` had meant "pages georef stands behind" and started counting every page — washington_dc recorded **140** where ~106 fit — while `misscale`, `outlier` and `deferred_unconfirmed` globbed filenames that no longer exist and read **0** on every run since #301.

Both now read the recorded verdict. Keys use the sidecar's own vocabulary (`1gcp`, plus `keymap-outlier` and `nofit`, never counted before), so manifests written since #301 are not comparable to older ones on these fields — they were wrong in that window regardless.

The two tests covering this passed throughout, because their fixtures wrote `"{}"` as sidecar content — a stub with no pose, which a file-existence check happily counts as a fit.

## What this says about earlier numbers

Miami's arms in the #297 publication A/B diverged because of this: 83 pages fitted one run, 82 the next, worth 5.5 points on that volume. Its per-volume deltas are the ones to distrust; volumes whose arms were byte-identical (detroit, NO-1951, champaign) are unaffected. Any A/B run before this landed has a noise floor nobody measured.

## Follow-up, not in this PR

Legacy shims that phase 3 left behind and can go once every volume has been refitted: `GEOREF_VARIANTS`, `page_fit_state`'s legacy branch and `LEGACY_UNLISTED_VERDICTS`, `georef_variant_mtime`'s five-variant loop, and the stale-suffix cleanup in `_process_one_image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
