### PR TITLE
Buffer the OSM download by 1 km past the relation boundary

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -46,6 +46,8 @@ export interface OsmRelationResponse {
   relation: {
     id: string;
     name: string | null;
+    /** Metres the download was grown past the administrative boundary, if any. */
+    bufferM: number | null;
     ways: [number, number][][];
   } | null;
 }

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -302,9 +302,15 @@ export function registerIiifApi(
           m.geometry.map((p: any) => [p.lon, p.lat] as [number, number]),
         )
         .filter((w: unknown[]) => w.length >= 2);
+      // download-osm records the buffer it used on the saved boundary, so the
+      // ring can say whether it traces the administrative line or the (larger)
+      // area actually downloaded. Absent on volumes fetched before buffering.
+      const bufferRaw = element.tags?.['mapsnap:buffer_m'];
+      const bufferM = bufferRaw == null ? null : Number(bufferRaw);
       return {
         relation: {
           id: name,
+          bufferM: Number.isFinite(bufferM) ? bufferM : null,
           name: element.tags?.name ?? null,
           ways,
         },

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -130,6 +130,7 @@ export function VolumeViewer() {
   const [osmRelation, setOsmRelation] = useState<{
     id: string;
     name: string | null;
+    bufferM: number | null;
     ways: [number, number][][];
   } | null>(null);
   const [adjacencyData, setAdjacencyData] = useState<AdjacencyData | null>(
@@ -491,6 +492,10 @@ export function VolumeViewer() {
             className="rmse-color-control"
             title={`Streets were downloaded from OSM ${osmRelation.id}${
               osmRelation.name ? ` (${osmRelation.name})` : ''
+            }${
+              osmRelation.bufferM
+                ? `, buffered by ${osmRelation.bufferM} m — the ring is the area actually downloaded, not the administrative line`
+                : ' (no buffer — the ring is the administrative boundary itself)'
             }. Pages crossing this ring cover ground whose streets are missing from the vocabulary.`}
           >
             <input
@@ -498,7 +503,13 @@ export function VolumeViewer() {
               checked={showOsmRelation}
               onChange={(e) => setShowOsmRelation(e.target.checked)}
             />
-            OSM boundary
+            {osmRelation.bufferM
+              ? `OSM boundary +${
+                  osmRelation.bufferM >= 1000
+                    ? `${osmRelation.bufferM / 1000} km`
+                    : `${osmRelation.bufferM} m`
+                }`
+              : 'OSM boundary'}
           </label>
         )}
         <div className="opacity-control">

--- a/mapsnap/download_osm.py
+++ b/mapsnap/download_osm.py
@@ -2,8 +2,8 @@
 
 Writes into a volume directory:
 
-    streets.osm.json   the named highways inside the relation
-    r<id>.json         the relation's own boundary geometry
+    streets.osm.json   the named highways inside the relation, plus a buffer
+    r<id>.json         the boundary of the area actually downloaded
 
 The boundary is what the volume viewer draws as a red ring, so a page whose
 ground falls OUTSIDE the download is visible as such -- its streets are absent
@@ -13,12 +13,25 @@ Which boundary belongs to a volume is recorded in its mapsnap.json manifest
 under params.relation, so a leftover r<id>.json from an earlier relation is
 simply ignored rather than needing to be cleaned up.
 
+An administrative relation is not the area a volume maps. Sheets routinely
+cover ground just outside the modern line -- richmond is an independent city
+with no containing county, and its 1925 volume reaches up to 618 m past the
+boundary into Henrico. So the download is buffered by BUFFER_M (default 1 km)
+and `r<id>.json` describes the BUFFERED extent, because that is what the ring
+is claiming: the area whose streets we actually have.
+
+The buffer is deliberately small. Widening it costs same-name ambiguity, not
+just bytes: 5 km around Kings County reaches lower Manhattan, where 165 of 482
+street names already exist in brooklyn vol 1 -- a second numbered grid across
+the river, which is the aliasing behind chicago p53N's 6,735 ft catastrophe.
+
 Usage:
-    python download_osm.py r<relation_id> DIR
+    python download_osm.py r<relation_id> DIR [--buffer-m 1000]
 """
 
 import argparse
 import json
+import math
 import sys
 import time
 import urllib.error
@@ -28,21 +41,41 @@ from pathlib import Path
 
 OVERPASS_URL = "https://overpass-api.de/api/interpreter"
 
+BUFFER_M = 1000.0
+"""How far past the relation to download, in metres.
+
+Richmond's worst page reaches 618 m beyond its city line; 1 km clears every
+affected page in the corpus with margin. Costs +4-7% area on county-seeded
+volumes and +29% on a compact one like Kings County."""
+
+SIMPLIFY_M = 50.0
+"""Douglas-Peucker tolerance for the buffered ring before it goes into an
+Overpass `poly:` filter. A buffered boundary has thousands of vertices and the
+query is a URL-encoded string; 50 m is far below the buffer itself, so it
+cannot pull the edge inside the unbuffered relation."""
+
 MAX_ATTEMPTS = 5  # total Overpass attempts before giving up
 INITIAL_RETRY_DELAY = 2.0  # seconds before the first retry; doubles each attempt
 MAX_RETRY_DELAY = 60.0  # cap on the exponential backoff delay
 
 
-def form_osm_query_relation(relation_id: int) -> str:
-    # relation_id = 1836428  # Orleans Parish
-    # relation_id = 369518  # Kings County aka Brooklyn
-    area_id = 3600000000 + relation_id
-    return f"""[out:json][timeout:120];
+def form_osm_query_polygons(rings: list[list[tuple[float, float]]]) -> str:
+    """Named highways inside any of ``rings`` ((lon, lat) sequences).
 
-area({area_id})->.searchArea;
-
+    A `poly:` filter rather than `area(3600000000 + id)`: the area form can only
+    select the relation exactly, and the point of the buffer is to reach past
+    it. Several rings because buffering a multi-part boundary (islands, or a
+    relation whose parts do not touch) can stay multi-part.
+    """
+    clauses = "\n".join(
+        'way["highway"]["name"](poly:"'
+        + " ".join(f"{lat:.6f} {lon:.6f}" for lon, lat in ring)
+        + '");'
+        for ring in rings
+    )
+    return f"""[out:json][timeout:180];
 (
-way(area.searchArea)["highway"]["name"];
+{clauses}
 );
 out body;
 >;
@@ -61,6 +94,89 @@ def form_relation_geometry_query(relation_id: int) -> str:
 rel({relation_id});
 out geom;
 """
+
+
+def relation_rings(boundary: dict) -> list[list[tuple[float, float]]]:
+    """(lon, lat) rings of a relation's member ways, from an ``out geom`` doc."""
+    element = (boundary.get("elements") or [{}])[0]
+    return [
+        [(p["lon"], p["lat"]) for p in member["geometry"]]
+        for member in element.get("members") or []
+        if member.get("type") == "way" and member.get("geometry")
+    ]
+
+
+def buffered_rings(
+    rings: list[list[tuple[float, float]]], buffer_m: float
+) -> list[list[tuple[float, float]]]:
+    """Outline(s) of ``rings`` grown by ``buffer_m`` metres.
+
+    The member ways are stitched into whatever polygons they form and buffered
+    in a local equirectangular metre frame; a relation whose ways do not close
+    (or that has none) falls back to buffering the lines themselves, which
+    still yields a usable download area rather than nothing.
+    """
+    from shapely.geometry import LineString, MultiPolygon, Polygon
+    from shapely.ops import linemerge, polygonize, unary_union
+
+    lats = [lat for ring in rings for _, lat in ring]
+    lons = [lon for ring in rings for lon, _ in ring]
+    if not lats:
+        return []
+    lat0 = sum(lats) / len(lats)
+    lon0 = sum(lons) / len(lons)
+    kx = 111_320.0 * math.cos(math.radians(lat0))
+    ky = 110_540.0
+    lines = [
+        LineString([((lon - lon0) * kx, (lat - lat0) * ky) for lon, lat in ring])
+        for ring in rings
+        if len(ring) >= 2
+    ]
+    # Stitch the member ways into whatever closed rings they form; a boundary
+    # whose ways do not close still buffers usefully as lines.
+    polygons = list(polygonize(linemerge(lines)))
+    shape = unary_union(polygons) if polygons else unary_union(lines)
+    grown = shape.buffer(buffer_m).simplify(SIMPLIFY_M)
+    parts = list(grown.geoms) if isinstance(grown, MultiPolygon) else [grown]
+    return [
+        [(x / kx + lon0, y / ky + lat0) for x, y in part.exterior.coords]
+        for part in parts
+        if isinstance(part, Polygon)
+    ]
+
+
+def boundary_document(
+    relation_id: int,
+    boundary: dict,
+    rings: list[list[tuple[float, float]]],
+    buffer_m: float,
+) -> dict:
+    """The downloaded area, in the shape the viewer already reads.
+
+    Same schema as an Overpass ``out geom`` relation (one member way per ring)
+    so the overlay needs no change, but the geometry is the BUFFERED outline --
+    the ring has to describe what was actually downloaded, not the
+    administrative line we grew it from.
+    """
+    tags = dict((boundary.get("elements") or [{}])[0].get("tags") or {})
+    tags["mapsnap:buffer_m"] = str(int(buffer_m))
+    return {
+        "elements": [
+            {
+                "type": "relation",
+                "id": relation_id,
+                "tags": tags,
+                "members": [
+                    {
+                        "type": "way",
+                        "role": "outer",
+                        "geometry": [{"lat": lat, "lon": lon} for lon, lat in ring],
+                    }
+                    for ring in rings
+                ],
+            }
+        ]
+    }
 
 
 def download_osm(
@@ -128,6 +244,16 @@ def main() -> None:
         metavar="DIR",
         help="Volume directory to write streets.osm.json and r<id>.json into",
     )
+    parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=BUFFER_M,
+        metavar="M",
+        help=(
+            "Download this far past the relation boundary (default: %(default)s). "
+            "Sheets routinely map ground just outside the modern line."
+        ),
+    )
     parsed = parser.parse_args()
 
     if not (parsed.relation.startswith("r") and parsed.relation[1:].isdigit()):
@@ -138,22 +264,39 @@ def main() -> None:
 
     out_dir = Path(parsed.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    output = out_dir / "streets.osm.json"
-    query = form_osm_query_relation(relation_id)
-    print(f"Querying relation r{relation_id}.", file=sys.stderr)
 
-    print(f"Running Overpass query:\n{query}", file=sys.stderr)
+    # The boundary comes FIRST now: the streets query is a polygon filter built
+    # from it, so the buffer has to exist before we can ask for streets.
+    print(f"Fetching the r{relation_id} boundary.", file=sys.stderr)
+    boundary = download_osm(form_relation_geometry_query(relation_id))
+    rings = relation_rings(boundary)
+    if not rings:
+        sys.exit(f"Error: relation r{relation_id} has no member way geometry")
+    grown = buffered_rings(rings, parsed.buffer_m)
+    if not grown:
+        sys.exit(f"Error: could not buffer r{relation_id}'s boundary")
+    print(
+        f"  {len(rings)} member way(s) -> {len(grown)} ring(s) buffered by "
+        f"{parsed.buffer_m:.0f} m ({sum(len(r) for r in grown)} vertices)",
+        file=sys.stderr,
+    )
+
+    query = form_osm_query_polygons(grown)
     result = download_osm(query)
     n_elements = len(result.get("elements", []))
+    output = out_dir / "streets.osm.json"
     output.write_text(json.dumps(result, indent=2))
     print(f"Wrote {n_elements} elements to {output}", file=sys.stderr)
 
-    boundary = download_osm(form_relation_geometry_query(relation_id))
     boundary_path = out_dir / f"r{relation_id}.json"
-    boundary_path.write_text(json.dumps(boundary, indent=2))
-    members = len((boundary.get("elements") or [{}])[0].get("members", []))
+    boundary_path.write_text(
+        json.dumps(
+            boundary_document(relation_id, boundary, grown, parsed.buffer_m), indent=2
+        )
+    )
     print(
-        f"Wrote the r{relation_id} boundary ({members} ways) to {boundary_path}",
+        f"Wrote the downloaded area ({parsed.buffer_m:.0f} m past r{relation_id}) "
+        f"to {boundary_path}",
         file=sys.stderr,
     )
 

--- a/mapsnap/download_osm_test.py
+++ b/mapsnap/download_osm_test.py
@@ -97,3 +97,65 @@ BOUNDARY = {
         {"type": "relation", "tags": {"name": "Richmond"}, "members": [{"type": "way"}]}
     ]
 }
+
+
+# --- buffering ---
+
+
+def square_relation(size_deg=0.01, lat=37.55):
+    """An `out geom` relation whose member ways form a closed square."""
+    c = [(0.0, lat), (size_deg, lat), (size_deg, lat + size_deg), (0.0, lat + size_deg)]
+    ways = [[c[i], c[(i + 1) % 4]] for i in range(4)]
+    return {
+        "elements": [
+            {
+                "type": "relation",
+                "tags": {"name": "Square"},
+                "members": [
+                    {
+                        "type": "way",
+                        "role": "outer",
+                        "geometry": [{"lat": la, "lon": lo} for lo, la in w],
+                    }
+                    for w in ways
+                ],
+            }
+        ]
+    }
+
+
+def test_buffer_grows_the_boundary_by_roughly_the_requested_metres():
+    from shapely.geometry import Point, Polygon
+
+    rings = dl.relation_rings(square_relation())
+    assert len(rings) == 4  # four member ways, not yet a ring
+    grown = dl.buffered_rings(rings, 1000.0)
+    assert len(grown) == 1
+
+    poly = Polygon(grown[0])
+    original = Polygon([(0.0, 37.55), (0.01, 37.55), (0.01, 37.56), (0.0, 37.56)])
+    assert poly.contains(original)
+    # A point 900 m west of the original edge is inside the buffer; 2.5 km is not.
+    deg_per_m = 1 / (111_320.0 * 0.79)
+    assert poly.contains(Point(-900 * deg_per_m, 37.555))
+    assert not poly.contains(Point(-2500 * deg_per_m, 37.555))
+
+
+def test_boundary_document_describes_the_buffered_extent():
+    # The ring the viewer draws must claim the area actually downloaded, not
+    # the administrative line it was grown from.
+    rings = dl.relation_rings(square_relation())
+    grown = dl.buffered_rings(rings, 1000.0)
+    doc = dl.boundary_document(42, square_relation(), grown, 1000.0)
+    element = doc["elements"][0]
+    assert element["tags"]["mapsnap:buffer_m"] == "1000"
+    assert element["tags"]["name"] == "Square"
+    assert len(element["members"]) == len(grown)
+    # Same schema the viewer already reads: way members carrying geometry.
+    assert all(m["type"] == "way" and m["geometry"] for m in element["members"])
+
+
+def test_poly_query_lists_lat_lon_pairs_per_ring():
+    query = dl.form_osm_query_polygons([[(1.5, 2.5), (3.5, 4.5), (5.5, 6.5)]])
+    assert 'poly:"2.500000 1.500000 4.500000 3.500000 6.500000 5.500000"' in query
+    assert '["highway"]["name"]' in query

--- a/mapsnap/pipeline_loc.py
+++ b/mapsnap/pipeline_loc.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from mapsnap.craft import volume_craft_images
+from mapsnap.download_osm import BUFFER_M
 from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import Step, list_pages, run_cmd, write_run_record
 
@@ -21,6 +22,17 @@ def main() -> None:
     parser.add_argument("dir", metavar="DIR", help="Directory containing manifest.json")
     parser.add_argument(
         "relation", metavar="RELATION", help="OSM relation ID for the street network"
+    )
+    parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=BUFFER_M,
+        metavar="M",
+        help=(
+            "Download streets this far past the relation boundary "
+            "(default: %(default)s). Sheets routinely map ground just outside "
+            "the modern administrative line."
+        ),
     )
     parser.add_argument(
         "--force",
@@ -42,7 +54,13 @@ def main() -> None:
     print(args.dir)
     print(args.relation)
     write_run_record(
-        dir_path, "loc", {"manifest": str(manifest), "relation": args.relation}
+        dir_path,
+        "loc",
+        {
+            "manifest": str(manifest),
+            "relation": args.relation,
+            "buffer_m": str(args.buffer_m),
+        },
     )
 
     step = Step(dir_path, force=args.force)
@@ -62,6 +80,8 @@ def main() -> None:
                 "download-osm",
                 args.relation,
                 str(dir_path),
+                "--buffer-m",
+                str(args.buffer_m),
             ]
         )
 

