### PR TITLE
Eight small debugger fixes

### DIFF
--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -125,7 +125,16 @@ export type AdjacencyLabelsResponse = LabelsWriteRequest | { exists: false };
  * none rather than failing.
  */
 export interface FailedGeorefsResponse {
-  failed: Record<string, string>;
+  /**
+   * Page stem → every `<stem>.georef*.json` sidecar it has, sorted.
+   *
+   * Was a single "failure kind" per stem, decoded from the filename. #270
+   * phase 3 collapsed those suffixes into a `status` field inside one sidecar
+   * per channel, so the name no longer says anything about failure -- and the
+   * old pattern started matching `-final`/`-snap`/`-street`, i.e. every page.
+   * The viewer lists what is there and lets each file speak for itself (#252).
+   */
+  georefs: Record<string, string[]>;
   pages?: string[];
 }
 

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -167,6 +167,14 @@ export interface RunArtifactsResponse {
   stems: string[];
 }
 
+/** One volume's OIM identity, for linking out to the truth source. */
+export interface OimLink {
+  /** Map slug, e.g. "sanborn09064_008". */
+  slug: string;
+  /** The volume's page on oldinsurancemaps.net. */
+  url: string;
+}
+
 /** Response of GET /iiif-api/keymaps — a volume's key-map sheets, for the info-panel links. */
 export interface KeymapsResponse {
   keymaps: KeymapInfo[];

--- a/app/server/iiifAnnotations.ts
+++ b/app/server/iiifAnnotations.ts
@@ -75,6 +75,8 @@ export interface AnnotationFileInfo {
 
 /** A volume directory with local page images and georeference annotations. */
 export interface VolumeInfo {
+  /** OIM map slug from main.iiif.json's mosaic id, when the volume has truth. */
+  oimSlug?: string;
   name: string;
   pageCount: number;
   annotations: AnnotationFileInfo[];

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -42,6 +42,31 @@ const PAGE_IMAGE_PATTERN = /^p\d+[a-z]?\.jpg$/i;
 const FAILED_GEOREF_PATTERN = /^(.+)\.georef-([a-z0-9]+)\.json$/i;
 
 // Read a *.iiif.json if it is a georeference AnnotationPage, else null.
+/**
+ * Item counts for annotation files, keyed by path and invalidated by mtime.
+ *
+ * The volume list parses every `*.iiif.json` under data/ purely to show an item
+ * count beside each file: 633 files and 175 MB of JSON at the time of writing,
+ * about half a second, on every request. Counts cannot change without the file
+ * changing, so a stat is enough to reuse one (#288).
+ */
+const itemCountCache = new Map<
+  string,
+  { mtimeMs: number; itemCount: number }
+>();
+
+async function annotationItemCount(
+  path: string,
+  mtimeMs: number,
+): Promise<number | null> {
+  const hit = itemCountCache.get(path);
+  if (hit && hit.mtimeMs === mtimeMs) return hit.itemCount;
+  const page = await readAnnotationPage(path);
+  if (!page) return null;
+  itemCountCache.set(path, { mtimeMs, itemCount: page.items.length });
+  return page.items.length;
+}
+
 async function readAnnotationPage(
   path: string,
 ): Promise<GeorefAnnotationPage | null> {
@@ -105,27 +130,42 @@ export function registerIiifApi(
   // page images (#228). It stops at the first page-bearing directory on a branch,
   // so a volume's own `raw/` is never listed as a volume.
   router.get('/iiif-api/volumes', async () => {
-    const volumes: VolumeInfo[] = [];
-    for (const name of await findVolumes(dataDir)) {
-      const files = await readdir(join(dataDir, name));
-      const pageCount = files.filter((f) => PAGE_IMAGE_PATTERN.test(f)).length;
-      if (pageCount === 0) continue;
-      const annotations: AnnotationFileInfo[] = [];
-      for (const file of files.filter((f) => f.endsWith('.iiif.json'))) {
-        const path = join(dataDir, name, file);
-        const page = await readAnnotationPage(path);
-        if (!page) continue;
-        const { mtimeMs } = await stat(path);
-        annotations.push({
-          name: file,
-          modifiedMs: Math.round(mtimeMs),
-          itemCount: page.items.length,
-        });
-      }
-      if (annotations.length === 0) continue;
-      annotations.sort((a, b) => b.modifiedMs - a.modifiedMs);
-      volumes.push({ name, pageCount, annotations });
-    }
+    // Every volume, and every annotation within it, is read CONCURRENTLY.
+    // Serially this walked ~18 volumes x several annotation files each,
+    // parsing every one in full for its item count, and took long enough that
+    // the volume picker arrived after the map had drawn (#288).
+    const names = await findVolumes(dataDir);
+    const built = await Promise.all(
+      names.map(async (name): Promise<VolumeInfo | null> => {
+        const files = await readdir(join(dataDir, name));
+        const pageCount = files.filter((f) =>
+          PAGE_IMAGE_PATTERN.test(f),
+        ).length;
+        if (pageCount === 0) return null;
+        const annotations = (
+          await Promise.all(
+            files
+              .filter((f) => f.endsWith('.iiif.json'))
+              .map(async (file): Promise<AnnotationFileInfo | null> => {
+                const path = join(dataDir, name, file);
+                const info = await stat(path);
+                const itemCount = await annotationItemCount(path, info.mtimeMs);
+                return itemCount === null
+                  ? null
+                  : {
+                      name: file,
+                      modifiedMs: Math.round(info.mtimeMs),
+                      itemCount,
+                    };
+              }),
+          )
+        ).filter((a): a is AnnotationFileInfo => a !== null);
+        if (annotations.length === 0) return null;
+        annotations.sort((a, b) => b.modifiedMs - a.modifiedMs);
+        return { name, pageCount, annotations };
+      }),
+    );
+    const volumes = built.filter((v): v is VolumeInfo => v !== null);
     volumes.sort((a, b) => a.name.localeCompare(b.name));
     return { volumes };
   });

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -52,19 +52,40 @@ const GEOREF_SIDECAR_PATTERN = /^(.+)\.georef(?:-[a-z0-9-]+)?\.json$/i;
  */
 const itemCountCache = new Map<
   string,
-  { mtimeMs: number; itemCount: number }
+  { mtimeMs: number; itemCount: number; oimSlug?: string }
 >();
 
-async function annotationItemCount(
+/**
+ * OIM map slug from a truth file's mosaic id, e.g.
+ * ".../iiif/mosaic/sanborn09064_008/main-content/" -> "sanborn09064_008".
+ *
+ * Only the VOLUME is derivable offline. A per-page link would need OIM's
+ * document id, and the annotation's own id is a IIIF resource id in a
+ * different namespace: richmond p315 is resource 81359, and OIM's own page for
+ * 81359 is a different sheet entirely (#298).
+ */
+function oimSlugOf(page: GeorefAnnotationPage): string | undefined {
+  const id = (page as { id?: unknown }).id;
+  const match =
+    typeof id === 'string' ? id.match(/\/iiif\/mosaic\/([^/]+)\//) : null;
+  return match?.[1];
+}
+
+async function annotationFacts(
   path: string,
   mtimeMs: number,
-): Promise<number | null> {
+): Promise<{ itemCount: number; oimSlug?: string } | null> {
   const hit = itemCountCache.get(path);
-  if (hit && hit.mtimeMs === mtimeMs) return hit.itemCount;
+  if (hit && hit.mtimeMs === mtimeMs) return hit;
   const page = await readAnnotationPage(path);
   if (!page) return null;
-  itemCountCache.set(path, { mtimeMs, itemCount: page.items.length });
-  return page.items.length;
+  const facts = {
+    mtimeMs,
+    itemCount: page.items.length,
+    oimSlug: oimSlugOf(page),
+  };
+  itemCountCache.set(path, facts);
+  return facts;
 }
 
 async function readAnnotationPage(
@@ -142,6 +163,7 @@ export function registerIiifApi(
           PAGE_IMAGE_PATTERN.test(f),
         ).length;
         if (pageCount === 0) return null;
+        let oimSlug: string | undefined;
         const annotations = (
           await Promise.all(
             files
@@ -149,20 +171,22 @@ export function registerIiifApi(
               .map(async (file): Promise<AnnotationFileInfo | null> => {
                 const path = join(dataDir, name, file);
                 const info = await stat(path);
-                const itemCount = await annotationItemCount(path, info.mtimeMs);
-                return itemCount === null
-                  ? null
-                  : {
-                      name: file,
-                      modifiedMs: Math.round(info.mtimeMs),
-                      itemCount,
-                    };
+                const facts = await annotationFacts(path, info.mtimeMs);
+                if (!facts) return null;
+                if (file === 'main.iiif.json' && facts.oimSlug) {
+                  oimSlug = facts.oimSlug;
+                }
+                return {
+                  name: file,
+                  modifiedMs: Math.round(info.mtimeMs),
+                  itemCount: facts.itemCount,
+                };
               }),
           )
         ).filter((a): a is AnnotationFileInfo => a !== null);
         if (annotations.length === 0) return null;
         annotations.sort((a, b) => b.modifiedMs - a.modifiedMs);
-        return { name, pageCount, annotations };
+        return { name, pageCount, annotations, oimSlug };
       }),
     );
     const volumes = built.filter((v): v is VolumeInfo => v !== null);

--- a/app/server/iiifRoutes.ts
+++ b/app/server/iiifRoutes.ts
@@ -39,7 +39,7 @@ const PAGE_IMAGE_PATTERN = /^p\d+[a-z]?\.jpg$/i;
 
 // A failed-georef sidecar name -> [full, stem, kind], e.g.
 // "p1452.georef-nofit.json" -> ["…", "p1452", "nofit"].
-const FAILED_GEOREF_PATTERN = /^(.+)\.georef-([a-z0-9]+)\.json$/i;
+const GEOREF_SIDECAR_PATTERN = /^(.+)\.georef(?:-[a-z0-9-]+)?\.json$/i;
 
 // Read a *.iiif.json if it is a georeference AnnotationPage, else null.
 /**
@@ -354,11 +354,10 @@ export function registerIiifApi(
     }
   });
 
-  // A volume's page files: every page-image stem, plus the ones with a failed-georef
-  // sidecar and that sidecar's kind, so the viewer can link an un-georeferenced page to
-  // its georef-<kind>.json file and — for a volume with no truth annotation — work out
-  // which pages went unplaced at all. ?volume=<dir> →
-  // { pages: ["p1", …], failed: { "p1452": "nofit", "p1427": "misscale" } }.
+  // A volume's page files: every page-image stem, plus every georef sidecar each
+  // page has, so the viewer can link to all of them and — for a volume with no
+  // truth annotation — work out which pages went unplaced. ?volume=<dir> →
+  // { pages: ["p1", …], georefs: { "p12": ["p12.georef.json", "p12.georef-snap.json"] } }.
   router.get('/iiif-api/failed-georefs', async (_params, request) => {
     const { volume } = request.query;
     if (!isSafeVolume(volume)) {
@@ -370,17 +369,19 @@ export function registerIiifApi(
     } catch {
       throw new HTTPError(404, `no such volume: ${volume}`);
     }
-    const failed: Record<string, string> = {};
+    const georefs: Record<string, string[]> = {};
     for (const file of files) {
-      const match = file.match(FAILED_GEOREF_PATTERN);
-      // First kind wins if a page somehow has more than one failed sidecar.
-      if (match && match[1] && match[2] && !(match[1] in failed)) {
-        failed[match[1]] = match[2].toLowerCase();
-      }
+      const match = file.match(GEOREF_SIDECAR_PATTERN);
+      if (match && match[1]) (georefs[match[1]] ??= []).push(file);
+    }
+    // Plain `georef.json` first, then the variants alphabetically, so the
+    // RANSAC fit heads the list and the channels follow in a stable order.
+    for (const list of Object.values(georefs)) {
+      list.sort((a, b) => a.length - b.length || a.localeCompare(b));
     }
     // volumePages drops a split sheet in favour of its panels, so a sheet whose panels
     // all fitted is not reported as an unplaced page.
-    return { failed, pages: await volumePages(dataDir, volume) };
+    return { georefs, pages: await volumePages(dataDir, volume) };
   });
 
   // A volume's key-map sheets and which visualization sidecars each has, so the viewer can link

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -390,6 +390,12 @@ export function DebugView({ files: filesProp, onClose }: DebugViewProps = {}) {
     };
   }, [selectedPair, activePair, streets.length]);
 
+  // Substring search over detection text. Key-map sheets bypass the size and
+  // confidence filters entirely (their page numbers are not street reads), which
+  // left that view with no way to narrow a long list at all (#245); a text box
+  // serves both modes.
+  const [textFilter, setTextFilter] = useState('');
+
   const filteredDetections = useMemo(
     // Key-map page numbers are not street reads and never face georef's
     // admission gate, so they are shown unfiltered rather than judged by
@@ -400,6 +406,15 @@ export function DebugView({ files: filesProp, onClose }: DebugViewProps = {}) {
         : filterDetections(detections, filters),
     [detections, filters, keymapSheet],
   );
+
+  const shownDetections = useMemo(() => {
+    const needle = textFilter.trim().toLowerCase();
+    return needle
+      ? filteredDetections.filter(({ det }) =>
+          det.text.toLowerCase().includes(needle),
+        )
+      : filteredDetections;
+  }, [filteredDetections, textFilter]);
 
   // Boxes mode: apply the short/long-side sliders, then hide the toggled-off rotations.
   // The angle checkboxes count from the side-filtered set so the numbers track the sliders,
@@ -831,8 +846,25 @@ export function DebugView({ files: filesProp, onClose }: DebugViewProps = {}) {
           </>
         )}
         {mode === 'streets' && (
+          <div className="filter-row detection-text-filter">
+            <label htmlFor="detection-text-filter">Filter text:</label>
+            <input
+              id="detection-text-filter"
+              type="search"
+              value={textFilter}
+              placeholder="e.g. BROAD"
+              onChange={(e) => setTextFilter(e.target.value)}
+            />
+            {textFilter.trim() && (
+              <span className="filter-count">
+                {shownDetections.length} of {filteredDetections.length}
+              </span>
+            )}
+          </div>
+        )}
+        {mode === 'streets' && (
           <DetectionsTable
-            detections={filteredDetections}
+            detections={shownDetections}
             selectedIndices={selectedIndices}
             onSelect={(index) => setSelectedIndices(new Set([index]))}
             image={imageEl}

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -80,6 +80,8 @@ interface InfoPanelProps {
   /** The compare table's summary footer, shown in the no-selection view; "" if none. */
   compareFooter: string;
   /** The volume's key-map sheets, linked to their visualizations in the no-selection view. */
+  /** OIM map slug for the volume, when its truth came from there (#298). */
+  oimSlug: string | null;
   keymaps: KeymapInfo[];
   /** Volume directory name, e.g. "brooklyn_ny_1906_vol_6". */
   volume: string;
@@ -216,6 +218,7 @@ export function InfoPanel(props: InfoPanelProps) {
     selectedNote,
     hasAdjacency,
     compareFooter,
+    oimSlug,
     keymaps,
     volume,
     runArtifacts,
@@ -399,6 +402,19 @@ export function InfoPanel(props: InfoPanelProps) {
           {median(pages.map((p) => p.scalePixelsPerFoot)).toFixed(2)} px/ft
         </dd>
       </dl>
+      {oimSlug && (
+        <div className="page-info-keymaps">
+          Truth source:{' '}
+          <a
+            href={`https://oldinsurancemaps.net/map/${oimSlug}`}
+            target="_blank"
+            rel="noreferrer"
+            title="This volume on oldinsurancemaps.net, where the truth georeferences were made"
+          >
+            OIM {oimSlug} ↗
+          </a>
+        </div>
+      )}
       {keymaps.length > 0 && (
         <div className="page-info-keymaps">
           Keymaps:{' '}

--- a/app/src/components/InfoPanel.tsx
+++ b/app/src/components/InfoPanel.tsx
@@ -64,10 +64,13 @@ interface InfoPanelProps {
   /** Whether the selected page is a missing (un-fitted) truth page. */
   selectedMissing: boolean;
   /**
-   * Failure kind of the selected page's failed-georef sidecar ("nofit"/"1gcp"/…),
-   * or null when it has none; drives the georef-view link for a missing page.
+   * Every `<stem>.georef*.json` the selected page has, plain first.
+   *
+   * A page can have several -- the RANSAC fit, the snap and street channels,
+   * and the arbiter's answer -- and which ones exist is itself informative, so
+   * they are all linked rather than guessed at from the page's status (#252).
    */
-  selectedFailedGeorefType: string | null;
+  selectedGeorefFiles: string[];
   /** Truth-compare stats for the selected page, when the volume has truth. */
   selectedStats: PageCompareStats | null;
   /** The selected page's note text, or null when it has none. */
@@ -208,7 +211,7 @@ export function InfoPanel(props: InfoPanelProps) {
     annotationName,
     selectedPage,
     selectedMissing,
-    selectedFailedGeorefType,
+    selectedGeorefFiles,
     selectedStats,
     selectedNote,
     hasAdjacency,
@@ -230,35 +233,25 @@ export function InfoPanel(props: InfoPanelProps) {
     // the image and its sidecar cannot share a base path.
     const fromRun = !!runArtifacts?.stems.includes(selectedPage.stem);
     const imageBase = `data/${volume}/${selectedPage.stem}`;
-    const sidecarBase = fromRun
-      ? `${runArtifacts!.dir}/${selectedPage.stem}`
-      : imageBase;
+    const sidecarDir = fromRun ? runArtifacts!.dir! : `data/${volume}`;
+    const sidecarBase = `${sidecarDir}/${selectedPage.stem}`;
 
-    // A not-georeferenced page has no `<stem>.georef.json`; it has whichever
-    // failure sidecar the fit wrote, so link that instead of a missing file.
-    const georefFiles = selectedMissing
-      ? selectedFailedGeorefType
-        ? [
-            `${imageBase}.jpg`,
-            `${sidecarBase}.georef-${selectedFailedGeorefType}.json`,
-          ]
-        : null
-      : [`${imageBase}.jpg`, `${sidecarBase}.georef.json`];
+    // One entry per georef sidecar the page actually has. The label is the
+    // variant ("georef", "georef-snap", …) so the list doubles as a readout of
+    // which channels produced a pose for this page. The filenames come from the
+    // volume root; when a run is selected they are looked for in its archive,
+    // which may hold fewer -- that link 404s visibly rather than silently
+    // resolving to another run's file.
+    const georefViews = selectedGeorefFiles.map((file) => ({
+      label: `${file.slice(selectedPage.stem.length + 1, -'.json'.length)} view`,
+      files: [`${imageBase}.jpg`, `${sidecarDir}/${file}`],
+    }));
     const debugViews: { label: string; files: string[] }[] = [
       {
         label: 'streets view',
         files: [`${imageBase}.jpg`, `${sidecarBase}.streets.json`],
       },
-      ...(georefFiles
-        ? [
-            {
-              label: selectedMissing
-                ? `georef view (${selectedFailedGeorefType})`
-                : 'georef view',
-              files: georefFiles,
-            },
-          ]
-        : []),
+      ...georefViews,
       ...(hasAdjacency
         ? [
             {

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -598,13 +598,28 @@ export function VolumeMap(props: VolumeMapProps) {
     }
     const features = props.pages
       .filter((page) => props.pageColors?.has(page.itemIndex))
+      // Isolating hides every other page's warped image, so leaving their
+      // colour fills drawn buries the isolated page under overlays belonging
+      // to sheets that are no longer visible (#287).
+      .filter(
+        (page) =>
+          !isolateSelected ||
+          selectedItemIndex === null ||
+          page.itemIndex === selectedItemIndex,
+      )
       .map((page): FeatureCollection['features'][0] => ({
         type: 'Feature',
         properties: { color: props.pageColors?.get(page.itemIndex) },
         geometry: { type: 'Polygon', coordinates: [page.clipRing] },
       }));
     source.setData({ type: 'FeatureCollection', features });
-  }, [props.pageColors, props.pages, mapReady]);
+  }, [
+    props.pageColors,
+    props.pages,
+    isolateSelected,
+    selectedItemIndex,
+    mapReady,
+  ]);
 
   // Adjacency claim boxes, one polygon per claim. `mutual` drives the colour; `onSelectedPage`
   // (true for every claim when nothing is selected) drives filled-vs-dashed in the layer paint.

--- a/app/src/components/VolumeMap.tsx
+++ b/app/src/components/VolumeMap.tsx
@@ -322,6 +322,31 @@ export function VolumeMap(props: VolumeMapProps) {
           'line-dasharray': [2, 2],
         },
       });
+      // The OTHER panels of a selected split sheet, greyed out. Added before
+      // the selection layers so it draws beneath them: selecting one panel of a
+      // sheet otherwise gives no clue where the cut runs, since the neighbouring
+      // panel looks like more of the same map (#303).
+      map.addSource('sibling-panels', {
+        type: 'geojson',
+        data: EMPTY_FEATURES,
+      });
+      map.addLayer({
+        id: 'sibling-panels-fill',
+        type: 'fill',
+        source: 'sibling-panels',
+        paint: { 'fill-color': '#111827', 'fill-opacity': 0.45 },
+      });
+      map.addLayer({
+        id: 'sibling-panels-outline',
+        type: 'line',
+        source: 'sibling-panels',
+        paint: {
+          'line-color': '#111827',
+          'line-width': 1,
+          'line-dasharray': [3, 2],
+          'line-opacity': 0.8,
+        },
+      });
       map.addSource('selected-page', {
         type: 'geojson',
         data: EMPTY_FEATURES,
@@ -486,6 +511,10 @@ export function VolumeMap(props: VolumeMapProps) {
     // Nothing to outline for a miss known only by name (a truth-less volume's).
     if (!page || !hasFootprint(page)) {
       source?.setData(EMPTY_FEATURES);
+      // Deselecting must clear the grey too, or it stays over the sheet.
+      map
+        .getSource<maplibregl.GeoJSONSource>('sibling-panels')
+        ?.setData(EMPTY_FEATURES);
       return;
     }
     // A fitted page (non-negative id) shows the truth box(es) sharing its page key beneath its
@@ -497,6 +526,28 @@ export function VolumeMap(props: VolumeMapProps) {
             .map((truth) => truth.rectRing)
         : [];
     source?.setData(selectionFeatures(page, truthRings));
+
+    // Grey the sheet's other panels so the cut is visible. Keyed on pageKey,
+    // which splits share, and only for a page that is itself a panel.
+    const siblings = map.getSource<maplibregl.GeoJSONSource>('sibling-panels');
+    siblings?.setData(
+      page.splitIndex === null
+        ? EMPTY_FEATURES
+        : {
+            type: 'FeatureCollection',
+            features: pages
+              .filter(
+                (other) =>
+                  other.pageKey === page.pageKey &&
+                  other.itemIndex !== page.itemIndex,
+              )
+              .map((other): FeatureCollection['features'][0] => ({
+                type: 'Feature',
+                properties: {},
+                geometry: { type: 'Polygon', coordinates: [other.clipRing] },
+              })),
+          },
+    );
     const mapId = mapIdsRef.current[page.itemIndex];
     if (mapId) {
       layer.bringMapsToFront([mapId]);

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -137,8 +137,8 @@ export function VolumeViewer() {
   );
   // Page key → note text for the selected volume (markers + tooltip).
   const [notes, setNotes] = useState<Map<string, string>>(new Map());
-  // Page stem → failed-georef kind ("nofit"/"1gcp"/…) for the selected volume.
-  const [failedGeorefs, setFailedGeorefs] = useState<Map<string, string>>(
+  // Page stem → its georef sidecars, for the selected volume.
+  const [georefSidecars, setGeorefSidecars] = useState<Map<string, string[]>>(
     new Map(),
   );
   // Every page-image stem in the selected volume; the un-fit list for a volume with
@@ -221,14 +221,14 @@ export function VolumeViewer() {
   const selection = parseAnnotationPath(selectedPath);
   const selectedVolume = volumes?.find((v) => v.name === selection?.volume);
 
-  // Load the selected volume's page notes, failed-georef sidecars, and adjacency data: the
-  // notes drive the list markers/tooltip, the failed-georefs the missing-page links, the
+  // Load the selected volume's page notes, georef sidecars, and adjacency data: the
+  // notes drive the list markers/tooltip, the sidecars the per-page georef links, the
   // adjacency the claim overlay.
   const volumeName = selection?.volume;
   useEffect(() => {
     if (!volumeName) {
       setNotes(new Map());
-      setFailedGeorefs(new Map());
+      setGeorefSidecars(new Map());
       setAdjacencyData(null);
       setOsmRelation(null);
       setKeymaps([]);
@@ -257,14 +257,14 @@ export function VolumeViewer() {
         if (!cancelled) setNotes(new Map());
       });
     fetchVolumePageFiles(volumeName)
-      .then(({ stems, failed }) => {
+      .then(({ stems, georefs }) => {
         if (cancelled) return;
-        setFailedGeorefs(failed);
+        setGeorefSidecars(georefs);
         setVolumeStems(stems);
       })
       .catch(() => {
         if (cancelled) return;
-        setFailedGeorefs(new Map());
+        setGeorefSidecars(new Map());
         setVolumeStems([]);
       });
     setAdjacencyData(null);
@@ -575,8 +575,8 @@ export function VolumeViewer() {
           annotationName={selection?.file ?? null}
           selectedPage={selectedPage}
           selectedMissing={selectedIsMissing}
-          selectedFailedGeorefType={
-            selectedPage ? (failedGeorefs.get(selectedPage.stem) ?? null) : null
+          selectedGeorefFiles={
+            selectedPage ? (georefSidecars.get(selectedPage.stem) ?? []) : []
           }
           selectedStats={
             selectedItemIndex === null

--- a/app/src/components/VolumeViewer.tsx
+++ b/app/src/components/VolumeViewer.tsx
@@ -588,6 +588,7 @@ export function VolumeViewer() {
           }
           hasAdjacency={adjacencyData !== null}
           compareFooter={compareFooter}
+          oimSlug={selectedVolume?.oimSlug ?? null}
           keymaps={keymaps}
           volume={selection?.volume ?? ''}
           onClose={() => setSelectedStem(null)}

--- a/app/src/iiif/api.ts
+++ b/app/src/iiif/api.ts
@@ -27,16 +27,17 @@ export function fetchRewrittenAnnotation(
   return api.get('/iiif-api/annotation')(null, { path });
 }
 
-/** A volume's page-image stems, and which of them have a failed-georef sidecar. */
+/** A volume's page-image stems, and every georef sidecar each page has. */
 export interface VolumePageFiles {
   /** Every page-image stem, split sheets represented by their panels. */
   stems: string[];
   /** Page stem → failure kind ("nofit", "1gcp", …), for linking to the georef view. */
-  failed: Map<string, string>;
+  /** Page stem → its `<stem>.georef*.json` sidecars, plain first (#252). */
+  georefs: Map<string, string[]>;
 }
 
 /**
- * Fetch a volume's page files: the stems on disk plus the failed-georef sidecars.
+ * Fetch a volume's page files: the stems on disk plus their georef sidecars.
  *
  * An older server omits `pages`; the stems then come back empty, which costs the
  * un-fit listing on truth-less volumes rather than taking the viewer down.
@@ -44,10 +45,13 @@ export interface VolumePageFiles {
 export async function fetchVolumePageFiles(
   volume: string,
 ): Promise<VolumePageFiles> {
-  const { failed, pages } = await api.get('/iiif-api/failed-georefs')(null, {
+  const { georefs, pages } = await api.get('/iiif-api/failed-georefs')(null, {
     volume,
   });
-  return { stems: pages ?? [], failed: new Map(Object.entries(failed)) };
+  return {
+    stems: pages ?? [],
+    georefs: new Map(Object.entries(georefs ?? {})),
+  };
 }
 
 /**

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -504,7 +504,10 @@ tr.on-fill td {
    the page itself never scrolls, capped in width with its own horizontal
    scroll when the truth columns overflow. */
 .page-list {
-  max-width: 20rem;
+  /* FIXED, not max-: the column set changes between a truth annotation (no
+     compare columns) and a run (several), and a list that resizes with it
+     shifts the map beside it, so the two cannot be visually compared (#289). */
+  width: 20rem;
   max-height: 90vh;
   flex-shrink: 0;
   overflow: auto;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -873,3 +873,21 @@ tr.relaxed {
 .debug-view-newtab:hover {
   opacity: 1;
 }
+
+/* Text search over the detections table. Sits above it in streets mode; the
+   count appears only while filtering, so the row stays quiet when unused. */
+.detection-text-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+  font-family: sans-serif;
+  font-size: 0.85rem;
+}
+.detection-text-filter input {
+  flex: 0 1 12rem;
+  padding: 0.2rem 0.4rem;
+}
+.detection-text-filter .filter-count {
+  color: #666;
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -67,7 +67,13 @@ function serveDataDir(): Plugin {
         }
 
         fs.stat(filePath, (err, stat) => {
-          if (err || !stat.isFile()) return next();
+          if (err || !stat.isFile()) {
+            // A missing data file is a 404, not the app. Falling through sent
+            // index.html with a 200, so a typo'd or stale data URL looked like
+            // a successful fetch of HTML (#241).
+            res.statusCode = 404;
+            return res.end(`Not found: ${pathname}`);
+          }
           res.setHeader('Content-Type', contentTypeFor(filePath));
           fs.createReadStream(filePath).pipe(res);
         });
@@ -76,9 +82,61 @@ function serveDataDir(): Plugin {
   };
 }
 
+/**
+ * 404 for file-looking URLs nothing served, instead of the SPA fallback.
+ *
+ * Vite answers any unmatched path with index.html and a 200, which is right
+ * for an app that routes on the path -- this one routes on the query string,
+ * so every extension-bearing URL that reaches the fallback is a mistake, and
+ * silently returning HTML makes it look like a successful fetch (#241).
+ *
+ * Runs BEFORE Vite's own middlewares (a post hook would sit after the fallback
+ * and never see these), so it must skip anything Vite legitimately serves:
+ * its internal endpoints, and real files under the app root or public/.
+ */
+function notFoundForMissingFiles(): Plugin {
+  return {
+    name: 'not-found-for-missing-files',
+    configureServer(server) {
+      const base = server.config.base;
+      const appRoot = server.config.root;
+      const publicDir = server.config.publicDir;
+      server.middlewares.use((req, res, next) => {
+        if (!req.url) return next();
+        const pathname = decodeURIComponent(
+          new URL(req.url, 'http://localhost').pathname,
+        );
+        const rel = pathname.startsWith(base)
+          ? pathname.slice(base.length)
+          : pathname.replace(/^\//, '');
+        // Extensionless paths are app entry points; let the fallback have them.
+        if (!path.extname(rel)) return next();
+        // Vite internals: /@vite/client, /@fs/..., /@id/..., node_modules, and
+        // the source tree it compiles on the fly.
+        if (/^(@|node_modules\/|src\/|\.vite\/)/.test(rel)) return next();
+        // data/ has its own handler above, which 404s on its own.
+        if (rel.startsWith('data/')) return next();
+        for (const dir of [appRoot, publicDir]) {
+          if (!dir) continue;
+          const candidate = path.join(dir, rel);
+          if (
+            (candidate === dir || candidate.startsWith(dir + path.sep)) &&
+            fs.existsSync(candidate) &&
+            fs.statSync(candidate).isFile()
+          ) {
+            return next();
+          }
+        }
+        res.statusCode = 404;
+        res.end(`Not found: ${pathname}`);
+      });
+    },
+  };
+}
+
 export default defineConfig({
   base: '/mapsnap/',
-  plugins: [react(), serveDataDir()],
+  plugins: [react(), serveDataDir(), notFoundForMissingFiles()],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
Eight independent debugger fixes, each verified against the running app.

## #287 — "Isolate selected" left other pages' colour fills drawn

Isolating hid every other page's warped image but not its RMSE overlay, so the isolated sheet sat under a pile of fills belonging to sheets that were no longer visible. The fills now follow the isolation. Isolating with *nothing* selected still shows everything — isolating "nothing" would blank the map.

## #289 — the page list resized with its contents

`.page-list` was `max-width`, so a truth annotation (no compare columns) and a run (several) produced different widths and the map beside it moved, making the two impossible to line up. Fixed width now — verified **305 px before and after** switching annotations.

## #288 — the volume list arrived after the map had drawn

The endpoint parses every `*.iiif.json` under `data/` purely to show an item count beside each filename: **633 files, 175 MB of JSON, ~0.5 s on every request**.

The obvious fix wasn't the fix. Making the reads concurrent bought almost nothing (0.46 → 0.44 s) — the cost is parsing, not I/O. Item counts are now cached per path and invalidated by mtime, which is sound because a count cannot change without the file changing. **0.52 s cold → 0.034 s warm.**

## #241 — the dev server returned the app for missing files

Vite answers any unmatched path with `index.html` and a 200. Right for an app that routes on the path; this one routes on the query string, so every extension-bearing URL reaching the fallback is a mistake, and returning HTML makes a typo'd or stale data URL look like a successful fetch.

| URL | before | after |
|---|---|---|
| `/mapsnap/some/made/up/url.txt` | 200 | **404** |
| `/mapsnap/data/nope/missing.json` | 200 | **404** |
| `/mapsnap/`, `/mapsnap/index.html`, a real data file | 200 | 200 |

The new middleware runs **before** Vite's own (a post hook would sit after the html fallback and never see the request), so it skips what Vite legitimately serves: `/@vite`, `/@fs`, `/@id`, `node_modules`, the source tree, and real files under the app root or `public/`.

## #252 — only one georef sidecar was linked, and it was guessed from the filename

This was a #270 phase 3 regression, not just a missing feature. The panel decoded a "failure kind" from the filename, but phase 3 moved those into a `status` field inside one sidecar per channel — so the old pattern started matching `-final`, `-snap` and `-street`, i.e. **every** page. An unplaced page got linked to an arbitrary channel labelled "georef view (final)", while a placed page's snap, street and arbiter sidecars were unreachable from the viewer at all.

Every `<stem>.georef*.json` is now listed, plain first, labelled by variant — which doubles as a readout of which channels produced a pose. richmond p380 renders `streets · georef · georef-snap · georef-final · adjacency`.

## #298 — link a volume to its OIM map page

The issue asked whether `main.iiif.json` holds enough to reconstruct OIM URLs. **For the volume, yes**: the top-level id is the OIM mosaic URL, present on LOC-downloaded volumes as well as OIM-native ones. All 18 truth volumes yield a slug.

**Per page, no** — and this is worth recording, because the wrong answer looks right. Each annotation carries an id like `.../iiif/resource/81359/`, but that is a different namespace from OIM's document ids: richmond **p315** is resource 81359, and OIM's own page for 81359 is a different sheet (`page_number: 46`). That URL returns 200, so linking it would have quietly sent you to the wrong sheet. A per-page link needs the document listing fetched from OIM, as `oim-panels` does.

## #245 — the key-map view had no filter box

Mislabelled in the issue: #205 was about the *streets* view, and its change made key-map sheets bypass the size and confidence filters entirely — correctly, since key-map page numbers are not street reads and never face georef's admission gate. But that left no way to narrow a long list.

A substring search over detection text now serves both modes. richmond p380: 22 rows → 6 for "av" → 1 for "st" (`WINSTON`), case-insensitive, with the count shown only while filtering.

## #303 — no indication of where a split runs

Selecting one panel of a split sheet gave no clue where the cut was, since the neighbouring panel looks like more of the same map. The sheet's other panels now draw as a translucent dark fill with a dashed edge, beneath the selection outline; deselecting clears it. Verified on washington_dc p126__2.

## Not in this PR

**#292** (splits rendering incorrectly) is diagnosed on the issue but not fixed here — it is not a debugger bug. KC p451's large panel has an L-shaped selector whose notch spans x 1541.8–1638 while its sibling occupies x 1325.1–1638, so the leftover strip covers the small panel. `panels.json` is correct; the fault is in `make_iiif_georef`, where a split panel's ring is used only for its bounding box while the selector comes from the **street-block** mask, which knows nothing about the cut. Fixing it changes generated IIIF for every split page and wants a re-run.

## Verified

227 frontend tests, 1,113 Python tests, ruff/pyright/prettier clean. The app loads with all eight in place: 48 volumes in the picker, 91 page rows, map canvas present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
