### PR TITLE
Make a crashed or skipped fit run diagnosable instead of silent

### DIFF
--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -1,5 +1,6 @@
 """Unified mapsnap command-line interface."""
 
+import faulthandler
 import importlib
 import sys
 
@@ -126,6 +127,22 @@ Commands:
 
 
 def main() -> None:
+    # A native crash (SIGSEGV/SIGBUS/SIGFPE) in numpy, shapely, cv2 or torch kills
+    # the process with no Python traceback at all -- #296 has taken out `snap`
+    # three times in ~60 fits, and every report so far is just "rc=245".
+    # faulthandler writes the C-level and Python stacks straight to fd 2 from the
+    # signal handler, so the next occurrence names the line.
+    faulthandler.enable()
+    # Line-buffer stdout so progress SURVIVES such a crash. Piped output is
+    # block-buffered by default, so the buffer dies with the process: the
+    # crashed runs looked like `snap` had produced nothing before dying, when in
+    # fact its output was simply lost. Without this the traceback above has no
+    # context about which page was being processed.
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except (AttributeError, ValueError):
+        pass
+
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
         print(HELP)
         sys.exit(0 if len(sys.argv) >= 2 else 1)

--- a/mapsnap/cli.py
+++ b/mapsnap/cli.py
@@ -138,10 +138,12 @@ def main() -> None:
     # crashed runs looked like `snap` had produced nothing before dying, when in
     # fact its output was simply lost. Without this the traceback above has no
     # context about which page was being processed.
-    try:
-        sys.stdout.reconfigure(line_buffering=True)
-    except (AttributeError, ValueError):
-        pass
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        try:
+            reconfigure(line_buffering=True)
+        except ValueError:  # already-detached or non-text stream
+            pass
 
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
         print(HELP)

--- a/mapsnap/cli_test.py
+++ b/mapsnap/cli_test.py
@@ -32,3 +32,27 @@ def test_every_command_module_imports(name: str) -> None:
     assert callable(getattr(module, "main", None)), (
         f"{module_name} has no main() for `mapsnap {name}`"
     )
+
+
+def test_fatal_signal_produces_a_python_traceback():
+    """A native crash must name the Python line, not just exit 245.
+
+    #296 has killed `snap` three times in ~60 fits and every report was a bare
+    exit code, because a SIGSEGV inside numpy/shapely/cv2/torch unwinds no
+    Python frames. faulthandler writes both stacks from the signal handler.
+    """
+    import subprocess
+    import sys
+
+    crash = (
+        "import ctypes\n"
+        "from mapsnap import cli\n"
+        "cli.faulthandler.enable()\n"
+        "ctypes.string_at(0)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", crash], capture_output=True, text=True, check=False
+    )
+    assert result.returncode != 0
+    assert "Fatal Python error" in result.stderr
+    assert "ctypes" in result.stderr

--- a/mapsnap/experiments.py
+++ b/mapsnap/experiments.py
@@ -316,6 +316,35 @@ def is_complete(run_dir: Path) -> bool:
     return (run_dir / "manifest.json").exists()
 
 