--- a/mapsnap/pipeline_oim.py
+++ b/mapsnap/pipeline_oim.py
@@ -6,6 +6,7 @@ import urllib.request
 from pathlib import Path
 
 from mapsnap.craft import volume_craft_images
+from mapsnap.download_osm import BUFFER_M
 from mapsnap.keymap.records import recorded_keymap_keys
 from mapsnap.utils import (
     Step,
@@ -58,6 +59,17 @@ def main() -> None:
         "relation", metavar="RELATION", help="OSM relation ID for the street network"
     )
     parser.add_argument(
+        "--buffer-m",
+        type=float,
+        default=BUFFER_M,
+        metavar="M",
+        help=(
+            "Download streets this far past the relation boundary "
+            "(default: %(default)s). Sheets routinely map ground just outside "
+            "the modern administrative line."
+        ),
+    )
+    parser.add_argument(
         "oim_prefix", metavar="OIM_PREFIX", help="OIM URL prefix for image downloads"
     )
     parser.add_argument(
@@ -91,6 +103,7 @@ def main() -> None:
         {
             "sanborn_slug": args.sanborn_slug,
             "relation": args.relation,
+            "buffer_m": str(args.buffer_m),
             "oim_prefix": args.oim_prefix,
         },
     )
@@ -136,6 +149,8 @@ def main() -> None:
                 "download-osm",
                 args.relation,
                 str(dir_path),
