### PR TITLE
Skeleton pages are not key-map expectations (#316 phase 0)

### DIFF
--- a/mapsnap/keymap/adjacency_assign.py
+++ b/mapsnap/keymap/adjacency_assign.py
@@ -57,6 +57,8 @@ import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from mapsnap.keymap.fit_keymap import collapse_skeleton_keys
+
 PROXIMITY_FACTOR = 1.5
 """How many page-pitches apart two printed numbers may be and still count as
 neighbours (see proximity_graph)."""
@@ -672,7 +674,8 @@ def plan_volume_repairs(
     mutual, one_sided = adjacency_graphs(volume)
     if not mutual:
         return [], {}
-    volume_keys = volume_page_keys(volume)
+    # Skeleton twins are not key-map expectations: the sheet names 201 once.
+    volume_keys = collapse_skeleton_keys(volume_page_keys(volume))
     splits = split_multiplicity(volume)
 
     sheet_panels: list[SheetNumbers] = []

--- a/mapsnap/keymap/detect_numbers_crnn.py
+++ b/mapsnap/keymap/detect_numbers_crnn.py
@@ -51,7 +51,11 @@ from mapsnap.keymap.detect_numbers_cnn import (
     detect_candidate_centers,
     nms_peaks,
 )
-from mapsnap.keymap.fit_keymap import key_stem, volume_page_keys
+from mapsnap.keymap.fit_keymap import (
+    collapse_skeleton_keys,
+    key_stem,
+    volume_page_keys,
+)
 from mapsnap.keymap.number_model import build_model, select_device
 from mapsnap.keymap.records import (
     detection_record,
@@ -72,7 +76,7 @@ def volume_pages_for(image_path: str) -> list[str]:
     """
     from mapsnap.keymap.pipeline import keymap_volume_dir
 
-    keys = volume_page_keys(keymap_volume_dir(Path(image_path)))
+    keys = collapse_skeleton_keys(volume_page_keys(keymap_volume_dir(Path(image_path))))
     return sorted(
         (key for key in keys if page_key_sort(key)[0] >= 1), key=page_key_sort
     )

--- a/mapsnap/keymap/fit_keymap.py
+++ b/mapsnap/keymap/fit_keymap.py
@@ -311,6 +311,33 @@ def volume_page_numbers(volume: Path) -> set[int]:
     return numbers
 
 
+def collapse_skeleton_keys(keys: set[str]) -> set[str]:
+    """Drop skeleton twins: a printed key map shows ``201`` once, never ``201S``.
+
+    ``pNs`` is a stripped-down copy of the same map as ``pN``, so wherever a
+    set of page keys stands for "what the key map can name", the skeleton must
+    not be a separate expectation: as a coverage denominator it deflates every
+    skeleton-heavy volume (philadelphia's key map can never name 58 of its 120
+    keys), and as a decode vocabulary it is a trap -- reads have been snapped
+    onto never-printed keys (philadelphia ``219S``, miami ``10S``), planting
+    the location under a key the sheet does not contain.
+
+    Only the exact pair collapses: ``NS`` with a bare ``N`` present. A lone
+    ``NS`` (no bare twin on disk) is kept -- the sheet presumably names it.
+    Compound suffixes like ``6NS`` are kept too, unlike compare's skeleton
+    rule which raises: a decode vocabulary must not take the pipeline down
+    over one odd stem, and keeping a key is the conservative direction here.
+    Measured across the 18 truth volumes every ``<digits>S`` family is exactly
+    such a pair (miami, new_orleans_1896, philadelphia, washington_dc), and
+    no volume has a directional bare+S pair this could confuse.
+    """
+    return {
+        key
+        for key in keys
+        if not (re.fullmatch(r"\d+S", key, re.IGNORECASE) and key[:-1] in keys)
+    }
+
+
 def volume_page_keys(volume: Path) -> set[str]:
     """All page keys present in the volume, letter suffixes included.
 

--- a/mapsnap/keymap/fit_keymap_test.py
+++ b/mapsnap/keymap/fit_keymap_test.py
@@ -160,3 +160,35 @@ def test_load_detections_keeps_lettered_keys(tmp_path):
     path.write_text(json.dumps(doc))
     detections = load_detections(path)
     assert [(d.key, d.number) for d in detections] == [("35A", 35), ("51", 51)]
+
+
+# --- skeleton collapse ---
+
+
+def test_collapse_skeleton_keys_drops_the_twin_only():
+    from mapsnap.keymap.fit_keymap import collapse_skeleton_keys
+
+    # The philadelphia shape: every S key has its bare twin -> the S goes.
+    assert collapse_skeleton_keys({"201", "201S", "202", "202S", "7"}) == {
+        "201",
+        "202",
+        "7",
+    }
+    # A lone skeleton with no bare twin is kept: the sheet presumably names it.
+    assert collapse_skeleton_keys({"35S", "36"}) == {"35S", "36"}
+    # Letter pages that merely END in other letters are untouched.
+    assert collapse_skeleton_keys({"12N", "55W", "1499K"}) == {"12N", "55W", "1499K"}
+    # Compound suffixes are kept, not raised on (unlike compare's skeleton
+    # rule): a decode vocabulary must not take the pipeline down.
+    assert collapse_skeleton_keys({"6NS", "6N"}) == {"6NS", "6N"}
+
+
+def test_collapse_skeleton_keys_is_why_reads_stop_landing_on_skeletons():
+    from mapsnap.keymap.fit_keymap import collapse_skeleton_keys
+
+    # The live-pollution case: philadelphia reads snapped onto 219S/227S/232S
+    # -- keys the printed sheet does not contain. With the vocabulary
+    # collapsed, those keys simply are not available to snap onto.
+    pages = collapse_skeleton_keys({"219", "219S", "227", "227S"})
+    assert "219S" not in pages and "227S" not in pages
+    assert pages == {"219", "227"}

--- a/mapsnap/keymap/identify.py
+++ b/mapsnap/keymap/identify.py
@@ -45,7 +45,11 @@ from mapsnap.keymap.detect_numbers_cnn import (
     detect_candidate_centers,
 )
 from mapsnap.keymap.detect_numbers_crnn import read_candidates, snap_to_pages
-from mapsnap.keymap.fit_keymap import page_number, volume_page_keys
+from mapsnap.keymap.fit_keymap import (
+    collapse_skeleton_keys,
+    page_number,
+    volume_page_keys,
+)
 from mapsnap.keymap.number_model import build_model, select_device
 from mapsnap.keymap.records import page_key_sort, write_keymaps_record
 from mapsnap.utils import image_stem
@@ -78,7 +82,11 @@ def is_letter_page(stem: str) -> bool:
 def volume_valid_pages(volume: Path) -> list[str]:
     """The volume's real page keys (positive, letters included, from its ``p*.jpg`` images)."""
     return sorted(
-        (key for key in volume_page_keys(volume) if page_key_sort(key)[0] >= 1),
+        (
+            key
+            for key in collapse_skeleton_keys(volume_page_keys(volume))
+            if page_key_sort(key)[0] >= 1
+        ),
         key=page_key_sort,
     )
 

--- a/mapsnap/keymap/pipeline.py
+++ b/mapsnap/keymap/pipeline.py
@@ -49,7 +49,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from mapsnap.keymap.adjacency_assign import repair_volume
-from mapsnap.keymap.fit_keymap import volume_page_keys
+from mapsnap.keymap.fit_keymap import collapse_skeleton_keys, volume_page_keys
 from mapsnap.keymap.records import keymap_path, page_key_sort
 from mapsnap.utils import default_centerlines, run_cmd
 
@@ -104,7 +104,7 @@ def valid_page_spec(keymap_images: list[Path]) -> str:
     """
     keys: set[str] = set()
     for volume in {keymap_volume_dir(image) for image in keymap_images}:
-        keys |= volume_page_keys(volume)
+        keys |= collapse_skeleton_keys(volume_page_keys(volume))
     return format_page_spec(key for key in keys if page_key_sort(key)[0] >= 1)
 
 


### PR DESCRIPTION
Phase 0 of #316 — the no-ML piece. A skeleton sheet (`pNs`) is a stripped copy of the same map as `pN`; the printed key map names `201` once, never `201S`. Everything that treated the skeleton as a separate page-key expectation was wrong in a distinct way:

| consumer | failure |
|---|---|
| CRNN decode vocabulary | offered never-printed keys for misreads to snap onto — **12 live reads had landed there** (philly `219S`/`227S`/`232S`/`238S`, miami `10S`), planting the location under a key the sheet doesn't contain while the bare page went unlocated |
| keymap-detect coverage | denominator counted unnameable keys — philadelphia's key map could never exceed 52% apparent coverage |
| adjacency assignment repair (#213) | chased permanently-missing skeleton keys |
| pipeline detect-target spec | asked the reader to find keys not on the sheet |

`collapse_skeleton_keys` drops `NS` only when bare `N` exists. Verified against the corpus before writing it: every `<digits>S` family across the 18 volumes is exactly such a pair, and **no volume has a directional bare+S collision** (chicago's `12N`/`55W` never come with a bare twin). Compound suffixes are kept rather than raised on — a decode vocabulary must not take the pipeline down over one odd stem (documented divergence from `redundant_skeleton_keys`).

Skeleton pages keep getting locations: the locator's stem-family fallback already serves `201`'s location to a `201S` lookup — that part was never broken.

## Measured, by re-detecting the four affected key maps

| volume | S-reads | honest coverage |
|---|---|---|
| **philadelphia** | 10 → **0** | **70% → 82%** — newly located: 206, 208, 219, 227, 232, 236, 238, 253 |
| miami | 1 → 0 | 66% → 67% (page 10) |
| washington_dc | 0 → 0 | unchanged |
| new_orleans_1896 | 0 → 0 | unchanged |

Nothing lost on any volume. (Philadelphia's oft-quoted "47% coverage" was always half phantom — its honest denominator is 66 nameable keys, not 120.)

The regenerated `keymap.json` reads are on disk (untracked data); their mtime change invalidates snap's candidate cache for these volumes, so the next fit picks up the new locations through vocab restriction, rescue centers and reconcile's keymap term.

1,119 tests (2 new), ruff and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
