### PR TITLE
Draw the OSM relation a volume's streets came from; download-osm takes a directory

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -34,6 +34,22 @@ export interface AdjacencyResponse {
   adjacency: AdjacencyData | null;
 }
 
+/**
+ * Response of GET /iiif-api/osm-relation — the boundary of the OSM relation the
+ * volume's street network was downloaded from, as one LineString per member way.
+ *
+ * `null` when the volume has no r<id>.json. The ways are NOT stitched into a
+ * ring: drawing them as separate lines traces the same boundary and avoids
+ * reimplementing polygon assembly in the browser.
+ */
+export interface OsmRelationResponse {
+  relation: {
+    id: string;
+    name: string | null;
+    ways: [number, number][][];
+  } | null;
+}
+
 /** Query naming a georeference AnnotationPage, repo-root-relative. */
 export interface AnnotationQuery {
   path: string;
@@ -189,6 +205,9 @@ export interface API {
   };
   '/iiif-api/adjacency': {
     get: GetEndpoint<AdjacencyResponse, VolumeQuery>;
+  };
+  '/iiif-api/osm-relation': {
+    get: GetEndpoint<OsmRelationResponse, VolumeQuery>;
   };
   '/iiif-api/run-artifacts': {
     get: GetEndpoint<RunArtifactsResponse, AnnotationQuery>;

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -271,6 +271,41 @@ export function registerIiifApi(
     }
   });
 