+                "--buffer-m",
+                str(args.buffer_m),
             ]
         )
 


### PR DESCRIPTION
An administrative relation is not the area a volume maps. Richmond is an independent city with no containing county, and its 1925 sheets reach up to **618 m past the modern line** into Henrico — so `BENTON`, `VAWTER` and `FENWICK`, the north–south streets of p383, appeared nowhere in its 2,294-entry `streets.txt` and the page could not be fit at all. Not a weak fit: an impossible one.

## The change

The streets query becomes a `poly:` filter over the buffered boundary instead of `area(3600000000 + id)`, which can only ever select the relation exactly. So the boundary is fetched **first** and the buffer built from it (shapely, in a local metre frame, simplified to 50 m so the query stays a sane length).

`r<id>.json` records the **buffered** outline, tagged `mapsnap:buffer_m` — the ring #308 draws has to claim the area actually downloaded, not the line it grew from, or it misstates the extent in the opposite direction from the bug it exists to expose. `run-loc`/`run-oim` take `--buffer-m` and record it in `mapsnap.json` under `params.buffer_m`.

Volumes fetched before this keep working and are labelled honestly: richmond reports `bufferM=1000` with one 107-vertex ring, fargo `bufferM=null` with its 138 raw member ways. The viewer's checkbox reads "OSM boundary +1 km" or plain "OSM boundary" accordingly.