+def archive_differs(
+    run_dir: Path, inputs: dict, git: dict, flag_tokens: list[str]
+) -> str | None:
+    """What an existing archive was built from that this run is not, or None.
+
+    Guards the "already archived, skipping" path. With an auto run id the id
+    itself encodes (commit, flags, inputs), so a collision means a genuine
+    match and this always returns None. With an explicit ``--tag`` it does not:
+    the tag is just a name, and re-using one after changing code or reads makes
+    `fit` republish the archived run and present it as the new one.
+
+    Returns a short human phrase naming the FIRST mismatch, for the error
+    message. A manifest that cannot be read counts as differing -- an archive
+    we cannot verify is not one we should silently trust.
+    """
+    try:
+        manifest = json.loads((run_dir / "manifest.json").read_text())
+    except (OSError, ValueError):
+        return "an unreadable manifest"
+    if manifest.get("inputs") != inputs:
+        return "inputs (reads, centerlines or truth)"
+    archived_sha = (manifest.get("git") or {}).get("sha")
+    if archived_sha and git.get("sha") and archived_sha != git["sha"]:
+        return f"a different commit ({archived_sha[:8]})"
+    if (manifest.get("flags") or []) != list(flag_tokens):
+        return "different flags"
+    return None
+
+
 def archive_run(
     dir_path: Path,
     run_id: str,

--- a/mapsnap/experiments_test.py
+++ b/mapsnap/experiments_test.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from mapsnap.experiments import (
+    archive_differs,
     archive_run,
     auto_run_id,
     build_manifest,
@@ -358,3 +359,62 @@ def test_truth_metrics_score_absent_without_centerlines(tmp_path):
     generated.write_text(json.dumps({"items": [item]}))
     metrics = truth_metrics(truth, generated)
     assert "score" not in metrics
+
+
+# --- archive reuse guard ---
+
+
+def _manifest(tmp_path, **over):
+    run = tmp_path / "artifacts" / "run1"
+    run.mkdir(parents=True)
+    doc = {
+        "run_id": "run1",
+        "git": {"sha": "a" * 40},
+        "flags": [],
+        "inputs": {"centerlines_sha": "sha256:abc"},
+    }
+    doc.update(over)
+    _write(run / "manifest.json", json.dumps(doc))
+    return run
+
+
+def test_archive_differs_accepts_a_matching_archive(tmp_path):
+    run = _manifest(tmp_path)
+    assert (
+        archive_differs(run, {"centerlines_sha": "sha256:abc"}, {"sha": "a" * 40}, [])
+        is None
+    )
+
+
+def test_archive_differs_catches_changed_reads(tmp_path):
+    # The incident this exists for: an A/B arm "re-run" under a tag the previous
+    # experiment had archived. fit skipped, and the old run's numbers were
+    # reported as the new arm's until the archives were purged by hand.
+    run = _manifest(tmp_path)
+    reason = archive_differs(
+        run, {"centerlines_sha": "sha256:CHANGED"}, {"sha": "a" * 40}, []
+    )
+    assert reason and "inputs" in reason
+
+
+def test_archive_differs_catches_a_different_commit(tmp_path):
+    run = _manifest(tmp_path)
+    reason = archive_differs(
+        run, {"centerlines_sha": "sha256:abc"}, {"sha": "b" * 40}, []
+    )
+    assert reason and "commit" in reason
+
+
+def test_archive_differs_catches_different_flags(tmp_path):
+    run = _manifest(tmp_path)
+    reason = archive_differs(
+        run, {"centerlines_sha": "sha256:abc"}, {"sha": "a" * 40}, ["--no-snap"]
+    )
+    assert reason and "flags" in reason
+
+
+def test_archive_differs_distrusts_an_unreadable_manifest(tmp_path):
+    run = tmp_path / "artifacts" / "run2"
+    run.mkdir(parents=True)
+    _write(run / "manifest.json", "{not json")
+    assert archive_differs(run, {}, {"sha": "a" * 40}, []) is not None

--- a/mapsnap/fit.py
+++ b/mapsnap/fit.py
@@ -175,6 +175,21 @@ def main() -> None:
     # would skip this run's computation for good and leave the tag permanently
     # empty.
     if experiments.is_complete(archive_dir):
+        # Skipping is only honest when the archived run would produce the same
+        # thing. An auto run id encodes (commit, flags, inputs) so a collision
+        # implies a match, but an explicit --tag is just a name: re-using one
+        # after changing code or reads silently republishes the OLD run and
+        # reports it as this one. That happened -- an A/B arm was "re-run" under
+        # a tag the previous experiment had already archived, and its stale
+        # numbers were reported as new until the archives were purged by hand.
+        stale = experiments.archive_differs(archive_dir, inputs, git, georef_extra)
+        if stale:
+            sys.exit(
+                f"Run {run_id} is already archived at {archive_dir}, but it was "
+                f"produced from different {stale}. Refusing to skip and report "
+                f"that run as this one: choose a new --tag, or delete the "
+                f"archive to recompute."
+            )
         print(f"Run {run_id} already archived at {archive_dir}; skipping computation.")
         return
 

--- a/mapsnap/osm_snap_experiment.py
+++ b/mapsnap/osm_snap_experiment.py
@@ -1138,6 +1138,11 @@ def cmd_candidates(
     else:
         init_worker(volume, vctx)
         for unit in stale:
+            # Which page we are ON, to stderr, before the work starts. The
+            # finished-page line below only prints on success, so a native crash
+            # (#296) would otherwise be attributable only to "the page after the
+            # last one logged". Stderr keeps stdout's parsed format unchanged.
+            print(f"snap: starting {unit.stem}", file=sys.stderr, flush=True)
             record_done(*snap_one_page(unit.stem))
     print(f"{len(stale)} pages computed; {len(existing)} total in {out_path}")
 


### PR DESCRIPTION
Two failure modes that have each cost real time today, both of which were only ever caught because I happened to check an exit code by hand.

## 1. `rc=245` now comes with a traceback (#296)

Three fits died in `snap` today — grand_rapids, richmond, new_orleans_1896 — across ~60 runs. Every report was a bare `rc=245`, because a SIGSEGV inside numpy, shapely, cv2 or torch unwinds no Python frames.

- **`faulthandler.enable()`** in the CLI entry writes the C-level and Python stacks straight to fd 2 from the signal handler, so the next occurrence names the line.
- **stdout is line-buffered.** Piped output is block-buffered by default, so the buffer dies with the process. The crashed runs *looked* like `snap` had produced no output before dying — I nearly reported "it crashes during startup" — when in fact it had simply been lost. Without this the traceback has no context about which page was in flight.
- **`snap: starting <stem>` to stderr** before each page, since snap's per-page line prints only on *success*: otherwise the crashing page is identifiable only as "the one after the last logged". Stderr keeps stdout's parsed format unchanged.

Verified by crashing a real subprocess: exit −11 now yields `Fatal Python error: Segmentation fault` and a full frame list. There's a regression test that does exactly that.

## 2. `fit` refuses to skip an archive built from something else

`fit` already refuses to *archive* a failed run — `run_cmd` exits with the stage's return code, so a segfaulting `snap` never reaches `archive_fit_run`, which is why today's crashed runs left no archive behind. That half was fine.

The open half was the other direction: `is_complete` only checked that a manifest **exists**, so an already-archived tag was skipped unconditionally. An auto run id encodes (commit, flags, inputs) and cannot collide misleadingly, but an explicit `--tag` is just a name. Re-using one after changing code or reads made `fit` print "already archived; skipping" and republish the **old** run as the new one.

That is not hypothetical — it happened during the publication A/B. An arm was "re-run" under a tag the previous experiment had already archived, and its stale numbers were reported as new until the archives were purged by hand.

`archive_differs` compares the archived manifest's inputs, commit and flags against the current run and names the first mismatch; `fit` exits rather than skip. An unreadable manifest counts as differing — an archive that cannot be verified is not one to trust silently.

Verified against a real archive: matching provenance still skips, today's HEAD reports `a different commit (39e64a54)`, a changed centerlines hash reports `inputs (reads, centerlines or truth)`.

## Why both, in one PR

They are the same defect in different clothes: a run that didn't do what its outputs claim, reported as if it had. Between them they would have caught **two of today's three incidents** without anyone remembering to look at `rc`.

1,119 tests (6 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