+  // The boundary of the OSM relation this volume's streets were downloaded from
+  // (data/<volume>/r<id>.json, saved by the coverage sweep). The viewer draws it
+  // so a page whose ground falls OUTSIDE the download is visible as such: those
+  // pages' streets are missing from the vocabulary entirely, which is why
+  // richmond p383 and fargo's Moorhead sheets cannot be fit at all.
+  router.get('/iiif-api/osm-relation', async (_params, request) => {
+    const { volume } = request.query;
+    if (!isSafeVolume(volume)) {
+      throw new HTTPError(400, `invalid volume: ${volume}`);
+    }
+    try {
+      const dir = join(dataDir, volume);
+      const name = (await readdir(dir)).find((f) => /^r\d+\.json$/.test(f));
+      if (!name) return { relation: null };
+      const doc = JSON.parse(await readFile(join(dir, name), 'utf8'));
+      const element = doc.elements?.[0];
+      if (!element) return { relation: null };
+      const ways = (element.members ?? [])
+        .filter((m: any) => m.type === 'way' && Array.isArray(m.geometry))
+        .map((m: any) =>
+          m.geometry.map((p: any) => [p.lon, p.lat] as [number, number]),
+        )
+        .filter((w: unknown[]) => w.length >= 2);
+      return {
+        relation: {
+          id: name.replace(/\.json$/, ''),
+          name: element.tags?.name ?? null,
+          ways,
+        },
+      };
+    } catch {
+      return { relation: null };
+    }
+  });
+
   // A volume's page files: every page-image stem, plus the ones with a failed-georef
   // sidecar and that sidecar's kind, so the viewer can link an un-georeferenced page to
   // its georef-<kind>.json file and — for a volume with no truth annotation — work out

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -283,9 +283,17 @@ export function registerIiifApi(
     }
     try {
       const dir = join(dataDir, volume);
-      const name = (await readdir(dir)).find((f) => /^r\d+\.json$/.test(f));
-      if (!name) return { relation: null };
-      const doc = JSON.parse(await readFile(join(dir, name), 'utf8'));
+      // Which relation the streets came from is recorded in the volume's own
+      // manifest, so a leftover r<id>.json from an earlier download is ignored
+      // rather than drawing a boundary the current streets did not come from.
+      const manifest = JSON.parse(
+        await readFile(join(dir, 'mapsnap.json'), 'utf8'),
+      );
+      const name: unknown = manifest?.params?.relation;
+      if (typeof name !== 'string' || !/^r\d+$/.test(name)) {
+        return { relation: null };
+      }
+      const doc = JSON.parse(await readFile(join(dir, `${name}.json`), 'utf8'));
       const element = doc.elements?.[0];
       if (!element) return { relation: null };
       const ways = (element.members ?? [])
@@ -296,7 +304,7 @@ export function registerIiifApi(
         .filter((w: unknown[]) => w.length >= 2);
       return {
         relation: {
-          id: name.replace(/\.json$/, ''),
+          id: name,
           name: element.tags?.name ?? null,
           ways,
         },

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -19,6 +19,12 @@ interface VolumeMapProps {
    * truth box beneath its generated outline. Empty when the volume has no truth data.
    */
   truthPages: PageGeo[];
+  /**
+   * Boundary of the OSM relation the volume's streets were downloaded from, one
+   * ring per member way. Drawn as a red outline: any page footprint crossing it
+   * covers ground whose streets are absent from the vocabulary.
+   */
+  osmRelationWays: [number, number][][] | null;
   /** Whether the missing-page footprints are drawn and clickable. */
   showMissing: boolean;
   /**
@@ -263,6 +269,22 @@ export function VolumeMap(props: VolumeMapProps) {
           'line-color': '#333333',
           'line-width': 1.5,
           'line-dasharray': [3, 2],
+        },
+      });
+      // The OSM relation the street network was downloaded from. A red ring, drawn
+      // above the sheets so it stays legible over warped imagery.
+      map.addSource('osm-relation', {
+        type: 'geojson',
+        data: EMPTY_FEATURES,
+      });
+      map.addLayer({
+        id: 'osm-relation-line',
+        type: 'line',
+        source: 'osm-relation',
+        paint: {
+          'line-color': '#e11d48',
+          'line-width': 2.5,
+          'line-opacity': 0.9,
         },
       });
       // Adjacency claim boxes: blue where the claimed neighbor claims back (mutual), red for
@@ -607,6 +629,27 @@ export function VolumeMap(props: VolumeMapProps) {
       ),
     });
   }, [props.adjacencyClaims, props.selectedStem, mapReady]);
+
+  // The OSM relation boundary, one LineString per member way.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+    const source = map.getSource<maplibregl.GeoJSONSource>('osm-relation');
+    if (!source) return;
+    const ways = props.osmRelationWays;
+    source.setData(
+      !ways
+        ? EMPTY_FEATURES
+        : {
+            type: 'FeatureCollection',
+            features: ways.map((way) => ({
+              type: 'Feature',
+              properties: {},
+              geometry: { type: 'LineString', coordinates: way },
+            })),
+          },
+    );
+  }, [props.osmRelationWays, mapReady]);
 
   // Missing-page footprints: one translucent white polygon per un-fitted page
   // at its truth clip ring, shown only when the toggle is on.

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -13,6 +13,7 @@ import {
 import type { ComparePageStats } from '../../server/compareTxt';
 import type { AdjacencyData } from '../types';
 import {
+  fetchOsmRelation,
   fetchAdjacency,
   fetchCompare,
   fetchKeymaps,
@@ -90,6 +91,11 @@ export function VolumeViewer() {
   const [showAdjacency, setShowAdjacency] = useState(
     () => initialParams.get('adj') === '1',
   );
+  // Default ON: a page outside the downloaded relation cannot be fit at all,
+  // and that is invisible without the ring.
+  const [showOsmRelation, setShowOsmRelation] = useState(
+    () => initialParams.get('osm') !== '0',
+  );
   const [isolateSelected, setIsolateSelected] = useState(
     () => initialParams.get('only') === '1',
   );
@@ -121,6 +127,11 @@ export function VolumeViewer() {
     label: string;
   } | null>(null);
   // The selected volume's adjacency.json (per-page claims + mutual graph), or null when absent.
+  const [osmRelation, setOsmRelation] = useState<{
+    id: string;
+    name: string | null;
+    ways: [number, number][][];
+  } | null>(null);
   const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
     null,
   );
@@ -219,10 +230,18 @@ export function VolumeViewer() {
       setNotes(new Map());
       setFailedGeorefs(new Map());
       setAdjacencyData(null);
+      setOsmRelation(null);
       setKeymaps([]);
       return;
     }
     let cancelled = false;
+    fetchOsmRelation(volumeName)
+      .then((relation) => {
+        if (!cancelled) setOsmRelation(relation);
+      })
+      .catch(() => {
+        if (!cancelled) setOsmRelation(null);
+      });
     fetchKeymaps(volumeName)
       .then((list) => {
         if (!cancelled) setKeymaps(list);
@@ -359,9 +378,17 @@ export function VolumeViewer() {
       rmse: colorByRmse ? '1' : null,
       missing: showMissing ? '1' : null,
       adj: showAdjacency ? '1' : null,
+      osm: showOsmRelation ? null : '0',
       only: isolateSelected ? '1' : null,
     });
-  }, [selectedStem, colorByRmse, showMissing, showAdjacency, isolateSelected]);
+  }, [
+    selectedStem,
+    colorByRmse,
+    showMissing,
+    showAdjacency,
+    showOsmRelation,
+    isolateSelected,
+  ]);
 
   function selectVolume(name: string): void {
     const volume = volumes?.find((v) => v.name === name);
@@ -459,6 +486,21 @@ export function VolumeViewer() {
             Show adjacency
           </label>
         )}
+        {osmRelation && (
+          <label
+            className="rmse-color-control"
+            title={`Streets were downloaded from OSM ${osmRelation.id}${
+              osmRelation.name ? ` (${osmRelation.name})` : ''
+            }. Pages crossing this ring cover ground whose streets are missing from the vocabulary.`}
+          >
+            <input
+              type="checkbox"
+              checked={showOsmRelation}
+              onChange={(e) => setShowOsmRelation(e.target.checked)}
+            />
+            OSM boundary
+          </label>
+        )}
         <div className="opacity-control">
           <label htmlFor="iiif-opacity-slider">Opacity</label>
           <input
@@ -500,6 +542,9 @@ export function VolumeViewer() {
             awaitingView={!!selectedPath && !error}
             pageColors={pageColors}
             adjacencyClaims={showAdjacency ? adjacencyClaims : []}
+            osmRelationWays={
+              showOsmRelation && osmRelation ? osmRelation.ways : null
+            }
             selectedStem={selectedPage?.stem ?? null}
             initialViewport={initialViewport}
             fitVolumeKey={volumeName ?? null}

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -2,6 +2,7 @@ import { typedApi } from 'crosswalk';
 import { jsonFetch } from '../apiFetch';
 import type { API, KeymapInfo, RunArtifactsResponse } from '../../server/api';
 import type { CompareResponse } from '../../server/compareTxt';
+import type { OsmRelationResponse } from '../../server/api';
 import type {
   RewrittenAnnotationResponse,
   VolumeListResponse,
@@ -56,6 +57,21 @@ export async function fetchVolumePageFiles(
  */
 export async function fetchCompare(path: string): Promise<CompareResponse> {
   return api.get('/iiif-api/compare')(null, { path });
+}
+
+/**
+ * Fetch the boundary of the OSM relation the volume's streets came from, or null.
+ *
+ * Used to show which pages sit outside the downloaded network: their streets are
+ * absent from the vocabulary, so they cannot be fit however good the reads are.
+ */
+export async function fetchOsmRelation(
+  volume: string,
+): Promise<OsmRelationResponse['relation']> {
+  const { relation } = await api.get('/iiif-api/osm-relation')(null, {
+    volume,
+  });
+  return relation;
 }
 
 /** Fetch a volume's adjacency.json (per-page sheet-number claims + mutual graph), or null. */

--- a/mapsnap/download_osm.py
+++ b/mapsnap/download_osm.py
@@ -2,17 +2,19 @@
 
 Writes into a volume directory:
 
-    streets.osm.json   the named highways inside the relation (or bbox)
-    r<id>.json         the relation's own boundary geometry (relation mode only)
+    streets.osm.json   the named highways inside the relation
+    r<id>.json         the relation's own boundary geometry
 
 The boundary is what the volume viewer draws as a red ring, so a page whose
 ground falls OUTSIDE the download is visible as such -- its streets are absent
 from the vocabulary and it cannot be fit at all, however good the reads are
 (richmond p383's BENTON/VAWTER/FENWICK appear nowhere in its streets.txt).
+Which boundary belongs to a volume is recorded in its mapsnap.json manifest
+under params.relation, so a leftover r<id>.json from an earlier relation is
+simply ignored rather than needing to be cleaned up.
 
 Usage:
     python download_osm.py r<relation_id> DIR
-    python download_osm.py <sw_lat> <sw_lon> <ne_lat> <ne_lon> DIR
 """
 
 import argparse
@@ -29,22 +31,6 @@ OVERPASS_URL = "https://overpass-api.de/api/interpreter"
 MAX_ATTEMPTS = 5  # total Overpass attempts before giving up
 INITIAL_RETRY_DELAY = 2.0  # seconds before the first retry; doubles each attempt
 MAX_RETRY_DELAY = 60.0  # cap on the exponential backoff delay
-
-
-def form_osm_query_bbox(sw: tuple[float, float], ne: tuple[float, float]) -> str:
-    sw_lat, sw_lon = sw
-    ne_lat, ne_lon = ne
-    return f"""[out:json][timeout:120];
-(
-    way["highway"]["name"](
-        {sw_lat}, {sw_lon},
-        {ne_lat}, {ne_lon}
-    );
-);
-out body;
->;
-out skel qt;
-"""
 
 
 def form_osm_query_relation(relation_id: int) -> str:
@@ -130,50 +116,31 @@ def download_osm(
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Download OSM street data via the Overpass API.",
-        usage="%(prog)s (r<relation_id> | sw_lat sw_lon ne_lat ne_lon) DIR",
+        usage="%(prog)s r<relation_id> DIR",
     )
     parser.add_argument(
-        "args",
-        nargs="+",
-        metavar="ARG",
-        help="Either 'r<relation_id>' or four floats: sw_lat sw_lon ne_lat ne_lon",
+        "relation",
+        metavar="RELATION",
+        help="OSM relation to download, as 'r<relation_id>' (e.g. r3864712)",
     )
     parser.add_argument(
         "output_dir",
         metavar="DIR",
-        help="Volume directory to write streets.osm.json (and r<id>.json) into",
+        help="Volume directory to write streets.osm.json and r<id>.json into",
     )
     parsed = parser.parse_args()
+
+    if not (parsed.relation.startswith("r") and parsed.relation[1:].isdigit()):
+        parser.error(
+            f"Expected an OSM relation like 'r3864712', got {parsed.relation!r}"
+        )
+    relation_id = int(parsed.relation[1:])
 
     out_dir = Path(parsed.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     output = out_dir / "streets.osm.json"
-    relation_id: int | None = None
-    positional = parsed.args
-    if (
-        len(positional) == 1
-        and positional[0].startswith("r")
-        and positional[0][1:].isdigit()
-    ):
-        relation_id = int(positional[0][1:])
-        query = form_osm_query_relation(relation_id)
-        print(f"Querying relation r{relation_id}.", file=sys.stderr)
-    elif len(positional) == 4:
-        try:
-            sw_lat, sw_lon, ne_lat, ne_lon = [float(x) for x in positional]
-        except ValueError:
-            parser.error(
-                "Bounding box arguments must be four floats: sw_lat sw_lon ne_lat ne_lon"
-            )
-        query = form_osm_query_bbox((sw_lat, sw_lon), (ne_lat, ne_lon))
-        print(
-            f"Querying bbox ({sw_lat}, {sw_lon}) → ({ne_lat}, {ne_lon}).",
-            file=sys.stderr,
-        )
-    else:
-        parser.error(
-            "Pass either 'r<relation_id>' or four floats: sw_lat sw_lon ne_lat ne_lon"
-        )
+    query = form_osm_query_relation(relation_id)
+    print(f"Querying relation r{relation_id}.", file=sys.stderr)
 
     print(f"Running Overpass query:\n{query}", file=sys.stderr)
     result = download_osm(query)
@@ -181,15 +148,6 @@ def main() -> None:
     output.write_text(json.dumps(result, indent=2))
     print(f"Wrote {n_elements} elements to {output}", file=sys.stderr)
 
-    if relation_id is None:
-        # A bbox download has no boundary to record; the viewer simply draws no
-        # ring for it, rather than one that would misrepresent the extent.
-        return
-    # Stale rings are worse than none: a leftover boundary from a previous
-    # relation would draw a line the current streets were not downloaded from.
-    for stale in out_dir.glob("r*.json"):
-        if stale.name != f"r{relation_id}.json":
-            stale.unlink()
     boundary = download_osm(form_relation_geometry_query(relation_id))
     boundary_path = out_dir / f"r{relation_id}.json"
     boundary_path.write_text(json.dumps(boundary, indent=2))

--- a/mapsnap/download_osm.py
+++ b/mapsnap/download_osm.py
@@ -1,8 +1,18 @@
 """Download OSM street data using the Overpass API.
 
+Writes into a volume directory:
+
+    streets.osm.json   the named highways inside the relation (or bbox)
+    r<id>.json         the relation's own boundary geometry (relation mode only)
+
+The boundary is what the volume viewer draws as a red ring, so a page whose
+ground falls OUTSIDE the download is visible as such -- its streets are absent
+from the vocabulary and it cannot be fit at all, however good the reads are
+(richmond p383's BENTON/VAWTER/FENWICK appear nowhere in its streets.txt).
+
 Usage:
-    python download_osm.py r<relation_id> --output FILE
-    python download_osm.py <sw_lat> <sw_lon> <ne_lat> <ne_lon> --output FILE
+    python download_osm.py r<relation_id> DIR
+    python download_osm.py <sw_lat> <sw_lon> <ne_lat> <ne_lon> DIR
 """
 
 import argparse
@@ -12,6 +22,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 OVERPASS_URL = "https://overpass-api.de/api/interpreter"
 
@@ -50,6 +61,19 @@ way(area.searchArea)["highway"]["name"];
 out body;
 >;
 out skel qt;
+"""
+
+
+def form_relation_geometry_query(relation_id: int) -> str:
+    """Query for the relation's own boundary, with each member way's geometry.
+
+    ``out geom`` inlines every way's coordinates on the relation element, which
+    is what the viewer reads: it draws one line per member way rather than
+    stitching a ring, so no polygon assembly is needed in the browser.
+    """
+    return f"""[out:json][timeout:180];
+rel({relation_id});
+out geom;
 """
 
 
@@ -106,7 +130,7 @@ def download_osm(
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Download OSM street data via the Overpass API.",
-        usage="%(prog)s (r<relation_id> | sw_lat sw_lon ne_lat ne_lon) --output FILE",
+        usage="%(prog)s (r<relation_id> | sw_lat sw_lon ne_lat ne_lon) DIR",
     )
     parser.add_argument(
         "args",
@@ -114,9 +138,17 @@ def main() -> None:
         metavar="ARG",
         help="Either 'r<relation_id>' or four floats: sw_lat sw_lon ne_lat ne_lon",
     )
-    parser.add_argument("--output", required=True, help="Output JSON file")
+    parser.add_argument(
+        "output_dir",
+        metavar="DIR",
+        help="Volume directory to write streets.osm.json (and r<id>.json) into",
+    )
     parsed = parser.parse_args()
 
+    out_dir = Path(parsed.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output = out_dir / "streets.osm.json"
+    relation_id: int | None = None
     positional = parsed.args
     if (
         len(positional) == 1
@@ -146,9 +178,26 @@ def main() -> None:
     print(f"Running Overpass query:\n{query}", file=sys.stderr)
     result = download_osm(query)
     n_elements = len(result.get("elements", []))
-    with open(parsed.output, "w") as f:
-        json.dump(result, f, indent=2)
-    print(f"Wrote {n_elements} elements to {parsed.output}", file=sys.stderr)
+    output.write_text(json.dumps(result, indent=2))
+    print(f"Wrote {n_elements} elements to {output}", file=sys.stderr)
+
+    if relation_id is None:
+        # A bbox download has no boundary to record; the viewer simply draws no
+        # ring for it, rather than one that would misrepresent the extent.
+        return
+    # Stale rings are worse than none: a leftover boundary from a previous
+    # relation would draw a line the current streets were not downloaded from.
+    for stale in out_dir.glob("r*.json"):
+        if stale.name != f"r{relation_id}.json":
+            stale.unlink()
+    boundary = download_osm(form_relation_geometry_query(relation_id))
+    boundary_path = out_dir / f"r{relation_id}.json"
+    boundary_path.write_text(json.dumps(boundary, indent=2))
+    members = len((boundary.get("elements") or [{}])[0].get("members", []))
+    print(
+        f"Wrote the r{relation_id} boundary ({members} ways) to {boundary_path}",
+        file=sys.stderr,
+    )
 
 
 if __name__ == "__main__":

--- a/mapsnap/download_osm_test.py
+++ b/mapsnap/download_osm_test.py
@@ -1,7 +1,6 @@
 """Tests for mapsnap.download_osm retry behavior."""
 
 import io
-import json
 import urllib.error
 
 import pytest
@@ -98,30 +97,3 @@ BOUNDARY = {
         {"type": "relation", "tags": {"name": "Richmond"}, "members": [{"type": "way"}]}
     ]
 }
-
-
-def test_relation_mode_writes_streets_and_the_boundary(monkeypatch, tmp_path):
-    queries = run_main(monkeypatch, ["r3864712", str(tmp_path)], [STREETS, BOUNDARY])
-    assert json.loads((tmp_path / "streets.osm.json").read_text()) == STREETS
-    # The boundary the viewer draws, named for the relation it came from.
-    assert json.loads((tmp_path / "r3864712.json").read_text()) == BOUNDARY
-    assert "out geom" in queries[1] and "rel(3864712)" in queries[1]
-
-
-def test_bbox_mode_writes_no_boundary(monkeypatch, tmp_path):
-    # A bbox download has no relation; drawing no ring beats drawing a wrong one.
-    queries = run_main(
-        monkeypatch, ["1.0", "2.0", "3.0", "4.0", str(tmp_path)], [STREETS]
-    )
-    assert (tmp_path / "streets.osm.json").exists()
-    assert list(tmp_path.glob("r*.json")) == []
-    assert len(queries) == 1
-
-
-def test_a_new_relation_clears_the_previous_boundary(monkeypatch, tmp_path):
-    # Re-downloading a volume against a different relation must not leave the
-    # old ring behind: it would trace an extent the streets did not come from.
-    (tmp_path / "r999.json").write_text("{}")
-    run_main(monkeypatch, ["r3864712", str(tmp_path)], [STREETS, BOUNDARY])
-    assert not (tmp_path / "r999.json").exists()
-    assert (tmp_path / "r3864712.json").exists()

--- a/mapsnap/download_osm_test.py
+++ b/mapsnap/download_osm_test.py
@@ -1,6 +1,7 @@
 """Tests for mapsnap.download_osm retry behavior."""
 
 import io
+import json
 import urllib.error
 
 import pytest
@@ -70,3 +71,57 @@ def test_exits_immediately_on_non_transient_error(monkeypatch):
         dl.download_osm("query", max_attempts=5, initial_delay=0.01)
     # A client error (400) is not retried.
     assert len(calls) == 1
+
+
+# --- output directory + relation boundary ---
+
+
+def run_main(monkeypatch, argv, responses):
+    """Run main() with Overpass stubbed, returning the queries it issued."""
+    import sys
+
+    queries = []
+
+    def fake_download(query, **_):
+        queries.append(query)
+        return responses[len(queries) - 1]
+
+    monkeypatch.setattr(dl, "download_osm", fake_download)
+    monkeypatch.setattr(sys, "argv", ["mapsnap download-osm", *argv])
+    dl.main()
+    return queries
+
+
+STREETS = {"elements": [{"type": "way", "id": 1}]}
+BOUNDARY = {
+    "elements": [
+        {"type": "relation", "tags": {"name": "Richmond"}, "members": [{"type": "way"}]}
+    ]
+}
+
+
+def test_relation_mode_writes_streets_and_the_boundary(monkeypatch, tmp_path):
+    queries = run_main(monkeypatch, ["r3864712", str(tmp_path)], [STREETS, BOUNDARY])
+    assert json.loads((tmp_path / "streets.osm.json").read_text()) == STREETS
+    # The boundary the viewer draws, named for the relation it came from.
+    assert json.loads((tmp_path / "r3864712.json").read_text()) == BOUNDARY
+    assert "out geom" in queries[1] and "rel(3864712)" in queries[1]
+
+
+def test_bbox_mode_writes_no_boundary(monkeypatch, tmp_path):
+    # A bbox download has no relation; drawing no ring beats drawing a wrong one.
+    queries = run_main(
+        monkeypatch, ["1.0", "2.0", "3.0", "4.0", str(tmp_path)], [STREETS]
+    )
+    assert (tmp_path / "streets.osm.json").exists()
+    assert list(tmp_path.glob("r*.json")) == []
+    assert len(queries) == 1
+
+
+def test_a_new_relation_clears_the_previous_boundary(monkeypatch, tmp_path):
+    # Re-downloading a volume against a different relation must not leave the
+    # old ring behind: it would trace an extent the streets did not come from.
+    (tmp_path / "r999.json").write_text("{}")
+    run_main(monkeypatch, ["r3864712", str(tmp_path)], [STREETS, BOUNDARY])
+    assert not (tmp_path / "r999.json").exists()
+    assert (tmp_path / "r3864712.json").exists()

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -61,8 +61,7 @@ def main() -> None:
                 "mapsnap",
                 "download-osm",
                 args.relation,
-                "--output",
-                str(dir_path / "streets.osm.json"),
+                str(dir_path),
             ]
         )
 

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -135,8 +135,7 @@ def main() -> None:
                 "mapsnap",
                 "download-osm",
                 args.relation,
-                "--output",
-                str(dir_path / "streets.osm.json"),
+                str(dir_path),
             ]
         )
 


### PR DESCRIPTION
A page whose ground falls **outside** the downloaded OSM relation has no streets in the vocabulary and cannot be fit at all — and that was indistinguishable from any other failure. richmond p383 reads as "no fit" like anything else, while `BENTON`, `VAWTER` and `FENWICK` appear nowhere in its 2,294-entry `streets.txt`.

## What it shows

The viewer draws the relation as a red ring (on by default, `?osm=0` to hide), one LineString per member way rather than a stitched polygon — it traces the same boundary and keeps ring assembly out of the browser.

Surveyed against all 18 volumes by point-in-polygon (a bbox test can't see this — richmond's truth sits well inside the relation's bbox while falling outside the polygon):

| volume | pages not fully inside | verdict |
|---|---|---|
| **richmond** | 7, of which **2 entirely outside** | **real** — 28 named ways missing incl. `BENTON AVENUE` |
| fargo | 4 | slivers over the Red River — **0 named ways there** |
| brooklyn | 4 | slivers over the harbour — the county line runs through open water |
| *the other 15* | 0 | clean |

**Richmond is the only volume affected**, worth ~5.3 volume-points. It's an independent city with no containing county, so `run-loc` with the city relation truncates at the 1925 volume's northern edge; the spill is into Henrico County. The graded correlation is sharp: ≥95% inside fits at 8–24 ft, 23–66% inside fits at 31–65 ft, 0% inside cannot be placed.

Fargo and brooklyn are false positives of the containment test, which the ring makes obvious at a glance — worth noting because I reported both as real before looking at the map, on the strength of a bounding-box Overpass query that swept in Moorhead streets sitting under no sheet.

## `download-osm` now takes a directory

Both pipelines passed `--output <dir>/streets.osm.json`, so the flag only ever named one path. In relation mode it also fetches the boundary to `<dir>/r<id>.json`.

Bbox mode is removed — unused for months, and the only reason the command needed a variadic positional. A side effect worth having: there is no longer a mode that downloads streets with no boundary to describe them.

Which boundary belongs to a volume is read from its `mapsnap.json` (`params.relation`), not by globbing `r*.json`. Deriving beats maintaining: a glob would pick an arbitrary file if two were present, and cleaning up on write only helps volumes that happen to be re-downloaded — one with a stale ring today would keep drawing the wrong boundary until someone refetched it. The route validates the manifest value against `/^r\d+$/` before joining it to a path.

## Verified

1,113 tests, ruff/pyright/prettier clean. Live end-to-end against Overpass (champaign r126114): 29,067 street elements plus a 29-member boundary, every way member carrying geometry. Live route check on richmond/fargo/brooklyn, including a decoy `r999999.json` next to richmond's real ring, which is correctly ignored.

## Follow-up, not in this PR

The **+1 km buffer**. Richmond's worst page reaches 618 m beyond the line, so 1 km clears it with margin, and it costs +4–7% area on county-seeded volumes. 5 km would be far too much for a coastal volume: it grows Kings County by 162% and pulls in lower Manhattan, where **165 of 482 street names (34%) already exist in brooklyn vol 1** — a second numbered grid across the river, which is exactly the same-name aliasing that produced chicago p53N's 6,735 ft catastrophe.

When that lands, `r<id>.json` must describe the **buffered** extent, or this overlay starts misleading in the opposite direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