## Why 1 km and not 5

The cost of a wider buffer is **same-name ambiguity, not bytes**. 5 km around Kings County grows it 162% and reaches lower Manhattan, where **165 of 482 street names already exist in brooklyn vol 1** — a second complete numbered grid across the river, which is the aliasing behind chicago p53N's 6,735 ft catastrophe. 1 km clears richmond's worst page with 60% margin and costs +4–7% area on county-seeded volumes.

## Measured on richmond: +0.69, and smaller than I predicted

Same code, same seed, only the street network differs:

| | score | placed |
|---|---|---|
| before (city relation) | 76.64 | 85/92 |
| after (+1 km) | **77.33** | **87/92** |

| page | before | after | |
|---|---|---|---|
| **p383__1** | unplaced | **8.7 ft** | the target case — its streets now exist |
| p382 | 22.9 | 18.5 | |
| p384 | 20.0 | 17.3 | |
| p379 | 6.5 | 6.5 | unchanged |
| p378 | unplaced | unplaced | still |
| **p380** | 16.0 | **68.6** | regression |
| **p383__2** | unplaced | **1,631 ft** | now placed, wrongly |

**I had projected ~5.3 volume-points and that model was wrong.** It counted the *weight at risk* — every page not fully inside the relation — as though all of it would reach ≤25 ft. Three of the seven were already fitting fine at 6–23 ft, and more vocabulary does nothing for a page that already had enough. Meanwhile the extra 1,081 street names bring new same-name candidates, which is why p380 and p383__2 got worse: the ambiguity cost I argued against at 5 km is visible at 1 km too, just small enough to be outweighed.

So: the buffer fixes the class of failure it was built for (a page with **no** streets), on the one volume in eighteen that needed it, and adds a little aliasing noise. Worth having and cheap; not several points.

**p383__2 is worth a look before this is called finished** — it moved from unplaced to a 1,631 ft disaster, and a disaster subtracts where an unplaced page is neutral.

## Scope

Surveyed all 18 volumes by point-in-polygon: richmond is the only one materially affected. Fargo's and brooklyn's apparent overhangs are slivers over the Red River and the harbour respectively — **0 named ways** under them, confirmed by querying OSM inside the exact polygons rather than their bounding boxes.

## Verified

1,113 tests (3 new: buffer distance, the boundary document describing the buffered extent, the poly query's lat/lon ordering), ruff/pyright/prettier clean. Offline against richmond's truth: 10 pages not fully covered at 0 m, **0 at both 650 m and 1 km**. Live: 21 member ways → one 107-vertex ring, 84,612 elements, vocabulary 2,294 → 3,218 names, and all three of p383's streets present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
